### PR TITLE
HttpRequestParts trait to combine http::Request and Parts

### DIFF
--- a/rama-http-types/src/lib.rs
+++ b/rama-http-types/src/lib.rs
@@ -26,9 +26,8 @@ pub use body_limit::BodyLimit;
 mod body_ext;
 pub use body_ext::BodyExtractExt;
 
-/// Type alias for [`http::Request`] whose body type
-/// defaults to [`Body`], the most common body type used with rama.
-pub type Request<T = Body> = http::Request<T>;
+mod request;
+pub use request::{HttpRequestParts, Request};
 
 /// Type alias for [`http::Response`] whose body type defaults to [`Body`], the most common body
 /// type used with rama.

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -1,14 +1,21 @@
-use crate::body::Body;
-use http::{Extensions, HeaderMap, HeaderValue, Method, Uri, Version, request::Parts};
+use crate::{
+    body::Body,
+    dep::http::{Extensions, HeaderMap, HeaderValue, Method, Uri, Version, request::Parts},
+};
 
-/// Type alias for [`http::Request`] whose body type
+/// Type alias for [`HttpRequest`] whose body type
 /// defaults to [`Body`], the most common body type used with rama.
+///
+/// [`HttpRequest`]: crate::dep::http::Request
 pub type Request<T = Body> = http::Request<T>;
 
-/// [`HttpRequestParts`] is used in places where don't need the [`Body`] of the [`http::Request`]
+/// [`HttpRequestParts`] is used in places where we don't need the [`ReqBody`] of the [`HttpRequest`]
 ///
-/// In those places we need to support using [`http::Request`] and [`http::request::Parts`]. By using
+/// In those places we need to support using [`HttpRequest`] and [`Parts`]. By using
 /// this trait we can support both types behind a single generic that implements this trait.
+///
+/// [`ReqBody`]: crate::dep::http_body::Body
+/// [`HttpRequest`]: crate::dep::http::Request
 pub trait HttpRequestParts {
     fn method(&self) -> &Method;
     fn method_mut(&mut self) -> &mut Method;

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -1,0 +1,107 @@
+use crate::body::Body;
+use http::{Extensions, HeaderMap, HeaderValue, Method, Uri, Version, request::Parts};
+
+/// Type alias for [`http::Request`] whose body type
+/// defaults to [`Body`], the most common body type used with rama.
+pub type Request<T = Body> = http::Request<T>;
+
+/// [`HttpRequestParts`] is used in places where don't need the [`Body`] of the [`http::Request`]
+///
+/// In those places we need to support using [`http::Request`] and [`http::request::Parts`]. By using
+/// this trait we can support both types behind a single generic that implements this trait.
+pub trait HttpRequestParts {
+    fn method(&self) -> &Method;
+    fn method_mut(&mut self) -> &mut Method;
+    fn uri(&self) -> &Uri;
+    fn uri_mut(&mut self) -> &mut Uri;
+    fn version(&self) -> Version;
+    fn version_mut(&mut self) -> &mut Version;
+    fn headers(&self) -> &HeaderMap<HeaderValue>;
+    fn headers_mut(&mut self) -> &mut HeaderMap<HeaderValue>;
+    fn extensions(&self) -> &Extensions;
+    fn extensions_mut(&mut self) -> &mut Extensions;
+}
+
+impl<Body> HttpRequestParts for http::Request<Body> {
+    fn method(&self) -> &Method {
+        self.method()
+    }
+
+    fn method_mut(&mut self) -> &mut Method {
+        self.method_mut()
+    }
+
+    fn uri(&self) -> &Uri {
+        self.uri()
+    }
+
+    fn uri_mut(&mut self) -> &mut Uri {
+        self.uri_mut()
+    }
+
+    fn version(&self) -> Version {
+        self.version()
+    }
+
+    fn version_mut(&mut self) -> &mut Version {
+        self.version_mut()
+    }
+
+    fn headers(&self) -> &HeaderMap<HeaderValue> {
+        self.headers()
+    }
+
+    fn headers_mut(&mut self) -> &mut HeaderMap<HeaderValue> {
+        self.headers_mut()
+    }
+
+    fn extensions(&self) -> &Extensions {
+        self.extensions()
+    }
+
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        self.extensions_mut()
+    }
+}
+
+impl HttpRequestParts for Parts {
+    fn method(&self) -> &Method {
+        &self.method
+    }
+
+    fn method_mut(&mut self) -> &mut Method {
+        &mut self.method
+    }
+
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    fn uri_mut(&mut self) -> &mut Uri {
+        &mut self.uri
+    }
+
+    fn version(&self) -> Version {
+        self.version
+    }
+
+    fn version_mut(&mut self) -> &mut Version {
+        &mut self.version
+    }
+
+    fn headers(&self) -> &HeaderMap<HeaderValue> {
+        &self.headers
+    }
+
+    fn headers_mut(&mut self) -> &mut HeaderMap<HeaderValue> {
+        &mut self.headers
+    }
+
+    fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
+    }
+}

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use rama_core::Context;
 use rama_core::error::OpaqueError;
-use rama_http_types::Method;
-use rama_http_types::{Request, Uri, Version, dep::http::request::Parts};
+use rama_http_types::{HttpRequestParts, Method};
+use rama_http_types::{Uri, Version};
 
 #[cfg(feature = "tls")]
 use crate::tls::SecureTransport;
