### PR TITLE
Add zstd certificate compression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -2761,6 +2762,7 @@ dependencies = [
  "rama-utils",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,9 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f47434dbb6a574e585ac008ee7fef3149b2c97db578809409d7abfc4a4dba"
+checksum = "477c2786c6d332805856da39868fb26c9e9878a95914723aebb8e0c03b0a5e56"
 dependencies = [
  "bitflags",
  "foreign-types",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad3f5684d3a43d706a2510cacf6a69deacc3187a78262e5c97b93dad42388af"
+checksum = "c1ef4ffb23eee3766621ba55c60e5299d4de98552509fca9ccf7bd6d57b1e6db"
 dependencies = [
  "autocfg",
  "bindgen 0.71.1",
@@ -2405,9 +2405,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring-tokio"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803429a9e7cb01f0e6f715b7a3cd05999b8706babb90e76653f357b9c297abde"
+checksum = "bf9946ee3eecebeb9c2b3c4cf557dbd5a6aa185ef48362a013feb4fb8d962a75"
 dependencies = [
  "rama-boring",
  "rama-boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ psl = "2"
 quickcheck = "1.0"
 quote = "1.0"
 radix_trie = "0.2"
-rama-boring = "0.3.0"
-rama-boring-tokio = "0.3.0"
+rama-boring = "0.3.1"
+rama-boring-tokio = "0.3.1"
 rama-core = { version = "0.3.0-alpha.1", path = "./rama-core" }
 rama-dns = { version = "0.3.0-alpha.1", path = "./rama-dns" }
 rama-error = { version = "0.3.0-alpha.1", path = "./rama-error" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,6 +342,7 @@ serde_html_form = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "io-std"], optional = true }
 tracing = { workspace = true, optional = true }
+zstd.workspace = true
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,7 @@ serde_html_form = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "io-std"], optional = true }
 tracing = { workspace = true, optional = true }
-zstd.workspace = true
+zstd = { workspace = true }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/rama-tls-boring/Cargo.toml
+++ b/rama-tls-boring/Cargo.toml
@@ -19,7 +19,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-compression = ["dep:flate2", "dep:brotli"]
+compression = ["dep:flate2", "dep:brotli", "dep:zstd"]
 ua = ["dep:rama-ua"]
 
 [dependencies]
@@ -38,6 +38,7 @@ rama-ua = { workspace = true, optional = true, features = ["tls"] }
 rama-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "io-std"] }
 tracing = { workspace = true }
+zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 

--- a/rama-tls-boring/src/client/compress_certificate.rs
+++ b/rama-tls-boring/src/client/compress_certificate.rs
@@ -77,3 +77,48 @@ impl CertificateCompressor for BrotliCertificateCompressor {
         Ok(())
     }
 }
+
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub(super) struct ZstdCertificateCompressor;
+
+impl CertificateCompressor for ZstdCertificateCompressor {
+    const ALGORITHM: CertificateCompressionAlgorithm = CertificateCompressionAlgorithm::ZSTD;
+    const CAN_COMPRESS: bool = true;
+    const CAN_DECOMPRESS: bool = true;
+
+    fn compress<W>(&self, input: &[u8], output: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        let mut writer = zstd::stream::Encoder::new(output, 0)?;
+        writer.write_all(input)?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    fn decompress<W>(&self, input: &[u8], output: &mut W) -> Result<()>
+    where
+        W: Write,
+    {
+        let mut reader = zstd::stream::Decoder::new(input)?;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf[..]) {
+                Err(e) => {
+                    if let io::ErrorKind::Interrupted = e.kind() {
+                        continue;
+                    }
+                    return Err(e);
+                }
+                Ok(size) => {
+                    if size == 0 {
+                        break;
+                    }
+                    output.write_all(&buf[..size])?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -27,7 +27,9 @@ use std::{fmt, sync::Arc};
 use tracing::{debug, trace};
 
 #[cfg(feature = "compression")]
-use super::compress_certificate::{BrotliCertificateCompressor, ZlibCertificateCompressor};
+use super::compress_certificate::{
+    BrotliCertificateCompressor, ZlibCertificateCompressor, ZstdCertificateCompressor,
+};
 
 use crate::keylog::new_key_log_file_handle;
 
@@ -504,10 +506,10 @@ impl TlsConnectorDataBuilder {
                         .context("build (boring) ssl connector: add certificate compression algorithm: brotli")?;
                     }
                     CertificateCompressionAlgorithm::Zstd => {
-                        // TODO implement this, tracking issue: https://github.com/plabayo/rama/issues/563
-                        debug!(
-                            "boring connector: certificate compression algorithm: zstd: not (yet) supported: ignore"
-                        );
+                        cfg_builder.add_certificate_compression_algorithm(
+                            ZstdCertificateCompressor::default(),
+                        )
+                        .context("build (boring) ssl connector: add certificate compression algorithm: zstd")?;
                     }
                     CertificateCompressionAlgorithm::Unknown(_) => {
                         debug!(


### PR DESCRIPTION
Depends on ["Add TLSEXT_cert_compression_zstd constant" PR](https://github.com/plabayo/rama-boring/pull/2) on `rama-boring`

Closes #563