### PR TITLE
Remove redundant `Sync` bound

### DIFF
--- a/rama-tcp/src/server/listener.rs
+++ b/rama-tcp/src/server/listener.rs
@@ -211,7 +211,7 @@ where
     pub async fn serve_fn<F, T, R, O, E>(self, f: F)
     where
         F: Factory<T, R, O, E>,
-        R: Future<Output = Result<O, E>> + Send + Sync + 'static,
+        R: Future<Output = Result<O, E>> + Send + 'static,
         O: Send + Sync + 'static,
         E: Send + Sync + 'static,
         T: FromContextRequest<State, TcpStream>,
@@ -267,7 +267,7 @@ where
     pub async fn serve_fn_graceful<F, T, R, O, E>(self, guard: ShutdownGuard, service: F)
     where
         F: Factory<T, R, O, E>,
-        R: Future<Output = Result<O, E>> + Send + Sync + 'static,
+        R: Future<Output = Result<O, E>> + Send + 'static,
         O: Send + Sync + 'static,
         E: Send + Sync + 'static,
         T: FromContextRequest<State, TcpStream>,


### PR DESCRIPTION
This PR removes a redundant `Sync` bound on the future that is returned by `f` in `serve_fn()` 

Futures generally shouldn't be `Sync`. This caused errors when working with functions whose return type is `impl Future<...> + Send`