@@ -60,10 +60,10 @@ impl RequestContext {
     }
 }
 
-impl<Body, State> TryFrom<(&Context<State>, &Request<Body>)> for RequestContext {
+impl<T: HttpRequestParts, State> TryFrom<(&Context<State>, &T)> for RequestContext {
     type Error = OpaqueError;
 
-    fn try_from((ctx, req): (&Context<State>, &Request<Body>)) -> Result<Self, Self::Error> {
+    fn try_from((ctx, req): (&Context<State>, &T)) -> Result<Self, Self::Error> {
         let uri = req.uri();
 
         let protocol = protocol_from_uri_or_context(ctx, uri, req.method());
@@ -135,96 +135,6 @@ impl<Body, State> TryFrom<(&Context<State>, &Request<Body>)> for RequestContext 
                 })
             })
             .unwrap_or_else(|| req.version());
-        tracing::trace!(uri = %uri, "request context: maybe detected http version: {http_version:?}");
-
-        Ok(RequestContext {
-            http_version,
-            protocol,
-            authority,
-        })
-    }
-}
-
-impl<State> TryFrom<(&Context<State>, &Parts)> for RequestContext {
-    type Error = OpaqueError;
-
-    fn try_from((ctx, parts): (&Context<State>, &Parts)) -> Result<Self, Self::Error> {
-        let uri = &parts.uri;
-
-        let protocol = protocol_from_uri_or_context(ctx, uri, &parts.method);
-        tracing::trace!(
-            uri = %uri, "request context: detected protocol: {protocol} (scheme: {:?})",
-            uri.scheme()
-        );
-
-        let default_port = uri
-            .port_u16()
-            .unwrap_or_else(|| protocol.default_port().unwrap_or(80));
-        tracing::trace!(uri = %uri, "request context: detected default port: {default_port}");
-
-        let proxy_authority_opt: Option<Authority> = ctx.get::<ProxyTarget>().map(|t| t.0.clone());
-        let sni_host_opt = ctx.get().and_then(try_get_host_from_secure_transport);
-        let authority = match (proxy_authority_opt, sni_host_opt) {
-            (Some(authority), _) => {
-                tracing::trace!(uri = %uri, %authority, "request context: use proxy target as authority");
-                authority
-            }
-            (None, Some(h)) => {
-                tracing::trace!(uri = %uri, host = %h, "request context: detected host from SNI");
-                (h, default_port).into()
-            }
-            (None, None) => {
-                uri
-                    .host()
-                    .and_then(|h| Host::try_from(h).ok().map(|h| {
-                        tracing::trace!(uri = %uri, host = %h, "request context: detected host from (abs) uri");
-                        (h, default_port).into()
-                    }))
-                    .or_else(|| {
-                        ctx.get::<Forwarded>().and_then(|f| {
-                            f.client_host().map(|fauth| {
-                                let (host, port) = fauth.clone().into_parts();
-                                let port = port.unwrap_or(default_port);
-                                tracing::trace!(uri = %uri, host = %host, "request context: detected host from forwarded info");
-                                (host, port).into()
-                            })
-                        })
-                    })
-                    .or_else(|| {
-                        parts
-                            .headers
-                            .get(rama_http_types::header::HOST)
-                            .and_then(|host| {
-                                host.try_into() // try to consume as Authority, otherwise as Host
-                                    .or_else(|_| Host::try_from(host).map(|h| {
-                                        tracing::trace!(uri = %uri, host = %h, "request context: detected host from host header");
-                                        (h, default_port).into()
-                                    }))
-                                    .ok()
-                            })
-                    })
-                    .ok_or_else(|| {
-                        OpaqueError::from_display(
-                            "RequestContext: no authourity found in http::request::Parts",
-                        )
-                    })?
-            }
-        };
-
-        tracing::trace!(uri = %uri, "request context: detected authority: {authority}");
-
-        let http_version = ctx
-            .get::<Forwarded>()
-            .and_then(|f| {
-                f.client_version().map(|v| match v {
-                    crate::forwarded::ForwardedVersion::HTTP_09 => Version::HTTP_09,
-                    crate::forwarded::ForwardedVersion::HTTP_10 => Version::HTTP_10,
-                    crate::forwarded::ForwardedVersion::HTTP_11 => Version::HTTP_11,
-                    crate::forwarded::ForwardedVersion::HTTP_2 => Version::HTTP_2,
-                    crate::forwarded::ForwardedVersion::HTTP_3 => Version::HTTP_3,
-                })
-            })
-            .unwrap_or(parts.version);
         tracing::trace!(uri = %uri, "request context: maybe detected http version: {http_version:?}");
 
         Ok(RequestContext {
@@ -313,7 +223,7 @@ impl<State> TryRefIntoTransportContext<State> for rama_http_types::dep::http::re
 mod tests {
     use super::*;
     use crate::forwarded::{Forwarded, ForwardedElement, NodeId};
-    use rama_http_types::header::FORWARDED;
+    use rama_http_types::{Request, header::FORWARDED};
 
     #[test]
     fn test_request_context_from_request() {


### PR DESCRIPTION
`HttpRequestParts` trait provides a single view over `http::Request` and `http::request::Parts`. This allows us to simplify some TryFrom implementations, and can probably be useful in other places to.

This was previously discussed on this PR: https://github.com/plabayo/rama/pull/491#discussion_r2079867624