### PR TITLE
Rename *Filter to *Matcher

### DIFF
--- a/examples/http_connect_proxy.rs
+++ b/examples/http_connect_proxy.rs
@@ -32,7 +32,7 @@ use rama::{
             trace::TraceLayer,
             upgrade::{UpgradeLayer, Upgraded},
         },
-        matcher::{DomainFilter, HttpMatcher, MethodFilter},
+        matcher::{DomainMatcher, HttpMatcher, MethodMatcher},
         response::Json,
         server::HttpServer,
         service::web::{
@@ -83,7 +83,7 @@ async fn main() {
                     .layer(ProxyAuthLayer::new(("john", "secret")))
                     // example of how one might insert an API layer into their proxy
                     .layer(HijackLayer::new(
-                        DomainFilter::new("echo.example"),
+                        DomainMatcher::new("echo.example"),
                         Arc::new(match_service!{
                             HttpMatcher::post("/lucky/:number") => |path: Path<APILuckyParams>| async move {
                                 Json(json!({
@@ -100,7 +100,7 @@ async fn main() {
                         })
                     ))
                     .layer(UpgradeLayer::new(
-                        MethodFilter::CONNECT,
+                        MethodMatcher::CONNECT,
                         service_fn(http_connect_accept),
                         service_fn(http_connect_proxy),
                     ))

--- a/examples/http_service_match.rs
+++ b/examples/http_service_match.rs
@@ -23,7 +23,7 @@
 use rama::{
     http::{
         layer::trace::TraceLayer,
-        matcher::{HttpMatcher, PathFilter},
+        matcher::{HttpMatcher, PathMatcher},
         response::{Html, Json, Redirect},
         server::HttpServer,
         service::web::match_service,
@@ -62,7 +62,7 @@ async fn main() {
             .service(
                     match_service!{
                         HttpMatcher::get("/") => Html(r##"<h1>Home</h1><a href="/echo">Echo Request</a>"##.to_string()),
-                        PathFilter::new("/echo") => |req: Request| async move {
+                        PathMatcher::new("/echo") => |req: Request| async move {
                             Json(json!({
                                 "method": req.method().as_str(),
                                 "path": req.uri().path(),

--- a/src/http/matcher/domain.rs
+++ b/src/http/matcher/domain.rs
@@ -75,11 +75,11 @@ mod test {
             (DomainMatcher::sub("example.com"), "www.EXAMPLE.com"),
             (DomainMatcher::sub("example.com"), "M.example.com"),
         ];
-        for (filter, host) in test_cases.into_iter() {
+        for (matcher, host) in test_cases.into_iter() {
             assert!(
-                filter.matches_host(host),
+                matcher.matches_host(host),
                 "({:?}).matches_host({})",
-                filter,
+                matcher,
                 host
             );
         }
@@ -94,11 +94,11 @@ mod test {
             (DomainMatcher::sub("w.example.com"), "www.example.com"),
             (DomainMatcher::sub("gel.com"), "kegel.com"),
         ];
-        for (filter, host) in test_cases.into_iter() {
+        for (matcher, host) in test_cases.into_iter() {
             assert!(
-                !filter.matches_host(host),
+                !matcher.matches_host(host),
                 "!({:?}).matches_host({})",
-                filter,
+                matcher,
                 host
             );
         }

--- a/src/http/matcher/domain.rs
+++ b/src/http/matcher/domain.rs
@@ -5,14 +5,14 @@ use crate::{
 use std::cmp::Ordering;
 
 #[derive(Debug, Clone)]
-/// Filter based on the (sub)domain of the request's URI.
+/// Matcher based on the (sub)domain of the request's URI.
 pub struct DomainMatcher {
     domain: String,
     sub: bool,
 }
 
 impl DomainMatcher {
-    /// create a new domain filter to filter on an exact URI host match.
+    /// create a new domain matcher to filter on an exact URI host match.
     pub fn new(domain: impl Into<String>) -> Self {
         Self {
             domain: domain.into().to_lowercase(),
@@ -20,7 +20,7 @@ impl DomainMatcher {
         }
     }
 
-    /// create a new domain filter to filter on a subdomain URI host match.
+    /// create a new domain matcher to filter on a subdomain URI host match.
     pub fn sub(domain: impl Into<String>) -> Self {
         Self {
             domain: domain.into().to_lowercase(),

--- a/src/http/matcher/domain.rs
+++ b/src/http/matcher/domain.rs
@@ -6,12 +6,12 @@ use std::cmp::Ordering;
 
 #[derive(Debug, Clone)]
 /// Filter based on the (sub)domain of the request's URI.
-pub struct DomainFilter {
+pub struct DomainMatcher {
     domain: String,
     sub: bool,
 }
 
-impl DomainFilter {
+impl DomainMatcher {
     /// create a new domain filter to filter on an exact URI host match.
     pub fn new(domain: impl Into<String>) -> Self {
         Self {
@@ -46,7 +46,7 @@ impl DomainFilter {
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for DomainFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for DomainMatcher {
     fn matches(
         &self,
         _ext: Option<&mut Extensions>,
@@ -68,12 +68,12 @@ mod test {
     #[test]
     fn matchest_host_match() {
         let test_cases = vec![
-            (DomainFilter::new("www.example.com"), "www.example.com"),
-            (DomainFilter::new("www.example.com"), "WwW.ExamplE.COM"),
-            (DomainFilter::sub("example.com"), "www.example.com"),
-            (DomainFilter::sub("example.com"), "m.example.com"),
-            (DomainFilter::sub("example.com"), "www.EXAMPLE.com"),
-            (DomainFilter::sub("example.com"), "M.example.com"),
+            (DomainMatcher::new("www.example.com"), "www.example.com"),
+            (DomainMatcher::new("www.example.com"), "WwW.ExamplE.COM"),
+            (DomainMatcher::sub("example.com"), "www.example.com"),
+            (DomainMatcher::sub("example.com"), "m.example.com"),
+            (DomainMatcher::sub("example.com"), "www.EXAMPLE.com"),
+            (DomainMatcher::sub("example.com"), "M.example.com"),
         ];
         for (filter, host) in test_cases.into_iter() {
             assert!(
@@ -88,11 +88,11 @@ mod test {
     #[test]
     fn matchest_host_no_match() {
         let test_cases = vec![
-            (DomainFilter::new("www.example.com"), "www.example.co"),
-            (DomainFilter::new("www.example.com"), "www.ejemplo.com"),
-            (DomainFilter::new("www.example.com"), "www3.example.com"),
-            (DomainFilter::sub("w.example.com"), "www.example.com"),
-            (DomainFilter::sub("gel.com"), "kegel.com"),
+            (DomainMatcher::new("www.example.com"), "www.example.co"),
+            (DomainMatcher::new("www.example.com"), "www.ejemplo.com"),
+            (DomainMatcher::new("www.example.com"), "www3.example.com"),
+            (DomainMatcher::sub("w.example.com"), "www.example.com"),
+            (DomainMatcher::sub("gel.com"), "kegel.com"),
         ];
         for (filter, host) in test_cases.into_iter() {
             assert!(

--- a/src/http/matcher/header.rs
+++ b/src/http/matcher/header.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// Filter based on the [`Request`]'s headers.
+/// Matcher based on the [`Request`]'s headers.
 ///
 /// [`Request`]: crate::http::Request
 pub struct HeaderMatcher {
@@ -20,7 +20,7 @@ enum HeaderMatcherKind {
 }
 
 impl HeaderMatcher {
-    /// Create a new header filter to filter on the existence of a header.
+    /// Create a new header matcher to filter on the existence of a header.
     pub fn exists(name: HeaderName) -> Self {
         Self {
             name,
@@ -28,7 +28,7 @@ impl HeaderMatcher {
         }
     }
 
-    /// Create a new header filter to filter on an exact header value match.
+    /// Create a new header matcher to filter on an exact header value match.
     pub fn is(name: HeaderName, value: HeaderValue) -> Self {
         Self {
             name,
@@ -36,7 +36,7 @@ impl HeaderMatcher {
         }
     }
 
-    /// Create a new header filter to filter that the header contains the given value.
+    /// Create a new header matcher to filter that the header contains the given value.
     pub fn contains(name: HeaderName, value: HeaderValue) -> Self {
         Self {
             name,

--- a/src/http/matcher/header.rs
+++ b/src/http/matcher/header.rs
@@ -68,25 +68,25 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_header_filter_exists() {
-        let filter = HeaderMatcher::exists("content-type".parse().unwrap());
+    fn test_header_matcher_exists() {
+        let matcher = HeaderMatcher::exists("content-type".parse().unwrap());
         let req = Request::builder()
             .header("content-type", "text/plain")
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_exists_no_match() {
-        let filter = HeaderMatcher::exists("content-type".parse().unwrap());
+    fn test_header_matcher_exists_no_match() {
+        let matcher = HeaderMatcher::exists("content-type".parse().unwrap());
         let req = Request::builder().body(()).unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_is() {
-        let filter = HeaderMatcher::is(
+    fn test_header_matcher_is() {
+        let matcher = HeaderMatcher::is(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -94,12 +94,12 @@ mod test {
             .header("content-type", "text/plain")
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_is_no_match() {
-        let filter = HeaderMatcher::is(
+    fn test_header_matcher_is_no_match() {
+        let matcher = HeaderMatcher::is(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -107,12 +107,12 @@ mod test {
             .header("content-type", "text/html")
             .body(())
             .unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_contains() {
-        let filter = HeaderMatcher::contains(
+    fn test_header_matcher_contains() {
+        let matcher = HeaderMatcher::contains(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -120,12 +120,12 @@ mod test {
             .header("content-type", "text/plain")
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_contains_no_match() {
-        let filter = HeaderMatcher::contains(
+    fn test_header_matcher_contains_no_match() {
+        let matcher = HeaderMatcher::contains(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -133,12 +133,12 @@ mod test {
             .header("content-type", "text/html")
             .body(())
             .unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_contains_multiple() {
-        let filter = HeaderMatcher::contains(
+    fn test_header_matcher_contains_multiple() {
+        let matcher = HeaderMatcher::contains(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -147,12 +147,12 @@ mod test {
             .header("content-type", "text/plain")
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_header_filter_contains_multiple_no_match() {
-        let filter = HeaderMatcher::contains(
+    fn test_header_matcher_contains_multiple_no_match() {
+        let matcher = HeaderMatcher::contains(
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
@@ -161,6 +161,6 @@ mod test {
             .header("content-type", "text/xml")
             .body(())
             .unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 }

--- a/src/http/matcher/method.rs
+++ b/src/http/matcher/method.rs
@@ -9,9 +9,9 @@ use std::{
 
 /// A filter that matches one or more HTTP methods.
 #[derive(Debug, Copy, Clone, PartialEq)]
-pub struct MethodFilter(u16);
+pub struct MethodMatcher(u16);
 
-impl MethodFilter {
+impl MethodMatcher {
     /// Match `CONNECT` requests.
     pub const CONNECT: Self = Self::from_bits(0b0_0000_0001);
     /// Match `DELETE` requests.
@@ -44,13 +44,13 @@ impl MethodFilter {
         self.bits() & other.bits() == other.bits()
     }
 
-    /// Performs the OR operation between the [`MethodFilter`] in `self` with `other`.
+    /// Performs the OR operation between the [`MethodMatcher`] in `self` with `other`.
     pub const fn or(self, other: Self) -> Self {
         Self(self.0 | other.0)
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for MethodFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for MethodMatcher {
     /// returns true on a match, false otherwise
     fn matches(
         &self,
@@ -58,48 +58,48 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for MethodFilter
         _ctx: &Context<State>,
         req: &Request<Body>,
     ) -> bool {
-        MethodFilter::try_from(req.method())
+        MethodMatcher::try_from(req.method())
             .ok()
             .map(|method| self.contains(method))
             .unwrap_or_default()
     }
 }
 
-/// Error type used when converting a [`Method`] to a [`MethodFilter`] fails.
+/// Error type used when converting a [`Method`] to a [`MethodMatcher`] fails.
 #[derive(Debug)]
-pub struct NoMatchingMethodFilter {
+pub struct NoMatchingMethodMatcher {
     method: Method,
 }
 
-impl NoMatchingMethodFilter {
-    /// Get the [`Method`] that couldn't be converted to a [`MethodFilter`].
+impl NoMatchingMethodMatcher {
+    /// Get the [`Method`] that couldn't be converted to a [`MethodMatcher`].
     pub fn method(&self) -> &Method {
         &self.method
     }
 }
 
-impl fmt::Display for NoMatchingMethodFilter {
+impl fmt::Display for NoMatchingMethodMatcher {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "no `MethodFilter` for `{}`", self.method.as_str())
+        write!(f, "no `MethodMatcher` for `{}`", self.method.as_str())
     }
 }
 
-impl std::error::Error for NoMatchingMethodFilter {}
+impl std::error::Error for NoMatchingMethodMatcher {}
 
-impl TryFrom<&Method> for MethodFilter {
-    type Error = NoMatchingMethodFilter;
+impl TryFrom<&Method> for MethodMatcher {
+    type Error = NoMatchingMethodMatcher;
 
     fn try_from(m: &Method) -> Result<Self, Self::Error> {
         match m {
-            &Method::CONNECT => Ok(MethodFilter::CONNECT),
-            &Method::DELETE => Ok(MethodFilter::DELETE),
-            &Method::GET => Ok(MethodFilter::GET),
-            &Method::HEAD => Ok(MethodFilter::HEAD),
-            &Method::OPTIONS => Ok(MethodFilter::OPTIONS),
-            &Method::PATCH => Ok(MethodFilter::PATCH),
-            &Method::POST => Ok(MethodFilter::POST),
-            &Method::PUT => Ok(MethodFilter::PUT),
-            &Method::TRACE => Ok(MethodFilter::TRACE),
+            &Method::CONNECT => Ok(MethodMatcher::CONNECT),
+            &Method::DELETE => Ok(MethodMatcher::DELETE),
+            &Method::GET => Ok(MethodMatcher::GET),
+            &Method::HEAD => Ok(MethodMatcher::HEAD),
+            &Method::OPTIONS => Ok(MethodMatcher::OPTIONS),
+            &Method::PATCH => Ok(MethodMatcher::PATCH),
+            &Method::POST => Ok(MethodMatcher::POST),
+            &Method::PUT => Ok(MethodMatcher::PUT),
+            &Method::TRACE => Ok(MethodMatcher::TRACE),
             other => Err(Self::Error {
                 method: other.clone(),
             }),
@@ -114,48 +114,48 @@ mod tests {
     #[test]
     fn from_http_method() {
         assert_eq!(
-            MethodFilter::try_from(&Method::CONNECT).unwrap(),
-            MethodFilter::CONNECT
+            MethodMatcher::try_from(&Method::CONNECT).unwrap(),
+            MethodMatcher::CONNECT
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::DELETE).unwrap(),
-            MethodFilter::DELETE
+            MethodMatcher::try_from(&Method::DELETE).unwrap(),
+            MethodMatcher::DELETE
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::GET).unwrap(),
-            MethodFilter::GET
+            MethodMatcher::try_from(&Method::GET).unwrap(),
+            MethodMatcher::GET
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::HEAD).unwrap(),
-            MethodFilter::HEAD
+            MethodMatcher::try_from(&Method::HEAD).unwrap(),
+            MethodMatcher::HEAD
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::OPTIONS).unwrap(),
-            MethodFilter::OPTIONS
+            MethodMatcher::try_from(&Method::OPTIONS).unwrap(),
+            MethodMatcher::OPTIONS
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::PATCH).unwrap(),
-            MethodFilter::PATCH
+            MethodMatcher::try_from(&Method::PATCH).unwrap(),
+            MethodMatcher::PATCH
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::POST).unwrap(),
-            MethodFilter::POST
+            MethodMatcher::try_from(&Method::POST).unwrap(),
+            MethodMatcher::POST
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::PUT).unwrap(),
-            MethodFilter::PUT
+            MethodMatcher::try_from(&Method::PUT).unwrap(),
+            MethodMatcher::PUT
         );
 
         assert_eq!(
-            MethodFilter::try_from(&Method::TRACE).unwrap(),
-            MethodFilter::TRACE
+            MethodMatcher::try_from(&Method::TRACE).unwrap(),
+            MethodMatcher::TRACE
         );
     }
 }

--- a/src/http/matcher/method.rs
+++ b/src/http/matcher/method.rs
@@ -7,7 +7,7 @@ use std::{
     fmt::{Debug, Formatter},
 };
 
-/// A filter that matches one or more HTTP methods.
+/// A matcher that matches one or more HTTP methods.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct MethodMatcher(u16);
 

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -8,26 +8,26 @@
 
 mod method;
 #[doc(inline)]
-pub use method::MethodFilter;
+pub use method::MethodMatcher;
 
 mod domain;
 #[doc(inline)]
-pub use domain::DomainFilter;
+pub use domain::DomainMatcher;
 
 pub mod uri;
-pub use uri::UriFilter;
+pub use uri::UriMatcher;
 
 mod version;
 #[doc(inline)]
-pub use version::VersionFilter;
+pub use version::VersionMatcher;
 
 mod path;
 #[doc(inline)]
-pub use path::{PathFilter, UriParams, UriParamsDeserializeError};
+pub use path::{PathMatcher, UriParams, UriParamsDeserializeError};
 
 mod header;
 #[doc(inline)]
-pub use header::HeaderFilter;
+pub use header::HeaderMatcher;
 
 use crate::{
     http::Request,
@@ -38,29 +38,29 @@ use crate::{
 #[derive(Debug, Clone)]
 /// A filter that is used to match an http [`Request`]
 pub struct HttpMatcher {
-    kind: HttpFilterKind,
+    kind: HttpMatcherKind,
     negate: bool,
 }
 
 #[derive(Debug, Clone)]
 /// A filter that is used to match an http [`Request`]
-pub enum HttpFilterKind {
-    /// zero or more [`HttpFilterKind`]s that all need to match in order for the filter to return `true`.
-    All(Vec<HttpFilterKind>),
-    /// [`MethodFilter`], a filter that matches one or more HTTP methods.
-    Method(MethodFilter),
-    /// [`PathFilter`], a filter based on the URI path.
-    Path(PathFilter),
-    /// [`DomainFilter`], a filter based on the (sub)domain of the request's URI.
-    Domain(DomainFilter),
-    /// [`VersionFilter`], a filter based on the HTTP version of the request.
-    Version(VersionFilter),
-    /// zero or more [`HttpFilterKind`]s that at least one needs to match in order for the filter to return `true`.
-    Any(Vec<HttpFilterKind>),
-    /// [`UriFilter`], a filter the request's URI, using a substring or regex pattern.
-    Uri(UriFilter),
-    /// [`HeaderFilter`], a filter based on the [`Request`]'s headers.
-    Header(HeaderFilter),
+pub enum HttpMatcherKind {
+    /// zero or more [`HttpMatcherKind`]s that all need to match in order for the filter to return `true`.
+    All(Vec<HttpMatcherKind>),
+    /// [`MethodMatcher`], a filter that matches one or more HTTP methods.
+    Method(MethodMatcher),
+    /// [`PathMatcher`], a filter based on the URI path.
+    Path(PathMatcher),
+    /// [`DomainMatcher`], a filter based on the (sub)domain of the request's URI.
+    Domain(DomainMatcher),
+    /// [`VersionMatcher`], a filter based on the HTTP version of the request.
+    Version(VersionMatcher),
+    /// zero or more [`HttpMatcherKind`]s that at least one needs to match in order for the filter to return `true`.
+    Any(Vec<HttpMatcherKind>),
+    /// [`UriMatcher`], a filter the request's URI, using a substring or regex pattern.
+    Uri(UriMatcher),
+    /// [`HeaderMatcher`], a filter based on the [`Request`]'s headers.
+    Header(HeaderMatcher),
     /// [`SocketMatcher`], a filter that matches on the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
@@ -70,25 +70,25 @@ pub enum HttpFilterKind {
 impl HttpMatcher {
     /// Create a new filter that matches one or more HTTP methods.
     ///
-    /// See [`MethodFilter`] for more information.
-    pub fn method(method: MethodFilter) -> Self {
+    /// See [`MethodMatcher`] for more information.
+    pub fn method(method: MethodMatcher) -> Self {
         Self {
-            kind: HttpFilterKind::Method(method),
+            kind: HttpMatcherKind::Method(method),
             negate: false,
         }
     }
 
     /// Create a filter that also matches one or more HTTP methods on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
-    pub fn and_method(mut self, method: MethodFilter) -> Self {
-        let filter = HttpFilterKind::Method(method);
+    /// See [`MethodMatcher`] for more information.
+    pub fn and_method(mut self, method: MethodMatcher) -> Self {
+        let filter = HttpMatcherKind::Method(method);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
@@ -96,663 +96,663 @@ impl HttpMatcher {
 
     /// Create a filter that can also match one or more HTTP methods as an alternative to the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
-    pub fn or_method(mut self, method: MethodFilter) -> Self {
-        let filter = HttpFilterKind::Method(method);
+    /// See [`MethodMatcher`] for more information.
+    pub fn or_method(mut self, method: MethodMatcher) -> Self {
+        let filter = HttpMatcherKind::Method(method);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::DELETE`] requests.
+    /// Create a new filter that matches [`MethodMatcher::DELETE`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_delete() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::DELETE),
+            kind: HttpMatcherKind::Method(MethodMatcher::DELETE),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::DELETE`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::DELETE`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_delete(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::DELETE);
+        let filter = HttpMatcherKind::Method(MethodMatcher::DELETE);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::DELETE`]
+    /// Add a new filter that can also match [`MethodMatcher::DELETE`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_delete(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::DELETE);
+        let filter = HttpMatcherKind::Method(MethodMatcher::DELETE);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::GET`] requests.
+    /// Create a new filter that matches [`MethodMatcher::GET`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_get() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::GET),
+            kind: HttpMatcherKind::Method(MethodMatcher::GET),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::GET`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::GET`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_get(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::GET);
+        let filter = HttpMatcherKind::Method(MethodMatcher::GET);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::GET`]
+    /// Add a new filter that can also match [`MethodMatcher::GET`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_get(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::GET);
+        let filter = HttpMatcherKind::Method(MethodMatcher::GET);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::HEAD`] requests.
+    /// Create a new filter that matches [`MethodMatcher::HEAD`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_head() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::HEAD),
+            kind: HttpMatcherKind::Method(MethodMatcher::HEAD),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::HEAD`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::HEAD`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_head(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::HEAD);
+        let filter = HttpMatcherKind::Method(MethodMatcher::HEAD);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::HEAD`]
+    /// Add a new filter that can also match [`MethodMatcher::HEAD`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_head(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::HEAD);
+        let filter = HttpMatcherKind::Method(MethodMatcher::HEAD);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::OPTIONS`] requests.
+    /// Create a new filter that matches [`MethodMatcher::OPTIONS`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_options() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::OPTIONS),
+            kind: HttpMatcherKind::Method(MethodMatcher::OPTIONS),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::OPTIONS`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::OPTIONS`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_options(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::OPTIONS);
+        let filter = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::OPTIONS`]
+    /// Add a new filter that can also match [`MethodMatcher::OPTIONS`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_options(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::OPTIONS);
+        let filter = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::PATCH`] requests.
+    /// Create a new filter that matches [`MethodMatcher::PATCH`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_patch() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::PATCH),
+            kind: HttpMatcherKind::Method(MethodMatcher::PATCH),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::PATCH`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::PATCH`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_patch(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::PATCH);
+        let filter = HttpMatcherKind::Method(MethodMatcher::PATCH);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::PATCH`]
+    /// Add a new filter that can also match [`MethodMatcher::PATCH`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_patch(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::PATCH);
+        let filter = HttpMatcherKind::Method(MethodMatcher::PATCH);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::POST`] requests.
+    /// Create a new filter that matches [`MethodMatcher::POST`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_post() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::POST),
+            kind: HttpMatcherKind::Method(MethodMatcher::POST),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::POST`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::POST`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_post(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::POST);
+        let filter = HttpMatcherKind::Method(MethodMatcher::POST);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::POST`]
+    /// Add a new filter that can also match [`MethodMatcher::POST`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_post(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::POST);
+        let filter = HttpMatcherKind::Method(MethodMatcher::POST);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::PUT`] requests.
+    /// Create a new filter that matches [`MethodMatcher::PUT`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_put() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::PUT),
+            kind: HttpMatcherKind::Method(MethodMatcher::PUT),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::PUT`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::PUT`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_put(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::PUT);
+        let filter = HttpMatcherKind::Method(MethodMatcher::PUT);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::PUT`]
+    /// Add a new filter that can also match [`MethodMatcher::PUT`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_put(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::PUT);
+        let filter = HttpMatcherKind::Method(MethodMatcher::PUT);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a new filter that matches [`MethodFilter::TRACE`] requests.
+    /// Create a new filter that matches [`MethodMatcher::TRACE`] requests.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn method_trace() -> Self {
         Self {
-            kind: HttpFilterKind::Method(MethodFilter::TRACE),
+            kind: HttpMatcherKind::Method(MethodMatcher::TRACE),
             negate: false,
         }
     }
 
-    /// Add a new filter that also matches [`MethodFilter::TRACE`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new filter that also matches [`MethodMatcher::TRACE`] on top of the existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn and_method_trace(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::TRACE);
+        let filter = HttpMatcherKind::Method(MethodMatcher::TRACE);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Add a new filter that can also match [`MethodFilter::TRACE`]
+    /// Add a new filter that can also match [`MethodMatcher::TRACE`]
     /// as an alternative tothe existing [`HttpMatcher`] filters.
     ///
-    /// See [`MethodFilter`] for more information.
+    /// See [`MethodMatcher`] for more information.
     pub fn or_method_trace(mut self) -> Self {
-        let filter = HttpFilterKind::Method(MethodFilter::TRACE);
+        let filter = HttpMatcherKind::Method(MethodMatcher::TRACE);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         };
         self
     }
 
-    /// Create a [`DomainFilter`] filter.
+    /// Create a [`DomainMatcher`] filter.
     pub fn domain(domain: impl Into<String>) -> Self {
         Self {
-            kind: HttpFilterKind::Domain(DomainFilter::new(domain)),
+            kind: HttpMatcherKind::Domain(DomainMatcher::new(domain)),
             negate: false,
         }
     }
 
-    /// Create a [`DomainFilter`] filter to also match on top of the existing set of [`HttpMatcher`] filters.
+    /// Create a [`DomainMatcher`] filter to also match on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`DomainFilter`] for more information.
+    /// See [`DomainMatcher`] for more information.
     pub fn and_domain(mut self, domain: impl Into<String>) -> Self {
-        let filter = HttpFilterKind::Domain(DomainFilter::new(domain));
+        let filter = HttpMatcherKind::Domain(DomainMatcher::new(domain));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`DomainFilter`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`DomainMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`DomainFilter`] for more information.
+    /// See [`DomainMatcher`] for more information.
     pub fn or_domain(mut self, domain: impl Into<String>) -> Self {
-        let filter = HttpFilterKind::Domain(DomainFilter::new(domain));
+        let filter = HttpMatcherKind::Domain(DomainMatcher::new(domain));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`VersionFilter`] filter.
-    pub fn version(version: VersionFilter) -> Self {
+    /// Create a [`VersionMatcher`] filter.
+    pub fn version(version: VersionMatcher) -> Self {
         Self {
-            kind: HttpFilterKind::Version(version),
+            kind: HttpMatcherKind::Version(version),
             negate: false,
         }
     }
 
-    /// Add a [`VersionFilter`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`VersionMatcher`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`VersionFilter`] for more information.
-    pub fn and_version(mut self, version: VersionFilter) -> Self {
-        let filter = HttpFilterKind::Version(version);
+    /// See [`VersionMatcher`] for more information.
+    pub fn and_version(mut self, version: VersionMatcher) -> Self {
+        let filter = HttpMatcherKind::Version(version);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`VersionFilter`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`VersionMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`VersionFilter`] for more information.
-    pub fn or_version(mut self, version: VersionFilter) -> Self {
-        let filter = HttpFilterKind::Version(version);
+    /// See [`VersionMatcher`] for more information.
+    pub fn or_version(mut self, version: VersionMatcher) -> Self {
+        let filter = HttpMatcherKind::Version(version);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`UriFilter`] filter.
+    /// Create a [`UriMatcher`] filter.
     pub fn uri(re: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpFilterKind::Uri(UriFilter::new(re)),
+            kind: HttpMatcherKind::Uri(UriMatcher::new(re)),
             negate: false,
         }
     }
 
-    /// Create a [`UriFilter`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Create a [`UriMatcher`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`UriFilter`] for more information.
+    /// See [`UriMatcher`] for more information.
     pub fn and_uri(mut self, re: impl AsRef<str>) -> Self {
-        let filter = HttpFilterKind::Uri(UriFilter::new(re));
+        let filter = HttpMatcherKind::Uri(UriMatcher::new(re));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`UriFilter`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`UriMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
     ///    
-    /// See [`UriFilter`] for more information.
+    /// See [`UriMatcher`] for more information.
     pub fn or_uri(mut self, re: impl AsRef<str>) -> Self {
-        let filter = HttpFilterKind::Uri(UriFilter::new(re));
+        let filter = HttpMatcherKind::Uri(UriMatcher::new(re));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`PathFilter`] filter.
+    /// Create a [`PathMatcher`] filter.
     pub fn path(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpFilterKind::Path(PathFilter::new(path)),
+            kind: HttpMatcherKind::Path(PathMatcher::new(path)),
             negate: false,
         }
     }
 
-    /// Add a [`PathFilter`] to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`PathMatcher`] to filter on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`PathFilter`] for more information.
+    /// See [`PathMatcher`] for more information.
     pub fn and_path(mut self, path: impl AsRef<str>) -> Self {
-        let filter = HttpFilterKind::Path(PathFilter::new(path));
+        let filter = HttpMatcherKind::Path(PathMatcher::new(path));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`PathFilter`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`PathMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`PathFilter`] for more information.
+    /// See [`PathMatcher`] for more information.
     pub fn or_path(mut self, path: impl AsRef<str>) -> Self {
-        let filter = HttpFilterKind::Path(PathFilter::new(path));
+        let filter = HttpMatcherKind::Path(PathMatcher::new(path));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter.
+    /// Create a [`HeaderMatcher`] filter.
     pub fn header(name: http::header::HeaderName, value: http::header::HeaderValue) -> Self {
         Self {
-            kind: HttpFilterKind::Header(HeaderFilter::is(name, value)),
+            kind: HttpMatcherKind::Header(HeaderMatcher::is(name, value)),
             negate: false,
         }
     }
 
-    /// Add a [`HeaderFilter`] to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`HeaderMatcher`] to filter on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn and_header(
         mut self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::is(name, value));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`HeaderMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn or_header(
         mut self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::is(name, value));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter when the given header exists
+    /// Create a [`HeaderMatcher`] filter when the given header exists
     /// to filter on the existence of a header.
     pub fn header_exists(name: http::header::HeaderName) -> Self {
         Self {
-            kind: HttpFilterKind::Header(HeaderFilter::exists(name)),
+            kind: HttpMatcherKind::Header(HeaderMatcher::exists(name)),
             negate: false,
         }
     }
 
-    /// Add a [`HeaderFilter`] to filter when the given header exists
+    /// Add a [`HeaderMatcher`] to filter when the given header exists
     /// on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn and_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::exists(name));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::exists(name));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter to match when the given header exists
+    /// Create a [`HeaderMatcher`] filter to match when the given header exists
     /// as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn or_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::exists(name));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::exists(name));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter to filter on it containing the given value.
+    /// Create a [`HeaderMatcher`] filter to filter on it containing the given value.
     pub fn header_contains(
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
         Self {
-            kind: HttpFilterKind::Header(HeaderFilter::contains(name, value)),
+            kind: HttpMatcherKind::Header(HeaderMatcher::contains(name, value)),
             negate: false,
         }
     }
 
-    /// Add a [`HeaderFilter`] to filter when it contains the given value
+    /// Add a [`HeaderMatcher`] to filter when it contains the given value
     /// on top of the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn and_header_contains(
         mut self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::contains(name, value));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`HeaderFilter`] filter to match if it contains the given value
+    /// Create a [`HeaderMatcher`] filter to match if it contains the given value
     /// as an alternative to the existing set of [`HttpMatcher`] filters.
     ///
-    /// See [`HeaderFilter`] for more information.
+    /// See [`HeaderMatcher`] for more information.
     pub fn or_header_contains(
         mut self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpFilterKind::Header(HeaderFilter::contains(name, value));
+        let filter = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
@@ -761,7 +761,7 @@ impl HttpMatcher {
     /// Create a [`SocketMatcher`] filter.
     pub fn socket(socket: SocketMatcher) -> Self {
         Self {
-            kind: HttpFilterKind::Socket(socket),
+            kind: HttpMatcherKind::Socket(socket),
             negate: false,
         }
     }
@@ -770,13 +770,13 @@ impl HttpMatcher {
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn and_socket(mut self, socket: SocketMatcher) -> Self {
-        let filter = HttpFilterKind::Socket(socket);
+        let filter = HttpMatcherKind::Socket(socket);
         match &mut self.kind {
-            HttpFilterKind::All(v) => {
+            HttpMatcherKind::All(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
             }
         }
         self
@@ -786,54 +786,54 @@ impl HttpMatcher {
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn or_socket(mut self, socket: SocketMatcher) -> Self {
-        let filter = HttpFilterKind::Socket(socket);
+        let filter = HttpMatcherKind::Socket(socket);
         match &mut self.kind {
-            HttpFilterKind::Any(v) => {
+            HttpMatcherKind::Any(v) => {
                 v.push(filter);
             }
             _ => {
-                self.kind = HttpFilterKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
             }
         }
         self
     }
 
-    /// Create a [`PathFilter`] filter to match for a GET request.
+    /// Create a [`PathMatcher`] filter to match for a GET request.
     pub fn get(path: impl AsRef<str>) -> Self {
         Self::method_get().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a POST request.
+    /// Create a [`PathMatcher`] filter to match for a POST request.
     pub fn post(path: impl AsRef<str>) -> Self {
         Self::method_post().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a PUT request.
+    /// Create a [`PathMatcher`] filter to match for a PUT request.
     pub fn put(path: impl AsRef<str>) -> Self {
         Self::method_put().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a DELETE request.
+    /// Create a [`PathMatcher`] filter to match for a DELETE request.
     pub fn delete(path: impl AsRef<str>) -> Self {
         Self::method_delete().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a PATCH request.
+    /// Create a [`PathMatcher`] filter to match for a PATCH request.
     pub fn patch(path: impl AsRef<str>) -> Self {
         Self::method_patch().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a HEAD request.
+    /// Create a [`PathMatcher`] filter to match for a HEAD request.
     pub fn head(path: impl AsRef<str>) -> Self {
         Self::method_head().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a OPTIONS request.
+    /// Create a [`PathMatcher`] filter to match for a OPTIONS request.
     pub fn options(path: impl AsRef<str>) -> Self {
         Self::method_options().and_path(path)
     }
 
-    /// Create a [`PathFilter`] filter to match for a TRACE request.
+    /// Create a [`PathMatcher`] filter to match for a TRACE request.
     pub fn trace(path: impl AsRef<str>) -> Self {
         Self::method_trace().and_path(path)
     }
@@ -863,7 +863,7 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for HttpMatcher 
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for HttpFilterKind {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for HttpMatcherKind {
     fn matches(
         &self,
         ext: Option<&mut Extensions>,
@@ -871,15 +871,15 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for HttpFilterKi
         req: &Request<Body>,
     ) -> bool {
         match self {
-            HttpFilterKind::All(all) => all.iter().matches_and(ext, ctx, req),
-            HttpFilterKind::Method(method) => method.matches(ext, ctx, req),
-            HttpFilterKind::Path(path) => path.matches(ext, ctx, req),
-            HttpFilterKind::Domain(domain) => domain.matches(ext, ctx, req),
-            HttpFilterKind::Version(version) => version.matches(ext, ctx, req),
-            HttpFilterKind::Uri(uri) => uri.matches(ext, ctx, req),
-            HttpFilterKind::Header(header) => header.matches(ext, ctx, req),
-            HttpFilterKind::Socket(socket) => socket.matches(ext, ctx, req),
-            HttpFilterKind::Any(all) => all.iter().matches_or(ext, ctx, req),
+            HttpMatcherKind::All(all) => all.iter().matches_and(ext, ctx, req),
+            HttpMatcherKind::Method(method) => method.matches(ext, ctx, req),
+            HttpMatcherKind::Path(path) => path.matches(ext, ctx, req),
+            HttpMatcherKind::Domain(domain) => domain.matches(ext, ctx, req),
+            HttpMatcherKind::Version(version) => version.matches(ext, ctx, req),
+            HttpMatcherKind::Uri(uri) => uri.matches(ext, ctx, req),
+            HttpMatcherKind::Header(header) => header.matches(ext, ctx, req),
+            HttpMatcherKind::Socket(socket) => socket.matches(ext, ctx, req),
+            HttpMatcherKind::Any(all) => all.iter().matches_or(ext, ctx, req),
         }
     }
 }

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -82,13 +82,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method(mut self, method: MethodMatcher) -> Self {
-        let filter = HttpMatcherKind::Method(method);
+        let matcher = HttpMatcherKind::Method(method);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -98,13 +98,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method(mut self, method: MethodMatcher) -> Self {
-        let filter = HttpMatcherKind::Method(method);
+        let matcher = HttpMatcherKind::Method(method);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -124,13 +124,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_delete(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::DELETE);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::DELETE);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -141,13 +141,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_delete(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::DELETE);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::DELETE);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -167,13 +167,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_get(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::GET);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::GET);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -184,13 +184,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_get(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::GET);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::GET);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -210,13 +210,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_head(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::HEAD);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::HEAD);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -227,13 +227,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_head(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::HEAD);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::HEAD);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -253,13 +253,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_options(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -270,13 +270,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_options(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -296,13 +296,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_patch(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::PATCH);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::PATCH);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -313,13 +313,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_patch(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::PATCH);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::PATCH);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -339,13 +339,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_post(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::POST);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::POST);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -356,13 +356,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_post(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::POST);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::POST);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -382,13 +382,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_put(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::PUT);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::PUT);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -399,13 +399,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_put(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::PUT);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::PUT);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -425,13 +425,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_trace(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::TRACE);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::TRACE);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         };
         self
@@ -442,13 +442,13 @@ impl HttpMatcher {
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_trace(mut self) -> Self {
-        let filter = HttpMatcherKind::Method(MethodMatcher::TRACE);
+        let matcher = HttpMatcherKind::Method(MethodMatcher::TRACE);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         };
         self
@@ -466,13 +466,13 @@ impl HttpMatcher {
     ///
     /// See [`DomainMatcher`] for more information.
     pub fn and_domain(mut self, domain: impl Into<String>) -> Self {
-        let filter = HttpMatcherKind::Domain(DomainMatcher::new(domain));
+        let matcher = HttpMatcherKind::Domain(DomainMatcher::new(domain));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -482,13 +482,13 @@ impl HttpMatcher {
     ///
     /// See [`DomainMatcher`] for more information.
     pub fn or_domain(mut self, domain: impl Into<String>) -> Self {
-        let filter = HttpMatcherKind::Domain(DomainMatcher::new(domain));
+        let matcher = HttpMatcherKind::Domain(DomainMatcher::new(domain));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -502,17 +502,17 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a [`VersionMatcher`] matcher to filter on top of the existing set of [`HttpMatcher`] matchers.
+    /// Add a [`VersionMatcher`] matcher to matcher on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`VersionMatcher`] for more information.
     pub fn and_version(mut self, version: VersionMatcher) -> Self {
-        let filter = HttpMatcherKind::Version(version);
+        let matcher = HttpMatcherKind::Version(version);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -522,13 +522,13 @@ impl HttpMatcher {
     ///
     /// See [`VersionMatcher`] for more information.
     pub fn or_version(mut self, version: VersionMatcher) -> Self {
-        let filter = HttpMatcherKind::Version(version);
+        let matcher = HttpMatcherKind::Version(version);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -546,13 +546,13 @@ impl HttpMatcher {
     ///
     /// See [`UriMatcher`] for more information.
     pub fn and_uri(mut self, re: impl AsRef<str>) -> Self {
-        let filter = HttpMatcherKind::Uri(UriMatcher::new(re));
+        let matcher = HttpMatcherKind::Uri(UriMatcher::new(re));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -562,13 +562,13 @@ impl HttpMatcher {
     ///    
     /// See [`UriMatcher`] for more information.
     pub fn or_uri(mut self, re: impl AsRef<str>) -> Self {
-        let filter = HttpMatcherKind::Uri(UriMatcher::new(re));
+        let matcher = HttpMatcherKind::Uri(UriMatcher::new(re));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -586,13 +586,13 @@ impl HttpMatcher {
     ///
     /// See [`PathMatcher`] for more information.
     pub fn and_path(mut self, path: impl AsRef<str>) -> Self {
-        let filter = HttpMatcherKind::Path(PathMatcher::new(path));
+        let matcher = HttpMatcherKind::Path(PathMatcher::new(path));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -602,13 +602,13 @@ impl HttpMatcher {
     ///
     /// See [`PathMatcher`] for more information.
     pub fn or_path(mut self, path: impl AsRef<str>) -> Self {
-        let filter = HttpMatcherKind::Path(PathMatcher::new(path));
+        let matcher = HttpMatcherKind::Path(PathMatcher::new(path));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -630,13 +630,13 @@ impl HttpMatcher {
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -650,13 +650,13 @@ impl HttpMatcher {
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -676,13 +676,13 @@ impl HttpMatcher {
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::exists(name));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::exists(name));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -693,13 +693,13 @@ impl HttpMatcher {
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::exists(name));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::exists(name));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -725,13 +725,13 @@ impl HttpMatcher {
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -746,13 +746,13 @@ impl HttpMatcher {
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let filter = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
+        let matcher = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self
@@ -770,13 +770,13 @@ impl HttpMatcher {
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn and_socket(mut self, socket: SocketMatcher) -> Self {
-        let filter = HttpMatcherKind::Socket(socket);
+        let matcher = HttpMatcherKind::Socket(socket);
         match &mut self.kind {
             HttpMatcherKind::All(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
             }
         }
         self
@@ -786,13 +786,13 @@ impl HttpMatcher {
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn or_socket(mut self, socket: SocketMatcher) -> Self {
-        let filter = HttpMatcherKind::Socket(socket);
+        let matcher = HttpMatcherKind::Socket(socket);
         match &mut self.kind {
             HttpMatcherKind::Any(v) => {
-                v.push(filter);
+                v.push(matcher);
             }
             _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, filter]);
+                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
             }
         }
         self

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -36,39 +36,39 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// A filter that is used to match an http [`Request`]
+/// A matcher that is used to match an http [`Request`]
 pub struct HttpMatcher {
     kind: HttpMatcherKind,
     negate: bool,
 }
 
 #[derive(Debug, Clone)]
-/// A filter that is used to match an http [`Request`]
+/// A matcher that is used to match an http [`Request`]
 pub enum HttpMatcherKind {
-    /// zero or more [`HttpMatcherKind`]s that all need to match in order for the filter to return `true`.
+    /// zero or more [`HttpMatcherKind`]s that all need to match in order for the matcher to return `true`.
     All(Vec<HttpMatcherKind>),
-    /// [`MethodMatcher`], a filter that matches one or more HTTP methods.
+    /// [`MethodMatcher`], a matcher that matches one or more HTTP methods.
     Method(MethodMatcher),
-    /// [`PathMatcher`], a filter based on the URI path.
+    /// [`PathMatcher`], a matcher based on the URI path.
     Path(PathMatcher),
-    /// [`DomainMatcher`], a filter based on the (sub)domain of the request's URI.
+    /// [`DomainMatcher`], a matcher based on the (sub)domain of the request's URI.
     Domain(DomainMatcher),
-    /// [`VersionMatcher`], a filter based on the HTTP version of the request.
+    /// [`VersionMatcher`], a matcher based on the HTTP version of the request.
     Version(VersionMatcher),
-    /// zero or more [`HttpMatcherKind`]s that at least one needs to match in order for the filter to return `true`.
+    /// zero or more [`HttpMatcherKind`]s that at least one needs to match in order for the matcher to return `true`.
     Any(Vec<HttpMatcherKind>),
-    /// [`UriMatcher`], a filter the request's URI, using a substring or regex pattern.
+    /// [`UriMatcher`], a matcher the request's URI, using a substring or regex pattern.
     Uri(UriMatcher),
-    /// [`HeaderMatcher`], a filter based on the [`Request`]'s headers.
+    /// [`HeaderMatcher`], a matcher based on the [`Request`]'s headers.
     Header(HeaderMatcher),
-    /// [`SocketMatcher`], a filter that matches on the [`SocketAddr`] of the peer.
+    /// [`SocketMatcher`], a matcher that matches on the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
     Socket(SocketMatcher),
 }
 
 impl HttpMatcher {
-    /// Create a new filter that matches one or more HTTP methods.
+    /// Create a new matcher that matches one or more HTTP methods.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method(method: MethodMatcher) -> Self {
@@ -78,7 +78,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Create a filter that also matches one or more HTTP methods on top of the existing [`HttpMatcher`] filters.
+    /// Create a matcher that also matches one or more HTTP methods on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method(mut self, method: MethodMatcher) -> Self {
@@ -94,7 +94,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a filter that can also match one or more HTTP methods as an alternative to the existing [`HttpMatcher`] filters.
+    /// Create a matcher that can also match one or more HTTP methods as an alternative to the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method(mut self, method: MethodMatcher) -> Self {
@@ -110,7 +110,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::DELETE`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::DELETE`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_delete() -> Self {
@@ -120,7 +120,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::DELETE`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::DELETE`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_delete(mut self) -> Self {
@@ -136,8 +136,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::DELETE`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::DELETE`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_delete(mut self) -> Self {
@@ -153,7 +153,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::GET`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::GET`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_get() -> Self {
@@ -163,7 +163,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::GET`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::GET`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_get(mut self) -> Self {
@@ -179,8 +179,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::GET`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::GET`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_get(mut self) -> Self {
@@ -196,7 +196,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::HEAD`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::HEAD`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_head() -> Self {
@@ -206,7 +206,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::HEAD`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::HEAD`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_head(mut self) -> Self {
@@ -222,8 +222,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::HEAD`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::HEAD`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_head(mut self) -> Self {
@@ -239,7 +239,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::OPTIONS`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::OPTIONS`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_options() -> Self {
@@ -249,7 +249,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::OPTIONS`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::OPTIONS`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_options(mut self) -> Self {
@@ -265,8 +265,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::OPTIONS`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::OPTIONS`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_options(mut self) -> Self {
@@ -282,7 +282,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::PATCH`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::PATCH`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_patch() -> Self {
@@ -292,7 +292,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::PATCH`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::PATCH`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_patch(mut self) -> Self {
@@ -308,8 +308,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::PATCH`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::PATCH`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_patch(mut self) -> Self {
@@ -325,7 +325,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::POST`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::POST`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_post() -> Self {
@@ -335,7 +335,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::POST`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::POST`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_post(mut self) -> Self {
@@ -351,8 +351,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::POST`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::POST`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_post(mut self) -> Self {
@@ -368,7 +368,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::PUT`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::PUT`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_put() -> Self {
@@ -378,7 +378,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::PUT`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::PUT`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_put(mut self) -> Self {
@@ -394,8 +394,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::PUT`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::PUT`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_put(mut self) -> Self {
@@ -411,7 +411,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a new filter that matches [`MethodMatcher::TRACE`] requests.
+    /// Create a new matcher that matches [`MethodMatcher::TRACE`] requests.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn method_trace() -> Self {
@@ -421,7 +421,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a new filter that also matches [`MethodMatcher::TRACE`] on top of the existing [`HttpMatcher`] filters.
+    /// Add a new matcher that also matches [`MethodMatcher::TRACE`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn and_method_trace(mut self) -> Self {
@@ -437,8 +437,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Add a new filter that can also match [`MethodMatcher::TRACE`]
-    /// as an alternative tothe existing [`HttpMatcher`] filters.
+    /// Add a new matcher that can also match [`MethodMatcher::TRACE`]
+    /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
     pub fn or_method_trace(mut self) -> Self {
@@ -454,7 +454,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`DomainMatcher`] filter.
+    /// Create a [`DomainMatcher`] matcher.
     pub fn domain(domain: impl Into<String>) -> Self {
         Self {
             kind: HttpMatcherKind::Domain(DomainMatcher::new(domain)),
@@ -462,7 +462,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Create a [`DomainMatcher`] filter to also match on top of the existing set of [`HttpMatcher`] filters.
+    /// Create a [`DomainMatcher`] matcher to also match on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`DomainMatcher`] for more information.
     pub fn and_domain(mut self, domain: impl Into<String>) -> Self {
@@ -478,7 +478,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`DomainMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`DomainMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`DomainMatcher`] for more information.
     pub fn or_domain(mut self, domain: impl Into<String>) -> Self {
@@ -494,7 +494,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`VersionMatcher`] filter.
+    /// Create a [`VersionMatcher`] matcher.
     pub fn version(version: VersionMatcher) -> Self {
         Self {
             kind: HttpMatcherKind::Version(version),
@@ -502,7 +502,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a [`VersionMatcher`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`VersionMatcher`] matcher to filter on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`VersionMatcher`] for more information.
     pub fn and_version(mut self, version: VersionMatcher) -> Self {
@@ -518,7 +518,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`VersionMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`VersionMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`VersionMatcher`] for more information.
     pub fn or_version(mut self, version: VersionMatcher) -> Self {
@@ -534,7 +534,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`UriMatcher`] filter.
+    /// Create a [`UriMatcher`] matcher.
     pub fn uri(re: impl AsRef<str>) -> Self {
         Self {
             kind: HttpMatcherKind::Uri(UriMatcher::new(re)),
@@ -542,7 +542,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Create a [`UriMatcher`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Create a [`UriMatcher`] matcher to filter on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`UriMatcher`] for more information.
     pub fn and_uri(mut self, re: impl AsRef<str>) -> Self {
@@ -558,7 +558,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`UriMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`UriMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///    
     /// See [`UriMatcher`] for more information.
     pub fn or_uri(mut self, re: impl AsRef<str>) -> Self {
@@ -574,7 +574,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`PathMatcher`] filter.
+    /// Create a [`PathMatcher`] matcher.
     pub fn path(path: impl AsRef<str>) -> Self {
         Self {
             kind: HttpMatcherKind::Path(PathMatcher::new(path)),
@@ -582,7 +582,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a [`PathMatcher`] to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`PathMatcher`] to filter on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`PathMatcher`] for more information.
     pub fn and_path(mut self, path: impl AsRef<str>) -> Self {
@@ -598,7 +598,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`PathMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`PathMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`PathMatcher`] for more information.
     pub fn or_path(mut self, path: impl AsRef<str>) -> Self {
@@ -614,7 +614,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter.
+    /// Create a [`HeaderMatcher`] matcher.
     pub fn header(name: http::header::HeaderName, value: http::header::HeaderValue) -> Self {
         Self {
             kind: HttpMatcherKind::Header(HeaderMatcher::is(name, value)),
@@ -622,7 +622,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a [`HeaderMatcher`] to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`HeaderMatcher`] to filter on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header(
@@ -642,7 +642,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`HeaderMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header(
@@ -662,7 +662,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter when the given header exists
+    /// Create a [`HeaderMatcher`] matcher when the given header exists
     /// to filter on the existence of a header.
     pub fn header_exists(name: http::header::HeaderName) -> Self {
         Self {
@@ -672,7 +672,7 @@ impl HttpMatcher {
     }
 
     /// Add a [`HeaderMatcher`] to filter when the given header exists
-    /// on top of the existing set of [`HttpMatcher`] filters.
+    /// on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header_exists(mut self, name: http::header::HeaderName) -> Self {
@@ -688,8 +688,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter to match when the given header exists
-    /// as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`HeaderMatcher`] matcher to match when the given header exists
+    /// as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header_exists(mut self, name: http::header::HeaderName) -> Self {
@@ -705,7 +705,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter to filter on it containing the given value.
+    /// Create a [`HeaderMatcher`] matcher to filter on it containing the given value.
     pub fn header_contains(
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
@@ -717,7 +717,7 @@ impl HttpMatcher {
     }
 
     /// Add a [`HeaderMatcher`] to filter when it contains the given value
-    /// on top of the existing set of [`HttpMatcher`] filters.
+    /// on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header_contains(
@@ -737,8 +737,8 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`HeaderMatcher`] filter to match if it contains the given value
-    /// as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`HeaderMatcher`] matcher to match if it contains the given value
+    /// as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header_contains(
@@ -758,7 +758,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`SocketMatcher`] filter.
+    /// Create a [`SocketMatcher`] matcher.
     pub fn socket(socket: SocketMatcher) -> Self {
         Self {
             kind: HttpMatcherKind::Socket(socket),
@@ -766,7 +766,7 @@ impl HttpMatcher {
         }
     }
 
-    /// Add a [`SocketMatcher`] filter to filter on top of the existing set of [`HttpMatcher`] filters.
+    /// Add a [`SocketMatcher`] matcher to filter on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn and_socket(mut self, socket: SocketMatcher) -> Self {
@@ -782,7 +782,7 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`SocketMatcher`] filter to match as an alternative to the existing set of [`HttpMatcher`] filters.
+    /// Create a [`SocketMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`SocketMatcher`] for more information.
     pub fn or_socket(mut self, socket: SocketMatcher) -> Self {
@@ -798,47 +798,47 @@ impl HttpMatcher {
         self
     }
 
-    /// Create a [`PathMatcher`] filter to match for a GET request.
+    /// Create a [`PathMatcher`] matcher to match for a GET request.
     pub fn get(path: impl AsRef<str>) -> Self {
         Self::method_get().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a POST request.
+    /// Create a [`PathMatcher`] matcher to match for a POST request.
     pub fn post(path: impl AsRef<str>) -> Self {
         Self::method_post().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a PUT request.
+    /// Create a [`PathMatcher`] matcher to match for a PUT request.
     pub fn put(path: impl AsRef<str>) -> Self {
         Self::method_put().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a DELETE request.
+    /// Create a [`PathMatcher`] matcher to match for a DELETE request.
     pub fn delete(path: impl AsRef<str>) -> Self {
         Self::method_delete().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a PATCH request.
+    /// Create a [`PathMatcher`] matcher to match for a PATCH request.
     pub fn patch(path: impl AsRef<str>) -> Self {
         Self::method_patch().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a HEAD request.
+    /// Create a [`PathMatcher`] matcher to match for a HEAD request.
     pub fn head(path: impl AsRef<str>) -> Self {
         Self::method_head().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a OPTIONS request.
+    /// Create a [`PathMatcher`] matcher to match for a OPTIONS request.
     pub fn options(path: impl AsRef<str>) -> Self {
         Self::method_options().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] filter to match for a TRACE request.
+    /// Create a [`PathMatcher`] matcher to match for a TRACE request.
     pub fn trace(path: impl AsRef<str>) -> Self {
         Self::method_trace().and_path(path)
     }
 
-    /// Negate the current filter
+    /// Negate the current matcher
     pub fn negate(self) -> Self {
         Self {
             kind: self.kind,

--- a/src/http/matcher/path/mod.rs
+++ b/src/http/matcher/path/mod.rs
@@ -93,7 +93,7 @@ enum PathMatcherKind {
 }
 
 #[derive(Debug, Clone)]
-/// Filter based on the URI path.
+/// Matcher based on the URI path.
 pub struct PathMatcher {
     kind: PathMatcherKind,
 }

--- a/src/http/matcher/path/mod.rs
+++ b/src/http/matcher/path/mod.rs
@@ -225,26 +225,26 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_path_filter_match_path() {
+    fn test_path_matcher_match_path() {
         struct TestCase {
             path: &'static str,
-            filter_path: &'static str,
+            matcher_path: &'static str,
             result: Option<UriParams>,
         }
 
         impl TestCase {
-            fn some(path: &'static str, filter_path: &'static str, result: UriParams) -> Self {
+            fn some(path: &'static str, matcher_path: &'static str, result: UriParams) -> Self {
                 Self {
                     path,
-                    filter_path,
+                    matcher_path,
                     result: Some(result),
                 }
             }
 
-            fn none(path: &'static str, filter_path: &'static str) -> Self {
+            fn none(path: &'static str, matcher_path: &'static str) -> Self {
                 Self {
                     path,
-                    filter_path,
+                    matcher_path,
                     result: None,
                 }
             }
@@ -344,30 +344,30 @@ mod test {
             }),
         ];
         for test_case in test_cases.into_iter() {
-            let filter = PathMatcher::new(test_case.filter_path);
-            let result = filter.matches_path(test_case.path);
+            let matcher = PathMatcher::new(test_case.matcher_path);
+            let result = matcher.matches_path(test_case.path);
             match (result.as_ref(), test_case.result.as_ref()) {
                 (None, None) => (),
                 (Some(result), Some(expected_result)) => {
                     assert_eq!(
                         result.params,
                         expected_result.params,
-                        "unexpected result params: ({}).filter({}) => {:?} != {:?}",
-                        test_case.filter_path,
+                        "unexpected result params: ({}).matcher({}) => {:?} != {:?}",
+                        test_case.matcher_path,
                         test_case.path,
                         result.params,
                         expected_result.params,
                     );
                     assert_eq!(
                         result.glob, expected_result.glob,
-                        "unexpected result glob: ({}).filter({}) => {:?} != {:?}",
-                        test_case.filter_path, test_case.path, result.glob, expected_result.glob,
+                        "unexpected result glob: ({}).matcher({}) => {:?} != {:?}",
+                        test_case.matcher_path, test_case.path, result.glob, expected_result.glob,
                     );
                 }
                 _ => {
                     panic!(
-                        "unexpected result: ({}).filter({}) => {:?} != {:?}",
-                        test_case.filter_path, test_case.path, result, test_case.result
+                        "unexpected result: ({}).matcher({}) => {:?} != {:?}",
+                        test_case.matcher_path, test_case.path, result, test_case.result
                     )
                 }
             }

--- a/src/http/matcher/uri.rs
+++ b/src/http/matcher/uri.rs
@@ -79,11 +79,11 @@ mod test {
                 "http://www.example.com/image.png",
             ),
         ];
-        for (filter, uri) in test_cases.into_iter() {
+        for (matcher, uri) in test_cases.into_iter() {
             assert!(
-                filter.matches_uri(&(uri.parse().unwrap())),
+                matcher.matches_uri(&(uri.parse().unwrap())),
                 "({:?}).matches_uri({})",
-                filter,
+                matcher,
                 uri
             );
         }
@@ -98,11 +98,11 @@ mod test {
                 "http://www.example.com/?style.css",
             ),
         ];
-        for (filter, uri) in test_cases.into_iter() {
+        for (matcher, uri) in test_cases.into_iter() {
             assert!(
-                !filter.matches_uri(&(uri.parse().unwrap())),
+                !matcher.matches_uri(&(uri.parse().unwrap())),
                 "!({:?}).matches_uri({})",
-                filter,
+                matcher,
                 uri
             );
         }

--- a/src/http/matcher/uri.rs
+++ b/src/http/matcher/uri.rs
@@ -14,13 +14,13 @@ pub mod dep {
 use dep::regex::Regex;
 
 #[derive(Debug, Clone)]
-/// Filter the request's URI, using a substring or regex pattern.
+/// Matcher the request's URI, using a substring or regex pattern.
 pub struct UriMatcher {
     re: Regex,
 }
 
 impl UriMatcher {
-    /// create a new Uri filter using a regex pattern.
+    /// create a new Uri matcher using a regex pattern.
     ///
     /// See docs at <https://docs.rs/regex> for more information on regex patterns.
     /// (e.g. to use flags like (?i) for case-insensitive matching)

--- a/src/http/matcher/uri.rs
+++ b/src/http/matcher/uri.rs
@@ -1,4 +1,4 @@
-//! provides a [`UriFilter`] matcher for filtering requests based on their URI.
+//! provides a [`UriMatcher`] matcher for filtering requests based on their URI.
 
 use crate::{
     http::{Request, Uri},
@@ -15,11 +15,11 @@ use dep::regex::Regex;
 
 #[derive(Debug, Clone)]
 /// Filter the request's URI, using a substring or regex pattern.
-pub struct UriFilter {
+pub struct UriMatcher {
     re: Regex,
 }
 
-impl UriFilter {
+impl UriMatcher {
     /// create a new Uri filter using a regex pattern.
     ///
     /// See docs at <https://docs.rs/regex> for more information on regex patterns.
@@ -38,13 +38,13 @@ impl UriFilter {
     }
 }
 
-impl From<Regex> for UriFilter {
+impl From<Regex> for UriMatcher {
     fn from(re: Regex) -> Self {
         Self { re }
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for UriFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for UriMatcher {
     fn matches(
         &self,
         _ext: Option<&mut Extensions>,
@@ -61,21 +61,21 @@ mod test {
 
     #[test]
     fn matchest_uri_match() {
-        let test_cases: Vec<(UriFilter, &str)> = vec![
+        let test_cases: Vec<(UriMatcher, &str)> = vec![
             (
-                UriFilter::new(r"www\.example\.com"),
+                UriMatcher::new(r"www\.example\.com"),
                 "http://www.example.com",
             ),
             (
-                UriFilter::new(r"(?i)www\.example\.com"),
+                UriMatcher::new(r"(?i)www\.example\.com"),
                 "http://WwW.ExamplE.COM",
             ),
             (
-                UriFilter::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
+                UriMatcher::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
                 "http://www.example.com/assets/style.css?foo=bar",
             ),
             (
-                UriFilter::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
+                UriMatcher::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
                 "http://www.example.com/image.png",
             ),
         ];
@@ -92,9 +92,9 @@ mod test {
     #[test]
     fn matchest_uri_no_match() {
         let test_cases = vec![
-            (UriFilter::new("www.example.com"), "http://WwW.ExamplE.COM"),
+            (UriMatcher::new("www.example.com"), "http://WwW.ExamplE.COM"),
             (
-                UriFilter::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
+                UriMatcher::new(r"(?i)^[^?]+\.(jpeg|png|gif|css)(\?|\z)"),
                 "http://www.example.com/?style.css",
             ),
         ];

--- a/src/http/matcher/version.rs
+++ b/src/http/matcher/version.rs
@@ -100,18 +100,18 @@ mod test {
     use crate::service::Matcher;
 
     #[test]
-    fn test_version_filter() {
-        let filter = VersionMatcher::HTTP_11;
+    fn test_version_matcher() {
+        let matcher = VersionMatcher::HTTP_11;
         let req = Request::builder()
             .version(Version::HTTP_11)
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_version_filter_any() {
-        let filter = VersionMatcher::HTTP_11
+    fn test_version_matcher_any() {
+        let matcher = VersionMatcher::HTTP_11
             .or(VersionMatcher::HTTP_10)
             .or(VersionMatcher::HTTP_11);
 
@@ -119,28 +119,28 @@ mod test {
             .version(Version::HTTP_10)
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
 
         let req = Request::builder()
             .version(Version::HTTP_11)
             .body(())
             .unwrap();
-        assert!(filter.matches(None, &Context::default(), &req));
+        assert!(matcher.matches(None, &Context::default(), &req));
 
         let req = Request::builder()
             .version(Version::HTTP_2)
             .body(())
             .unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 
     #[test]
-    fn test_version_filter_fail() {
-        let filter = VersionMatcher::HTTP_11;
+    fn test_version_matcher_fail() {
+        let matcher = VersionMatcher::HTTP_11;
         let req = Request::builder()
             .version(Version::HTTP_10)
             .body(())
             .unwrap();
-        assert!(!filter.matches(None, &Context::default(), &req));
+        assert!(!matcher.matches(None, &Context::default(), &req));
     }
 }

--- a/src/http/matcher/version.rs
+++ b/src/http/matcher/version.rs
@@ -4,24 +4,24 @@ use crate::{
 };
 use std::fmt::{self, Debug, Formatter};
 
-/// A filter that matches one or more HTTP methods.
+/// A matcher that matches one or more HTTP methods.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct VersionMatcher(u16);
 
 impl VersionMatcher {
-    /// A filter that matches HTTP/0.9 requests.
+    /// A matcher that matches HTTP/0.9 requests.
     pub const HTTP_09: Self = Self::from_bits(0b0_0000_0010);
 
-    /// A filter that matches HTTP/1.0 requests.
+    /// A matcher that matches HTTP/1.0 requests.
     pub const HTTP_10: Self = Self::from_bits(0b0_0000_0100);
 
-    /// A filter that matches HTTP/1.1 requests.
+    /// A matcher that matches HTTP/1.1 requests.
     pub const HTTP_11: Self = Self::from_bits(0b0_0000_1000);
 
-    /// A filter that matches HTTP/2.0 (h2) requests.
+    /// A matcher that matches HTTP/2.0 (h2) requests.
     pub const HTTP_2: Self = Self::from_bits(0b0_0001_0000);
 
-    /// A filter that matches HTTP/3.0 (h3) requests.
+    /// A matcher that matches HTTP/3.0 (h3) requests.
     pub const HTTP_3: Self = Self::from_bits(0b0_0010_0000);
 
     const fn bits(&self) -> u16 {

--- a/src/http/service/web/service.rs
+++ b/src/http/service/web/service.rs
@@ -15,7 +15,7 @@ use std::{convert::Infallible, future::Future, marker::PhantomData, sync::Arc};
 /// Note that this service boxes all the internal services, so it is not as efficient as it could be.
 /// For those locations where you need do not desire the convenience over performance,
 /// you can instead use a tuple of `(M, S)` tuples, where M is a matcher and S is a service,
-/// e.g. `((MethodFilter::GET, service_a), (MethodFilter::POST, service_b), service_fallback)`.
+/// e.g. `((MethodMatcher::GET, service_a), (MethodMatcher::POST, service_b), service_fallback)`.
 pub struct WebService<State> {
     endpoints: Vec<Arc<Endpoint<State>>>,
     not_found: Arc<BoxService<State, Request, Response, Infallible>>,
@@ -294,7 +294,7 @@ all_the_tuples_no_last_special_case!(impl_matcher_service_tuple);
 /// # Example
 ///
 /// ```rust
-/// use rama::http::matcher::{HttpMatcher, MethodFilter};
+/// use rama::http::matcher::{HttpMatcher, MethodMatcher};
 /// use rama::http::{Body, Request, Response, StatusCode};
 /// use rama::http::dep::http_body_util::BodyExt;
 /// use rama::service::{Context, Service};
@@ -304,7 +304,7 @@ all_the_tuples_no_last_special_case!(impl_matcher_service_tuple);
 ///   let svc = rama::http::service::web::match_service! {
 ///     HttpMatcher::get("/hello") => "hello",
 ///     HttpMatcher::post("/world") => "world",
-///     MethodFilter::CONNECT => "connect",
+///     MethodMatcher::CONNECT => "connect",
 ///     _ => StatusCode::NOT_FOUND,
 ///   };
 ///
@@ -321,7 +321,7 @@ all_the_tuples_no_last_special_case!(impl_matcher_service_tuple);
 /// Which is short for the following:
 ///
 /// ```rust
-/// use rama::http::matcher::{HttpMatcher, MethodFilter};
+/// use rama::http::matcher::{HttpMatcher, MethodMatcher};
 /// use rama::http::{Body, Request, Response, StatusCode};
 /// use rama::http::dep::http_body_util::BodyExt;
 /// use rama::http::service::web::IntoEndpointService;
@@ -332,7 +332,7 @@ all_the_tuples_no_last_special_case!(impl_matcher_service_tuple);
 ///   let svc = (
 ///     (HttpMatcher::get("/hello"), "hello".into_endpoint_service()),
 ///     (HttpMatcher::post("/world"), "world".into_endpoint_service()),
-///     (MethodFilter::CONNECT, "connect".into_endpoint_service()),
+///     (MethodMatcher::CONNECT, "connect".into_endpoint_service()),
 ///     StatusCode::NOT_FOUND.into_endpoint_service(),
 ///   );
 ///
@@ -361,7 +361,7 @@ pub use __match_service as match_service;
 #[cfg(test)]
 mod test {
     use crate::http::dep::http_body_util::BodyExt;
-    use crate::http::matcher::MethodFilter;
+    use crate::http::matcher::MethodMatcher;
     use crate::http::Body;
 
     use super::*;
@@ -496,7 +496,7 @@ mod test {
         let svc = match_service! {
             HttpMatcher::get("/hello") => "hello",
             HttpMatcher::post("/world") => "world",
-            MethodFilter::CONNECT => "connect",
+            MethodMatcher::CONNECT => "connect",
             _ => StatusCode::NOT_FOUND,
         };
 

--- a/src/stream/matcher/ip.rs
+++ b/src/stream/matcher/ip.rs
@@ -171,8 +171,8 @@ mod test {
     }
 
     #[test]
-    fn test_socket_filter_http() {
-        let filter = IpNetMatcher::new([127, 0, 0, 1]);
+    fn test_socket_matcher_http() {
+        let matcher = IpNetMatcher::new([127, 0, 0, 1]);
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -182,28 +182,28 @@ mod test {
             .unwrap();
 
         // test #1: no match: test with no socket info registered
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #2: no match: test with different socket info (ip addr difference)
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 2], 8080).into()));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #3: match: test with correct address
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #4: match: test with missing socket info, but it's seen as optional
-        let filter = IpNetMatcher::optional([127, 0, 0, 1]);
+        let matcher = IpNetMatcher::optional([127, 0, 0, 1]);
         let mut ctx = Context::default();
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #5: match: valid ipv4 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV4);
+        let matcher = IpNetMatcher::new(SUBNET_IPV4);
         for subnet in SUBNET_IPV4_VALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             ctx.insert(SocketInfo::new(None, addr));
             assert!(
-                filter.matches(None, &ctx, &req),
+                matcher.matches(None, &ctx, &req),
                 "valid ipv4 subnets => {} >=? {} ({})",
                 SUBNET_IPV4,
                 addr,
@@ -212,12 +212,12 @@ mod test {
         }
 
         // test #6: match: valid ipv6 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV6);
+        let matcher = IpNetMatcher::new(SUBNET_IPV6);
         for subnet in SUBNET_IPV6_VALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             ctx.insert(SocketInfo::new(None, addr));
             assert!(
-                filter.matches(None, &ctx, &req),
+                matcher.matches(None, &ctx, &req),
                 "valid ipv6 subnets => {} >=? {} ({})",
                 SUBNET_IPV6,
                 addr,
@@ -226,12 +226,12 @@ mod test {
         }
 
         // test #7: match: invalid ipv4 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV4);
+        let matcher = IpNetMatcher::new(SUBNET_IPV4);
         for subnet in SUBNET_IPV4_INVALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             ctx.insert(SocketInfo::new(None, addr));
             assert!(
-                !filter.matches(None, &ctx, &req),
+                !matcher.matches(None, &ctx, &req),
                 "invalid ipv4 subnets => {} >=? {} ({})",
                 SUBNET_IPV4,
                 addr,
@@ -240,12 +240,12 @@ mod test {
         }
 
         // test #8: match: invalid ipv6 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV6);
+        let matcher = IpNetMatcher::new(SUBNET_IPV6);
         for subnet in SUBNET_IPV6_INVALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             ctx.insert(SocketInfo::new(None, addr));
             assert!(
-                !filter.matches(None, &ctx, &req),
+                !matcher.matches(None, &ctx, &req),
                 "invalid ipv6 subnets => {} >=? {} ({})",
                 SUBNET_IPV6,
                 addr,
@@ -255,8 +255,8 @@ mod test {
     }
 
     #[test]
-    fn test_socket_filter_socket_trait() {
-        let filter = IpNetMatcher::new([127, 0, 0, 1]);
+    fn test_socket_matcher_socket_trait() {
+        let matcher = IpNetMatcher::new([127, 0, 0, 1]);
 
         let ctx = Context::default();
 
@@ -288,24 +288,24 @@ mod test {
 
         // test #1: no match: test with different socket info (ip addr difference)
         socket.peer_addr = Some(([127, 0, 0, 2], 8080).into());
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #2: match: test with correct address
         socket.peer_addr = Some(([127, 0, 0, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #3: match: test with missing socket info, but it's seen as optional
-        let filter = IpNetMatcher::optional([127, 0, 0, 1]);
+        let matcher = IpNetMatcher::optional([127, 0, 0, 1]);
         socket.peer_addr = None;
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #4: match: valid ipv4 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV4);
+        let matcher = IpNetMatcher::new(SUBNET_IPV4);
         for subnet in SUBNET_IPV4_VALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             socket.peer_addr = Some(addr);
             assert!(
-                filter.matches(None, &ctx, &socket),
+                matcher.matches(None, &ctx, &socket),
                 "valid ipv4 subnets => {} >=? {} ({})",
                 SUBNET_IPV4,
                 addr,
@@ -314,12 +314,12 @@ mod test {
         }
 
         // test #5: match: valid ipv6 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV6);
+        let matcher = IpNetMatcher::new(SUBNET_IPV6);
         for subnet in SUBNET_IPV6_VALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             socket.peer_addr = Some(addr);
             assert!(
-                filter.matches(None, &ctx, &socket),
+                matcher.matches(None, &ctx, &socket),
                 "valid ipv6 subnets => {} >=? {} ({})",
                 SUBNET_IPV6,
                 addr,
@@ -328,12 +328,12 @@ mod test {
         }
 
         // test #6: match: invalid ipv4 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV4);
+        let matcher = IpNetMatcher::new(SUBNET_IPV4);
         for subnet in SUBNET_IPV4_INVALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             socket.peer_addr = Some(addr);
             assert!(
-                !filter.matches(None, &ctx, &socket),
+                !matcher.matches(None, &ctx, &socket),
                 "invalid ipv4 subnets => {} >=? {} ({})",
                 SUBNET_IPV4,
                 addr,
@@ -342,12 +342,12 @@ mod test {
         }
 
         // test #7: match: invalid ipv6 subnets
-        let filter = IpNetMatcher::new(SUBNET_IPV6);
+        let matcher = IpNetMatcher::new(SUBNET_IPV6);
         for subnet in SUBNET_IPV6_INVALID_CASES.iter() {
             let addr = socket_addr_from_case(subnet);
             socket.peer_addr = Some(addr);
             assert!(
-                !filter.matches(None, &ctx, &socket),
+                !matcher.matches(None, &ctx, &socket),
                 "invalid ipv6 subnets => {} >=? {} ({})",
                 SUBNET_IPV6,
                 addr,

--- a/src/stream/matcher/ip.rs
+++ b/src/stream/matcher/ip.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// Filter based on whether or not the [`IpNet`] contains the [`SocketAddr`] of the peer.
+/// Matcher based on whether or not the [`IpNet`] contains the [`SocketAddr`] of the peer.
 ///
 /// [`SocketAddr`]: std::net::SocketAddr
 pub struct IpNetMatcher {
@@ -16,9 +16,9 @@ pub struct IpNetMatcher {
 }
 
 impl IpNetMatcher {
-    /// create a new IP network filter to filter on an IP Network.
+    /// create a new IP network matcher to filter on an IP Network.
     ///
-    /// This filter will not match in case socket address could not be found,
+    /// This matcher will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
     /// use the [`IpNetMatcher::optional`] constructor..
     pub fn new(net: impl IntoIpNet) -> Self {
@@ -28,9 +28,9 @@ impl IpNetMatcher {
         }
     }
 
-    /// create a new IP network filter to filter on an IP network
+    /// create a new IP network matcher to filter on an IP network
     ///
-    /// This filter will match in case socket address could not be found.
+    /// This matcher will match in case socket address could not be found.
     /// Use the [`IpNetMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     pub fn optional(net: impl IntoIpNet) -> Self {

--- a/src/stream/matcher/loopback.rs
+++ b/src/stream/matcher/loopback.rs
@@ -10,17 +10,17 @@ use crate::{
 /// matching only if the ip is a loopback address.
 ///
 /// [`SocketAddr`]: std::net::SocketAddr
-pub struct LoopbackFilter {
+pub struct LoopbackMatcher {
     optional: bool,
 }
 
-impl LoopbackFilter {
+impl LoopbackMatcher {
     /// create a new loopback filter to filter on the ip part a [`SocketAddr`],
     /// matching only if the ip is a loopback address.
     ///
     /// This filter will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
-    /// use the [`LoopbackFilter::optional`] constructor..
+    /// use the [`LoopbackMatcher::optional`] constructor..
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
     pub fn new() -> Self {
@@ -31,7 +31,7 @@ impl LoopbackFilter {
     /// matching only if the ip is a loopback address or no socket address could be found.
     ///
     /// This filter will match in case socket address could not be found.
-    /// Use the [`LoopbackFilter::new`] constructor if you want do not want
+    /// Use the [`LoopbackMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
@@ -40,13 +40,13 @@ impl LoopbackFilter {
     }
 }
 
-impl Default for LoopbackFilter {
+impl Default for LoopbackMatcher {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for LoopbackFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for LoopbackMatcher {
     fn matches(
         &self,
         _ext: Option<&mut Extensions>,
@@ -59,7 +59,7 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for LoopbackFilt
     }
 }
 
-impl<State, Socket> crate::service::Matcher<State, Socket> for LoopbackFilter
+impl<State, Socket> crate::service::Matcher<State, Socket> for LoopbackMatcher
 where
     Socket: crate::stream::Socket,
 {
@@ -85,7 +85,7 @@ mod test {
 
     #[test]
     fn test_port_filter_http() {
-        let filter = LoopbackFilter::new();
+        let filter = LoopbackMatcher::new();
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -124,14 +124,14 @@ mod test {
         assert!(filter.matches(None, &ctx, &req));
 
         // test #7: match: test with missing socket info, but it's seen as optional
-        let filter = LoopbackFilter::optional();
+        let filter = LoopbackMatcher::optional();
         let ctx = Context::default();
         assert!(filter.matches(None, &ctx, &req));
     }
 
     #[test]
     fn test_port_filter_socket_trait() {
-        let filter = LoopbackFilter::new();
+        let filter = LoopbackMatcher::new();
 
         let ctx = Context::default();
 
@@ -185,7 +185,7 @@ mod test {
         assert!(filter.matches(None, &ctx, &socket));
 
         // test #7: match: test with missing socket info, but it's seen as optional
-        let filter = LoopbackFilter::optional();
+        let filter = LoopbackMatcher::optional();
         socket.peer_addr = None;
         assert!(filter.matches(None, &ctx, &socket));
     }

--- a/src/stream/matcher/loopback.rs
+++ b/src/stream/matcher/loopback.rs
@@ -84,8 +84,8 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_port_filter_http() {
-        let filter = LoopbackMatcher::new();
+    fn test_port_matcher_http() {
+        let matcher = LoopbackMatcher::new();
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -95,43 +95,43 @@ mod test {
             .unwrap();
 
         // test #1: no match: test with no socket info registered
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #2: no match: test with network address (ipv4)
         ctx.insert(SocketInfo::new(None, ([192, 168, 0, 1], 8080).into()));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #3: no match: test with network address (ipv6)
         ctx.insert(SocketInfo::new(
             None,
             ([1, 1, 1, 1, 1, 1, 1, 1], 8080).into(),
         ));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #4: match: test with loopback address (ipv4)
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #5: match: test with another loopback address (ipv4)
         ctx.insert(SocketInfo::new(None, ([127, 3, 2, 1], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #6: match: test with loopback address (ipv6)
         ctx.insert(SocketInfo::new(
             None,
             ([0, 0, 0, 0, 0, 0, 0, 1], 8080).into(),
         ));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #7: match: test with missing socket info, but it's seen as optional
-        let filter = LoopbackMatcher::optional();
+        let matcher = LoopbackMatcher::optional();
         let ctx = Context::default();
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
     }
 
     #[test]
-    fn test_port_filter_socket_trait() {
-        let filter = LoopbackMatcher::new();
+    fn test_port_matcher_socket_trait() {
+        let matcher = LoopbackMatcher::new();
 
         let ctx = Context::default();
 
@@ -162,31 +162,31 @@ mod test {
         };
 
         // test #1: no match: test with no socket info registered
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #2: no match: test with network address (ipv4)
         socket.peer_addr = Some(([192, 168, 0, 1], 8080).into());
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #3: no match: test with network address (ipv6)
         socket.peer_addr = Some(([1, 1, 1, 1, 1, 1, 1, 1], 8080).into());
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #4: match: test with loopback address (ipv4)
         socket.peer_addr = Some(([127, 0, 0, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #5: match: test with another loopback address (ipv4)
         socket.peer_addr = Some(([127, 3, 2, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #6: match: test with loopback address (ipv6)
         socket.peer_addr = Some(([0, 0, 0, 0, 0, 0, 0, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #7: match: test with missing socket info, but it's seen as optional
-        let filter = LoopbackMatcher::optional();
+        let matcher = LoopbackMatcher::optional();
         socket.peer_addr = None;
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
     }
 }

--- a/src/stream/matcher/loopback.rs
+++ b/src/stream/matcher/loopback.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// Filter based on the ip part of the [`SocketAddr`] of the peer,
+/// Matcher based on the ip part of the [`SocketAddr`] of the peer,
 /// matching only if the ip is a loopback address.
 ///
 /// [`SocketAddr`]: std::net::SocketAddr
@@ -15,10 +15,10 @@ pub struct LoopbackMatcher {
 }
 
 impl LoopbackMatcher {
-    /// create a new loopback filter to filter on the ip part a [`SocketAddr`],
+    /// create a new loopback matcher to filter on the ip part a [`SocketAddr`],
     /// matching only if the ip is a loopback address.
     ///
-    /// This filter will not match in case socket address could not be found,
+    /// This matcher will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
     /// use the [`LoopbackMatcher::optional`] constructor..
     ///
@@ -27,10 +27,10 @@ impl LoopbackMatcher {
         Self { optional: false }
     }
 
-    /// create a new loopback filter to filter on the ip part a [`SocketAddr`],
+    /// create a new loopback matcher to filter on the ip part a [`SocketAddr`],
     /// matching only if the ip is a loopback address or no socket address could be found.
     ///
-    /// This filter will match in case socket address could not be found.
+    /// This matcher will match in case socket address could not be found.
     /// Use the [`LoopbackMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     ///

--- a/src/stream/matcher/mod.rs
+++ b/src/stream/matcher/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// A filter to match on a [`Socket`].
+/// A matcher to match on a [`Socket`].
 ///
 /// [`Socket`]: crate::stream::Socket
 pub struct SocketMatcher {
@@ -37,32 +37,32 @@ pub struct SocketMatcher {
 }
 
 #[derive(Debug, Clone)]
-/// The different kinds of socket filters.
+/// The different kinds of socket matchers.
 enum SocketMatcherKind {
-    /// [`SocketAddressMatcher`], a filter that matches on the [`SocketAddr`] of the peer.
+    /// [`SocketAddressMatcher`], a matcher that matches on the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
     SocketAddress(SocketAddressMatcher),
-    /// [`LoopbackMatcher`], a filter that matches if the peer address is a loopback address.
+    /// [`LoopbackMatcher`], a matcher that matches if the peer address is a loopback address.
     Loopback(LoopbackMatcher),
-    /// [`PortMatcher`], a filter based on the port part of the [`SocketAddr`] of the peer.
+    /// [`PortMatcher`], a matcher based on the port part of the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
     Port(PortMatcher),
-    /// [`IpNetMatcher`], a filter to match on whether or not
+    /// [`IpNetMatcher`], a matcher to match on whether or not
     /// the [`IpNet`] contains the [`SocketAddr`] of the peer.
     ///
     /// [`IpNet`]: ipnet::IpNet
     /// [`SocketAddr`]: std::net::SocketAddr
     IpNet(IpNetMatcher),
-    /// zero or more filters that all need to match in order for the filter to return `true`.
+    /// zero or more matchers that all need to match in order for the matcher to return `true`.
     All(Vec<SocketMatcherKind>),
-    /// `true` if no filters are defined, or any of the defined filters match.
+    /// `true` if no matchers are defined, or any of the defined matcher match.
     Any(Vec<SocketMatcherKind>),
 }
 
 impl SocketMatcher {
-    /// Create a new socket address filter to filter on a socket address.
+    /// Create a new socket address matcher to filter on a socket address.
     ///
     /// See [`SocketAddressMatcher::new`] for more information.
     pub fn socket_addr(addr: impl Into<std::net::SocketAddr>) -> Self {
@@ -72,8 +72,8 @@ impl SocketMatcher {
         }
     }
 
-    /// Create a new optional socket address filter to filter on a socket address,
-    /// this filter will match in case socket address could not be found.
+    /// Create a new optional socket address matcher to filter on a socket address,
+    /// this matcher will match in case socket address could not be found.
     ///
     /// See [`SocketAddressMatcher::optional`] for more information.
     pub fn optional_socket_addr(addr: impl Into<std::net::SocketAddr>) -> Self {
@@ -83,7 +83,7 @@ impl SocketMatcher {
         }
     }
 
-    /// Add a new socket address filter to the existing [`SocketMatcher`] to also filter on a socket address.
+    /// Add a new socket address matcher to the existing [`SocketMatcher`] to also filter on a socket address.
     pub fn and_socket_addr(mut self, addr: impl Into<std::net::SocketAddr>) -> Self {
         match &mut self.kind {
             SocketMatcherKind::All(filters) => {
@@ -101,7 +101,7 @@ impl SocketMatcher {
         self
     }
 
-    /// Add a new socket address filter to the existing [`SocketMatcher`] as an alternative filter to match on a socket address.
+    /// Add a new socket address matcher to the existing [`SocketMatcher`] as an alternative filter to match on a socket address.
     ///
     /// See [`SocketAddressMatcher::new`] for more information.
     pub fn or_socket_addr(mut self, addr: impl Into<std::net::SocketAddr>) -> Self {
@@ -121,7 +121,7 @@ impl SocketMatcher {
         self
     }
 
-    /// create a new loopback filter to filter on whether or not the peer address is a loopback address.
+    /// create a new loopback matcher to filter on whether or not the peer address is a loopback address.
     ///
     /// See [`LoopbackMatcher::new`] for more information.
     pub fn loopback() -> Self {
@@ -131,8 +131,8 @@ impl SocketMatcher {
         }
     }
 
-    /// Create a new optional loopback filter to filter on whether or not the peer address is a loopback address,
-    /// this filter will match in case socket address could not be found.
+    /// Create a new optional loopback matcher to filter on whether or not the peer address is a loopback address,
+    /// this matcher will match in case socket address could not be found.
     ///
     /// See [`LoopbackMatcher::optional`] for more information.
     pub fn optional_loopback() -> Self {
@@ -142,7 +142,7 @@ impl SocketMatcher {
         }
     }
 
-    /// Add a new loopback filter to the existing [`SocketMatcher`] to also filter on whether or not the peer address is a loopback address.
+    /// Add a new loopback matcher to the existing [`SocketMatcher`] to also filter on whether or not the peer address is a loopback address.
     ///
     /// See [`LoopbackMatcher::new`] for more information.
     pub fn and_loopback(mut self) -> Self {
@@ -160,7 +160,7 @@ impl SocketMatcher {
         self
     }
 
-    /// Add a new loopback filter to the existing [`SocketMatcher`] as an alternative filter to match on whether or not the peer address is a loopback address.
+    /// Add a new loopback matcher to the existing [`SocketMatcher`] as an alternative filter to match on whether or not the peer address is a loopback address.
     ///
     /// See [`LoopbackMatcher::new`] for more information.
     pub fn or_loopback(mut self) -> Self {
@@ -178,7 +178,7 @@ impl SocketMatcher {
         self
     }
 
-    /// create a new port filter to filter on the port part a [`SocketAddr`](std::net::SocketAddr).
+    /// create a new port matcher to filter on the port part a [`SocketAddr`](std::net::SocketAddr).
     ///
     /// See [`PortMatcher::new`] for more information.
     pub fn port(port: u16) -> Self {
@@ -188,8 +188,8 @@ impl SocketMatcher {
         }
     }
 
-    /// Create a new optional port filter to filter on the port part a [`SocketAddr`](std::net::SocketAddr),
-    /// this filter will match in case socket address could not be found.
+    /// Create a new optional port matcher to filter on the port part a [`SocketAddr`](std::net::SocketAddr),
+    /// this matcher will match in case socket address could not be found.
     ///
     /// See [`PortMatcher::optional`] for more information.
     pub fn optional_port(port: u16) -> Self {
@@ -199,8 +199,8 @@ impl SocketMatcher {
         }
     }
 
-    /// Add a new port filter to the existing [`SocketMatcher`] to
-    /// also filter on the port part of the [`SocketAddr`](std::net::SocketAddr).
+    /// Add a new port matcher to the existing [`SocketMatcher`] to
+    /// also matcher on the port part of the [`SocketAddr`](std::net::SocketAddr).
     ///
     /// See [`PortMatcher::new`] for more information.
     pub fn and_port(mut self, port: u16) -> Self {
@@ -218,7 +218,7 @@ impl SocketMatcher {
         self
     }
 
-    /// Add a new port filter to the existing [`SocketMatcher`] as an alternative filter
+    /// Add a new port matcher to the existing [`SocketMatcher`] as an alternative filter
     /// to match on the port part of the [`SocketAddr`](std::net::SocketAddr).
     ///     
     /// See [`PortMatcher::new`] for more information.
@@ -237,7 +237,7 @@ impl SocketMatcher {
         self
     }
 
-    /// create a new IP network filter to filter on an IP Network.
+    /// create a new IP network matcher to filter on an IP Network.
     ///
     /// See [`IpNetMatcher::new`] for more information.
     pub fn ip_net(ip_net: impl ip::IntoIpNet) -> Self {
@@ -247,8 +247,8 @@ impl SocketMatcher {
         }
     }
 
-    /// Create a new optional IP network filter to filter on an IP Network,
-    /// this filter will match in case socket address could not be found.
+    /// Create a new optional IP network matcher to filter on an IP Network,
+    /// this matcher will match in case socket address could not be found.
     ///
     /// See [`IpNetMatcher::optional`] for more information.
     pub fn optional_ip_net(ip_net: impl ip::IntoIpNet) -> Self {
@@ -258,7 +258,7 @@ impl SocketMatcher {
         }
     }
 
-    /// Add a new IP network filter to the existing [`SocketMatcher`] to also filter on an IP Network.
+    /// Add a new IP network matcher to the existing [`SocketMatcher`] to also filter on an IP Network.
     ///
     /// See [`IpNetMatcher::new`] for more information.
     pub fn and_ip_net(mut self, ip_net: impl ip::IntoIpNet) -> Self {
@@ -276,7 +276,7 @@ impl SocketMatcher {
         self
     }
 
-    /// Add a new IP network filter to the existing [`SocketMatcher`] as an alternative filter to match on an IP Network.
+    /// Add a new IP network matcher to the existing [`SocketMatcher`] as an alternative filter to match on an IP Network.
     ///
     /// See [`IpNetMatcher::new`] for more information.
     pub fn or_ip_net(mut self, ip_net: impl ip::IntoIpNet) -> Self {
@@ -294,7 +294,7 @@ impl SocketMatcher {
         self
     }
 
-    /// Negate the current filter
+    /// Negate the current matcher
     pub fn negate(self) -> Self {
         Self {
             kind: self.kind,

--- a/src/stream/matcher/mod.rs
+++ b/src/stream/matcher/mod.rs
@@ -8,19 +8,19 @@
 
 mod socket;
 #[doc(inline)]
-pub use socket::SocketAddressFilter;
+pub use socket::SocketAddressMatcher;
 
 mod port;
 #[doc(inline)]
-pub use port::PortFilter;
+pub use port::PortMatcher;
 
 mod loopback;
 #[doc(inline)]
-pub use loopback::LoopbackFilter;
+pub use loopback::LoopbackMatcher;
 
 mod ip;
 #[doc(inline)]
-pub use ip::IpNetFilter;
+pub use ip::IpNetMatcher;
 
 use crate::{
     http::Request,
@@ -32,42 +32,42 @@ use crate::{
 ///
 /// [`Socket`]: crate::stream::Socket
 pub struct SocketMatcher {
-    kind: SocketFilterKind,
+    kind: SocketMatcherKind,
     negate: bool,
 }
 
 #[derive(Debug, Clone)]
 /// The different kinds of socket filters.
-enum SocketFilterKind {
-    /// [`SocketAddressFilter`], a filter that matches on the [`SocketAddr`] of the peer.
+enum SocketMatcherKind {
+    /// [`SocketAddressMatcher`], a filter that matches on the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
-    SocketAddress(SocketAddressFilter),
-    /// [`LoopbackFilter`], a filter that matches if the peer address is a loopback address.
-    Loopback(LoopbackFilter),
-    /// [`PortFilter`], a filter based on the port part of the [`SocketAddr`] of the peer.
+    SocketAddress(SocketAddressMatcher),
+    /// [`LoopbackMatcher`], a filter that matches if the peer address is a loopback address.
+    Loopback(LoopbackMatcher),
+    /// [`PortMatcher`], a filter based on the port part of the [`SocketAddr`] of the peer.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
-    Port(PortFilter),
-    /// [`IpNetFilter`], a filter to match on whether or not
+    Port(PortMatcher),
+    /// [`IpNetMatcher`], a filter to match on whether or not
     /// the [`IpNet`] contains the [`SocketAddr`] of the peer.
     ///
     /// [`IpNet`]: ipnet::IpNet
     /// [`SocketAddr`]: std::net::SocketAddr
-    IpNet(IpNetFilter),
+    IpNet(IpNetMatcher),
     /// zero or more filters that all need to match in order for the filter to return `true`.
-    All(Vec<SocketFilterKind>),
+    All(Vec<SocketMatcherKind>),
     /// `true` if no filters are defined, or any of the defined filters match.
-    Any(Vec<SocketFilterKind>),
+    Any(Vec<SocketMatcherKind>),
 }
 
 impl SocketMatcher {
     /// Create a new socket address filter to filter on a socket address.
     ///
-    /// See [`SocketAddressFilter::new`] for more information.
+    /// See [`SocketAddressMatcher::new`] for more information.
     pub fn socket_addr(addr: impl Into<std::net::SocketAddr>) -> Self {
         Self {
-            kind: SocketFilterKind::SocketAddress(SocketAddressFilter::new(addr)),
+            kind: SocketMatcherKind::SocketAddress(SocketAddressMatcher::new(addr)),
             negate: false,
         }
     }
@@ -75,10 +75,10 @@ impl SocketMatcher {
     /// Create a new optional socket address filter to filter on a socket address,
     /// this filter will match in case socket address could not be found.
     ///
-    /// See [`SocketAddressFilter::optional`] for more information.
+    /// See [`SocketAddressMatcher::optional`] for more information.
     pub fn optional_socket_addr(addr: impl Into<std::net::SocketAddr>) -> Self {
         Self {
-            kind: SocketFilterKind::SocketAddress(SocketAddressFilter::optional(addr)),
+            kind: SocketMatcherKind::SocketAddress(SocketAddressMatcher::optional(addr)),
             negate: false,
         }
     }
@@ -86,15 +86,15 @@ impl SocketMatcher {
     /// Add a new socket address filter to the existing [`SocketMatcher`] to also filter on a socket address.
     pub fn and_socket_addr(mut self, addr: impl Into<std::net::SocketAddr>) -> Self {
         match &mut self.kind {
-            SocketFilterKind::All(filters) => {
-                filters.push(SocketFilterKind::SocketAddress(SocketAddressFilter::new(
+            SocketMatcherKind::All(filters) => {
+                filters.push(SocketMatcherKind::SocketAddress(SocketAddressMatcher::new(
                     addr,
                 )));
             }
             _ => {
-                self.kind = SocketFilterKind::All(vec![
+                self.kind = SocketMatcherKind::All(vec![
                     self.kind,
-                    SocketFilterKind::SocketAddress(SocketAddressFilter::new(addr)),
+                    SocketMatcherKind::SocketAddress(SocketAddressMatcher::new(addr)),
                 ]);
             }
         }
@@ -103,18 +103,18 @@ impl SocketMatcher {
 
     /// Add a new socket address filter to the existing [`SocketMatcher`] as an alternative filter to match on a socket address.
     ///
-    /// See [`SocketAddressFilter::new`] for more information.
+    /// See [`SocketAddressMatcher::new`] for more information.
     pub fn or_socket_addr(mut self, addr: impl Into<std::net::SocketAddr>) -> Self {
         match &mut self.kind {
-            SocketFilterKind::Any(filters) => {
-                filters.push(SocketFilterKind::SocketAddress(SocketAddressFilter::new(
+            SocketMatcherKind::Any(filters) => {
+                filters.push(SocketMatcherKind::SocketAddress(SocketAddressMatcher::new(
                     addr,
                 )));
             }
             _ => {
-                self.kind = SocketFilterKind::Any(vec![
+                self.kind = SocketMatcherKind::Any(vec![
                     self.kind,
-                    SocketFilterKind::SocketAddress(SocketAddressFilter::new(addr)),
+                    SocketMatcherKind::SocketAddress(SocketAddressMatcher::new(addr)),
                 ]);
             }
         }
@@ -123,10 +123,10 @@ impl SocketMatcher {
 
     /// create a new loopback filter to filter on whether or not the peer address is a loopback address.
     ///
-    /// See [`LoopbackFilter::new`] for more information.
+    /// See [`LoopbackMatcher::new`] for more information.
     pub fn loopback() -> Self {
         Self {
-            kind: SocketFilterKind::Loopback(LoopbackFilter::new()),
+            kind: SocketMatcherKind::Loopback(LoopbackMatcher::new()),
             negate: false,
         }
     }
@@ -134,26 +134,26 @@ impl SocketMatcher {
     /// Create a new optional loopback filter to filter on whether or not the peer address is a loopback address,
     /// this filter will match in case socket address could not be found.
     ///
-    /// See [`LoopbackFilter::optional`] for more information.
+    /// See [`LoopbackMatcher::optional`] for more information.
     pub fn optional_loopback() -> Self {
         Self {
-            kind: SocketFilterKind::Loopback(LoopbackFilter::optional()),
+            kind: SocketMatcherKind::Loopback(LoopbackMatcher::optional()),
             negate: false,
         }
     }
 
     /// Add a new loopback filter to the existing [`SocketMatcher`] to also filter on whether or not the peer address is a loopback address.
     ///
-    /// See [`LoopbackFilter::new`] for more information.
+    /// See [`LoopbackMatcher::new`] for more information.
     pub fn and_loopback(mut self) -> Self {
         match &mut self.kind {
-            SocketFilterKind::All(filters) => {
-                filters.push(SocketFilterKind::Loopback(LoopbackFilter::new()));
+            SocketMatcherKind::All(filters) => {
+                filters.push(SocketMatcherKind::Loopback(LoopbackMatcher::new()));
             }
             _ => {
-                self.kind = SocketFilterKind::All(vec![
+                self.kind = SocketMatcherKind::All(vec![
                     self.kind,
-                    SocketFilterKind::Loopback(LoopbackFilter::new()),
+                    SocketMatcherKind::Loopback(LoopbackMatcher::new()),
                 ]);
             }
         }
@@ -162,16 +162,16 @@ impl SocketMatcher {
 
     /// Add a new loopback filter to the existing [`SocketMatcher`] as an alternative filter to match on whether or not the peer address is a loopback address.
     ///
-    /// See [`LoopbackFilter::new`] for more information.
+    /// See [`LoopbackMatcher::new`] for more information.
     pub fn or_loopback(mut self) -> Self {
         match &mut self.kind {
-            SocketFilterKind::Any(filters) => {
-                filters.push(SocketFilterKind::Loopback(LoopbackFilter::new()));
+            SocketMatcherKind::Any(filters) => {
+                filters.push(SocketMatcherKind::Loopback(LoopbackMatcher::new()));
             }
             _ => {
-                self.kind = SocketFilterKind::Any(vec![
+                self.kind = SocketMatcherKind::Any(vec![
                     self.kind,
-                    SocketFilterKind::Loopback(LoopbackFilter::new()),
+                    SocketMatcherKind::Loopback(LoopbackMatcher::new()),
                 ]);
             }
         }
@@ -180,10 +180,10 @@ impl SocketMatcher {
 
     /// create a new port filter to filter on the port part a [`SocketAddr`](std::net::SocketAddr).
     ///
-    /// See [`PortFilter::new`] for more information.
+    /// See [`PortMatcher::new`] for more information.
     pub fn port(port: u16) -> Self {
         Self {
-            kind: SocketFilterKind::Port(PortFilter::new(port)),
+            kind: SocketMatcherKind::Port(PortMatcher::new(port)),
             negate: false,
         }
     }
@@ -191,10 +191,10 @@ impl SocketMatcher {
     /// Create a new optional port filter to filter on the port part a [`SocketAddr`](std::net::SocketAddr),
     /// this filter will match in case socket address could not be found.
     ///
-    /// See [`PortFilter::optional`] for more information.
+    /// See [`PortMatcher::optional`] for more information.
     pub fn optional_port(port: u16) -> Self {
         Self {
-            kind: SocketFilterKind::Port(PortFilter::optional(port)),
+            kind: SocketMatcherKind::Port(PortMatcher::optional(port)),
             negate: false,
         }
     }
@@ -202,16 +202,16 @@ impl SocketMatcher {
     /// Add a new port filter to the existing [`SocketMatcher`] to
     /// also filter on the port part of the [`SocketAddr`](std::net::SocketAddr).
     ///
-    /// See [`PortFilter::new`] for more information.
+    /// See [`PortMatcher::new`] for more information.
     pub fn and_port(mut self, port: u16) -> Self {
         match &mut self.kind {
-            SocketFilterKind::All(filters) => {
-                filters.push(SocketFilterKind::Port(PortFilter::new(port)));
+            SocketMatcherKind::All(filters) => {
+                filters.push(SocketMatcherKind::Port(PortMatcher::new(port)));
             }
             _ => {
-                self.kind = SocketFilterKind::All(vec![
+                self.kind = SocketMatcherKind::All(vec![
                     self.kind,
-                    SocketFilterKind::Port(PortFilter::new(port)),
+                    SocketMatcherKind::Port(PortMatcher::new(port)),
                 ]);
             }
         }
@@ -221,16 +221,16 @@ impl SocketMatcher {
     /// Add a new port filter to the existing [`SocketMatcher`] as an alternative filter
     /// to match on the port part of the [`SocketAddr`](std::net::SocketAddr).
     ///     
-    /// See [`PortFilter::new`] for more information.
+    /// See [`PortMatcher::new`] for more information.
     pub fn or_port(mut self, port: u16) -> Self {
         match &mut self.kind {
-            SocketFilterKind::Any(filters) => {
-                filters.push(SocketFilterKind::Port(PortFilter::new(port)));
+            SocketMatcherKind::Any(filters) => {
+                filters.push(SocketMatcherKind::Port(PortMatcher::new(port)));
             }
             _ => {
-                self.kind = SocketFilterKind::Any(vec![
+                self.kind = SocketMatcherKind::Any(vec![
                     self.kind,
-                    SocketFilterKind::Port(PortFilter::new(port)),
+                    SocketMatcherKind::Port(PortMatcher::new(port)),
                 ]);
             }
         }
@@ -239,10 +239,10 @@ impl SocketMatcher {
 
     /// create a new IP network filter to filter on an IP Network.
     ///
-    /// See [`IpNetFilter::new`] for more information.
+    /// See [`IpNetMatcher::new`] for more information.
     pub fn ip_net(ip_net: impl ip::IntoIpNet) -> Self {
         Self {
-            kind: SocketFilterKind::IpNet(IpNetFilter::new(ip_net)),
+            kind: SocketMatcherKind::IpNet(IpNetMatcher::new(ip_net)),
             negate: false,
         }
     }
@@ -250,26 +250,26 @@ impl SocketMatcher {
     /// Create a new optional IP network filter to filter on an IP Network,
     /// this filter will match in case socket address could not be found.
     ///
-    /// See [`IpNetFilter::optional`] for more information.
+    /// See [`IpNetMatcher::optional`] for more information.
     pub fn optional_ip_net(ip_net: impl ip::IntoIpNet) -> Self {
         Self {
-            kind: SocketFilterKind::IpNet(IpNetFilter::optional(ip_net)),
+            kind: SocketMatcherKind::IpNet(IpNetMatcher::optional(ip_net)),
             negate: false,
         }
     }
 
     /// Add a new IP network filter to the existing [`SocketMatcher`] to also filter on an IP Network.
     ///
-    /// See [`IpNetFilter::new`] for more information.
+    /// See [`IpNetMatcher::new`] for more information.
     pub fn and_ip_net(mut self, ip_net: impl ip::IntoIpNet) -> Self {
         match &mut self.kind {
-            SocketFilterKind::All(filters) => {
-                filters.push(SocketFilterKind::IpNet(IpNetFilter::new(ip_net)));
+            SocketMatcherKind::All(filters) => {
+                filters.push(SocketMatcherKind::IpNet(IpNetMatcher::new(ip_net)));
             }
             _ => {
-                self.kind = SocketFilterKind::All(vec![
+                self.kind = SocketMatcherKind::All(vec![
                     self.kind,
-                    SocketFilterKind::IpNet(IpNetFilter::new(ip_net)),
+                    SocketMatcherKind::IpNet(IpNetMatcher::new(ip_net)),
                 ]);
             }
         }
@@ -278,16 +278,16 @@ impl SocketMatcher {
 
     /// Add a new IP network filter to the existing [`SocketMatcher`] as an alternative filter to match on an IP Network.
     ///
-    /// See [`IpNetFilter::new`] for more information.
+    /// See [`IpNetMatcher::new`] for more information.
     pub fn or_ip_net(mut self, ip_net: impl ip::IntoIpNet) -> Self {
         match &mut self.kind {
-            SocketFilterKind::Any(filters) => {
-                filters.push(SocketFilterKind::IpNet(IpNetFilter::new(ip_net)));
+            SocketMatcherKind::Any(filters) => {
+                filters.push(SocketMatcherKind::IpNet(IpNetMatcher::new(ip_net)));
             }
             _ => {
-                self.kind = SocketFilterKind::Any(vec![
+                self.kind = SocketMatcherKind::Any(vec![
                     self.kind,
-                    SocketFilterKind::IpNet(IpNetFilter::new(ip_net)),
+                    SocketMatcherKind::IpNet(IpNetMatcher::new(ip_net)),
                 ]);
             }
         }
@@ -303,7 +303,7 @@ impl SocketMatcher {
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketFilterKind {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketMatcherKind {
     fn matches(
         &self,
         ext: Option<&mut Extensions>,
@@ -311,12 +311,12 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketFilter
         req: &Request<Body>,
     ) -> bool {
         match self {
-            SocketFilterKind::SocketAddress(filter) => filter.matches(ext, ctx, req),
-            SocketFilterKind::IpNet(filter) => filter.matches(ext, ctx, req),
-            SocketFilterKind::Loopback(filter) => filter.matches(ext, ctx, req),
-            SocketFilterKind::All(filters) => filters.iter().matches_and(ext, ctx, req),
-            SocketFilterKind::Any(filters) => filters.iter().matches_or(ext, ctx, req),
-            SocketFilterKind::Port(filter) => filter.matches(ext, ctx, req),
+            SocketMatcherKind::SocketAddress(filter) => filter.matches(ext, ctx, req),
+            SocketMatcherKind::IpNet(filter) => filter.matches(ext, ctx, req),
+            SocketMatcherKind::Loopback(filter) => filter.matches(ext, ctx, req),
+            SocketMatcherKind::All(filters) => filters.iter().matches_and(ext, ctx, req),
+            SocketMatcherKind::Any(filters) => filters.iter().matches_or(ext, ctx, req),
+            SocketMatcherKind::Port(filter) => filter.matches(ext, ctx, req),
         }
     }
 }
@@ -337,18 +337,18 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketMatche
     }
 }
 
-impl<State, Socket> crate::service::Matcher<State, Socket> for SocketFilterKind
+impl<State, Socket> crate::service::Matcher<State, Socket> for SocketMatcherKind
 where
     Socket: crate::stream::Socket,
 {
     fn matches(&self, ext: Option<&mut Extensions>, ctx: &Context<State>, stream: &Socket) -> bool {
         match self {
-            SocketFilterKind::SocketAddress(filter) => filter.matches(ext, ctx, stream),
-            SocketFilterKind::IpNet(filter) => filter.matches(ext, ctx, stream),
-            SocketFilterKind::Loopback(filter) => filter.matches(ext, ctx, stream),
-            SocketFilterKind::Port(filter) => filter.matches(ext, ctx, stream),
-            SocketFilterKind::All(filters) => filters.iter().matches_and(ext, ctx, stream),
-            SocketFilterKind::Any(filters) => filters.iter().matches_or(ext, ctx, stream),
+            SocketMatcherKind::SocketAddress(filter) => filter.matches(ext, ctx, stream),
+            SocketMatcherKind::IpNet(filter) => filter.matches(ext, ctx, stream),
+            SocketMatcherKind::Loopback(filter) => filter.matches(ext, ctx, stream),
+            SocketMatcherKind::Port(filter) => filter.matches(ext, ctx, stream),
+            SocketMatcherKind::All(filters) => filters.iter().matches_and(ext, ctx, stream),
+            SocketMatcherKind::Any(filters) => filters.iter().matches_or(ext, ctx, stream),
         }
     }
 }

--- a/src/stream/matcher/port.rs
+++ b/src/stream/matcher/port.rs
@@ -9,17 +9,17 @@ use crate::{
 /// Filter based on the port part of the [`SocketAddr`] of the peer.
 ///
 /// [`SocketAddr`]: std::net::SocketAddr
-pub struct PortFilter {
+pub struct PortMatcher {
     port: u16,
     optional: bool,
 }
 
-impl PortFilter {
+impl PortMatcher {
     /// create a new port filter to filter on the port part a [`SocketAddr`]
     ///
     /// This filter will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
-    /// use the [`PortFilter::optional`] constructor..
+    /// use the [`PortMatcher::optional`] constructor..
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
     pub fn new(port: u16) -> Self {
@@ -32,7 +32,7 @@ impl PortFilter {
     /// create a new port filter to filter on the port part a [`SocketAddr`]
     ///
     /// This filter will match in case socket address could not be found.
-    /// Use the [`PortFilter::new`] constructor if you want do not want
+    /// Use the [`PortMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     ///
     /// [`SocketAddr`]: std::net::SocketAddr
@@ -44,7 +44,7 @@ impl PortFilter {
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for PortFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for PortMatcher {
     fn matches(
         &self,
         _ext: Option<&mut Extensions>,
@@ -57,7 +57,7 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for PortFilter {
     }
 }
 
-impl<State, Socket> crate::service::Matcher<State, Socket> for PortFilter
+impl<State, Socket> crate::service::Matcher<State, Socket> for PortMatcher
 where
     Socket: crate::stream::Socket,
 {
@@ -83,7 +83,7 @@ mod test {
 
     #[test]
     fn test_port_filter_http() {
-        let filter = PortFilter::new(8080);
+        let filter = PortMatcher::new(8080);
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -108,14 +108,14 @@ mod test {
         assert!(filter.matches(None, &ctx, &req));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = PortFilter::optional(8080);
+        let filter = PortMatcher::optional(8080);
         let ctx = Context::default();
         assert!(filter.matches(None, &ctx, &req));
     }
 
     #[test]
     fn test_port_filter_socket_trait() {
-        let filter = PortFilter::new(8080);
+        let filter = PortMatcher::new(8080);
 
         let ctx = Context::default();
 
@@ -157,7 +157,7 @@ mod test {
         assert!(filter.matches(None, &ctx, &socket));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = PortFilter::optional(8080);
+        let filter = PortMatcher::optional(8080);
         socket.peer_addr = None;
         assert!(filter.matches(None, &ctx, &socket));
     }

--- a/src/stream/matcher/port.rs
+++ b/src/stream/matcher/port.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-/// Filter based on the port part of the [`SocketAddr`] of the peer.
+/// Matcher based on the port part of the [`SocketAddr`] of the peer.
 ///
 /// [`SocketAddr`]: std::net::SocketAddr
 pub struct PortMatcher {
@@ -15,9 +15,9 @@ pub struct PortMatcher {
 }
 
 impl PortMatcher {
-    /// create a new port filter to filter on the port part a [`SocketAddr`]
+    /// create a new port matcher to filter on the port part a [`SocketAddr`]
     ///
-    /// This filter will not match in case socket address could not be found,
+    /// This matcher will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
     /// use the [`PortMatcher::optional`] constructor..
     ///
@@ -29,9 +29,9 @@ impl PortMatcher {
         }
     }
 
-    /// create a new port filter to filter on the port part a [`SocketAddr`]
+    /// create a new port matcher to filter on the port part a [`SocketAddr`]
     ///
-    /// This filter will match in case socket address could not be found.
+    /// This matcher will match in case socket address could not be found.
     /// Use the [`PortMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     ///

--- a/src/stream/matcher/port.rs
+++ b/src/stream/matcher/port.rs
@@ -82,8 +82,8 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_port_filter_http() {
-        let filter = PortMatcher::new(8080);
+    fn test_port_matcher_http() {
+        let matcher = PortMatcher::new(8080);
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -93,29 +93,29 @@ mod test {
             .unwrap();
 
         // test #1: no match: test with no socket info registered
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #2: no match: test with different socket info (port difference)
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8081).into()));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #3: match: test with matching port
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 2], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #4: match: test with different ip, same port
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = PortMatcher::optional(8080);
+        let matcher = PortMatcher::optional(8080);
         let ctx = Context::default();
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
     }
 
     #[test]
-    fn test_port_filter_socket_trait() {
-        let filter = PortMatcher::new(8080);
+    fn test_port_matcher_socket_trait() {
+        let matcher = PortMatcher::new(8080);
 
         let ctx = Context::default();
 
@@ -146,19 +146,19 @@ mod test {
         };
 
         // test #1: no match: test with different socket info (port difference)
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #2: match: test with correct port
         socket.peer_addr = Some(([127, 0, 0, 2], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #3: match: test with another correct address
         socket.peer_addr = Some(([127, 0, 0, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = PortMatcher::optional(8080);
+        let matcher = PortMatcher::optional(8080);
         socket.peer_addr = None;
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
     }
 }

--- a/src/stream/matcher/socket.rs
+++ b/src/stream/matcher/socket.rs
@@ -18,7 +18,7 @@ impl SocketAddressMatcher {
     ///
     /// This matcher will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
-    /// use the [`SocketAdressMatcher::optional`] constructor..
+    /// use the [`SocketAddressMatcher::optional`] constructor..
     pub fn new(addr: impl Into<SocketAddr>) -> Self {
         Self {
             addr: addr.into(),
@@ -29,7 +29,7 @@ impl SocketAddressMatcher {
     /// create a new socket address matcher to filter on a socket address
     ///
     /// This matcher will match in case socket address could not be found.
-    /// Use the [`SocketAdressMatcher::new`] constructor if you want do not want
+    /// Use the [`SocketAddressMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     pub fn optional(addr: impl Into<SocketAddr>) -> Self {
         Self {

--- a/src/stream/matcher/socket.rs
+++ b/src/stream/matcher/socket.rs
@@ -7,16 +7,16 @@ use crate::{
 use std::net::SocketAddr;
 
 #[derive(Debug, Clone)]
-/// Filter based on the [`SocketAddr`] of the peer.
+/// Matcher based on the [`SocketAddr`] of the peer.
 pub struct SocketAddressMatcher {
     addr: SocketAddr,
     optional: bool,
 }
 
 impl SocketAddressMatcher {
-    /// create a new socket address filter to filter on a socket address
+    /// create a new socket address matcher to filter on a socket address
     ///
-    /// This filter will not match in case socket address could not be found,
+    /// This matcher will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
     /// use the [`SocketAdressMatcher::optional`] constructor..
     pub fn new(addr: impl Into<SocketAddr>) -> Self {
@@ -26,9 +26,9 @@ impl SocketAddressMatcher {
         }
     }
 
-    /// create a new socket address filter to filter on a socket address
+    /// create a new socket address matcher to filter on a socket address
     ///
-    /// This filter will match in case socket address could not be found.
+    /// This matcher will match in case socket address could not be found.
     /// Use the [`SocketAdressMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     pub fn optional(addr: impl Into<SocketAddr>) -> Self {

--- a/src/stream/matcher/socket.rs
+++ b/src/stream/matcher/socket.rs
@@ -8,17 +8,17 @@ use std::net::SocketAddr;
 
 #[derive(Debug, Clone)]
 /// Filter based on the [`SocketAddr`] of the peer.
-pub struct SocketAddressFilter {
+pub struct SocketAddressMatcher {
     addr: SocketAddr,
     optional: bool,
 }
 
-impl SocketAddressFilter {
+impl SocketAddressMatcher {
     /// create a new socket address filter to filter on a socket address
     ///
     /// This filter will not match in case socket address could not be found,
     /// if you want to match in case socket address could not be found,
-    /// use the [`SocketAddressFilter::optional`] constructor..
+    /// use the [`SocketAdressMatcher::optional`] constructor..
     pub fn new(addr: impl Into<SocketAddr>) -> Self {
         Self {
             addr: addr.into(),
@@ -29,7 +29,7 @@ impl SocketAddressFilter {
     /// create a new socket address filter to filter on a socket address
     ///
     /// This filter will match in case socket address could not be found.
-    /// Use the [`SocketAddressFilter::new`] constructor if you want do not want
+    /// Use the [`SocketAdressMatcher::new`] constructor if you want do not want
     /// to match in case socket address could not be found.
     pub fn optional(addr: impl Into<SocketAddr>) -> Self {
         Self {
@@ -39,7 +39,7 @@ impl SocketAddressFilter {
     }
 }
 
-impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketAddressFilter {
+impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketAddressMatcher {
     fn matches(
         &self,
         _ext: Option<&mut Extensions>,
@@ -52,7 +52,7 @@ impl<State, Body> crate::service::Matcher<State, Request<Body>> for SocketAddres
     }
 }
 
-impl<State, Socket> crate::service::Matcher<State, Socket> for SocketAddressFilter
+impl<State, Socket> crate::service::Matcher<State, Socket> for SocketAddressMatcher
 where
     Socket: crate::stream::Socket,
 {
@@ -77,7 +77,7 @@ mod test {
 
     #[test]
     fn test_socket_filter_http() {
-        let filter = SocketAddressFilter::new(([127, 0, 0, 1], 8080));
+        let filter = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -102,14 +102,14 @@ mod test {
         assert!(filter.matches(None, &ctx, &req));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = SocketAddressFilter::optional(([127, 0, 0, 1], 8080));
+        let filter = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
         let ctx = Context::default();
         assert!(filter.matches(None, &ctx, &req));
     }
 
     #[test]
     fn test_socket_filter_socket_trait() {
-        let filter = SocketAddressFilter::new(([127, 0, 0, 1], 8080));
+        let filter = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
 
         let ctx = Context::default();
 
@@ -151,7 +151,7 @@ mod test {
         assert!(filter.matches(None, &ctx, &socket));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = SocketAddressFilter::optional(([127, 0, 0, 1], 8080));
+        let filter = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
         socket.peer_addr = None;
         assert!(filter.matches(None, &ctx, &socket));
     }

--- a/src/stream/matcher/socket.rs
+++ b/src/stream/matcher/socket.rs
@@ -76,8 +76,8 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_socket_filter_http() {
-        let filter = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
+    fn test_socket_matcher_http() {
+        let matcher = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
 
         let mut ctx = Context::default();
         let req = Request::builder()
@@ -87,29 +87,29 @@ mod test {
             .unwrap();
 
         // test #1: no match: test with no socket info registered
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #2: no match: test with different socket info (port difference)
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8081).into()));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #3: no match: test with different socket info (ip addr difference)
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 2], 8080).into()));
-        assert!(!filter.matches(None, &ctx, &req));
+        assert!(!matcher.matches(None, &ctx, &req));
 
         // test #4: match: test with correct address
         ctx.insert(SocketInfo::new(None, ([127, 0, 0, 1], 8080).into()));
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
+        let matcher = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
         let ctx = Context::default();
-        assert!(filter.matches(None, &ctx, &req));
+        assert!(matcher.matches(None, &ctx, &req));
     }
 
     #[test]
-    fn test_socket_filter_socket_trait() {
-        let filter = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
+    fn test_socket_matcher_socket_trait() {
+        let matcher = SocketAddressMatcher::new(([127, 0, 0, 1], 8080));
 
         let ctx = Context::default();
 
@@ -140,19 +140,19 @@ mod test {
         };
 
         // test #1: no match: test with different socket info (port difference)
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #2: no match: test with different socket info (ip addr difference)
         socket.peer_addr = Some(([127, 0, 0, 2], 8080).into());
-        assert!(!filter.matches(None, &ctx, &socket));
+        assert!(!matcher.matches(None, &ctx, &socket));
 
         // test #3: match: test with correct address
         socket.peer_addr = Some(([127, 0, 0, 1], 8080).into());
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
 
         // test #5: match: test with missing socket info, but it's seen as optional
-        let filter = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
+        let matcher = SocketAddressMatcher::optional(([127, 0, 0, 1], 8080));
         socket.peer_addr = None;
-        assert!(filter.matches(None, &ctx, &socket));
+        assert!(matcher.matches(None, &ctx, &socket));
     }
 }


### PR DESCRIPTION
Hi,

I closed my initial PR #114 by accident. This is a new attempt. :)
I just renamed a lot of types as proposed in #91 and aligned the comments and a few variable names.