### PR TITLE
Remove unused `zstd` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,7 +2374,6 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
- "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -342,7 +342,6 @@ serde_html_form = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "io-std"], optional = true }
 tracing = { workspace = true, optional = true }
-zstd = { workspace = true }
 
 [build-dependencies]
 rustversion = { workspace = true }


### PR DESCRIPTION
This was accidentally introduced in the wrong place.