### PR TITLE
Separate http mitm proxy example into a boring and rustls version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -382,8 +382,12 @@ name = "http_listener_hello"
 required-features = ["http-full"]
 
 [[example]]
-name = "http_mitm_proxy"
-required-features = ["http-full"]
+name = "http_mitm_proxy_boring"
+required-features = ["http-full", "boring"]
+
+[[example]]
+name = "http_mitm_proxy_rustls"
+required-features = ["http-full", "rustls"]
 
 [[example]]
 name = "http_pooled_client"

--- a/docs/book/src/proxies/mitm.md
+++ b/docs/book/src/proxies/mitm.md
@@ -13,9 +13,15 @@
 
 [Examples](https://github.com/plabayo/rama/tree/main/examples):
 
-- [/examples/http_mitm_proxy.rs](https://github.com/plabayo/rama/tree/main/examples/http_mitm_proxy.rs):
+- [/examples/http_mitm_proxy_boring.rs](https://github.com/plabayo/rama/tree/main/examples/http_mitm_proxy_boring.rs):
   Spawns a minimal http proxy which accepts http/1.1 and h2 connections alike,
-  and proxies them to the target host;
+  and proxies them to the target host, using boring for tls;
+  - Similar to [/examples/http_connect_proxy.rs](https://github.com/plabayo/rama/tree/main/examples/http_connect_proxy.rs)
+    but MITM for both http and https requests alike.
+
+- [/examples/http_mitm_proxy_rustls.rs](https://github.com/plabayo/rama/tree/main/examples/http_mitm_proxy_rustls.rs):
+  Spawns a minimal http proxy which accepts http/1.1 and h2 connections alike,
+  and proxies them to the target host, using rustls for tls;
   - Similar to [/examples/http_connect_proxy.rs](https://github.com/plabayo/rama/tree/main/examples/http_connect_proxy.rs)
     but MITM for both http and https requests alike.
 

--- a/tests/integration/examples/example_tests/http_mitm_proxy_boring.rs
+++ b/tests/integration/examples/example_tests/http_mitm_proxy_boring.rs
@@ -3,7 +3,7 @@ use rama::{
     Context, Layer,
     http::{BodyExtractExt, Request, response::Json, server::HttpServer},
     net::address::ProxyAddress,
-    net::tls::{ApplicationProtocol, server::SelfSignedData},
+    net::tls::server::SelfSignedData,
     rt::Executor,
     service::service_fn,
     tcp::server::TcpListener,
@@ -36,7 +36,7 @@ async fn test_http_mitm_proxy() {
         ..Default::default()
     })
     .expect("self signed acceptor data")
-    .with_alpn_protocols(&[ApplicationProtocol::HTTP_2, ApplicationProtocol::HTTP_11])
+    .with_alpn_protocols_http_auto()
     .with_env_key_logger()
     .expect("with env key logger")
     .build();
@@ -60,7 +60,7 @@ async fn test_http_mitm_proxy() {
             .await;
     });
 
-    let runner = utils::ExampleRunner::interactive("http_mitm_proxy", Some("rustls"));
+    let runner = utils::ExampleRunner::interactive("http_mitm_proxy_boring", Some("boring"));
 
     let mut ctx = Context::default();
     ctx.insert(ProxyAddress::try_from("http://john:secret@127.0.0.1:62017").unwrap());

--- a/tests/integration/examples/example_tests/http_mitm_proxy_rustls.rs
+++ b/tests/integration/examples/example_tests/http_mitm_proxy_rustls.rs
@@ -1,0 +1,91 @@
+use super::utils;
+use rama::{
+    Context, Layer,
+    http::{BodyExtractExt, Request, response::Json, server::HttpServer},
+    net::address::ProxyAddress,
+    net::tls::server::SelfSignedData,
+    rt::Executor,
+    service::service_fn,
+    tcp::server::TcpListener,
+    tls::rustls::server::{TlsAcceptorDataBuilder, TlsAcceptorLayer},
+};
+use serde_json::{Value, json};
+
+#[tokio::test]
+#[ignore]
+async fn test_http_mitm_proxy() {
+    utils::init_tracing();
+
+    tokio::spawn(async {
+        HttpServer::auto(Executor::default())
+            .listen(
+                "127.0.0.1:63005",
+                service_fn(async |req: Request| {
+                    Ok(Json(json!({
+                        "method": req.method().as_str(),
+                        "path": req.uri().path(),
+                    })))
+                }),
+            )
+            .await
+            .unwrap();
+    });
+
+    let data = TlsAcceptorDataBuilder::new_self_signed(SelfSignedData {
+        organisation_name: Some("Example Server Acceptor".to_owned()),
+        ..Default::default()
+    })
+    .expect("self signed acceptor data")
+    .with_alpn_protocols_http_auto()
+    .with_env_key_logger()
+    .expect("with env key logger")
+    .build();
+
+    let executor = Executor::default();
+
+    let tcp_service = TlsAcceptorLayer::new(data).into_layer(HttpServer::auto(executor).service(
+        service_fn(async |req: Request| {
+            Ok(Json(json!({
+                "method": req.method().as_str(),
+                "path": req.uri().path(),
+            })))
+        }),
+    ));
+
+    tokio::spawn(async {
+        TcpListener::bind("127.0.0.1:63006")
+            .await
+            .unwrap_or_else(|e| panic!("bind TCP Listener: secure web service: {e}"))
+            .serve(tcp_service)
+            .await;
+    });
+
+    let runner = utils::ExampleRunner::interactive("http_mitm_proxy_rustls", Some("rustls"));
+
+    let mut ctx = Context::default();
+    ctx.insert(ProxyAddress::try_from("http://john:secret@127.0.0.1:62019").unwrap());
+
+    // test http request proxy flow
+    let result = runner
+        .get("http://127.0.0.1:63005/foo/bar")
+        .send(ctx.clone())
+        .await
+        .unwrap()
+        .try_into_json::<Value>()
+        .await
+        .unwrap();
+    let expected_value = json!({"method":"GET","path":"/foo/bar"});
+    assert_eq!(expected_value, result);
+
+    // test https request proxy flow
+    let result = runner
+        .get("https://127.0.0.1:63006/foo/bar")
+        .send(ctx.clone())
+        .await
+        .unwrap()
+        .try_into_json::<Value>()
+        .await
+        .unwrap();
+    let expected_value = json!({"method":"GET","path":"/foo/bar"});
+    assert_eq!(expected_value, result);
+}

--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -17,7 +17,9 @@ mod http_key_value_store;
 #[cfg(feature = "http-full")]
 mod http_listener_hello;
 #[cfg(all(feature = "http-full", feature = "rustls"))]
-mod http_mitm_proxy;
+mod http_mitm_proxy_boring;
+#[cfg(all(feature = "http-full", feature = "rustls"))]
+mod http_mitm_proxy_rustls;
 #[cfg(feature = "http-full")]
 mod http_pooled_client;
 #[cfg(feature = "http-full")]


### PR DESCRIPTION
@GlenDC as discussed, separate example into a boring and rustls specific version, and undo tls changes in rustls crate