### PR TITLE
Make sure all examples are referenced in rama book

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,9 @@ jobs:
       - name: rustfmt
         run: |
           cargo fmt --all --check
+      - name: extra-checks
+        run: |
+          ./scripts/extra-checks.sh
 
   check-all-features:
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -21,6 +21,9 @@ clippy-fix *ARGS:
 typos:
 	typos -w
 
+extra-checks:
+	{{justfile_directory()}}/scripts/extra-checks.sh
+
 doc:
 	RUSTDOCFLAGS="-D rustdoc::broken-intra-doc-links" cargo doc --all-features --no-deps
 
@@ -41,7 +44,7 @@ test-spec: test-spec-h2
 test-ignored:
 	cargo test --features=cli,telemetry,compression,http-full,proxy-full,tcp,rustls --workspace -- --ignored
 
-qq: lint check clippy doc
+qq: lint check clippy doc extra-checks
 
 qa: qq test
 

--- a/scripts/extra-checks.sh
+++ b/scripts/extra-checks.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+
+exit_code=0
+
+# Make sure all examples are included in the rama book
+for example in $(cd $SCRIPT_DIR/.. && find examples -type f -name '*.rs' -not -name 'mod.rs'); do
+    if ! grep -qr "$example" docs/book; then
+        echo "Example $example, missing in rama book"
+        exit_code=1
+    fi
+done
+
+exit $exit_code

--- a/scripts/extra-checks.sh
+++ b/scripts/extra-checks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 


### PR DESCRIPTION
- Should prevent us from forgetting to add examples to rama book
- Can be extended in the future for other checks we think are needed