### PR TITLE
cli: add serve command

### DIFF
--- a/docs/book/src/deploy/rama-cli.md
+++ b/docs/book/src/deploy/rama-cli.md
@@ -20,6 +20,7 @@ Commands:
   echo   rama echo service (echos the http request and tls client config)
   ip     rama ip service (returns the ip address of the client)
   fp     rama fp service (used for FP collection in purpose of UA emulation)
+  serve  rama serve service (serves a file, directory or placeholder page)
   help   Print this message or the help of the given subcommand(s)
 
 Options:

--- a/rama-cli/src/cmd/mod.rs
+++ b/rama-cli/src/cmd/mod.rs
@@ -5,4 +5,5 @@ pub mod fp;
 pub mod http;
 pub mod ip;
 pub mod proxy;
+pub mod serve;
 pub mod tls;

--- a/rama-cli/src/cmd/proxy/mod.rs
+++ b/rama-cli/src/cmd/proxy/mod.rs
@@ -3,7 +3,7 @@
 use clap::Args;
 use rama::{
     Context, Layer, Service,
-    error::BoxError,
+    error::{BoxError, ErrorContext, OpaqueError},
     http::{
         Body, IntoResponse, Request, Response, StatusCode,
         client::EasyHttpWebClient,
@@ -58,13 +58,13 @@ pub async fn run(cfg: CliCommandProxy) -> Result<(), BoxError> {
     let graceful = rama::graceful::Shutdown::default();
 
     tracing::info!("starting proxy on: {}", cfg.bind);
+    let tcp_service = TcpListener::build()
+        .bind(cfg.bind)
+        .await
+        .map_err(OpaqueError::from_boxed)
+        .context("bind proxy service")?;
 
     graceful.spawn_task_fn(async move |guard| {
-        let tcp_service = TcpListener::build()
-            .bind(cfg.bind)
-            .await
-            .expect("bind proxy to 127.0.0.1:62001");
-
         let exec = Executor::graceful(guard.clone());
         let http_service = HttpServer::auto(exec).service(
             (

--- a/rama-cli/src/cmd/serve/mod.rs
+++ b/rama-cli/src/cmd/serve/mod.rs
@@ -1,4 +1,4 @@
-//! Serve service that serves a file, directory or placeholder page
+//! Serve service that serves a file, directory or placeholder page.
 
 use clap::Args;
 use rama::{

--- a/rama-cli/src/cmd/serve/mod.rs
+++ b/rama-cli/src/cmd/serve/mod.rs
@@ -1,0 +1,179 @@
+//! Serve service that serves a file, directory or placeholder page
+
+use clap::Args;
+use rama::{
+    Service,
+    cli::{ForwardKind, service::serve::ServeServiceBuilder},
+    error::BoxError,
+    http::{IntoResponse, Request, Response, matcher::HttpMatcher},
+    layer::HijackLayer,
+    net::tls::{
+        ApplicationProtocol, DataEncoding,
+        server::{SelfSignedData, ServerAuth, ServerAuthData, ServerConfig},
+    },
+    rt::Executor,
+    tcp::server::TcpListener,
+};
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as ENGINE;
+
+use std::{convert::Infallible, time::Duration};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[derive(Debug, Args)]
+/// rama serve service (serves a file, directory or placeholder page)
+pub struct CliCommandServe {
+    #[arg(short = 'p', long, default_value_t = 8080)]
+    /// the port to listen on
+    port: u16,
+
+    #[arg(short = 'i', long, default_value = "127.0.0.1")]
+    /// the interface to listen on
+    interface: String,
+
+    #[arg(short = 'c', long, default_value_t = 0)]
+    /// the number of concurrent connections to allow
+    ///
+    /// (0 = no limit)
+    concurrent: usize,
+
+    #[arg(short = 't', long, default_value_t = 8)]
+    /// the timeout in seconds for each connection
+    ///
+    /// (0 = no timeout)
+    timeout: u64,
+
+    #[arg(long, short = 'f')]
+    /// enable support for one of the following "forward" headers or protocols
+    ///
+    /// Supported headers:
+    ///
+    /// Forwarded ("for="), X-Forwarded-For
+    ///
+    /// X-Client-IP Client-IP, X-Real-IP
+    ///
+    /// CF-Connecting-IP, True-Client-IP
+    ///
+    /// Or using HaProxy protocol.
+    forward: Option<ForwardKind>,
+
+    #[arg(long, short = 's')]
+    /// run serve service in secure mode (enable TLS)
+    secure: bool,
+}
+
+/// run the rama serve service
+pub async fn run(cfg: CliCommandServe) -> Result<(), BoxError> {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let maybe_tls_server_config = cfg.secure.then(|| {
+        let tls_key_pem_raw = match std::env::var("RAMA_TLS_KEY") {
+            Ok(raw) => raw,
+            Err(_) => {
+                return ServerConfig {
+                    application_layer_protocol_negotiation: Some(vec![
+                        ApplicationProtocol::HTTP_2,
+                        ApplicationProtocol::HTTP_11,
+                    ]),
+                    ..ServerConfig::new(ServerAuth::SelfSigned(SelfSignedData::default()))
+                };
+            }
+        };
+        let tls_key_pem_raw = std::str::from_utf8(
+            &ENGINE
+                .decode(tls_key_pem_raw)
+                .expect("base64 decode RAMA_TLS_KEY")[..],
+        )
+        .expect("base64-decoded RAMA_TLS_KEY valid utf-8")
+        .try_into()
+        .expect("tls_key_pem_raw => NonEmptyStr (RAMA_TLS_KEY)");
+        let tls_crt_pem_raw = std::env::var("RAMA_TLS_CRT").expect("RAMA_TLS_CRT");
+        let tls_crt_pem_raw = std::str::from_utf8(
+            &ENGINE
+                .decode(tls_crt_pem_raw)
+                .expect("base64 decode RAMA_TLS_CRT")[..],
+        )
+        .expect("base64-decoded RAMA_TLS_CRT valid utf-8")
+        .try_into()
+        .expect("tls_crt_pem_raw => NonEmptyStr (RAMA_TLS_CRT)");
+        ServerConfig {
+            application_layer_protocol_negotiation: Some(vec![
+                ApplicationProtocol::HTTP_2,
+                ApplicationProtocol::HTTP_11,
+            ]),
+            ..ServerConfig::new(ServerAuth::Single(ServerAuthData {
+                private_key: DataEncoding::Pem(tls_key_pem_raw),
+                cert_chain: DataEncoding::Pem(tls_crt_pem_raw),
+                ocsp: None,
+            }))
+        }
+    });
+
+    let maybe_acme_service = std::env::var("RAMA_ACME_DATA")
+        .map(|data| {
+            let mut iter = data.trim().splitn(2, ',');
+            let key = iter.next().expect("acme data key");
+            let value = iter.next().expect("acme data value");
+
+            HijackLayer::new(
+                HttpMatcher::path(format!("/.well-known/acme-challenge/{key}")),
+                AcmeService(value.to_owned()),
+            )
+        })
+        .ok();
+
+    let graceful = rama::graceful::Shutdown::default();
+
+    let tcp_service = ServeServiceBuilder::new()
+        .concurrent(cfg.concurrent)
+        .timeout(Duration::from_secs(cfg.timeout))
+        .maybe_forward(cfg.forward)
+        .maybe_tls_server_config(maybe_tls_server_config)
+        .http_layer(maybe_acme_service)
+        .build(Executor::graceful(graceful.guard()))
+        .expect("build serve service");
+
+    let address = format!("{}:{}", cfg.interface, cfg.port);
+    tracing::info!("starting serve service on: {}", address);
+
+    graceful.spawn_task_fn(async move |guard| {
+        let tcp_listener = TcpListener::build()
+            .bind(address)
+            .await
+            .expect("bind serve service");
+
+        tracing::info!("serve service ready");
+        tcp_listener.serve_graceful(guard, tcp_service).await;
+    });
+
+    graceful
+        .shutdown_with_limit(Duration::from_secs(30))
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct AcmeService(String);
+
+impl Service<(), Request> for AcmeService {
+    type Response = Response;
+    type Error = Infallible;
+
+    async fn serve(
+        &self,
+        _ctx: rama::Context<()>,
+        _req: Request,
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(self.0.clone().into_response())
+    }
+}

--- a/rama-cli/src/cmd/serve/mod.rs
+++ b/rama-cli/src/cmd/serve/mod.rs
@@ -145,17 +145,13 @@ pub async fn run(cfg: CliCommandServe) -> Result<(), BoxError> {
         .maybe_tls_server_config(maybe_tls_server_config)
         .http_layer(maybe_acme_service)
         .maybe_content_path(cfg.path)
-        .build(Executor::graceful(graceful.guard()))
-        .expect("build serve service");
+        .build(Executor::graceful(graceful.guard()))?;
 
     tracing::info!("starting serve service on: {}", cfg.bind);
 
-    graceful.spawn_task_fn(async move |guard| {
-        let tcp_listener = TcpListener::build()
-            .bind(cfg.bind)
-            .await
-            .expect("bind serve service");
+    let tcp_listener = TcpListener::build().bind(cfg.bind).await?;
 
+    graceful.spawn_task_fn(async move |guard| {
         tracing::info!("serve service ready");
         tcp_listener.serve_graceful(guard, tcp_service).await;
     });

--- a/rama-cli/src/cmd/serve/mod.rs
+++ b/rama-cli/src/cmd/serve/mod.rs
@@ -18,13 +18,19 @@ use rama::{
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as ENGINE;
 
-use std::{convert::Infallible, time::Duration};
+use std::{convert::Infallible, path::PathBuf, time::Duration};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, Args)]
 /// rama serve service (serves a file, directory or placeholder page)
 pub struct CliCommandServe {
+    /// The path to the file or directory to serve
+    ///
+    /// If not provided, a placeholder page will be served.
+    #[arg()]
+    path: Option<PathBuf>,
+
     #[arg(short = 'p', long, default_value_t = 8080)]
     /// the port to listen on
     port: u16,
@@ -139,6 +145,7 @@ pub async fn run(cfg: CliCommandServe) -> Result<(), BoxError> {
         .maybe_forward(cfg.forward)
         .maybe_tls_server_config(maybe_tls_server_config)
         .http_layer(maybe_acme_service)
+        .maybe_content_path(cfg.path)
         .build(Executor::graceful(graceful.guard()))
         .expect("build serve service");
 

--- a/rama-cli/src/main.rs
+++ b/rama-cli/src/main.rs
@@ -8,7 +8,7 @@ use clap::{Parser, Subcommand};
 use rama::error::BoxError;
 
 pub mod cmd;
-use cmd::{echo, fp, http, ip, proxy, tls};
+use cmd::{echo, fp, http, ip, proxy, serve, tls};
 
 pub mod error;
 
@@ -38,6 +38,7 @@ enum CliCommands {
     Echo(echo::CliCommandEcho),
     Ip(ip::CliCommandIp),
     Fp(fp::CliCommandFingerprint),
+    Serve(serve::CliCommandServe),
 }
 
 #[tokio::main]
@@ -52,6 +53,7 @@ async fn main() -> Result<(), BoxError> {
         CliCommands::Echo(cfg) => echo::run(cfg).await,
         CliCommands::Ip(cfg) => ip::run(cfg).await,
         CliCommands::Fp(cfg) => fp::run(cfg).await,
+        CliCommands::Serve(cfg) => serve::run(cfg).await,
     } {
         Ok(()) => Ok(()),
         Err(err) => {

--- a/rama-fp/infra/deployments/echo/fly.toml
+++ b/rama-fp/infra/deployments/echo/fly.toml
@@ -7,8 +7,8 @@ app = 'rama-echo'
 primary_region = 'lhr'
 
 [processes]
-app_secure = "echo -i 0.0.0.0 -p 8443 -c 2048 -t 16 -f haproxy -s"
-app_insecure = "echo -i 0.0.0.0 -p 8080 -c 2048 -t 16 -f haproxy"
+app_secure = "echo --bind 0.0.0.0:8443 -c 2048 -t 16 -f haproxy -s"
+app_insecure = "echo --bind 0.0.0.0:8080 -c 2048 -t 16 -f haproxy"
 
 [build]
 image = 'glendc/rama:latest'

--- a/rama-fp/infra/deployments/fp-h1/fly.toml
+++ b/rama-fp/infra/deployments/fp-h1/fly.toml
@@ -2,8 +2,8 @@ app = 'rama-fp-h1'
 primary_region = 'lhr'
 
 [processes]
-app_secure = "fp -i 0.0.0.0 -p 8443 -c 2048 -t 16 -f haproxy --http-version h1 -s"
-app_insecure = "fp -i 0.0.0.0 -p 8080 -c 2048 -t 16 -f haproxy --http-version h1"
+app_secure = "fp --bind 0.0.0.0:8443 -c 2048 -t 16 -f haproxy --http-version h1 -s"
+app_insecure = "fp --bind 0.0.0.0:8080 -c 2048 -t 16 -f haproxy --http-version h1"
 
 [build]
 image = "glendc/rama:latest"

--- a/rama-fp/infra/deployments/fp/fly.toml
+++ b/rama-fp/infra/deployments/fp/fly.toml
@@ -2,8 +2,8 @@ app = 'rama-fp'
 primary_region = 'lhr'
 
 [processes]
-app_secure = "fp -i 0.0.0.0 -p 8443 -c 2048 -t 16 -f haproxy --http-version auto -s"
-app_insecure = "fp -i 0.0.0.0 -p 8080 -c 2048 -t 16 -f haproxy --http-version auto"
+app_secure = "fp --bind 0.0.0.0:8443 -c 2048 -t 16 -f haproxy --http-version auto -s"
+app_insecure = "fp --bind 0.0.0.0:8080 -c 2048 -t 16 -f haproxy --http-version auto"
 
 [build]
 image = "glendc/rama:latest"

--- a/rama-http/src/service/web/endpoint/mod.rs
+++ b/rama-http/src/service/web/endpoint/mod.rs
@@ -45,6 +45,16 @@ where
 /// A static [`Service`] that serves a pre-defined response.
 pub struct StaticService<R>(R);
 
+impl<R> StaticService<R>
+where
+    R: IntoResponse + Clone + Send + Sync + 'static,
+{
+    /// Create a new [`StaticService`] with the given response.
+    pub fn new(response: R) -> Self {
+        Self(response)
+    }
+}
+
 impl<T> fmt::Debug for StaticService<T>
 where
     T: fmt::Debug,

--- a/rama-http/src/service/web/endpoint/mod.rs
+++ b/rama-http/src/service/web/endpoint/mod.rs
@@ -42,7 +42,8 @@ where
     }
 }
 
-struct StaticService<R>(R);
+/// A static [`Service`] that serves a pre-defined response.
+pub struct StaticService<R>(R);
 
 impl<T> fmt::Debug for StaticService<T>
 where

--- a/rama-http/src/service/web/mod.rs
+++ b/rama-http/src/service/web/mod.rs
@@ -6,7 +6,7 @@ pub use service::{WebService, match_service};
 
 mod endpoint;
 #[doc(inline)]
-pub use endpoint::{EndpointServiceFn, IntoEndpointService, extract};
+pub use endpoint::{EndpointServiceFn, IntoEndpointService, StaticService, extract};
 
 pub mod k8s;
 #[doc(inline)]

--- a/src/cli/service/mod.rs
+++ b/src/cli/service/mod.rs
@@ -7,3 +7,4 @@
 
 pub mod echo;
 pub mod ip;
+pub mod serve;

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -247,10 +247,9 @@ impl<H> ServeServiceBuilder<H>
 where
     H: Layer<ServeService, Service: Service<(), Request, Response = Response, Error = BoxError>>,
 {
-    #[allow(unused_mut)]
     /// build a tcp service ready to serve files
     pub fn build(
-        mut self,
+        self,
         executor: Executor,
     ) -> Result<impl Service<(), TcpStream, Response = (), Error = Infallible>, BoxError> {
         let tcp_forwarded_layer = match &self.forward {

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -227,8 +227,8 @@ impl<H> ServeServiceBuilder<H> {
         }
     }
 
-    pub fn content_path(mut self, path: PathBuf) -> Self {
-        self.content_path = Some(path);
+    pub fn content_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.content_path = Some(path.into());
         self
     }
 
@@ -237,8 +237,8 @@ impl<H> ServeServiceBuilder<H> {
         self
     }
 
-    pub fn set_content_path(&mut self, path: PathBuf) -> &mut Self {
-        self.content_path = Some(path);
+    pub fn set_content_path(&mut self, path: impl Into<PathBuf>) -> &mut Self {
+        self.content_path = Some(path.into());
         self
     }
 }

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -332,19 +332,3 @@ impl Service<(), Request> for ServeService {
         Ok(Html(include_str!("../../../docs/index.html")).into_response())
     }
 }
-
-pub mod mode {
-    //! operation modes of the serve service
-
-    #[derive(Debug, Clone)]
-    #[non_exhaustive]
-    pub struct Placheholder;
-
-    #[derive(Debug, Clone)]
-    #[non_exhaustive]
-    pub struct File;
-
-    #[derive(Debug, Clone)]
-    #[non_exhaustive]
-    pub struct Dir;
-}

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -329,15 +329,15 @@ where
             }
         };
 
-        let serve_service = match self.content_path {
+        let serve_service = match &self.content_path {
             None => Either3::A(
                 Html(include_str!("../../../docs/index.html"))
                     .into_endpoint_service()
                     .boxed(),
             ),
-            Some(ref path) if path.is_file() => Either3::B(ServeFile::new(path.clone())),
-            Some(ref path) if path.is_dir() => Either3::C(ServeDir::new(path)),
-            Some(ref path) => {
+            Some(path) if path.is_file() => Either3::B(ServeFile::new(path.clone())),
+            Some(path) if path.is_dir() => Either3::C(ServeDir::new(path)),
+            Some(path) => {
                 return Err(OpaqueError::from_display(format!(
                     "invalid path {path:?}: no such file or directory"
                 ))

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -1,7 +1,4 @@
-//! Serve '[`Service`] that serves a file or directory using [`ServeDir`], or a placeholder page.
-//!
-//! [`Service`]: crate::Service
-//! [`ServeDir`]: crate::ServeDir
+//! Serve '[`Service`] that serves a file or directory using [`ServeFile`] or [`ServeDir`], or a placeholder page.
 
 use crate::{
     Layer, Service,

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -332,3 +332,19 @@ impl Service<(), Request> for ServeService {
         Ok(Html(include_str!("../../../docs/index.html")).into_response())
     }
 }
+
+pub mod mode {
+    //! operation modes of the serve service
+
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub struct Placheholder;
+
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub struct File;
+
+    #[derive(Debug, Clone)]
+    #[non_exhaustive]
+    pub struct Dir;
+}

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -12,19 +12,17 @@ use crate::{
             forwarded::GetForwardedHeadersLayer, required_header::AddRequiredResponseHeadersLayer,
             trace::TraceLayer, ua::UserAgentClassifierLayer,
         },
+        response::Html,
         server::HttpServer,
+        service::{
+            fs::{ServeDir, ServeFile},
+            web::StaticService,
+        },
     },
     layer::{ConsumeErrLayer, LimitLayer, TimeoutLayer, limit::policy::ConcurrentPolicy},
     net::stream::layer::http::BodyLimitLayer,
     proxy::haproxy::server::HaProxyLayer,
     rt::Executor,
-};
-use rama_http::{
-    response::Html,
-    service::{
-        fs::{ServeDir, ServeFile},
-        web::StaticService,
-    },
 };
 
 use std::{convert::Infallible, path::PathBuf, time::Duration};

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -19,12 +19,11 @@ use crate::{
     proxy::haproxy::server::HaProxyLayer,
     rt::Executor,
 };
-use rama_core::service::BoxService;
 use rama_http::{
     response::Html,
     service::{
         fs::{ServeDir, ServeFile},
-        web::IntoEndpointService,
+        web::StaticService,
     },
 };
 
@@ -330,11 +329,9 @@ where
         };
 
         let serve_service = match &self.content_path {
-            None => Either3::A(
-                Html(include_str!("../../../docs/index.html"))
-                    .into_endpoint_service()
-                    .boxed(),
-            ),
+            None => Either3::A(StaticService::new(Html(include_str!(
+                "../../../docs/index.html"
+            )))),
             Some(path) if path.is_file() => Either3::B(ServeFile::new(path.clone())),
             Some(path) if path.is_dir() => Either3::C(ServeDir::new(path)),
             Some(path) => {
@@ -358,5 +355,5 @@ where
     }
 }
 
-type ServeStaticHtml = BoxService<(), Request, Response, Infallible>;
+type ServeStaticHtml = StaticService<Html<&'static str>>;
 type ServeService = Either3<ServeStaticHtml, ServeFile, ServeDir>;

--- a/src/cli/service/serve.rs
+++ b/src/cli/service/serve.rs
@@ -1,0 +1,334 @@
+//! Serve '[`Service`] that serves a file or directory using [`ServeDir`], or a placeholder page.
+//!
+//! [`Service`]: crate::Service
+//! [`ServeDir`]: crate::ServeDir
+
+use crate::{
+    Context, Layer, Service,
+    cli::ForwardKind,
+    combinators::{Either3, Either7},
+    error::{BoxError, OpaqueError},
+    http::{
+        IntoResponse, Request, Response, Version,
+        headers::{CFConnectingIp, ClientIp, TrueClientIp, XClientIp, XRealIp},
+        layer::{
+            forwarded::GetForwardedHeadersLayer, required_header::AddRequiredResponseHeadersLayer,
+            trace::TraceLayer, ua::UserAgentClassifierLayer,
+        },
+        server::HttpServer,
+    },
+    layer::{ConsumeErrLayer, LimitLayer, TimeoutLayer, limit::policy::ConcurrentPolicy},
+    net::stream::layer::http::BodyLimitLayer,
+    proxy::haproxy::server::HaProxyLayer,
+    rt::Executor,
+};
+use rama_http::response::Html;
+// TODO(kornelijus): serve file or directory
+// use rama_http::service::fs::ServeDir;
+use std::{convert::Infallible, time::Duration};
+use tokio::net::TcpStream;
+
+#[cfg(feature = "boring")]
+use crate::{
+    net::tls::server::ServerConfig,
+    tls::boring::server::{TlsAcceptorData, TlsAcceptorLayer},
+};
+
+#[cfg(all(feature = "rustls", not(feature = "boring")))]
+use crate::tls::rustls::server::{TlsAcceptorData, TlsAcceptorLayer};
+
+#[cfg(feature = "boring")]
+type TlsConfig = ServerConfig;
+
+#[cfg(all(feature = "rustls", not(feature = "boring")))]
+type TlsConfig = TlsAcceptorData;
+
+#[derive(Debug, Clone)]
+/// Builder that can be used to run your own serve [`Service`],
+/// serving a file or directory, or a placeholder page.
+pub struct ServeServiceBuilder<H> {
+    concurrent_limit: usize,
+    body_limit: usize,
+    timeout: Duration,
+    forward: Option<ForwardKind>,
+
+    #[cfg(any(feature = "rustls", feature = "boring"))]
+    tls_server_config: Option<TlsConfig>,
+
+    http_version: Option<Version>,
+
+    http_service_builder: H,
+}
+
+impl Default for ServeServiceBuilder<()> {
+    fn default() -> Self {
+        Self {
+            concurrent_limit: 0,
+            body_limit: 1024 * 1024,
+            timeout: Duration::ZERO,
+            forward: None,
+
+            #[cfg(any(feature = "rustls", feature = "boring"))]
+            tls_server_config: None,
+
+            http_version: None,
+
+            http_service_builder: (),
+        }
+    }
+}
+
+impl ServeServiceBuilder<()> {
+    /// Create a new [`ServeServiceBuilder`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<H> ServeServiceBuilder<H> {
+    /// set the number of concurrent connections to allow
+    ///
+    /// (0 = no limit)
+    pub fn concurrent(mut self, limit: usize) -> Self {
+        self.concurrent_limit = limit;
+        self
+    }
+
+    /// set the number of concurrent connections to allow
+    ///
+    /// (0 = no limit)
+    pub fn set_concurrent(&mut self, limit: usize) -> &mut Self {
+        self.concurrent_limit = limit;
+        self
+    }
+
+    /// set the body limit in bytes for each request
+    pub fn body_limit(mut self, limit: usize) -> Self {
+        self.body_limit = limit;
+        self
+    }
+
+    /// set the body limit in bytes for each request
+    pub fn set_body_limit(&mut self, limit: usize) -> &mut Self {
+        self.body_limit = limit;
+        self
+    }
+
+    /// set the timeout in seconds for each connection
+    ///
+    /// (0 = no timeout)
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// set the timeout in seconds for each connection
+    ///
+    /// (0 = no timeout)
+    pub fn set_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// enable support for one of the following "forward" headers or protocols
+    ///
+    /// Supported headers:
+    ///
+    /// Forwarded ("for="), X-Forwarded-For
+    ///
+    /// X-Client-IP Client-IP, X-Real-IP
+    ///
+    /// CF-Connecting-IP, True-Client-IP
+    ///
+    /// Or using HaProxy protocol.
+    pub fn forward(self, kind: ForwardKind) -> Self {
+        self.maybe_forward(Some(kind))
+    }
+
+    /// enable support for one of the following "forward" headers or protocols
+    ///
+    /// Same as [`Self::forward`] but without consuming `self`.
+    pub fn set_forward(&mut self, kind: ForwardKind) -> &mut Self {
+        self.forward = Some(kind);
+        self
+    }
+
+    /// maybe enable support for one of the following "forward" headers or protocols.
+    ///
+    /// See [`Self::forward`] for more information.
+    pub fn maybe_forward(mut self, maybe_kind: Option<ForwardKind>) -> Self {
+        self.forward = maybe_kind;
+        self
+    }
+
+    #[cfg(any(feature = "rustls", feature = "boring"))]
+    /// define a tls server cert config to be used for tls terminaton
+    /// by the serve service.
+    pub fn tls_server_config(mut self, cfg: TlsConfig) -> Self {
+        self.tls_server_config = Some(cfg);
+        self
+    }
+
+    #[cfg(any(feature = "rustls", feature = "boring"))]
+    /// define a tls server cert config to be used for tls terminaton
+    /// by the serve service.
+    pub fn set_tls_server_config(&mut self, cfg: TlsConfig) -> &mut Self {
+        self.tls_server_config = Some(cfg);
+        self
+    }
+
+    #[cfg(any(feature = "rustls", feature = "boring"))]
+    /// define a tls server cert config to be used for tls terminaton
+    /// by the serve service.
+    pub fn maybe_tls_server_config(mut self, cfg: Option<TlsConfig>) -> Self {
+        self.tls_server_config = cfg;
+        self
+    }
+
+    /// set the http version to use for the http server (auto by default)
+    pub fn http_version(mut self, version: Version) -> Self {
+        self.http_version = Some(version);
+        self
+    }
+
+    /// maybe set the http version to use for the http server (auto by default)
+    pub fn maybe_http_version(mut self, version: Option<Version>) -> Self {
+        self.http_version = version;
+        self
+    }
+
+    /// set the http version to use for the http server (auto by default)
+    pub fn set_http_version(&mut self, version: Version) -> &mut Self {
+        self.http_version = Some(version);
+        self
+    }
+
+    /// add a custom http layer which will be applied to the existing http layers
+    pub fn http_layer<H2>(self, layer: H2) -> ServeServiceBuilder<(H, H2)> {
+        ServeServiceBuilder {
+            concurrent_limit: self.concurrent_limit,
+            body_limit: self.body_limit,
+            timeout: self.timeout,
+            forward: self.forward,
+
+            #[cfg(any(feature = "rustls", feature = "boring"))]
+            tls_server_config: self.tls_server_config,
+
+            http_version: self.http_version,
+
+            http_service_builder: (self.http_service_builder, layer),
+        }
+    }
+}
+
+impl<H> ServeServiceBuilder<H>
+where
+    H: Layer<ServeService, Service: Service<(), Request, Response = Response, Error = BoxError>>,
+{
+    #[allow(unused_mut)]
+    /// build a tcp service ready to serve files
+    pub fn build(
+        mut self,
+        executor: Executor,
+    ) -> Result<impl Service<(), TcpStream, Response = (), Error = Infallible>, BoxError> {
+        let tcp_forwarded_layer = match &self.forward {
+            Some(ForwardKind::HaProxy) => Some(HaProxyLayer::default()),
+            _ => None,
+        };
+
+        let http_service = self.build_http();
+
+        #[cfg(all(feature = "rustls", not(feature = "boring")))]
+        let tls_cfg = self.tls_server_config;
+
+        #[cfg(feature = "boring")]
+        let tls_cfg: Option<TlsAcceptorData> = match self.tls_server_config {
+            Some(cfg) => Some(cfg.try_into()?),
+            None => None,
+        };
+
+        let tcp_service_builder = (
+            ConsumeErrLayer::trace(tracing::Level::DEBUG),
+            (self.concurrent_limit > 0)
+                .then(|| LimitLayer::new(ConcurrentPolicy::max(self.concurrent_limit))),
+            (!self.timeout.is_zero()).then(|| TimeoutLayer::new(self.timeout)),
+            tcp_forwarded_layer,
+            BodyLimitLayer::request_only(self.body_limit),
+            #[cfg(any(feature = "rustls", feature = "boring"))]
+            tls_cfg.map(|cfg| {
+                #[cfg(feature = "boring")]
+                return TlsAcceptorLayer::new(cfg).with_store_client_hello(true);
+                #[cfg(all(feature = "rustls", not(feature = "boring")))]
+                TlsAcceptorLayer::new(cfg).with_store_client_hello(true)
+            }),
+        );
+
+        let http_transport_service = match self.http_version {
+            Some(Version::HTTP_2) => Either3::A(HttpServer::h2(executor).service(http_service)),
+            Some(Version::HTTP_11 | Version::HTTP_10 | Version::HTTP_09) => {
+                Either3::B(HttpServer::http1().service(http_service))
+            }
+            Some(_) => {
+                return Err(OpaqueError::from_display("unsupported http version").into_boxed());
+            }
+            None => Either3::C(HttpServer::auto(executor).service(http_service)),
+        };
+
+        Ok(tcp_service_builder.into_layer(http_transport_service))
+    }
+
+    /// build an http service ready to serve files
+    pub fn build_http(
+        &self,
+    ) -> impl Service<(), Request, Response: IntoResponse, Error = Infallible> + use<H> {
+        let http_forwarded_layer = match &self.forward {
+            None | Some(ForwardKind::HaProxy) => None,
+            Some(ForwardKind::Forwarded) => Some(Either7::A(GetForwardedHeadersLayer::forwarded())),
+            Some(ForwardKind::XForwardedFor) => {
+                Some(Either7::B(GetForwardedHeadersLayer::x_forwarded_for()))
+            }
+            Some(ForwardKind::XClientIp) => {
+                Some(Either7::C(GetForwardedHeadersLayer::<XClientIp>::new()))
+            }
+            Some(ForwardKind::ClientIp) => {
+                Some(Either7::D(GetForwardedHeadersLayer::<ClientIp>::new()))
+            }
+            Some(ForwardKind::XRealIp) => {
+                Some(Either7::E(GetForwardedHeadersLayer::<XRealIp>::new()))
+            }
+            Some(ForwardKind::CFConnectingIp) => {
+                Some(Either7::F(GetForwardedHeadersLayer::<CFConnectingIp>::new()))
+            }
+            Some(ForwardKind::TrueClientIp) => {
+                Some(Either7::G(GetForwardedHeadersLayer::<TrueClientIp>::new()))
+            }
+        };
+
+        (
+            TraceLayer::new_for_http(),
+            AddRequiredResponseHeadersLayer::default(),
+            UserAgentClassifierLayer::new(),
+            ConsumeErrLayer::default(),
+            http_forwarded_layer,
+        )
+            .into_layer(self.http_service_builder.layer(ServeService {}))
+    }
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+/// The inner serve-service used by the [`ServeServiceBuilder`].
+pub struct ServeService {}
+
+impl Service<(), Request> for ServeService {
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        mut ctx: Context<()>,
+        req: Request,
+    ) -> Result<Self::Response, Self::Error> {
+        Ok(Html(include_str!("../../../docs/index.html")).into_response())
+    }
+}

--- a/test-files/hello.txt
+++ b/test-files/hello.txt
@@ -1,0 +1,1 @@
+Hello, World!

--- a/tests/integration/cli/cli_tests/http_serve.rs
+++ b/tests/integration/cli/cli_tests/http_serve.rs
@@ -1,0 +1,112 @@
+use std::path::PathBuf;
+
+use super::utils;
+
+#[tokio::test]
+#[ignore]
+async fn test_http_serve_placeholder() {
+    let _guard = utils::RamaService::serve(63104, None);
+    let lines = utils::RamaService::http(vec!["https://127.0.0.1:63104"]).unwrap();
+
+    assert!(lines.contains("GET /"), "req method, lines: {lines:?}",);
+    assert!(
+        lines.contains("HTTP/2.0 200 OK"),
+        "http res status, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("content-type: text/html"),
+        "res content-type, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains(r##"href="https://github.com/plabayo/rama"##),
+        "res html rama link, lines: {lines:?}",
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_http_serve_file() {
+    let _guard = utils::RamaService::serve(63105, Some(PathBuf::from("test-files/hello.txt")));
+    let lines = utils::RamaService::http(vec!["https://127.0.0.1:63105"]).unwrap();
+
+    assert!(lines.contains("GET /"), "req method, lines: {lines:?}",);
+    assert!(
+        lines.contains("HTTP/2.0 200 OK"),
+        "res status, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("content-type: text/plain"),
+        "res content-type, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("Hello, World!"),
+        "res body, lines: {lines:?}",
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_http_serve_dir() {
+    let _guard = utils::RamaService::serve(63106, Some(PathBuf::from("test-files")));
+    let lines = utils::RamaService::http(vec!["https://127.0.0.1:63106/hello.txt"]).unwrap();
+
+    assert!(
+        lines.contains("GET /hello.txt"),
+        "req method, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("HTTP/2.0 200 OK"),
+        "res status, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("content-type: text/plain"),
+        "res content-type, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("Hello, World!"),
+        "res body, lines: {lines:?}",
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_http_serve_dir_index() {
+    let _guard = utils::RamaService::serve(63107, Some(PathBuf::from("test-files")));
+
+    let cases = vec![
+        "https://127.0.0.1:63107",
+        "https://127.0.0.1:63107/index.html",
+    ];
+
+    for url in cases {
+        let lines = utils::RamaService::http(vec![url]).unwrap();
+        assert!(lines.contains("GET /"), "req method, lines: {lines:?}",);
+        assert!(
+            lines.contains("HTTP/2.0 200 OK"),
+            "res status, lines: {lines:?}",
+        );
+        assert!(
+            lines.contains("content-type: text/html"),
+            "res content-type, lines: {lines:?}",
+        );
+        assert!(
+            lines.contains("<b>HTML!</b>"),
+            "res index.html, lines: {lines:?}",
+        );
+    }
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_http_serve_dir_404() {
+    let _guard = utils::RamaService::serve(63108, Some(PathBuf::from("test-files")));
+    let lines = utils::RamaService::http(vec!["https://127.0.0.1:63108/missing.txt"]).unwrap();
+    assert!(
+        lines.contains("GET /missing.txt"),
+        "req method, lines: {lines:?}",
+    );
+    assert!(
+        lines.contains("HTTP/2.0 404 Not Found"),
+        "res status, lines: {lines:?}",
+    );
+}

--- a/tests/integration/cli/cli_tests/mod.rs
+++ b/tests/integration/cli/cli_tests/mod.rs
@@ -3,3 +3,4 @@ mod utils;
 mod help;
 mod http_echo;
 mod http_ip;
+mod http_serve;

--- a/tests/integration/cli/cli_tests/utils/mod.rs
+++ b/tests/integration/cli/cli_tests/utils/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{
     io::{BufRead, BufReader},
+    net::SocketAddr,
     process::Child,
     thread,
 };
@@ -26,8 +27,8 @@ impl RamaService {
             .command()
             .stdout(std::process::Stdio::piped())
             .arg("ip")
-            .arg("-p")
-            .arg(port.to_string())
+            .arg("--bind")
+            .arg(format!("127.0.0.1:{port}"))
             .env(
                 "RUST_LOG",
                 std::env::var("RUST_LOG").unwrap_or("info".into()),
@@ -86,8 +87,8 @@ impl RamaService {
         builder
             .stdout(std::process::Stdio::piped())
             .arg("echo")
-            .arg("-p")
-            .arg(port.to_string())
+            .arg("--bind")
+            .arg(format!("127.0.0.1:{port}"))
             .env(
                 "RUST_LOG",
                 std::env::var("RUST_LOG").unwrap_or("info".into()),


### PR DESCRIPTION
Closes #508 

- [x] serve docs page by default
- [x] serve single file
- [x] serve directory

extra:
- [x] update docs for `rama-cli` usage
- [x] error when path is invalid
- [x] replace cli args port `-p` and interface `-i` with `--bind` using `rama::net::SocketAddress`
  - [x] update cli usage in fly.io deployments
  - [x] update cli usage in integration tests