### PR TITLE
262: use aws-lc by default for rustls

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,7 +66,7 @@ jobs:
           cargo check --all --all-targets --all-features
       - name: clippy
         run: |
-          cargo clippy --all --all-targets ---all-features
+          cargo clippy --all --all-targets --all-features
       - name: rustfmt
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,10 +25,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: check
         run: |
-          cargo check --all --all-targets --all-features
+          cargo check --all --all-targets --features=full
       - name: clippy
         run: |
-          cargo clippy --all --all-targets --all-features
+          cargo clippy --all --all-targets --features=full
       - name: rustfmt
         run: |
           cargo fmt --all -- --check
@@ -44,27 +44,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: check
         run: |
-          cargo check --all --all-targets --all-features
+          cargo check --all --all-targets --features=full
       - name: clippy
         run: |
-          cargo clippy --all --all-targets --all-features
+          cargo clippy --all --all-targets --features=full
       - name: rustfmt
         run: |
           cargo fmt --all -- --check
 
-  check-docs:
+  check-all-features:
     runs-on: ubuntu-latest
-    needs: [check, check-msrv]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{env.RUST_TOOLCHAIN}}
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
-      - name: cargo doc
-        env:
-          RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"
-        run: cargo doc --all-features --no-deps --workspace
+      - name: check
+        run: |
+          cargo check --all --all-targets --all-features
+      - name: clippy
+        run: |
+          cargo clippy --all --all-targets ---all-features
+      - name: rustfmt
+        run: |
+          cargo fmt --all -- --check
 
   test-msrv:
     needs: [check, check-msrv]
@@ -76,7 +81,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-beta:
     needs: [check, check-msrv]
@@ -88,9 +93,21 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test:
+    needs: [check, check-msrv]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{env.RUST_TOOLCHAIN}}
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: cargo test --features=full --workspace
+
+  test-all-features:
     needs: [check, check-msrv]
     runs-on: ubuntu-latest
     steps:
@@ -112,7 +129,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-windows-beta:
     needs: [check, check-msrv]
@@ -124,7 +141,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-windows:
     needs: [check, check-msrv]
@@ -136,7 +153,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-macos-msrv:
     needs: [check, check-msrv]
@@ -148,7 +165,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-macos-beta:
     needs: [check, check-msrv]
@@ -160,7 +177,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-macos:
     needs: [check, check-msrv]
@@ -172,7 +189,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace
+        run: cargo test --features=full --workspace
 
   test-ignored-msrv:
     needs: [check, check-msrv]
@@ -184,7 +201,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-ignored-beta:
     needs: [check, check-msrv]
@@ -196,7 +213,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-ignored:
     needs: [check, check-msrv]
@@ -208,7 +225,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-ignored-macos-msrv:
     needs: [check, check-msrv]
@@ -220,7 +237,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-ignored-macos-beta:
     needs: [check, check-msrv]
@@ -232,7 +249,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-ignored-macos:
     needs: [check, check-msrv]
@@ -244,7 +261,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-features --workspace -- --ignored
+        run: cargo test --features=full --workspace -- --ignored
 
   test-docs:
     needs: [check, check-msrv]
@@ -256,7 +273,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --doc --all-features --workspace
+        run: cargo test --doc --features=full --workspace
 
   test-examples-beta:
     needs: [check, check-msrv]
@@ -268,7 +285,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-msrv:
     needs: [check, check-msrv]
@@ -280,7 +297,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples:
     needs: [check, check-msrv]
@@ -292,43 +309,46 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-windows-beta:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-windows-msrv:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-windows:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-macos-beta:
     needs: [check, check-msrv]
@@ -340,7 +360,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_BETA}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-macos-msrv:
     needs: [check, check-msrv]
@@ -352,7 +372,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN_MSRV}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   test-examples-macos:
     needs: [check, check-msrv]
