### PR TITLE
Remove high cardinality label

### DIFF
--- a/rama-http/src/layer/opentelemetry.rs
+++ b/rama-http/src/layer/opentelemetry.rs
@@ -2,10 +2,7 @@
 //!
 //! [`Layer`]: rama_core::Layer
 
-use crate::{
-    IntoResponse, Request, Response,
-    headers::{HeaderMapExt, UserAgent},
-};
+use crate::{IntoResponse, Request, Response};
 use rama_core::telemetry::opentelemetry::{
     AttributesFactory, InstrumentationScope, KeyValue, MeterOptions, ServiceInfo, global,
     metrics::{Counter, Histogram, Meter},
@@ -24,7 +21,7 @@ use std::{borrow::Cow, fmt, sync::Arc, time::SystemTime};
 
 use semantic_conventions::attribute::{
     HTTP_REQUEST_METHOD, HTTP_RESPONSE_STATUS_CODE, NETWORK_PROTOCOL_VERSION, SERVER_PORT,
-    URL_SCHEME, USER_AGENT_ORIGINAL,
+    URL_SCHEME,
 };
 
 const HTTP_SERVER_DURATION: &str = "http.requests.duration";
@@ -251,7 +248,7 @@ impl<S, F> RequestMetricsService<S, F> {
     {
         let mut attributes = self
             .attributes_factory
-            .attributes(6 + self.base_attributes.len(), ctx);
+            .attributes(5 + self.base_attributes.len(), ctx);
         attributes.extend(self.base_attributes.iter().cloned());
 
         // server info
@@ -271,9 +268,6 @@ impl<S, F> RequestMetricsService<S, F> {
             attributes.push(KeyValue::new(URL_SCHEME, protocol.to_string()));
         }
 
-        // Common attrs (Request Info)
-        // <https://github.com/open-telemetry/semantic-conventions/blob/v1.21.0/docs/http/http-spans.md#common-attributes>
-
         attributes.push(KeyValue::new(HTTP_REQUEST_METHOD, req.method().to_string()));
         if let Some(http_version) = request_ctx.as_ref().and_then(|rc| match rc.http_version {
             rama_http_types::Version::HTTP_09 => Some("0.9"),
@@ -284,10 +278,6 @@ impl<S, F> RequestMetricsService<S, F> {
             _ => None,
         }) {
             attributes.push(KeyValue::new(NETWORK_PROTOCOL_VERSION, http_version));
-        }
-
-        if let Some(ua) = req.headers().typed_get::<UserAgent>() {
-            attributes.push(KeyValue::new(USER_AGENT_ORIGINAL, ua.to_string()));
         }
 
         attributes


### PR DESCRIPTION
This label can be present on spans/traces, but not on metrics.

If it is there, it might explode label cardinality, and since the default exporter in OTLP uses cumulative metrics, this could easily lead to a lot memory being used.

Delta temporality looks really promising for this (only keep changes from last push vs keep everything in memory), but is only supported by some backends. Prometheus right now is starting to support it behind an experimental feature flag, so that look promising. But until then we have to be very careful about label cardinality, and even after that we have to be aware of it as it might be a huge burden on the metrics storage backend