### PR TITLE
Issue 534/ Implement SubdomainTrieMatcher Logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +856,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fid-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6956a1e60e2d1412b44b4169d44a03dae518f8583d3e10090c912c105e48447"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "flate2"
@@ -1795,6 +1814,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "louds-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936de6c22f08e7135a921f8ada907acd0d88880c4f42b5591f634b9f1dd8e07f"
+dependencies = [
+ "fid-rs",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +2612,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "trie-rs",
  "uuid",
  "zstd",
 ]
@@ -2903,6 +2932,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3917,6 +3966,15 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "trie-rs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f88f4b0a1ebd6c3d16be3e45eb0e8089372ccadd88849b7ca162ba64b5e6f6"
+dependencies = [
+ "louds-rs",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,16 +572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,15 +852,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fid-rs"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6956a1e60e2d1412b44b4169d44a03dae518f8583d3e10090c912c105e48447"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "flate2"
@@ -1814,15 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "louds-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936de6c22f08e7135a921f8ada907acd0d88880c4f42b5591f634b9f1dd8e07f"
-dependencies = [
- "fid-rs",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1954,6 +1932,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -2403,6 +2390,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rama"
 version = "0.2.0-alpha.14"
 dependencies = [
@@ -2593,6 +2590,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pin-project-lite",
+ "radix_trie",
  "rama-core",
  "rama-http-backend",
  "rama-http-types",
@@ -2612,7 +2610,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "trie-rs",
  "uuid",
  "zstd",
 ]
@@ -2932,26 +2929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3966,15 +3943,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "trie-rs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f88f4b0a1ebd6c3d16be3e45eb0e8089372ccadd88849b7ca162ba64b5e6f6"
-dependencies = [
- "louds-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ chrono = "0.4"
 smol_str = "0.3"
 tower-service = "0.3"
 tower-layer = "0.3"
+radix_trie = "0.2"
 
 [workspace.lints.rust]
 unreachable_pub = "deny"

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { workspace = true, features = ["macros", "fs", "io-std"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-trie-rs = "0.4.2"
+radix_trie = { workspace = true }
 
 [dev-dependencies]
 brotli = { workspace = true }

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -43,6 +43,7 @@ mime_guess = { workspace = true }
 nanoid = { workspace = true }
 percent-encoding = { workspace = true }
 pin-project-lite = { workspace = true }
+radix_trie = { workspace = true }
 rama-core = { version = "0.2.0-alpha.14", path = "../rama-core" }
 rama-http-types = { version = "0.2.0-alpha.14", path = "../rama-http-types" }
 rama-macros = { version = "0.2.0-alpha.14", path = "../rama-macros" }
@@ -58,7 +59,6 @@ tokio = { workspace = true, features = ["macros", "fs", "io-std"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-radix_trie = { workspace = true }
 
 [dev-dependencies]
 brotli = { workspace = true }

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -58,6 +58,7 @@ tokio = { workspace = true, features = ["macros", "fs", "io-std"] }
 tokio-util = { workspace = true, features = ["io"] }
 tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
+trie-rs = "0.4.2"
 
 [dev-dependencies]
 brotli = { workspace = true }

--- a/rama-http/src/matcher/mod.rs
+++ b/rama-http/src/matcher/mod.rs
@@ -615,6 +615,42 @@ impl<State, Body> HttpMatcher<State, Body> {
         self.or(Self::custom(matcher))
     }
 
+    /// Create a [`SubdomainTrieMatcher`] matcher that matches if the request domain is a subdomain of the provided domains.
+    ///
+    /// See [`SubdomainTrieMatcher`] for more information.
+    pub fn any_subdomain<I, S>(domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        HttpMatcher {
+            kind: HttpMatcherKind::SubdomainTrie(SubdomainTrieMatcher::new(domains)),
+            negate: false,
+        }
+    }
+
+    /// Add a [`SubdomainTrieMatcher`] matcher that matches if the request domain is a subdomain of the provided domains on top of the existing set of [`HttpMatcher`] matchers.
+    ///
+    /// See [`SubdomainTrieMatcher`] for more information.
+    pub fn and_any_subdomain<I, S>(self, domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.and(Self::any_subdomain(domains))
+    }
+
+    /// Create a [`SubdomainTrieMatcher`] matcher that matches if the request domain is a subdomain of the provided domains as an alternative to the existing set of [`HttpMatcher`] matchers.
+    ///
+    /// See [`SubdomainTrieMatcher`] for more information.
+    pub fn or_any_subdomain<I, S>(self, domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.or(Self::any_subdomain(domains))
+    }
+
     /// Create a [`PathMatcher`] matcher to match for a POST request.
     pub fn post(path: impl AsRef<str>) -> Self {
         Self::method_post().and_path(path)

--- a/rama-http/src/matcher/subdomain_trie.rs
+++ b/rama-http/src/matcher/subdomain_trie.rs
@@ -23,6 +23,10 @@ impl SubdomainTrieMatcher {
         Self { trie }
     }
 
+    // Checks if the reversed domain has an ancestor in the trie.
+    //
+    // The domain is reversed to match the way Radix Tries store domains. `get_ancestor` is used
+    // to check if any prefix of the reversed domain exists in the trie, indicating a match.
     pub fn is_match(&self, domain: impl AsRef<str>) -> bool {
         let reversed = reverse_domain(domain.as_ref());
         self.trie.get_ancestor(&reversed).is_some()
@@ -101,6 +105,8 @@ mod subdomain_trie_tests {
         assert_eq!(reverse_domain("example.com"), "com.example.");
         assert_eq!(reverse_domain(".example.com"), "com.example.");
         assert_eq!(reverse_domain("sub.example.com"), "com.example.sub.");
+        assert_eq!(reverse_domain("localhost"), "localhost.");
+        assert_eq!(reverse_domain(""), ".");
     }
 
     #[test]

--- a/rama-http/src/matcher/subdomain_trie.rs
+++ b/rama-http/src/matcher/subdomain_trie.rs
@@ -1,0 +1,173 @@
+use trie_rs::TrieBuilder;
+use crate::Request;
+use rama_core::{Context, context::Extensions, matcher::Matcher};
+use rama_net::http::RequestContext;
+use rama_net::address::{Host};
+
+#[derive(Debug, Clone)]
+pub struct SubdomainTrieMatcher {
+    trie: trie_rs::Trie<u8>,
+}
+
+impl SubdomainTrieMatcher {
+    pub fn new<I, S>(domains: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut builder = TrieBuilder::new();
+        for domain in domains {
+            let reversed = reverse_domain(domain.as_ref());
+            builder.push(reversed.as_bytes());
+        }
+        let trie = builder.build();
+        Self { trie }
+    }
+
+    pub fn is_match(&self, domain: &str) -> bool {
+        let reversed = reverse_domain(domain);
+        let domain_parts = reversed.split('.');
+
+        let mut prefix = String::new();
+
+        for part in domain_parts {
+            prefix.push_str(part);
+            prefix.push('.');
+
+            if self.trie.exact_match(prefix.as_bytes()) {
+                return true;
+            }
+        }
+        
+        false
+    }
+
+}
+
+fn reverse_domain(domain: &str) -> String {
+    let from = domain.strip_prefix('.').unwrap_or(domain);
+    let mut domain = from.split('.').rev().collect::<Vec<&str>>().join(".");
+    domain.push('.');
+    domain
+}
+
+impl<State, Body> Matcher<State, Request<Body>> for SubdomainTrieMatcher {
+    fn matches(
+        &self,
+        ext: Option<&mut Extensions>,
+        ctx: &Context<State>,
+        req: &Request<Body>,
+    ) -> bool {
+        let host = match ctx.get::<RequestContext>() {
+            Some(req_ctx) => req_ctx.authority.host().clone(),
+            None => {
+                let req_ctx: RequestContext = match (ctx, req).try_into() {
+                    Ok(rc) => rc,
+                    Err(err) => {
+                        tracing::error!(error = %err, "SubdomainTrieMatcher: failed to extract request context");
+                        return false;
+                    }
+                };
+                let host = req_ctx.authority.host().clone();
+                if let Some(ext) = ext {
+                    ext.insert(req_ctx);
+                }
+                host
+            }
+        };
+
+        match host {
+            Host::Name(domain) => {
+                let is_match = self.is_match(domain.as_str());
+                tracing::trace!("SubdomainTrieMatcher: matching '{}' => {}", domain, is_match);
+                is_match
+            }
+            Host::Address(_) => {
+                tracing::trace!("SubdomainTrieMatcher: ignoring numeric address");
+                false
+            }
+        }
+    }
+}
+
+impl FromIterator<String> for SubdomainTrieMatcher {
+    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
+        let domains: Vec<String> = iter.into_iter().collect();
+
+        SubdomainTrieMatcher::new(domains)
+    }
+}
+
+impl<'a> FromIterator<&'a str> for SubdomainTrieMatcher {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
+        let domains: Vec<&str> = iter.into_iter().collect();
+
+        SubdomainTrieMatcher::new(domains)
+    }
+}
+
+#[cfg(test)]
+mod subdomain_trie_tests {
+    use super::*;
+
+    #[test]
+    fn test_reverse_domain() {
+        assert_eq!(reverse_domain("example.com"), "com.example.");
+        assert_eq!(reverse_domain(".example.com"), "com.example.");
+        assert_eq!(reverse_domain("sub.example.com"), "com.example.sub.");
+    }
+
+    #[test]
+    fn test_trie_matching() {
+        let matcher = SubdomainTrieMatcher::new(vec!["example.com", "sub.domain.org"]);
+        assert!(matcher.is_match("example.com"));
+        assert!(matcher.is_match(".example.com"));
+        assert!(matcher.is_match("sub.domain.org"));
+        assert!(matcher.is_match("sub.example.com"));
+        assert!(!matcher.is_match("domain.org"));
+        assert!(!matcher.is_match("other.com"));
+    }
+
+    #[test]
+    fn test_from_iterator_string() {
+        let domains: Vec<String> = vec!["example.com".to_string(), "sub.domain.org".to_string()];
+        let matcher: SubdomainTrieMatcher = domains.into_iter().collect();
+
+        assert!(matcher.is_match("example.com"));
+    }
+
+    #[test]
+    fn test_from_iterator_str() {
+        let domains: Vec<&str> = vec!["example.com", "sub.domain.org"];
+        let matcher: SubdomainTrieMatcher = domains.into_iter().collect();
+
+        assert!(matcher.is_match("example.com"));
+    }
+
+    #[test]
+    fn test_path_matching_with_trie() {
+        let domains: Vec<String> = vec!["example.com".to_string(), "sub.domain.org".to_string()];
+        let matcher: SubdomainTrieMatcher = domains.into_iter().collect();
+
+        let path = "sub.example.com";
+
+        let request = Request::builder().uri(path).body(()).unwrap();
+        let ctx = Context::default();
+
+        assert!(matcher.matches(None, &ctx, &request));
+    }
+
+    #[test]
+    fn test_non_matching_path() {
+        let domains: Vec<String> = vec!["example.com".to_string()];
+        let matcher: SubdomainTrieMatcher = domains.into_iter().collect();
+
+        let path = "nonmatching.com";
+
+        let request = Request::builder().uri(path).body(()).unwrap();
+        let ctx = Context::default();
+
+        assert!(!matcher.matches(None, &ctx, &request));
+    }
+}
+


### PR DESCRIPTION
Closes #534

Added a trie-based domain matcher for efficient subdomain matching.
Ensured `sub.domain.com` returns `true` if `domain.com` is present but not vice-versa.

Please review and suggest any improvements. If there are any concerns about the logic or potential edge cases, kindly point them out! I'd appreciate any feedback as I'm still learning.