### PR TITLE
refactor(proxy): introduce ProxyContext for transport layer

### DIFF
--- a/rama-net/src/transport.rs
+++ b/rama-net/src/transport.rs
@@ -26,6 +26,23 @@ pub struct TransportContext {
     pub authority: Authority,
 }
 
+/// The context as relevant to the proxy layer.
+///
+/// This is used to pass proxy related information to the transport layer.
+#[derive(Debug, Clone)]
+pub struct ProxyContext {
+    /// The transport protocol used by the proxy.
+    pub protocol: TransportProtocol,
+}
+
+impl From<TransportContext> for ProxyContext {
+    fn from(ctx: TransportContext) -> Self {
+        Self {
+            protocol: ctx.protocol,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// The protocol used for the transport layer.
 pub enum TransportProtocol {

--- a/rama-proxy/src/proxydb/csv.rs
+++ b/rama-proxy/src/proxydb/csv.rs
@@ -216,10 +216,7 @@ impl From<std::io::Error> for ProxyCsvRowReaderError {
 mod tests {
     use super::*;
     use crate::ProxyFilter;
-    use rama_net::{
-        transport::{TransportContext, TransportProtocol},
-        Protocol,
-    };
+    use rama_net::transport::{ProxyContext, TransportProtocol};
     use rama_utils::str::NonEmptyString;
     use std::str::FromStr;
 
@@ -538,11 +535,8 @@ mod tests {
     #[test]
     fn test_proxy_is_match_happy_path_proxy_with_any_filter_string_cases() {
         let proxy = parse_csv_row("id,1,,1,,,,,,,authority,*,*,*,*,*,*,0").unwrap();
-        let ctx = TransportContext {
+        let ctx = ProxyContext {
             protocol: TransportProtocol::Tcp,
-            app_protocol: Some(Protocol::HTTPS),
-            http_version: None,
-            authority: "localhost:8443".try_into().unwrap(),
         };
 
         for filter in [
@@ -589,11 +583,8 @@ mod tests {
         let proxy =
             parse_csv_row("id,1,,1,,,,,,,authority,pool,continent,country,state,city,carrier,42")
                 .unwrap();
-        let ctx = TransportContext {
+        let ctx = ProxyContext {
             protocol: TransportProtocol::Tcp,
-            app_protocol: Some(Protocol::HTTPS),
-            http_version: None,
-            authority: "localhost:8443".try_into().unwrap(),
         };
 
         for filter in [

--- a/rama-proxy/src/proxydb/internal.rs
+++ b/rama-proxy/src/proxydb/internal.rs
@@ -2,7 +2,7 @@ use super::{ProxyFilter, StringFilter};
 use rama_net::{
     address::ProxyAddress,
     asn::Asn,
-    transport::{TransportContext, TransportProtocol},
+    transport::{ProxyContext, TransportProtocol},
 };
 use rama_utils::str::NonEmptyString;
 use serde::{Deserialize, Serialize};
@@ -87,8 +87,8 @@ fn proxydb_insert_validator(proxy: &Proxy) -> bool {
 }
 
 impl Proxy {
-    /// Check if the proxy is a match for the given[`TransportContext`] and [`ProxyFilter`].
-    pub fn is_match(&self, ctx: &TransportContext, filter: &ProxyFilter) -> bool {
+    /// Check if the proxy is a match for the given[`ProxyContext`] and [`ProxyFilter`].
+    pub fn is_match(&self, ctx: &ProxyContext, filter: &ProxyFilter) -> bool {
         if let Some(id) = &filter.id {
             if id != &self.id {
                 return false;

--- a/rama-proxy/src/proxydb/update.rs
+++ b/rama-proxy/src/proxydb/update.rs
@@ -61,7 +61,7 @@ where
 
     async fn get_proxy_if(
         &self,
-        ctx: rama_net::transport::TransportContext,
+        ctx: rama_net::transport::ProxyContext,
         filter: super::ProxyFilter,
         predicate: impl super::ProxyQueryPredicate,
     ) -> Result<super::Proxy, Self::Error> {
@@ -79,7 +79,7 @@ where
 
     async fn get_proxy(
         &self,
-        ctx: rama_net::transport::TransportContext,
+        ctx: rama_net::transport::ProxyContext,
         filter: super::ProxyFilter,
     ) -> Result<super::Proxy, Self::Error> {
         match self.0.load().deref().deref() {
@@ -121,7 +121,7 @@ mod tests {
     use crate::{Proxy, ProxyFilter};
     use rama_net::{
         asn::Asn,
-        transport::{TransportContext, TransportProtocol},
+        transport::{ProxyContext, TransportProtocol},
     };
     use rama_utils::str::NonEmptyString;
 
@@ -132,11 +132,8 @@ mod tests {
         let (reader, _) = proxy_db_updater::<Proxy>();
         assert!(reader
             .get_proxy(
-                TransportContext {
+                ProxyContext {
                     protocol: TransportProtocol::Tcp,
-                    app_protocol: None,
-                    http_version: None,
-                    authority: "proxy.example.com:1080".parse().unwrap(),
                 },
                 ProxyFilter::default(),
             )
@@ -150,11 +147,8 @@ mod tests {
 
         assert!(reader
             .get_proxy(
-                TransportContext {
+                ProxyContext {
                     protocol: TransportProtocol::Tcp,
-                    app_protocol: None,
-                    http_version: None,
-                    authority: "proxy.example.com:1080".parse().unwrap(),
                 },
                 ProxyFilter::default(),
             )
@@ -186,11 +180,8 @@ mod tests {
             "id",
             reader
                 .get_proxy(
-                    TransportContext {
+                    ProxyContext {
                         protocol: TransportProtocol::Tcp,
-                        app_protocol: None,
-                        http_version: None,
-                        authority: "proxy.example.com:1080".parse().unwrap(),
                     },
                     ProxyFilter::default(),
                 )
@@ -201,11 +192,8 @@ mod tests {
 
         assert!(reader
             .get_proxy(
-                TransportContext {
+                ProxyContext {
                     protocol: TransportProtocol::Udp,
-                    app_protocol: None,
-                    http_version: None,
-                    authority: "proxy.example.com:1080".parse().unwrap(),
                 },
                 ProxyFilter::default(),
             )
@@ -216,11 +204,8 @@ mod tests {
             "id",
             reader
                 .get_proxy(
-                    TransportContext {
+                    ProxyContext {
                         protocol: TransportProtocol::Tcp,
-                        app_protocol: None,
-                        http_version: None,
-                        authority: "proxy.example.com:1080".parse().unwrap(),
                     },
                     ProxyFilter::default(),
                 )


### PR DESCRIPTION
Resolve https://github.com/plabayo/rama/issues/387

Simplify transport context handling by introducing a dedicated ProxyContext struct that only contains the essential transport protocol information needed for proxy selection.

- Add new ProxyContext struct in rama-net/transport.rs
- Replace TransportContext with ProxyContext in ProxyDB trait and implementations
- Remove unused app_protocol, http_version and authority fields from proxy selection logic
- Update tests to use simplified ProxyContext

This change reduces coupling between the proxy and transport layers by only exposing the minimal required information for proxy selection.