### PR TITLE
strip default ports from authority header in h2

### DIFF
--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -244,7 +244,7 @@ fn sanitize_client_req_header<S, B>(
                 // as some reverse proxies such as nginx respond 404 if authority is not an exact match
                 let authority = match request_ctx.is_authority_default_port() {
                     true => request_ctx.authority.host().to_string(),
-                    false => request_ctx.authority.host().to_string(),
+                    false => request_ctx.authority.to_string(),
                 };
 
                 uri_parts.authority = Some(

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -10,7 +10,7 @@ use rama_http_types::{
     header::{CONNECTION, HOST, KEEP_ALIVE, PROXY_CONNECTION, TRANSFER_ENCODING, UPGRADE},
     headers::HeaderMapExt,
 };
-use rama_net::{Protocol, address::ProxyAddress, http::RequestContext};
+use rama_net::{address::ProxyAddress, http::RequestContext};
 use std::fmt;
 use tokio::sync::Mutex;
 
@@ -242,10 +242,9 @@ fn sanitize_client_req_header<S, B>(
 
                 // Default port is stripped in browsers. It's important that we also do this
                 // as some reverse proxies such as nginx respond 404 if authority is not an exact match
-                let authority = match (&request_ctx.protocol, request_ctx.authority.port()) {
-                    (&Protocol::HTTP, 80) => request_ctx.authority.host().to_string(),
-                    (&Protocol::HTTPS, 443) => request_ctx.authority.host().to_string(),
-                    (_, _) => request_ctx.authority.to_string(),
+                let authority = match request_ctx.is_authority_default_port() {
+                    true => request_ctx.authority.host().to_string(),
+                    false => request_ctx.authority.host().to_string(),
                 };
 
                 uri_parts.authority = Some(

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -242,9 +242,10 @@ fn sanitize_client_req_header<S, B>(
 
                 // Default port is stripped in browsers. It's important that we also do this
                 // as some reverse proxies such as nginx respond 404 if authority is not an exact match
-                let authority = match request_ctx.is_authority_default_port() {
-                    true => request_ctx.authority.host().to_string(),
-                    false => request_ctx.authority.to_string(),
+                let authority = if request_ctx.authority_has_default_port() {
+                    request_ctx.authority.host().to_string()
+                } else {
+                    request_ctx.authority.to_string()
                 };
 
                 uri_parts.authority = Some(

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -43,8 +43,7 @@ impl TryFrom<&str> for ProxyAddress {
                                 h,
                                 protocol
                                     .as_ref()
-                                    .map(|proto| proto.default_port())
-                                    .flatten()
+                                    .and_then(|proto| proto.default_port())
                                     .unwrap_or(80),
                             )
                                 .into()
@@ -68,8 +67,7 @@ impl TryFrom<&str> for ProxyAddress {
                         h,
                         protocol
                             .as_ref()
-                            .map(|proto| proto.default_port())
-                            .flatten()
+                            .and_then(|proto| proto.default_port())
                             .unwrap_or(80),
                     )
                         .into()

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -41,7 +41,11 @@ impl TryFrom<&str> for ProxyAddress {
                         Host::try_from(&slice[i + 1..]).map(|h| {
                             (
                                 h,
-                                protocol.as_ref().unwrap_or(&Protocol::HTTP).default_port(),
+                                protocol
+                                    .as_ref()
+                                    .map(|proto| proto.default_port())
+                                    .flatten()
+                                    .unwrap_or(80),
                             )
                                 .into()
                         })
@@ -62,7 +66,11 @@ impl TryFrom<&str> for ProxyAddress {
                 Host::try_from(slice).map(|h| {
                     (
                         h,
-                        protocol.as_ref().unwrap_or(&Protocol::HTTP).default_port(),
+                        protocol
+                            .as_ref()
+                            .map(|proto| proto.default_port())
+                            .flatten()
+                            .unwrap_or(80),
                     )
                         .into()
                 })

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -54,7 +54,7 @@ pub struct RequestContext {
 
 impl RequestContext {
     /// Check if [`Authority`] is using the default port for the [`Protocol`] set in this [`RequestContext`]
-    pub fn is_authority_default_port(&self) -> bool {
+    pub fn authority_has_default_port(&self) -> bool {
         self.protocol.default_port() == Some(self.authority.port())
     }
 }

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -207,14 +207,13 @@ impl Protocol {
         }
     }
 
-    /// Return a port that can be used as default in case no port is defined.
-    ///
-    /// NOTE that this is not going to be valid for non-http ports.
-    pub fn default_port(&self) -> u16 {
+    /// Returns the default port for this [`Protocol`]
+    pub fn default_port(&self) -> Option<u16> {
         match &self.0 {
-            ProtocolKind::Https | ProtocolKind::Wss => 443,
-            ProtocolKind::Http | ProtocolKind::Ws => 80,
-            ProtocolKind::Socks5 | ProtocolKind::Socks5h | ProtocolKind::Custom(_) => 80, // \_(ツ)_/¯
+            ProtocolKind::Https | ProtocolKind::Wss => Some(443),
+            ProtocolKind::Http | ProtocolKind::Ws => Some(80),
+            ProtocolKind::Socks5 | ProtocolKind::Socks5h => Some(1080),
+            ProtocolKind::Custom(_) => None,
         }
     }
 

--- a/rama-ua/src/emulate/service.rs
+++ b/rama-ua/src/emulate/service.rs
@@ -789,9 +789,12 @@ fn compute_sec_fetch_site_value(
                     let referer_protocol =
                         Protocol::maybe_from_uri_scheme_str_and_method(uri.scheme(), method);
 
-                    let default_port = uri
-                        .port_u16()
-                        .or_else(|| referer_protocol.as_ref().map(|p| p.default_port()));
+                    let default_port = uri.port_u16().or_else(|| {
+                        referer_protocol
+                            .as_ref()
+                            .map(|p| p.default_port())
+                            .flatten()
+                    });
 
                     let maybe_authority = uri
                         .host()
@@ -903,7 +906,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -920,7 +923,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -937,7 +940,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -951,7 +954,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -965,7 +968,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -990,7 +993,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -1015,7 +1018,7 @@ mod tests {
                 preserve_ua_header: true,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -1041,7 +1044,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -1074,7 +1077,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("ramaproxy.org").unwrap(),
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: None,
@@ -1111,7 +1114,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::EXAMPLE_NAME,
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: None,
@@ -1150,7 +1153,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("ramaproxy.org").unwrap(),
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: None,
@@ -1207,7 +1210,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("www.google.com").unwrap(),
-                    Protocol::HTTP.default_port(),
+                    Protocol::HTTP.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTP,
                 requested_client_hints: None,
@@ -1277,7 +1280,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("www.google.com").unwrap(),
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: None,
@@ -1327,7 +1330,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("www.google.com").unwrap(),
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: None,
@@ -1400,7 +1403,7 @@ mod tests {
                 preserve_ua_header: false,
                 request_authority: Authority::new(
                     Host::from_str("www.google.com").unwrap(),
-                    Protocol::HTTPS.default_port(),
+                    Protocol::HTTPS.default_port().unwrap(),
                 ),
                 protocol: Protocol::HTTPS,
                 requested_client_hints: Some(vec![

--- a/rama-ua/src/emulate/service.rs
+++ b/rama-ua/src/emulate/service.rs
@@ -789,12 +789,9 @@ fn compute_sec_fetch_site_value(
                     let referer_protocol =
                         Protocol::maybe_from_uri_scheme_str_and_method(uri.scheme(), method);
 
-                    let default_port = uri.port_u16().or_else(|| {
-                        referer_protocol
-                            .as_ref()
-                            .map(|p| p.default_port())
-                            .flatten()
-                    });
+                    let default_port = uri
+                        .port_u16()
+                        .or_else(|| referer_protocol.as_ref().and_then(|p| p.default_port()));
 
                     let maybe_authority = uri
                         .host()


### PR DESCRIPTION
Browsers by default strip port from authority header if port is the default port for that specific protocol.
Some reverse proxies (eg nginx with some configs) do exact matches on authority header and return 404, if it doesn't match. Meaning authority header `example.com:443` will be seen as invalid and only `example.com` will be accepted.
