### PR TITLE
Implement `HttpMatcher::and` and `HttpMatcher::or`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +635,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +955,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipnet",
+ "itertools",
  "mime",
  "mime_guess",
  "paste",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ httpdate = "1.0"
 hyper = "1.2"
 hyper-util = "0.1.3"
 ipnet = "2.9.0"
+itertools = "0.12.1"
 mime = "0.3.17"
 mime_guess = { version = "2", default-features = false }
 paste = "1.0"
@@ -140,6 +141,7 @@ uuid = { workspace = true, features = ["v4"] }
 [dev-dependencies]
 brotli = { workspace = true }
 flate2 = { workspace = true }
+itertools = { workspace = true }
 rustversion = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -703,7 +703,6 @@ where
 
 #[cfg(test)]
 mod test {
-    use http::{HeaderName, HeaderValue};
     use itertools::Itertools;
 
     use crate::service::Matcher;
@@ -855,37 +854,6 @@ mod test {
 
             let matcher = (a.or(b)).and(c.or(d)).and(e.negate());
             let req = Request::builder().body(()).unwrap();
-            assert_eq!(
-                matcher.matches(None, &Context::default(), &req),
-                expected,
-                "({:#?}).matches({:#?})",
-                matcher,
-                req
-            );
-        }
-    }
-
-    #[test]
-    fn test_matcher_negation_and_header_contains() {
-        let matcher = HttpMatcher::method_get().negate().and_header_contains(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("text/plain"),
-        );
-
-        let cases = [
-            ("PUT", "text/plain", true),
-            ("PUT", "text/html", false),
-            ("GET", "text/plain", false),
-            ("GET", "text/html", false),
-        ];
-
-        for (method, header_value, expected) in cases {
-            let req = Request::builder()
-                .method(method)
-                .header("content-type", header_value)
-                .body(())
-                .unwrap();
-
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
                 expected,

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -619,13 +619,34 @@ mod test {
         let matcher = HttpMatcher::method_post()
             .and(HttpMatcher::version(VersionMatcher::HTTP_2))
             .and(HttpMatcher::domain("www.example.com"));
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_2)
-            .uri("www.example.com")
-            .body(())
-            .unwrap();
-        assert!(matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", true),
+            ("POST", Version::HTTP_2, "www.lorem.com", false),
+            ("POST", Version::HTTP_3, "www.example.com", false),
+            ("POST", Version::HTTP_3, "www.lorem.com", false),
+            ("GET", Version::HTTP_2, "www.example.com", false),
+            ("GET", Version::HTTP_2, "www.lorem.com", false),
+            ("GET", Version::HTTP_3, "www.example.com", false),
+            ("GET", Version::HTTP_3, "www.lorem.com", false),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -634,13 +655,34 @@ mod test {
             .negate()
             .and(HttpMatcher::version(VersionMatcher::HTTP_2))
             .and(HttpMatcher::domain("www.example.com"));
-        let req = Request::builder()
-            .method("GET")
-            .version(Version::HTTP_2)
-            .uri("www.example.com")
-            .body(())
-            .unwrap();
-        assert!(matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", false),
+            ("POST", Version::HTTP_2, "www.lorem.com", false),
+            ("POST", Version::HTTP_3, "www.example.com", false),
+            ("POST", Version::HTTP_3, "www.lorem.com", false),
+            ("GET", Version::HTTP_2, "www.example.com", true),
+            ("GET", Version::HTTP_2, "www.lorem.com", false),
+            ("GET", Version::HTTP_3, "www.example.com", false),
+            ("GET", Version::HTTP_3, "www.lorem.com", false),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -649,13 +691,34 @@ mod test {
             .and(HttpMatcher::version(VersionMatcher::HTTP_2))
             .and(HttpMatcher::domain("www.example.com"))
             .negate();
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_2)
-            .uri("www.example.com")
-            .body(())
-            .unwrap();
-        assert!(!matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", false),
+            ("POST", Version::HTTP_2, "www.lorem.com", true),
+            ("POST", Version::HTTP_3, "www.example.com", true),
+            ("POST", Version::HTTP_3, "www.lorem.com", true),
+            ("GET", Version::HTTP_2, "www.example.com", true),
+            ("GET", Version::HTTP_2, "www.lorem.com", true),
+            ("GET", Version::HTTP_3, "www.example.com", true),
+            ("GET", Version::HTTP_3, "www.lorem.com", true),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -663,13 +726,34 @@ mod test {
         let matcher = HttpMatcher::method_post()
             .or(HttpMatcher::version(VersionMatcher::HTTP_2))
             .or(HttpMatcher::domain("www.example.com"));
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_3)
-            .uri("www.lorem.com")
-            .body(())
-            .unwrap();
-        assert!(matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", true),
+            ("POST", Version::HTTP_2, "www.lorem.com", true),
+            ("POST", Version::HTTP_3, "www.example.com", true),
+            ("POST", Version::HTTP_3, "www.lorem.com", true),
+            ("GET", Version::HTTP_2, "www.example.com", true),
+            ("GET", Version::HTTP_2, "www.lorem.com", true),
+            ("GET", Version::HTTP_3, "www.example.com", true),
+            ("GET", Version::HTTP_3, "www.lorem.com", false),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -678,13 +762,34 @@ mod test {
             .negate()
             .or(HttpMatcher::version(VersionMatcher::HTTP_2))
             .or(HttpMatcher::domain("www.example.com"));
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_3)
-            .uri("www.example.com")
-            .body(())
-            .unwrap();
-        assert!(matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", true),
+            ("POST", Version::HTTP_2, "www.lorem.com", true),
+            ("POST", Version::HTTP_3, "www.example.com", true),
+            ("POST", Version::HTTP_3, "www.lorem.com", false),
+            ("GET", Version::HTTP_2, "www.example.com", true),
+            ("GET", Version::HTTP_2, "www.lorem.com", true),
+            ("GET", Version::HTTP_3, "www.example.com", true),
+            ("GET", Version::HTTP_3, "www.lorem.com", true),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -693,13 +798,34 @@ mod test {
             .or(HttpMatcher::version(VersionMatcher::HTTP_2))
             .or(HttpMatcher::domain("www.example.com"))
             .negate();
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_2)
-            .uri("www.example.com")
-            .body(())
-            .unwrap();
-        assert!(!matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.example.com", false),
+            ("POST", Version::HTTP_2, "www.lorem.com", false),
+            ("POST", Version::HTTP_3, "www.example.com", false),
+            ("POST", Version::HTTP_3, "www.lorem.com", false),
+            ("GET", Version::HTTP_2, "www.example.com", false),
+            ("GET", Version::HTTP_2, "www.lorem.com", false),
+            ("GET", Version::HTTP_3, "www.example.com", false),
+            ("GET", Version::HTTP_3, "www.lorem.com", true),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -710,13 +836,44 @@ mod test {
                     .or(HttpMatcher::version(VersionMatcher::HTTP_3)),
             )
             .and(HttpMatcher::domain("www.example.com").negate());
-        let req = Request::builder()
-            .method("POST")
-            .version(Version::HTTP_2)
-            .uri("www.lorem.com")
-            .body(())
-            .unwrap();
-        assert!(matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("POST", Version::HTTP_2, "www.lorem.com", true),
+            ("POST", Version::HTTP_2, "www.example.com", false),
+            ("POST", Version::HTTP_3, "www.lorem.com", true),
+            ("POST", Version::HTTP_3, "www.example.com", false),
+            ("POST", Version::HTTP_09, "www.lorem.com", false),
+            ("POST", Version::HTTP_09, "www.example.com", false),
+            ("GET", Version::HTTP_2, "www.lorem.com", true),
+            ("GET", Version::HTTP_2, "www.example.com", false),
+            ("GET", Version::HTTP_3, "www.lorem.com", true),
+            ("GET", Version::HTTP_3, "www.example.com", false),
+            ("GET", Version::HTTP_09, "www.lorem.com", false),
+            ("GET", Version::HTTP_09, "www.example.com", false),
+            ("PUT", Version::HTTP_2, "www.lorem.com", false),
+            ("PUT", Version::HTTP_2, "www.example.com", false),
+            ("PUT", Version::HTTP_3, "www.lorem.com", false),
+            ("PUT", Version::HTTP_3, "www.example.com", false),
+            ("PUT", Version::HTTP_09, "www.lorem.com", false),
+            ("PUT", Version::HTTP_09, "www.example.com", false),
+        ];
+
+        for (method, version, uri, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .version(version)
+                .uri(uri)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 
     #[test]
@@ -725,11 +882,28 @@ mod test {
             "content-type".parse().unwrap(),
             "text/plain".parse().unwrap(),
         );
-        let req = Request::builder()
-            .method("GET")
-            .header("content-type", "text/html")
-            .body(())
-            .unwrap();
-        assert!(!matcher.matches(None, &Context::default(), &req));
+
+        let cases = [
+            ("PUT", "text/plain", true),
+            ("PUT", "text/html", false),
+            ("GET", "text/plain", false),
+            ("GET", "text/html", false),
+        ];
+
+        for (method, header_value, expected) in cases {
+            let req = Request::builder()
+                .method(method)
+                .header("content-type", header_value)
+                .body(())
+                .unwrap();
+
+            assert_eq!(
+                matcher.matches(None, &Context::default(), &req),
+                expected,
+                "({:#?}).matches({:#?})",
+                matcher,
+                req
+            );
+        }
     }
 }

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -709,29 +709,16 @@ mod test {
 
     use super::*;
 
-    struct TrueMatcher;
+    struct BooleanMatcher(bool);
 
-    impl Matcher<(), Request<()>> for TrueMatcher {
+    impl Matcher<(), Request<()>> for BooleanMatcher {
         fn matches(
             &self,
             _ext: Option<&mut Extensions>,
             _ctx: &Context<()>,
             _req: &Request<()>,
         ) -> bool {
-            true
-        }
-    }
-
-    struct FalseMatcher;
-
-    impl Matcher<(), Request<()>> for FalseMatcher {
-        fn matches(
-            &self,
-            _ext: Option<&mut Extensions>,
-            _ctx: &Context<()>,
-            _req: &Request<()>,
-        ) -> bool {
-            false
+            self.0
         }
     }
 
@@ -739,51 +726,51 @@ mod test {
     fn test_matcher_ands_combination() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
         ];
@@ -805,51 +792,51 @@ mod test {
     fn test_matcher_negation_with_ands_combination() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
         ];
@@ -871,51 +858,51 @@ mod test {
     fn test_matcher_ands_combination_negated() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
         ];
@@ -937,51 +924,51 @@ mod test {
     fn test_matcher_ors_combination() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
         ];
@@ -1003,51 +990,51 @@ mod test {
     fn test_matcher_negation_with_ors_combination() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 true,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
         ];
@@ -1069,51 +1056,51 @@ mod test {
     fn test_matcher_ors_combination_negated() {
         let cases = [
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(TrueMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(true)),
                 false,
             ),
             (
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
-                HttpMatcher::custom(FalseMatcher),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
+                HttpMatcher::custom(BooleanMatcher(false)),
                 true,
             ),
         ];

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -45,8 +45,8 @@ pub struct HttpMatcher {
 #[derive(Debug, Clone)]
 /// A matcher that is used to match an http [`Request`]
 pub enum HttpMatcherKind {
-    /// zero or more [`HttpMatcherKind`]s that all need to match in order for the matcher to return `true`.
-    All(Vec<HttpMatcherKind>),
+    /// zero or more [`HttpMatcher`]s that all need to match in order for the matcher to return `true`.
+    All(Vec<HttpMatcher>),
     /// [`MethodMatcher`], a matcher that matches one or more HTTP methods.
     Method(MethodMatcher),
     /// [`PathMatcher`], a matcher based on the URI path.
@@ -55,8 +55,8 @@ pub enum HttpMatcherKind {
     Domain(DomainMatcher),
     /// [`VersionMatcher`], a matcher based on the HTTP version of the request.
     Version(VersionMatcher),
-    /// zero or more [`HttpMatcherKind`]s that at least one needs to match in order for the matcher to return `true`.
-    Any(Vec<HttpMatcherKind>),
+    /// zero or more [`HttpMatcher`]s that at least one needs to match in order for the matcher to return `true`.
+    Any(Vec<HttpMatcher>),
     /// [`UriMatcher`], a matcher the request's URI, using a substring or regex pattern.
     Uri(UriMatcher),
     /// [`HeaderMatcher`], a matcher based on the [`Request`]'s headers.
@@ -81,33 +81,15 @@ impl HttpMatcher {
     /// Create a matcher that also matches one or more HTTP methods on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method(mut self, method: MethodMatcher) -> Self {
-        let matcher = HttpMatcherKind::Method(method);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method(self, method: MethodMatcher) -> Self {
+        self.and(Self::method(method))
     }
 
     /// Create a matcher that can also match one or more HTTP methods as an alternative to the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method(mut self, method: MethodMatcher) -> Self {
-        let matcher = HttpMatcherKind::Method(method);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method(self, method: MethodMatcher) -> Self {
+        self.or(Self::method(method))
     }
 
     /// Create a new matcher that matches [`MethodMatcher::DELETE`] requests.
@@ -123,34 +105,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::DELETE`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_delete(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::DELETE);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_delete(self) -> Self {
+        self.and(Self::method_delete())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::DELETE`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_delete(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::DELETE);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_delete(self) -> Self {
+        self.or(Self::method_delete())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::GET`] requests.
@@ -166,34 +130,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::GET`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_get(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::GET);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_get(self) -> Self {
+        self.and(Self::method_get())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::GET`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_get(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::GET);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_get(self) -> Self {
+        self.or(Self::method_get())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::HEAD`] requests.
@@ -209,34 +155,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::HEAD`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_head(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::HEAD);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_head(self) -> Self {
+        self.and(Self::method_head())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::HEAD`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_head(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::HEAD);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_head(self) -> Self {
+        self.or(Self::method_head())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::OPTIONS`] requests.
@@ -252,34 +180,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::OPTIONS`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_options(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_options(self) -> Self {
+        self.and(Self::method_options())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::OPTIONS`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_options(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::OPTIONS);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_options(self) -> Self {
+        self.or(Self::method_options())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::PATCH`] requests.
@@ -295,34 +205,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::PATCH`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_patch(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::PATCH);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_patch(self) -> Self {
+        self.and(Self::method_patch())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::PATCH`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_patch(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::PATCH);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_patch(self) -> Self {
+        self.or(Self::method_patch())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::POST`] requests.
@@ -338,34 +230,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::POST`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_post(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::POST);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_post(self) -> Self {
+        self.and(Self::method_post())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::POST`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_post(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::POST);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_post(self) -> Self {
+        self.or(Self::method_post())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::PUT`] requests.
@@ -381,34 +255,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::PUT`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_put(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::PUT);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_put(self) -> Self {
+        self.and(Self::method_put())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::PUT`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_put(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::PUT);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_put(self) -> Self {
+        self.or(Self::method_put())
     }
 
     /// Create a new matcher that matches [`MethodMatcher::TRACE`] requests.
@@ -424,34 +280,16 @@ impl HttpMatcher {
     /// Add a new matcher that also matches [`MethodMatcher::TRACE`] on top of the existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn and_method_trace(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::TRACE);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn and_method_trace(self) -> Self {
+        self.and(Self::method_trace())
     }
 
     /// Add a new matcher that can also match [`MethodMatcher::TRACE`]
     /// as an alternative tothe existing [`HttpMatcher`] matchers.
     ///
     /// See [`MethodMatcher`] for more information.
-    pub fn or_method_trace(mut self) -> Self {
-        let matcher = HttpMatcherKind::Method(MethodMatcher::TRACE);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        };
-        self
+    pub fn or_method_trace(self) -> Self {
+        self.or(Self::method_trace())
     }
 
     /// Create a [`DomainMatcher`] matcher.
@@ -465,33 +303,15 @@ impl HttpMatcher {
     /// Create a [`DomainMatcher`] matcher to also match on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`DomainMatcher`] for more information.
-    pub fn and_domain(mut self, domain: impl Into<String>) -> Self {
-        let matcher = HttpMatcherKind::Domain(DomainMatcher::new(domain));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_domain(self, domain: impl Into<String>) -> Self {
+        self.and(Self::domain(domain))
     }
 
     /// Create a [`DomainMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`DomainMatcher`] for more information.
-    pub fn or_domain(mut self, domain: impl Into<String>) -> Self {
-        let matcher = HttpMatcherKind::Domain(DomainMatcher::new(domain));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_domain(self, domain: impl Into<String>) -> Self {
+        self.or(Self::domain(domain))
     }
 
     /// Create a [`VersionMatcher`] matcher.
@@ -505,33 +325,15 @@ impl HttpMatcher {
     /// Add a [`VersionMatcher`] matcher to matcher on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`VersionMatcher`] for more information.
-    pub fn and_version(mut self, version: VersionMatcher) -> Self {
-        let matcher = HttpMatcherKind::Version(version);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_version(self, version: VersionMatcher) -> Self {
+        self.and(Self::version(version))
     }
 
     /// Create a [`VersionMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`VersionMatcher`] for more information.
-    pub fn or_version(mut self, version: VersionMatcher) -> Self {
-        let matcher = HttpMatcherKind::Version(version);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_version(self, version: VersionMatcher) -> Self {
+        self.or(Self::version(version))
     }
 
     /// Create a [`UriMatcher`] matcher.
@@ -545,33 +347,15 @@ impl HttpMatcher {
     /// Create a [`UriMatcher`] matcher to match on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`UriMatcher`] for more information.
-    pub fn and_uri(mut self, re: impl AsRef<str>) -> Self {
-        let matcher = HttpMatcherKind::Uri(UriMatcher::new(re));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_uri(self, re: impl AsRef<str>) -> Self {
+        self.and(Self::uri(re))
     }
 
     /// Create a [`UriMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///    
     /// See [`UriMatcher`] for more information.
-    pub fn or_uri(mut self, re: impl AsRef<str>) -> Self {
-        let matcher = HttpMatcherKind::Uri(UriMatcher::new(re));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_uri(self, re: impl AsRef<str>) -> Self {
+        self.or(Self::uri(re))
     }
 
     /// Create a [`PathMatcher`] matcher.
@@ -585,33 +369,15 @@ impl HttpMatcher {
     /// Add a [`PathMatcher`] to match on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`PathMatcher`] for more information.
-    pub fn and_path(mut self, path: impl AsRef<str>) -> Self {
-        let matcher = HttpMatcherKind::Path(PathMatcher::new(path));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_path(self, path: impl AsRef<str>) -> Self {
+        self.and(Self::path(path))
     }
 
     /// Create a [`PathMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`PathMatcher`] for more information.
-    pub fn or_path(mut self, path: impl AsRef<str>) -> Self {
-        let matcher = HttpMatcherKind::Path(PathMatcher::new(path));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_path(self, path: impl AsRef<str>) -> Self {
+        self.or(Self::path(path))
     }
 
     /// Create a [`HeaderMatcher`] matcher.
@@ -626,40 +392,22 @@ impl HttpMatcher {
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header(
-        mut self,
+        self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+        self.and(Self::header(name, value))
     }
 
     /// Create a [`HeaderMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header(
-        mut self,
+        self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::is(name, value));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+        self.or(Self::header(name, value))
     }
 
     /// Create a [`HeaderMatcher`] matcher when the given header exists
@@ -675,34 +423,16 @@ impl HttpMatcher {
     /// on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
-    pub fn and_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::exists(name));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_header_exists(self, name: http::header::HeaderName) -> Self {
+        self.and(Self::header_exists(name))
     }
 
     /// Create a [`HeaderMatcher`] matcher to match when the given header exists
     /// as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`HeaderMatcher`] for more information.
-    pub fn or_header_exists(mut self, name: http::header::HeaderName) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::exists(name));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_header_exists(self, name: http::header::HeaderName) -> Self {
+        self.or(Self::header_exists(name))
     }
 
     /// Create a [`HeaderMatcher`] matcher to match on it containing the given value.
@@ -721,20 +451,11 @@ impl HttpMatcher {
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn and_header_contains(
-        mut self,
+        self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+        self.and(Self::header_contains(name, value))
     }
 
     /// Create a [`HeaderMatcher`] matcher to match if it contains the given value
@@ -742,20 +463,11 @@ impl HttpMatcher {
     ///
     /// See [`HeaderMatcher`] for more information.
     pub fn or_header_contains(
-        mut self,
+        self,
         name: http::header::HeaderName,
         value: http::header::HeaderValue,
     ) -> Self {
-        let matcher = HttpMatcherKind::Header(HeaderMatcher::contains(name, value));
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+        self.or(Self::header_contains(name, value))
     }
 
     /// Create a [`SocketMatcher`] matcher.
@@ -769,33 +481,15 @@ impl HttpMatcher {
     /// Add a [`SocketMatcher`] matcher to match on top of the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`SocketMatcher`] for more information.
-    pub fn and_socket(mut self, socket: SocketMatcher) -> Self {
-        let matcher = HttpMatcherKind::Socket(socket);
-        match &mut self.kind {
-            HttpMatcherKind::All(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::All(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn and_socket(self, socket: SocketMatcher) -> Self {
+        self.and(Self::socket(socket))
     }
 
     /// Create a [`SocketMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     ///
     /// See [`SocketMatcher`] for more information.
-    pub fn or_socket(mut self, socket: SocketMatcher) -> Self {
-        let matcher = HttpMatcherKind::Socket(socket);
-        match &mut self.kind {
-            HttpMatcherKind::Any(v) => {
-                v.push(matcher);
-            }
-            _ => {
-                self.kind = HttpMatcherKind::Any(vec![self.kind, matcher]);
-            }
-        }
-        self
+    pub fn or_socket(self, socket: SocketMatcher) -> Self {
+        self.or(Self::socket(socket))
     }
 
     /// Create a [`PathMatcher`] matcher to match for a GET request.
@@ -836,6 +530,34 @@ impl HttpMatcher {
     /// Create a [`PathMatcher`] matcher to match for a TRACE request.
     pub fn trace(path: impl AsRef<str>) -> Self {
         Self::method_trace().and_path(path)
+    }
+
+    /// Add a [`HttpMatcher`] to match on top of the existing set of [`HttpMatcher`] matchers.
+    pub fn and(mut self, matcher: HttpMatcher) -> Self {
+        match (self.negate, &mut self.kind) {
+            (false, HttpMatcherKind::All(v)) => {
+                v.push(matcher);
+                self
+            }
+            _ => HttpMatcher {
+                kind: HttpMatcherKind::All(vec![self, matcher]),
+                negate: false,
+            },
+        }
+    }
+
+    /// Create a [`HttpMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
+    pub fn or(mut self, matcher: HttpMatcher) -> Self {
+        match (self.negate, &mut self.kind) {
+            (false, HttpMatcherKind::Any(v)) => {
+                v.push(matcher);
+                self
+            }
+            _ => HttpMatcher {
+                kind: HttpMatcherKind::Any(vec![self, matcher]),
+                negate: false,
+            },
+        }
     }
 
     /// Negate the current matcher

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -703,7 +703,8 @@ where
 
 #[cfg(test)]
 mod test {
-    use http::{HeaderName, HeaderValue, Version};
+    use http::{HeaderName, HeaderValue};
+    use itertools::Itertools;
 
     use crate::service::Matcher;
 
@@ -722,24 +723,15 @@ mod test {
         }
     }
 
-    const TRUTH_TABLE: [(bool, bool, bool); 8] = [
-        (true, true, true),
-        (true, true, false),
-        (true, false, true),
-        (true, false, false),
-        (false, true, true),
-        (false, true, false),
-        (false, false, true),
-        (false, false, false),
-    ];
-
     #[test]
     fn test_matcher_ands_combination() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .and(HttpMatcher::custom(BooleanMatcher(b)))
-                .and(HttpMatcher::custom(BooleanMatcher(c)));
-            let expected = a && b && c;
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = v[0] && v[1] && v[2];
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.and(b).and(c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -753,12 +745,13 @@ mod test {
 
     #[test]
     fn test_matcher_negation_with_ands_combination() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .negate()
-                .and(HttpMatcher::custom(BooleanMatcher(b)))
-                .and(HttpMatcher::custom(BooleanMatcher(c)));
-            let expected = !a && b && c;
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = !v[0] && v[1] && v[2];
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.negate().and(b).and(c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -772,12 +765,13 @@ mod test {
 
     #[test]
     fn test_matcher_ands_combination_negated() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .and(HttpMatcher::custom(BooleanMatcher(b)))
-                .and(HttpMatcher::custom(BooleanMatcher(c)))
-                .negate();
-            let expected = !(a && b && c);
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = !(v[0] && v[1] && v[2]);
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.and(b).and(c).negate();
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -791,11 +785,13 @@ mod test {
 
     #[test]
     fn test_matcher_ors_combination() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .or(HttpMatcher::custom(BooleanMatcher(b)))
-                .or(HttpMatcher::custom(BooleanMatcher(c)));
-            let expected = a || b || c;
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = v[0] || v[1] || v[2];
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.or(b).or(c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -809,12 +805,13 @@ mod test {
 
     #[test]
     fn test_matcher_negation_with_ors_combination() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .negate()
-                .or(HttpMatcher::custom(BooleanMatcher(b)))
-                .or(HttpMatcher::custom(BooleanMatcher(c)));
-            let expected = !a || b || c;
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = !v[0] || v[1] || v[2];
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.negate().or(b).or(c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -828,12 +825,13 @@ mod test {
 
     #[test]
     fn test_matcher_ors_combination_negated() {
-        for (a, b, c) in TRUTH_TABLE {
-            let matcher = HttpMatcher::custom(BooleanMatcher(a))
-                .or(HttpMatcher::custom(BooleanMatcher(b)))
-                .or(HttpMatcher::custom(BooleanMatcher(c)))
-                .negate();
-            let expected = !(a || b || c);
+        for v in [true, false].into_iter().permutations(3) {
+            let expected = !(v[0] || v[1] || v[2]);
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+
+            let matcher = a.or(b).or(c).negate();
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -847,42 +845,16 @@ mod test {
 
     #[test]
     fn test_matcher_or_and_or_and_negation() {
-        let matcher = (HttpMatcher::method_post().or(HttpMatcher::method_get()))
-            .and(
-                HttpMatcher::version(VersionMatcher::HTTP_2)
-                    .or(HttpMatcher::version(VersionMatcher::HTTP_3)),
-            )
-            .and(HttpMatcher::domain("www.example.com").negate());
+        for v in [true, false].into_iter().permutations(5) {
+            let expected = (v[0] || v[1]) && (v[2] || v[3]) && !v[4];
+            let a = HttpMatcher::custom(BooleanMatcher(v[0]));
+            let b = HttpMatcher::custom(BooleanMatcher(v[1]));
+            let c = HttpMatcher::custom(BooleanMatcher(v[2]));
+            let d = HttpMatcher::custom(BooleanMatcher(v[3]));
+            let e = HttpMatcher::custom(BooleanMatcher(v[4]));
 
-        let cases = [
-            ("POST", Version::HTTP_2, "www.lorem.com", true),
-            ("POST", Version::HTTP_2, "www.example.com", false),
-            ("POST", Version::HTTP_3, "www.lorem.com", true),
-            ("POST", Version::HTTP_3, "www.example.com", false),
-            ("POST", Version::HTTP_09, "www.lorem.com", false),
-            ("POST", Version::HTTP_09, "www.example.com", false),
-            ("GET", Version::HTTP_2, "www.lorem.com", true),
-            ("GET", Version::HTTP_2, "www.example.com", false),
-            ("GET", Version::HTTP_3, "www.lorem.com", true),
-            ("GET", Version::HTTP_3, "www.example.com", false),
-            ("GET", Version::HTTP_09, "www.lorem.com", false),
-            ("GET", Version::HTTP_09, "www.example.com", false),
-            ("PUT", Version::HTTP_2, "www.lorem.com", false),
-            ("PUT", Version::HTTP_2, "www.example.com", false),
-            ("PUT", Version::HTTP_3, "www.lorem.com", false),
-            ("PUT", Version::HTTP_3, "www.example.com", false),
-            ("PUT", Version::HTTP_09, "www.lorem.com", false),
-            ("PUT", Version::HTTP_09, "www.example.com", false),
-        ];
-
-        for (method, version, uri, expected) in cases {
-            let req = Request::builder()
-                .method(method)
-                .version(version)
-                .uri(uri)
-                .body(())
-                .unwrap();
-
+            let matcher = (a.or(b)).and(c.or(d)).and(e.negate());
+            let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
                 expected,

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -722,61 +722,24 @@ mod test {
         }
     }
 
+    const TRUTH_TABLE: [(bool, bool, bool); 8] = [
+        (true, true, true),
+        (true, true, false),
+        (true, false, true),
+        (true, false, false),
+        (false, true, true),
+        (false, true, false),
+        (false, false, true),
+        (false, false, false),
+    ];
+
     #[test]
     fn test_matcher_ands_combination() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.and(b).and(c);
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .and(HttpMatcher::custom(BooleanMatcher(b)))
+                .and(HttpMatcher::custom(BooleanMatcher(c)));
+            let expected = a && b && c;
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -790,59 +753,12 @@ mod test {
 
     #[test]
     fn test_matcher_negation_with_ands_combination() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.negate().and(b).and(c);
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .negate()
+                .and(HttpMatcher::custom(BooleanMatcher(b)))
+                .and(HttpMatcher::custom(BooleanMatcher(c)));
+            let expected = !a && b && c;
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -856,59 +772,12 @@ mod test {
 
     #[test]
     fn test_matcher_ands_combination_negated() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.and(b).and(c).negate();
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .and(HttpMatcher::custom(BooleanMatcher(b)))
+                .and(HttpMatcher::custom(BooleanMatcher(c)))
+                .negate();
+            let expected = !(a && b && c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -922,59 +791,11 @@ mod test {
 
     #[test]
     fn test_matcher_ors_combination() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.or(b).or(c);
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .or(HttpMatcher::custom(BooleanMatcher(b)))
+                .or(HttpMatcher::custom(BooleanMatcher(c)));
+            let expected = a || b || c;
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -988,59 +809,12 @@ mod test {
 
     #[test]
     fn test_matcher_negation_with_ors_combination() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                true,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.negate().or(b).or(c);
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .negate()
+                .or(HttpMatcher::custom(BooleanMatcher(b)))
+                .or(HttpMatcher::custom(BooleanMatcher(c)));
+            let expected = !a || b || c;
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),
@@ -1054,59 +828,12 @@ mod test {
 
     #[test]
     fn test_matcher_ors_combination_negated() {
-        let cases = [
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(true)),
-                false,
-            ),
-            (
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                HttpMatcher::custom(BooleanMatcher(false)),
-                true,
-            ),
-        ];
-
-        for (a, b, c, expected) in cases {
-            let matcher = a.or(b).or(c).negate();
+        for (a, b, c) in TRUTH_TABLE {
+            let matcher = HttpMatcher::custom(BooleanMatcher(a))
+                .or(HttpMatcher::custom(BooleanMatcher(b)))
+                .or(HttpMatcher::custom(BooleanMatcher(c)))
+                .negate();
+            let expected = !(a || b || c);
             let req = Request::builder().body(()).unwrap();
             assert_eq!(
                 matcher.matches(None, &Context::default(), &req),

--- a/src/http/matcher/mod.rs
+++ b/src/http/matcher/mod.rs
@@ -703,7 +703,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use http::Version;
+    use http::{HeaderName, HeaderValue, Version};
 
     use crate::service::Matcher;
 
@@ -1182,8 +1182,8 @@ mod test {
     #[test]
     fn test_matcher_negation_and_header_contains() {
         let matcher = HttpMatcher::method_get().negate().and_header_contains(
-            "content-type".parse().unwrap(),
-            "text/plain".parse().unwrap(),
+            HeaderName::from_static("content-type"),
+            HeaderValue::from_static("text/plain"),
         );
 
         let cases = [

--- a/src/http/service/web/endpoint/mod.rs
+++ b/src/http/service/web/endpoint/mod.rs
@@ -1,6 +1,5 @@
 use crate::{
-    http::matcher::HttpMatcher,
-    http::{IntoResponse, Request, Response},
+    http::{matcher::HttpMatcher, Body, IntoResponse, Request, Response},
     service::{BoxService, Context, Service, ServiceBuilder},
 };
 use std::convert::Infallible;
@@ -9,7 +8,7 @@ use std::future::Future;
 pub mod extract;
 
 pub(crate) struct Endpoint<State> {
-    pub(crate) matcher: HttpMatcher,
+    pub(crate) matcher: HttpMatcher<State, Body>,
     pub(crate) service: BoxService<State, Request, Response, Infallible>,
 }
 

--- a/src/http/service/web/service.rs
+++ b/src/http/service/web/service.rs
@@ -3,7 +3,7 @@ use crate::{
     http::{
         matcher::{HttpMatcher, UriParams},
         service::fs::ServeDir,
-        IntoResponse, Request, Response, StatusCode, Uri,
+        Body, IntoResponse, Request, Response, StatusCode, Uri,
     },
     service::{context::Extensions, service_fn, BoxService, Context, Matcher, Service},
 };
@@ -145,7 +145,7 @@ where
     }
 
     /// add a route to the web service which matches the given matcher, using the given service.
-    pub fn on<I, T>(mut self, matcher: HttpMatcher, service: I) -> Self
+    pub fn on<I, T>(mut self, matcher: HttpMatcher<State, Body>, service: I) -> Self
     where
         I: IntoEndpointService<State, T>,
     {


### PR DESCRIPTION
Addresses part of  https://github.com/plabayo/rama/issues/92 and https://github.com/plabayo/rama/issues/93 for `http` layer.

- Modifies `HttpMatcherKind::All` and `HttpMatcherKind::Any` variants to contain `Vec<HttpMatcher>` instead of `Vec<HttpKind>`. This way the negation of each matcher is preserved, and this fixes the bug I mentioned in the above issue.
- Implements `HttpMatcher::and` and `HttpMatcher::or` methods.
- Updates existing `HttpMatcher::and_*` and `HttpMatcher::or_*` methods to use new methods.
- Adds `HttpKind::Custom(_)` variant for custom matcher implementations.
- Adds tests.