### PR TITLE
Extract Rama Echo's HTTP service out to a separate function

### DIFF
--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -38,10 +38,6 @@ use crate::{
     rt::Executor,
     ua::profile::UserAgentDatabase,
 };
-use serde::Serialize;
-use serde_json::json;
-use std::{convert::Infallible, time::Duration};
-use tokio::net::TcpStream;
 #[cfg(any(feature = "rustls", feature = "boring"))]
 use crate::{
     net::fingerprint::{Ja3, Ja4},
@@ -49,6 +45,10 @@ use crate::{
     tls::std::server::TlsAcceptorLayer,
     tls::types::{SecureTransport, client::ClientHelloExtension},
 };
+use serde::Serialize;
+use serde_json::json;
+use std::{convert::Infallible, time::Duration};
+use tokio::net::TcpStream;
 
 #[derive(Debug, Clone)]
 /// Builder that can be used to run your own echo [`Service`],
@@ -307,23 +307,30 @@ where
     }
 
     /// build an http service ready to echo http traffic back
-    pub fn build_http(&self) -> impl Service<(), Request, Response: IntoResponse, Error = Infallible> + use<H> {
+    pub fn build_http(
+        &self,
+    ) -> impl Service<(), Request, Response: IntoResponse, Error = Infallible> + use<H> {
         let http_forwarded_layer = match &self.forward {
             None => None,
-            Some(ForwardKind::Forwarded) =>
-                Some(Either7::A(GetForwardedHeadersLayer::forwarded())),
-            Some(ForwardKind::XForwardedFor) =>
-                Some(Either7::B(GetForwardedHeadersLayer::x_forwarded_for())),
-            Some(ForwardKind::XClientIp) =>
-                Some(Either7::C(GetForwardedHeadersLayer::<XClientIp>::new())),
-            Some(ForwardKind::ClientIp) =>
-                Some(Either7::D(GetForwardedHeadersLayer::<ClientIp>::new())),
-            Some(ForwardKind::XRealIp) =>
-                Some(Either7::E(GetForwardedHeadersLayer::<XRealIp>::new())),
-            Some(ForwardKind::CFConnectingIp) =>
-                Some(Either7::F(GetForwardedHeadersLayer::<CFConnectingIp>::new())),
-            Some(ForwardKind::TrueClientIp) =>
-                Some(Either7::G(GetForwardedHeadersLayer::<TrueClientIp>::new())),
+            Some(ForwardKind::Forwarded) => Some(Either7::A(GetForwardedHeadersLayer::forwarded())),
+            Some(ForwardKind::XForwardedFor) => {
+                Some(Either7::B(GetForwardedHeadersLayer::x_forwarded_for()))
+            }
+            Some(ForwardKind::XClientIp) => {
+                Some(Either7::C(GetForwardedHeadersLayer::<XClientIp>::new()))
+            }
+            Some(ForwardKind::ClientIp) => {
+                Some(Either7::D(GetForwardedHeadersLayer::<ClientIp>::new()))
+            }
+            Some(ForwardKind::XRealIp) => {
+                Some(Either7::E(GetForwardedHeadersLayer::<XRealIp>::new()))
+            }
+            Some(ForwardKind::CFConnectingIp) => {
+                Some(Either7::F(GetForwardedHeadersLayer::<CFConnectingIp>::new()))
+            }
+            Some(ForwardKind::TrueClientIp) => {
+                Some(Either7::G(GetForwardedHeadersLayer::<TrueClientIp>::new()))
+            }
             Some(ForwardKind::HaProxy) => None,
         };
 
@@ -334,10 +341,9 @@ where
             ConsumeErrLayer::default(),
             http_forwarded_layer,
         )
-            .into_layer(
-                self.http_service_builder
-                    .layer(EchoService { uadb: self.uadb.clone() }),
-            )
+            .into_layer(self.http_service_builder.layer(EchoService {
+                uadb: self.uadb.clone(),
+            }))
     }
 }
 

--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -274,9 +274,9 @@ where
         };
 
         #[cfg(any(feature = "rustls", feature = "boring"))]
-        let tls_acceptor_data = match self.tls_server_config {
+        let tls_acceptor_data = match &self.tls_server_config {
             None => None,
-            Some(cfg) => Some(cfg.try_into()?),
+            Some(cfg) => Some(cfg.clone().try_into()?),
         };
 
         let tcp_service_builder = (
@@ -307,7 +307,7 @@ where
     }
 
     /// build an http service ready to echo http traffic back
-    pub fn build_http(&self) -> impl Service<(), Request, Response = impl IntoResponse, Error = Infallible> {
+    pub fn build_http(&self) -> impl Service<(), Request, Response: IntoResponse, Error = Infallible> + use<H> {
         let http_forwarded_layer = match &self.forward {
             None => None,
             Some(ForwardKind::Forwarded) =>

--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -273,7 +273,7 @@ where
             _ => None,
         };
 
-let http_service = self.build_http();
+        let http_service = self.build_http();
 
         #[cfg(any(feature = "rustls", feature = "boring"))]
         let tls_acceptor_data = match self.tls_server_config {
@@ -291,7 +291,6 @@ let http_service = self.build_http();
             #[cfg(any(feature = "rustls", feature = "boring"))]
             tls_acceptor_data.map(|data| TlsAcceptorLayer::new(data).with_store_client_hello(true)),
         );
-
 
         let http_transport_service = match self.http_version {
             Some(Version::HTTP_2) => Either3::A(HttpServer::h2(executor).service(http_service)),


### PR DESCRIPTION
By creating a separate function for the HTTP-service-building code of Rama Echo, the echo service can be nested inside of other HTTP servers. Any other solution I could think of (ingress, manually sending a request, ...) would show a different fingerprint and thus defeat its purpose.