### PR TITLE
add auto Tls acceptor service (== TlsPeekRouter)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -506,7 +506,7 @@ required-features = ["dns", "socks5"]
 
 [[example]]
 name = "socks5_connect_proxy_mitm_proxy"
-required-features = ["dns", "socks5", "http-full"]
+required-features = ["dns", "socks5", "boring", "http-full"]
 
 [[example]]
 name = "socks5_connect_proxy_over_tls"

--- a/rama-core/src/service/mod.rs
+++ b/rama-core/src/service/mod.rs
@@ -4,7 +4,7 @@
 
 mod svc;
 #[doc(inline)]
-pub use svc::{BoxService, Service};
+pub use svc::{BoxService, RejectError, RejectService, Service};
 
 pub mod handler;
 pub use handler::service_fn;

--- a/rama-core/src/service/svc.rs
+++ b/rama-core/src/service/svc.rs
@@ -2,6 +2,8 @@
 
 use crate::Context;
 use crate::error::BoxError;
+use std::fmt;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -190,6 +192,78 @@ macro_rules! impl_service_either {
 
 crate::combinators::impl_either!(impl_service_either);
 
+rama_utils::macros::error::static_str_error! {
+    #[doc = "request rejected"]
+    pub struct RejectError;
+}
+
+/// A [`Service`]] which always rejects with an error.
+pub struct RejectService<R = (), E = RejectError> {
+    error: E,
+    _phantom: PhantomData<fn() -> R>,
+}
+
+impl Default for RejectService {
+    fn default() -> Self {
+        RejectService {
+            error: RejectError,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<R, E: Clone + Send + Sync + 'static> RejectService<R, E> {
+    /// Create a new [`RejectService`].
+    pub fn new(error: E) -> Self {
+        Self {
+            error,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<R, E: Clone> Clone for RejectService<R, E> {
+    fn clone(&self) -> Self {
+        Self {
+            error: self.error.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<R, E: fmt::Debug> fmt::Debug for RejectService<R, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RejectService")
+            .field("error", &self.error)
+            .field(
+                "_phantom",
+                &format_args!("{}", std::any::type_name::<fn() -> R>()),
+            )
+            .finish()
+    }
+}
+
+impl<S, Request, Response, Error> Service<S, Request> for RejectService<Response, Error>
+where
+    S: 'static,
+    Request: 'static,
+    Response: Send + 'static,
+    Error: Clone + Send + Sync + 'static,
+{
+    type Response = Response;
+    type Error = Error;
+
+    #[inline]
+    fn serve(
+        &self,
+        _ctx: Context<S>,
+        _req: Request,
+    ) -> impl Future<Output = Result<Self::Response, Self::Error>> + Send + '_ {
+        let error = self.error.clone();
+        std::future::ready(Err(error))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,6 +308,7 @@ mod tests {
         assert_send::<AddSvc>();
         assert_send::<MulSvc>();
         assert_send::<BoxService<(), (), (), ()>>();
+        assert_send::<RejectService>();
     }
 
     #[test]
@@ -243,6 +318,7 @@ mod tests {
         assert_sync::<AddSvc>();
         assert_sync::<MulSvc>();
         assert_sync::<BoxService<(), (), (), ()>>();
+        assert_sync::<RejectService>();
     }
 
     #[tokio::test]
@@ -307,5 +383,15 @@ mod tests {
 
         let response = svc.serve(ctx, 1).await.unwrap();
         assert_eq!(response, 2);
+    }
+
+    #[tokio::test]
+    async fn reject_svc() {
+        let svc = RejectService::default();
+
+        let ctx = Context::default();
+
+        let err = svc.serve(ctx, 1).await.unwrap_err();
+        assert_eq!(err.to_string(), RejectError::new().to_string());
     }
 }

--- a/rama-net/src/tls/server/mod.rs
+++ b/rama-net/src/tls/server/mod.rs
@@ -6,3 +6,7 @@ pub use config::{
     CacheKind, ClientVerifyMode, DynamicCertIssuer, DynamicIssuer, SelfSignedData, ServerAuth,
     ServerAuthData, ServerCertIssuerData, ServerCertIssuerKind, ServerConfig,
 };
+
+mod peek;
+#[doc(inline)]
+pub use peek::{NoTlsRejectError, TlsPeekRouter};

--- a/rama-net/src/tls/server/peek.rs
+++ b/rama-net/src/tls/server/peek.rs
@@ -1,0 +1,249 @@
+use rama_core::{
+    Context, Service,
+    error::{BoxError, ErrorContext},
+    service::RejectService,
+};
+use std::{fmt, io::IoSlice, pin::Pin, task::Poll};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+
+/// A [`Service`] router that can be used to support
+/// tls traffic as well as non-tls traffic.
+///
+/// By default non-tls traffic is rejected using [`RejectService`].
+/// Use [`TlsPeekRouter::with_fallback`] to configure the fallback service.
+pub struct TlsPeekRouter<T, F = RejectService<(), NoTlsRejectError>> {
+    tls_acceptor: T,
+    fallback: F,
+}
+
+rama_utils::macros::error::static_str_error! {
+    #[doc = "non-tls connection is rejected"]
+    pub struct NoTlsRejectError;
+}
+
+impl<T> TlsPeekRouter<T> {
+    /// Create a new [`TlsPeekRouter`].
+    pub fn new(tls_acceptor: T) -> Self {
+        Self {
+            tls_acceptor,
+            fallback: RejectService::new(NoTlsRejectError),
+        }
+    }
+
+    /// Attach a fallback [`Service`] tp this [`TlsPeekRouter`].
+    pub fn with_fallback<F>(self, fallback: F) -> TlsPeekRouter<T, F> {
+        TlsPeekRouter {
+            tls_acceptor: self.tls_acceptor,
+            fallback,
+        }
+    }
+}
+
+impl<T: Clone, F: Clone> Clone for TlsPeekRouter<T, F> {
+    fn clone(&self) -> Self {
+        Self {
+            tls_acceptor: self.tls_acceptor.clone(),
+            fallback: self.fallback.clone(),
+        }
+    }
+}
+
+impl<T: fmt::Debug, F: fmt::Debug> fmt::Debug for TlsPeekRouter<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TlsPeekRouter")
+            .field("tls_acceptor", &self.tls_acceptor)
+            .field("fallback", &self.fallback)
+            .finish()
+    }
+}
+
+impl<State, Stream, Response, T, F> Service<State, Stream> for TlsPeekRouter<T, F>
+where
+    State: Clone + Send + Sync + 'static,
+    Stream: crate::stream::Stream + Unpin,
+    Response: Send + 'static,
+    T: Service<State, TlsPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    F: Service<State, TlsPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+{
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        ctx: Context<State>,
+        mut stream: Stream,
+    ) -> Result<Self::Response, Self::Error> {
+        let mut peek_buf = [0u8; TLS_HEADER_PEEK_LEN];
+        let n = stream
+            .read(&mut peek_buf)
+            .await
+            .context("try to read tls prefix header")?;
+
+        let is_tls = n == TLS_HEADER_PEEK_LEN && matches!(peek_buf, [0x16, 0x03, 0x00..=0x04, ..]);
+        tracing::trace!(%is_tls, "tls prefix header read");
+
+        let offset = TLS_HEADER_PEEK_LEN - n;
+        if offset > 0 {
+            peek_buf.copy_within(..n, offset);
+        }
+
+        let stream = TlsPeekStream {
+            prefix: peek_buf,
+            offset,
+            inner: stream,
+        };
+
+        if is_tls {
+            self.tls_acceptor
+                .serve(ctx, stream)
+                .await
+                .map_err(Into::into)
+        } else {
+            self.fallback.serve(ctx, stream).await.map_err(Into::into)
+        }
+    }
+}
+
+const TLS_HEADER_PEEK_LEN: usize = 5;
+type TlsPrefixHeader = [u8; TLS_HEADER_PEEK_LEN];
+
+pub struct TlsPeekStream<S> {
+    prefix: TlsPrefixHeader,
+    offset: usize,
+    inner: S,
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for TlsPeekStream<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        if self.offset < TLS_HEADER_PEEK_LEN - 1 {
+            let remaining = &self.prefix[self.offset..];
+            let to_copy = remaining.len().min(buf.remaining());
+
+            if to_copy > 0 {
+                buf.put_slice(&self.prefix[..to_copy]);
+                self.offset += to_copy;
+                return Poll::Ready(Ok(()));
+            }
+        }
+
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for TlsPeekStream<S> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.get_mut().inner).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rama_core::service::service_fn;
+    use std::convert::Infallible;
+    use tokio::io::{AsyncWriteExt, duplex};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_peek_router() {
+        let tls_service = service_fn(async |_, _| Ok::<_, Infallible>("tls"));
+        let plain_service = service_fn(async |_, _| Ok::<_, Infallible>("plain"));
+
+        let peek_tls_svc = TlsPeekRouter::new(tls_service).with_fallback(plain_service);
+
+        let response = peek_tls_svc
+            .serve(Context::default(), std::io::Cursor::new(b"".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("plain", response);
+
+        let response = peek_tls_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"\x16\x03\x03\x00\x2afoo".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("tls", response);
+
+        let response = peek_tls_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foo".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("plain", response);
+
+        let response = peek_tls_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foobar".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("plain", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_stream() -> std::io::Result<()> {
+        let prefix = b"\x16\x03\x01\x00\x2a";
+        let payload = b"actual application data";
+
+        let (mut client, server) = duplex(64);
+
+        let mut input_data = prefix.to_vec();
+        input_data.extend_from_slice(payload);
+
+        let w_input_data = input_data.clone();
+        tokio::spawn(async move {
+            client.write_all(&w_input_data).await.unwrap();
+            client.shutdown().await.unwrap();
+        });
+
+        let mut peek_buf = [0u8; 5];
+        let mut sniff_stream = server;
+        sniff_stream.read_exact(&mut peek_buf).await?;
+        assert_eq!(&peek_buf, prefix);
+
+        let mut buffered = TlsPeekStream {
+            prefix: peek_buf,
+            offset: 0,
+            inner: sniff_stream,
+        };
+
+        let mut all_data = Vec::new();
+        buffered.read_to_end(&mut all_data).await?;
+        assert_eq!(all_data, input_data);
+
+        Ok(())
+    }
+}

--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -57,7 +57,12 @@ mod tls_boring_dynamic_certs;
 #[cfg(all(feature = "dns", feature = "socks5", feature = "http-full"))]
 mod socks5_connect_proxy;
 
-#[cfg(all(feature = "dns", feature = "socks5", feature = "http-full"))]
+#[cfg(all(
+    feature = "dns",
+    feature = "boring",
+    feature = "socks5",
+    feature = "http-full"
+))]
 mod socks5_connect_proxy_mitm_proxy;
 
 #[cfg(all(feature = "socks5", feature = "boring", feature = "http-full"))]

--- a/tests/integration/examples/example_tests/socks5_connect_proxy_mitm_proxy.rs
+++ b/tests/integration/examples/example_tests/socks5_connect_proxy_mitm_proxy.rs
@@ -4,6 +4,7 @@ use super::utils;
 
 use rama::{
     Context, Service,
+    error::{ErrorContext, OpaqueError},
     http::{
         Body, BodyExtractExt, Request, client::HttpConnector, server::HttpServer,
         service::web::Router,
@@ -12,11 +13,20 @@ use rama::{
         Protocol,
         address::{ProxyAddress, SocketAddress},
         client::{ConnectorService, EstablishedClientConnection},
+        tls::{
+            ApplicationProtocol,
+            client::{ClientConfig, ClientHelloExtension, ServerVerifyMode},
+            server::{SelfSignedData, ServerAuth, ServerConfig},
+        },
         user::{Basic, ProxyCredential},
     },
     proxy::socks5::Socks5ProxyConnector,
     rt::Executor,
     tcp::{client::service::TcpConnector, server::TcpListener},
+    tls::boring::{
+        client::TlsConnector,
+        server::{TlsAcceptorData, TlsAcceptorService},
+    },
 };
 
 #[tokio::test]
@@ -26,23 +36,29 @@ async fn test_socks5_connect_proxy_mitm_proxy() {
 
     let _runner = utils::ExampleRunner::<()>::interactive(
         "socks5_connect_proxy_mitm_proxy",
-        Some("socks5,dns"),
+        Some("socks5,boring,dns"),
     );
 
     // wait for example to run... this is dirty
     tokio::time::sleep(Duration::from_secs(10)).await;
 
     let http_socket_addr = spawn_http_server().await;
+    let https_socket_addr = spawn_https_server().await;
 
-    test_http_client_over_socks5_proxy_connect_with_mitm_cap(http_socket_addr).await;
+    test_http_client_over_socks5_proxy_connect_with_mitm_cap(http_socket_addr, https_socket_addr)
+        .await;
 }
 
-async fn test_http_client_over_socks5_proxy_connect_with_mitm_cap(http_socket_addr: SocketAddress) {
+async fn test_http_client_over_socks5_proxy_connect_with_mitm_cap(
+    http_socket_addr: SocketAddress,
+    https_socket_addr: SocketAddress,
+) {
     let proxy_socket_addr = SocketAddress::local_ipv4(62022);
 
     tracing::info!(
         %proxy_socket_addr,
         %http_socket_addr,
+        %https_socket_addr,
         "local servers up and running",
     );
 
@@ -50,7 +66,24 @@ async fn test_http_client_over_socks5_proxy_connect_with_mitm_cap(http_socket_ad
     // we can probably simplify this by using the interactive runner client
     // instead of having to do this manually...
 
-    let client = HttpConnector::new(Socks5ProxyConnector::required(TcpConnector::new()));
+    let client = HttpConnector::new(
+        TlsConnector::auto(Socks5ProxyConnector::required(TcpConnector::new()))
+            .with_connector_data(
+                ClientConfig {
+                    server_verify_mode: Some(ServerVerifyMode::Disable),
+                    store_server_certificate_chain: true,
+                    extensions: Some(vec![
+                        ClientHelloExtension::ApplicationLayerProtocolNegotiation(vec![
+                            ApplicationProtocol::HTTP_2,
+                            ApplicationProtocol::HTTP_11,
+                        ]),
+                    ]),
+                    ..Default::default()
+                }
+                .try_into()
+                .expect("create tls client config"),
+            ),
+    );
 
     let mut ctx = Context::default();
     ctx.insert(ProxyAddress {
@@ -59,41 +92,49 @@ async fn test_http_client_over_socks5_proxy_connect_with_mitm_cap(http_socket_ad
         credential: Some(ProxyCredential::Basic(Basic::new("john", "secret"))),
     });
 
-    let uri = format!("http://{http_socket_addr}/ping");
-    tracing::info!(
-        %uri,
-        "try to establish proxied connection over SOCKS5 within a TLS Tunnel",
-    );
+    let test_uris = [
+        format!("http://{http_socket_addr}/ping"),
+        format!("https://{https_socket_addr}/ping"),
+    ];
 
-    let request = Request::builder()
-        .uri(uri.clone())
-        .body(Body::empty())
-        .expect("build simple GET request");
+    for uri in test_uris {
+        tracing::info!(
+            %uri,
+            "try to establish proxied connection over SOCKS5 MITM Proxy",
+        );
 
-    let EstablishedClientConnection {
-        ctx,
-        req,
-        conn: http_service,
-    } = client
-        .connect(ctx, request)
-        .await
-        .expect("establish a proxied connection ready to make http requests");
+        let request = Request::builder()
+            .uri(uri.clone())
+            .body(Body::empty())
+            .expect("build simple GET request");
 
-    tracing::info!(
-        %uri,
-        "try to make GET http request and try to receive response text",
-    );
+        let EstablishedClientConnection {
+            ctx,
+            req,
+            conn: http_service,
+        } = client
+            .connect(ctx.clone(), request)
+            .await
+            .expect("establish a proxied connection ready to make http(s) requests");
 
-    let resp = http_service
-        .serve(ctx, req)
-        .await
-        .expect("make http request via socks5 proxy")
-        .try_into_string()
-        .await
-        .expect("get response text");
+        tracing::info!(
+            %uri,
+            "try to make GET http(s) request and try to receive response text",
+        );
 
-    assert_eq!("pong", resp);
-    tracing::info!("ping-pong succeeded, bye now!")
+        let resp = http_service
+            .serve(ctx, req)
+            .await
+            .expect("make http(s) request via socks5 proxy")
+            .try_into_string()
+            .await
+            .expect("get response text");
+
+        assert_eq!("pong", resp);
+        tracing::info!("ping-pong succeeded");
+    }
+
+    tracing::info!("bye now!");
 }
 
 async fn spawn_http_server() -> SocketAddress {
@@ -112,4 +153,41 @@ async fn spawn_http_server() -> SocketAddress {
     tokio::spawn(tcp_service.serve(server));
 
     bind_addr
+}
+
+async fn spawn_https_server() -> SocketAddress {
+    let tcp_service = TcpListener::bind(SocketAddress::default_ipv4(0))
+        .await
+        .expect("bind HTTP server on open port");
+
+    let bind_addr = tcp_service
+        .local_addr()
+        .expect("get bind address of http server")
+        .into();
+
+    let app = Router::new().get("/ping", "pong");
+    let http_server = HttpServer::auto(Executor::default()).service(Arc::new(app));
+
+    let data = new_tls_service_data().expect("create tls service data");
+    let https_server = TlsAcceptorService::new(data, http_server, false);
+
+    tokio::spawn(tcp_service.serve(https_server));
+
+    bind_addr
+}
+
+fn new_tls_service_data() -> Result<TlsAcceptorData, OpaqueError> {
+    let tls_server_config = ServerConfig {
+        application_layer_protocol_negotiation: Some(vec![
+            ApplicationProtocol::HTTP_2,
+            ApplicationProtocol::HTTP_11,
+        ]),
+        ..ServerConfig::new(ServerAuth::SelfSigned(SelfSignedData {
+            organisation_name: Some("Socks5 Https Test Server".to_owned()),
+            ..Default::default()
+        }))
+    };
+    tls_server_config
+        .try_into()
+        .context("create tls server config")
 }


### PR DESCRIPTION
Add initial impl of `TlsPeekRouter`, incl unit tests of its core logic.
And integrate this new `TlsPeekRouter`into socks5 MITM example.

Closes #547