### PR TITLE
update deps: replaced futures crate with futures_lite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,28 +397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -428,31 +412,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.30"
+name = "futures-lite"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -473,16 +448,10 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -874,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,9 +989,8 @@ dependencies = [
  "brotli 5.0.0",
  "bytes",
  "flate2",
- "futures",
  "futures-core",
- "futures-util",
+ "futures-lite",
  "h2",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,8 @@ bytes = "1"
 argh = "0.1"
 crossterm = "0.27"
 flate2 = "1.0"
-futures = "0.3.29"
+futures-lite = "2.3.0"
 futures-core = "0.3"
-futures-util = { version = "0.3", default-features = false }
 h2 = "0.4"
 headers = "0.4"
 http = "1"
@@ -101,9 +100,8 @@ async-compression = { workspace = true, features = ["tokio", "brotli", "zlib", "
 base64 = { workspace = true }
 bitflags = { workspace = true }
 bytes = { workspace = true }
-futures = { workspace = true }
 futures-core = { workspace = true }
-futures-util = { workspace = true, features = ["alloc"] }
+futures-lite = { workspace = true }
 h2 = { workspace = true }
 headers = { workspace = true }
 http = { workspace = true }

--- a/src/http/body.rs
+++ b/src/http/body.rs
@@ -5,8 +5,8 @@ use crate::http::dep::{
     http_body_util::BodyExt,
 };
 use bytes::Bytes;
-use futures_util::stream::Stream;
-use futures_util::TryStream;
+use futures_core::TryStream;
+use futures_lite::stream::Stream;
 use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -166,7 +166,7 @@ impl Stream for BodyDataStream {
     #[inline]
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
-            match futures_util::ready!(Pin::new(&mut self.inner).poll_frame(cx)?) {
+            match futures_lite::ready!(Pin::new(&mut self.inner).poll_frame(cx)?) {
                 Some(frame) => match frame.into_data() {
                     Ok(data) => return Poll::Ready(Some(Ok(data))),
                     Err(_frame) => {}
@@ -221,7 +221,7 @@ where
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
         let stream = self.project().stream.get_pin_mut();
-        match futures_util::ready!(stream.try_poll_next(cx)) {
+        match futures_lite::ready!(stream.try_poll_next(cx)) {
             Some(Ok(chunk)) => Poll::Ready(Some(Ok(Frame::data(chunk.into())))),
             Some(Err(err)) => Poll::Ready(Some(Err(Error::new(err)))),
             None => Poll::Ready(None),

--- a/src/http/layer/catch_panic.rs
+++ b/src/http/layer/catch_panic.rs
@@ -84,7 +84,7 @@
 //! # }
 //! ```
 
-use futures_util::future::FutureExt;
+use futures_lite::future::FutureExt;
 use std::{any::Any, panic::AssertUnwindSafe};
 
 use crate::http::{Body, HeaderValue, Request, Response, StatusCode};

--- a/src/http/layer/compression/body.rs
+++ b/src/http/layer/compression/body.rs
@@ -10,7 +10,7 @@ use crate::http::HeaderMap;
 use async_compression::tokio::bufread::{BrotliEncoder, GzipEncoder, ZlibEncoder, ZstdEncoder};
 
 use bytes::{Buf, Bytes};
-use futures_util::ready;
+use futures_lite::ready;
 use pin_project_lite::pin_project;
 use std::{
     io,

--- a/src/http/layer/decompression/body.rs
+++ b/src/http/layer/decompression/body.rs
@@ -12,7 +12,7 @@ use async_compression::tokio::bufread::GzipDecoder;
 use async_compression::tokio::bufread::ZlibDecoder;
 use async_compression::tokio::bufread::ZstdDecoder;
 use bytes::{Buf, Bytes};
-use futures_util::ready;
+use futures_lite::ready;
 use pin_project_lite::pin_project;
 use std::task::Context;
 use std::{io, marker::PhantomData, pin::Pin, task::Poll};

--- a/src/http/layer/map_response_body.rs
+++ b/src/http/layer/map_response_body.rs
@@ -11,7 +11,7 @@
 //! use rama::service::{self, ServiceBuilder, service_fn, Service};
 //! use rama::http::layer::map_response_body::MapResponseBodyLayer;
 //! use rama::error::BoxError;
-//! use futures::ready;
+//! use futures_lite::ready;
 //!
 //! // A wrapper for a `http_body::Body` that prints the size of data chunks
 //! pin_project_lite::pin_project! {

--- a/src/http/layer/trace/body.rs
+++ b/src/http/layer/trace/body.rs
@@ -1,7 +1,7 @@
 use super::{DefaultOnBodyChunk, DefaultOnEos, DefaultOnFailure, OnBodyChunk, OnEos, OnFailure};
 use crate::http::dep::http_body::{Body, Frame};
 use crate::http::layer::classify::ClassifyEos;
-use futures_core::ready;
+use futures_lite::ready;
 use pin_project_lite::pin_project;
 use std::{
     fmt,

--- a/src/http/layer/trace/mod.rs
+++ b/src/http/layer/trace/mod.rs
@@ -620,7 +620,7 @@ mod tests {
     }
 
     async fn streaming_body(_req: Request) -> Result<Response, BoxError> {
-        use futures::stream::iter;
+        use futures_lite::stream::iter;
 
         let stream = iter(vec![
             Ok::<_, BoxError>(Bytes::from("one")),

--- a/src/http/layer/util/compression.rs
+++ b/src/http/layer/util/compression.rs
@@ -1,8 +1,8 @@
 //! Types used by compression and decompression middleware.
 
 use bytes::{Buf, Bytes, BytesMut};
-use futures_core::Stream;
-use futures_util::ready;
+use futures_lite::ready;
+use futures_lite::Stream;
 use pin_project_lite::pin_project;
 use std::{
     io,

--- a/src/http/server/hyper_conn.rs
+++ b/src/http/server/hyper_conn.rs
@@ -5,7 +5,6 @@ use crate::service::Service;
 use crate::service::{Context, HyperService};
 use crate::stream::Stream;
 use crate::tcp::utils::is_connection_error;
-use futures::FutureExt;
 use hyper::server::conn::http1::Builder as Http1Builder;
 use hyper::server::conn::http2::Builder as Http2Builder;
 use hyper_util::{rt::TokioIo, server::conn::auto::Builder as AutoBuilder};
@@ -51,7 +50,7 @@ impl HyperConnServer for Http1Builder {
         let mut conn = pin!(self.serve_connection(stream, service).with_upgrades());
 
         if let Some(guard) = guard {
-            let mut cancelled_fut = pin!(guard.cancelled().fuse());
+            let mut cancelled_fut = pin!(guard.cancelled());
 
             loop {
                 select! {
@@ -92,7 +91,7 @@ impl HyperConnServer for Http2Builder<Executor> {
         let mut conn = pin!(self.serve_connection(stream, service));
 
         if let Some(guard) = guard {
-            let mut cancelled_fut = pin!(guard.cancelled().fuse());
+            let mut cancelled_fut = pin!(guard.cancelled());
 
             loop {
                 select! {
@@ -133,7 +132,7 @@ impl HyperConnServer for AutoBuilder<Executor> {
         let mut conn = pin!(self.serve_connection_with_upgrades(stream, service));
 
         if let Some(guard) = guard {
-            let mut cancelled_fut = pin!(guard.cancelled().fuse());
+            let mut cancelled_fut = pin!(guard.cancelled());
 
             loop {
                 select! {

--- a/src/http/service/fs/mod.rs
+++ b/src/http/service/fs/mod.rs
@@ -1,7 +1,7 @@
 //! File system related services.
 
 use bytes::Bytes;
-use futures_util::Stream;
+use futures_lite::Stream;
 use http_body::{Body, Frame};
 use pin_project_lite::pin_project;
 use std::{

--- a/src/service/layer/limit/mod.rs
+++ b/src/service/layer/limit/mod.rs
@@ -82,7 +82,7 @@ mod tests {
     use crate::service::{service_fn, Context, Layer, Service};
     use std::convert::Infallible;
 
-    use futures_util::future::join_all;
+    use futures_lite::future::zip;
 
     #[tokio::test]
     async fn test_limit() {
@@ -102,9 +102,7 @@ mod tests {
         let future_1 = service_1.serve(Context::default(), "Hello");
         let future_2 = service_2.serve(Context::default(), "Hello");
 
-        let mut results = join_all(vec![future_1, future_2]).await;
-        let result_1 = results.pop().unwrap();
-        let result_2 = results.pop().unwrap();
+        let (result_1, result_2) = zip(future_1, future_2).await;
 
         // check that one request succeeded and the other failed
         if result_1.is_err() {

--- a/src/stream/layer/tracker/bytes.rs
+++ b/src/stream/layer/tracker/bytes.rs
@@ -400,6 +400,8 @@ mod tests {
         assert_eq!(handle.read(), 9);
         assert_eq!(handle.written(), 9);
 
-        futures::future::join_all(vec![task_1, task_2]).await;
+        let (t1, t2) = futures_lite::future::zip(task_1, task_2).await;
+        t1.unwrap();
+        t2.unwrap();
     }
 }


### PR DESCRIPTION
Should close #150 by replacing `futures` and `futures-core` crate with `futures_lite` crate.

Could not replace `futures_util` crate, as I did not find an easy way to replace `futures_util::TryStream`.
The farthest I got was replacing
```
where
    S: TryStream,
    S::Ok: Into<Bytes>,
    S::Error: Into<BoxError>,
```
with 
```
where
  S: Stream<Item = Result<Bytes, BoxError>>
```

But that created more problems than solutions. I am open to guidance on this task.

Also, not sure how to fix clippy warning:

```
warning: unused `std::result::Result` in tuple element 0 that must be used
   --> src/stream/layer/tracker/bytes.rs:403:9
    |
403 |         futures_lite::future::zip(task_1, task_2).await;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` on by default
```

Is ignoring the result the solution to go?