### PR TITLE
feat(http-types): implement IntoResponse for Either types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,6 +2316,7 @@ dependencies = [
  "mime_guess",
  "paste",
  "pin-project-lite",
+ "rama-core",
  "rama-error",
  "rama-utils",
  "serde",

--- a/rama-http-types/Cargo.toml
+++ b/rama-http-types/Cargo.toml
@@ -26,6 +26,7 @@ mime = { workspace = true }
 mime_guess = { workspace = true }
 paste = { workspace = true }
 pin-project-lite = { workspace = true }
+rama-core = { version = "0.2.0-alpha.7", path = "../rama-core" }
 rama-error = { version = "0.2.0-alpha.7", path = "../rama-error" }
 rama-utils = { version = "0.2.0-alpha.7", path = "../rama-utils" }
 serde = { workspace = true, features = ["derive"] }

--- a/rama-http-types/src/response/into_response.rs
+++ b/rama-http-types/src/response/into_response.rs
@@ -422,3 +422,70 @@ macro_rules! impl_into_response {
 }
 
 all_the_tuples_no_last_special_case!(impl_into_response);
+
+macro_rules! impl_into_response_either {
+    ($id:ident, $($param:ident),+ $(,)?) => {
+        impl<$($param),+> IntoResponse for rama_core::combinators::$id<$($param),+>
+        where
+            $($param: IntoResponse),+
+        {
+            fn into_response(self) -> Response {
+                match self {
+                    $(
+                        rama_core::combinators::$id::$param(val) => val.into_response(),
+                    )+
+                }
+            }
+        }
+    };
+}
+
+rama_core::combinators::impl_either!(impl_into_response_either);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama_core::combinators::Either;
+
+    #[test]
+    fn test_either_into_response() {
+        let left: Either<&'static str, Vec<u8>> = Either::A("hello");
+        let right: Either<&'static str, Vec<u8>> = Either::B(vec![1, 2, 3]);
+
+        let left_res = left.into_response();
+        assert_eq!(
+            left_res.headers().get(header::CONTENT_TYPE).unwrap(),
+            mime::TEXT_PLAIN_UTF_8.as_ref()
+        );
+
+        let right_res = right.into_response();
+        assert_eq!(
+            right_res.headers().get(header::CONTENT_TYPE).unwrap(),
+            mime::APPLICATION_OCTET_STREAM.as_ref()
+        );
+    }
+
+    #[test]
+    fn test_either3_into_response() {
+        use rama_core::combinators::Either3;
+
+        let a: Either3<&'static str, Vec<u8>, StatusCode> = Either3::A("hello");
+        let b: Either3<&'static str, Vec<u8>, StatusCode> = Either3::B(vec![1, 2, 3]);
+        let c: Either3<&'static str, Vec<u8>, StatusCode> = Either3::C(StatusCode::NOT_FOUND);
+
+        let a_res = a.into_response();
+        assert_eq!(
+            a_res.headers().get(header::CONTENT_TYPE).unwrap(),
+            mime::TEXT_PLAIN_UTF_8.as_ref()
+        );
+
+        let b_res = b.into_response();
+        assert_eq!(
+            b_res.headers().get(header::CONTENT_TYPE).unwrap(),
+            mime::APPLICATION_OCTET_STREAM.as_ref()
+        );
+
+        let c_res = c.into_response();
+        assert_eq!(c_res.status(), StatusCode::NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Resolve https://github.com/plabayo/rama/issues/395

Add IntoResponse implementations for Either types from rama_core::combinators. This allows Either types to be used as responses in handlers.

Added unit tests to verify the implementations work correctly for:
- Either<&str, Vec<u8>>
- Either3<&str, Vec<u8>, StatusCode>