### PR TITLE
Fix boring tls termination example and test

### DIFF
--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -46,8 +46,8 @@ mod tcp_listener_layers;
 // Running example manually does work via curl,
 // but automated test fails and not important enough for now
 // :shrug:
-// #[cfg(all(feature = "boring", feature = "haproxy", feature ="http-full"))]
-// mod tls_boring_termination;
+#[cfg(all(feature = "boring", feature = "haproxy", feature = "http-full"))]
+mod tls_boring_termination;
 
 #[cfg(all(feature = "rustls", feature = "haproxy", feature = "http-full"))]
 mod tls_termination;


### PR DESCRIPTION
This example was writing an http response directly without waiting for a proper http request. In itself there was nothing wrong with this example directly, but it was not a valid http server for sure. This broke the test that was using this example as a server because hyper will crash when there is unexpected data in the connection buffers.

In some occasions this example did work: either due to very lucky timing or because the retry layer repeated enough until it got lucky. This also explains the problems we saw where the retry layer seemed stuck from the outside, which we thought was a bug, but might have just been this bug infinitely repeating