### PR TITLE
Use workspace dependencies where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,64 @@ categories = ["asynchronous", "network-programming"]
 authors = ["Glen De Cauwsemaecker <glen@plabayo.tech>"]
 rust-version = "1.75.0"
 
+[workspace.dependencies]
+anyhow = "1.0"
+async-compression = "0.4"
+base64 = "0.22"
+bitflags = "2.4"
+brotli = "3"
+bytes = "1"
+clap = "4.4"
+crossterm = "0.27"
+flate2 = "1.0"
+futures = "0.3.29"
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false }
+h2 = "0.4"
+headers = "0.4"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
+http-range-header = "0.4.0"
+httparse = "1.8"
+httpdate = "1.0"
+hyper = "1.2"
+hyper-util = "0.1.3"
+ipnet = "2.9.0"
+mime = "0.3.17"
+mime_guess = { version = "2", default-features = false }
+paste = "1.0"
+percent-encoding = "2.1"
+pin-project-lite = "0.2.13"
+pki-types = "1"
+proc-macro2 = "1.0"
+prometheus = "0.13.3"
+quickcheck = "1.0"
+quote = "1.0"
+ratatui = "0.25"
+rcgen = "0.12.0"
+regex = "1.10.3"
+rustls = "0.22"
+rustls-native-certs = "=0.7.0"
+rustls-pemfile = "2.1"
+rustversion = "1.0.9"
+serde = "1.0"
+serde_json = "1.0"
+serde_urlencoded = "0.7"
+syn = "2.0"
+sync_wrapper = "1.0"
+tempfile = "3.10"
+tokio = "1.35"
+tokio-graceful = "0.1"
+tokio-rustls = "0.25"
+tokio-test = "0.4.3"
+tokio-util = "0.7"
+tracing = "0.1"
+tracing-subscriber = "0.3.17"
+trybuild = "1.0.63"
+uuid = "1.6"
+zstd = "0.13"
+
 [package]
 name = "rama"
 readme = "README.md"
@@ -33,64 +91,62 @@ full = ["compression"]
 compression = ["dep:async-compression"]
 
 [build-dependencies]
-rustversion = "1.0.9"
+rustversion = { workspace = true }
 
 [dependencies]
-async-compression = { version = "0.4", optional = true, features = ["tokio", "brotli", "zlib", "gzip", "zstd"] }
-base64 = { version = "0.22" }
-bitflags = "2.4"
-bytes = "1"
-futures = "0.3.29"
-futures-core = "0.3"
-futures-util = { version = "0.3", default-features = false, features = [
-    "alloc",
-] }
-h2 = "0.4"
-headers = "0.4"
-http = "1"
-http-body = "1"
-http-body-util = "0.1"
-http-range-header = "0.4.0"
-httparse = "1.8"
-httpdate = "1.0"
-hyper = { version = "1.2", features = ["http1", "http2", "server", "client"] }
-hyper-util = { version = "0.1.3", features = ["tokio", "server-auto"] }
-ipnet = "2.9.0"
-mime = "0.3.17"
-mime_guess = { version = "2", default_features = false }
-paste = "1.0"
-percent-encoding = "2.1"
-pin-project-lite = "0.2.13"
+async-compression = { workspace = true, features = ["tokio", "brotli", "zlib", "gzip", "zstd"], optional = true }
+base64 = { workspace = true }
+bitflags = { workspace = true }
+bytes = { workspace = true }
+futures = { workspace = true }
+futures-core = { workspace = true }
+futures-util = { workspace = true, features = ["alloc"] }
+h2 = { workspace = true }
+headers = { workspace = true }
+http = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+http-range-header = { workspace = true }
+httparse = { workspace = true }
+httpdate = { workspace = true }
+hyper = { workspace = true, features = ["http1", "http2", "server", "client"] }
+hyper-util = { workspace = true, features = ["tokio", "server-auto"] }
+ipnet = { workspace = true }
+mime = { workspace = true }
+mime_guess = { workspace = true }
+paste = { workspace = true }
+percent-encoding = { workspace = true }
+pin-project-lite = { workspace = true }
 pki-types = { package = "rustls-pki-types", version = "^1" }
-prometheus = "0.13.3"
-quickcheck = "1.0"
+prometheus = { workspace = true }
+quickcheck = { workspace = true }
 rama-macros = { path = "rama-macros" }
-rcgen = "0.12.0"
-regex = "1.10.3"
-rustls = "0.22"
-rustls-native-certs = "=0.7.0"
-rustls-pemfile = "2.1"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_urlencoded = "0.7"
-sync_wrapper = "1.0"
-tokio = { version = "1", features = ["macros", "fs"] }
-tokio-graceful = "0.1"
-tokio-rustls = "0.25"
-tokio-util = "0.7"
-tracing = { version = "0.1" }
-uuid = { version = "1.6", features = ["v4"] }
+rcgen = { workspace = true }
+regex = { workspace = true }
+rustls = { workspace = true }
+rustls-native-certs = { workspace = true }
+rustls-pemfile = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+sync_wrapper = { workspace = true }
+tokio = { workspace = true, features = ["macros", "fs"] }
+tokio-graceful = { workspace = true }
+tokio-rustls = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
-brotli = "3"
-flate2 = "1.0"
-rustversion = "1.0.9"
-tempfile = "3.10"
-tokio = { version = "1", features = ["full"] }
-tokio-test = { version = "0.4.3" }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-zstd = "0.13"
+brotli = { workspace = true }
+flate2 = { workspace = true }
+rustversion = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-test = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+zstd = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rama-cli/Cargo.toml
+++ b/rama-cli/Cargo.toml
@@ -12,12 +12,12 @@ rust-version = { workspace = true }
 default-run = "rama"
 
 [dependencies]
-anyhow = "1.0"
-clap = { version = "4.4", features = [ "derive" ] }
-crossterm = "0.27"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+crossterm = { workspace = true }
 rama = { version = "0.2", path = ".." }
-ratatui = "0.25"
-tokio = { version = "1.35", features = [ "rt-multi-thread", "macros" ] }
+ratatui = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
 [[bin]]
 name = "rama"

--- a/rama-fp/Cargo.toml
+++ b/rama-fp/Cargo.toml
@@ -12,16 +12,16 @@ rust-version = { workspace = true }
 default-run = "rama-fp"
 
 [dependencies]
-anyhow = "1.0"
-base64 = { version = "0.22" }
-clap = { version = "4.4", features = ["derive"] }
+anyhow = { workspace = true }
+base64 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 rama = { version = "0.2", path = "..", features = ["full"] }
-serde = "1.0"
-serde_json = "1.0"
-serde_urlencoded = "0.7"
-tokio = { version = "1.35", features = ["rt-multi-thread", "macros"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [[bin]]
 name = "rama-fp"

--- a/rama-macros/Cargo.toml
+++ b/rama-macros/Cargo.toml
@@ -14,17 +14,14 @@ rust-version = { workspace = true }
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = [
-    "full",
-    "parsing",
-] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full", "parsing"] }
 
 [dev-dependencies]
 rama = { path = "..", features = ["full"] }
-syn = { version = "2.0", features = ["full", "extra-traits"] }
-trybuild = "1.0.63"
+syn = { workspace = true, features = ["full", "extra-traits"] }
+trybuild = { workspace = true }
 
 [package.metadata.cargo-public-api-crates]
 allowed = []


### PR DESCRIPTION
Fix #89.

I took `cargo-autoinherit` for a spin since there was an open issue about it 😁 