### PR TITLE
fix naming on tls.md

### DIFF
--- a/docs/book/src/proxies/tls.md
+++ b/docs/book/src/proxies/tls.md
@@ -14,7 +14,7 @@
   Spawns a mini handmade http server, as well as a TLS termination proxy, forwarding the
   plain text stream to the first.
 - [/examples/mtls_tunnel_and_service.rs](https://github.com/plabayo/rama/blob/main/examples/mtls_tunnel_and_service.rs):
-  Example of how to do mTls (manual Tls, where the client also needs a certificate) using rama,
+  Example of how to do mTLS (mutual TLS, where the client also needs a certificate) using rama,
   as well as how one might use this concept to provide a tunnel service build with these concepts;
 
 ## Description


### PR DESCRIPTION
This PR fixes a small mistake on the `tlsh.md` part of the documentation. I imagine that you meant `mutual` instead of `manual`.