### PR TITLE
Remove sync bound from Service::Error

### DIFF
--- a/rama-core/src/inspect/request.rs
+++ b/rama-core/src/inspect/request.rs
@@ -8,7 +8,7 @@ use crate::{Context, Service};
 /// anyway not yet be produced at the point this inspector would be layered.
 pub trait RequestInspector<StateIn, RequestIn>: Send + Sync + 'static {
     /// The type of error returned by the service.
-    type Error: Send + Sync + 'static;
+    type Error: Send + 'static;
     type RequestOut: Send + 'static;
     type StateOut: Clone + Send + Sync + 'static;
 

--- a/rama-core/src/service/svc.rs
+++ b/rama-core/src/service/svc.rs
@@ -11,7 +11,7 @@ pub trait Service<S, Request>: Sized + Send + Sync + 'static {
     type Response: Send + 'static;
 
     /// The type of error returned by the service.
-    type Error: Send + Sync + 'static;
+    type Error: Send + 'static;
 
     /// Serve a response or error for the given request,
     /// using the given context.


### PR DESCRIPTION
This bound is not needed so we can remove it.
Smaller bounds make everything easier, and it also clearly shows what the actual restrictions are