@@ -364,7 +384,7 @@ jobs:
           toolchain: ${{env.RUST_TOOLCHAIN}}
       - uses: Swatinem/rust-cache@v2
       - name: Run doc tests
-        run: cargo test --all-features --examples --workspace
+        run: cargo test --features=full --examples --workspace
 
   cargo-hack:
     needs: [check, check-msrv]
@@ -433,6 +453,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test-all-features
       - test-examples
       - test-msrv
       - test-beta
@@ -497,6 +518,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test-all-features
       - test-examples
       - test-msrv
       - test-beta

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -123,6 +123,7 @@ jobs:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -135,6 +136,7 @@ jobs:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -147,6 +149,7 @@ jobs:
     needs: [check, check-msrv]
     runs-on: windows-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a47f2fb521b70c11ce7369a6c5fa4bd6af7e5d62ec06303875bafe7c6ba245"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2927c7af777b460b7ccd95f8b67acd7b4c04ec8896bf0c8e80ba30523cffc057"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +228,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -274,10 +324,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -319,6 +389,15 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -447,6 +526,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,6 +617,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -790,6 +881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1031,15 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -969,6 +1078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1098,16 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1070,6 +1195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1087,6 +1218,22 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1295,6 +1442,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1534,7 @@ dependencies = [
  "hyper-util",
  "ipnet",
  "iri-string",
- "itertools",
+ "itertools 0.13.0",
  "mime",
  "mime_guess",
  "opentelemetry",
@@ -1589,6 +1746,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1607,6 +1770,7 @@ version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1651,6 +1815,7 @@ version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1784,6 +1949,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2359,6 +2530,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2609,6 +2792,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rustls = { version = "0.23", default-features = false, features = [
     "logging",
     "std",
     "tls12",
-    "ring",
+    "aws_lc_rs",
 ] }
 rustls-native-certs = "=0.7.1"
 rustls-pemfile = "2.1"
@@ -76,7 +76,7 @@ tokio-graceful = "0.1"
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "logging",
     "tls12",
-    "ring",
+    "aws_lc_rs",
 ] }
 tokio-test = "0.4.4"
 tokio-util = "0.7"
@@ -124,6 +124,7 @@ telemetry = [
     "dep:opentelemetry-semantic-conventions",
 ]
 compression = ["dep:async-compression"]
+rustls-ring = ["tokio-rustls/ring", "rustls/ring"]
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/justfile
+++ b/justfile
@@ -7,10 +7,10 @@ sort:
 lint: fmt sort
 
 check:
-	cargo check --all --all-targets --all-features
+	cargo check --all --all-targets --features=full
 
 clippy:
-	cargo clippy --all --all-targets --all-features
+	cargo clippy --all --all-targets --features=full
 
 clippy-fix:
 	cargo clippy --fix
@@ -19,19 +19,19 @@ typos:
 	typos -w
 
 doc:
-	RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --all-features --no-deps
+	RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --features=full --no-deps
 
 doc-open:
-	RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --all-features --no-deps --open
+	RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --features=full --no-deps --open
 
 hack:
 	cargo hack check --each-feature --no-dev-deps --workspace
 
 test:
-	cargo test --all-features --workspace
+	cargo test --features=full --workspace
 
 test-ignored:
-	cargo test --all-features --workspace -- --ignored
+	cargo test --features=full --workspace -- --ignored
 
 qa: lint check clippy doc test
 

--- a/tests/example_tests/utils/mod.rs
+++ b/tests/example_tests/utils/mod.rs
@@ -68,7 +68,7 @@ where
     /// This function panics if the server process cannot be spawned.
     pub fn interactive(example_name: impl AsRef<str>) -> Self {
         let child = escargot::CargoBuild::new()
-            .arg("--all-features")
+            .arg("--features=full")
             .example(example_name.as_ref())
             .manifest_path("Cargo.toml")
             .target_dir("./target/")


### PR DESCRIPTION
allow ring to be enabled (again)
using rustls-ring

Closes #262