### PR TITLE
Remove const in HeapReader::new()

### DIFF
--- a/src/net/stream/read.rs
+++ b/src/net/stream/read.rs
@@ -19,7 +19,7 @@ pin_project! {
 
 impl HeapReader {
     /// Creates a new `HeapReader` with the specified bytes data.
-    pub const fn new(data: Vec<u8>) -> Self {
+    pub fn new(data: Vec<u8>) -> Self {
         Self {
             inner: Cursor::new(data),
         }


### PR DESCRIPTION
Rama is generating this error when building with the justfile or executing `cargo run`: `std::io::Cursor::<T>::new is not yet stable as a const fn`

To resolve this error remove the const from `HeapReader::new()`