### PR TITLE
Support dropping idle connections from the pool

### DIFF
--- a/rama-http-backend/src/client/mod.rs
+++ b/rama-http-backend/src/client/mod.rs
@@ -173,10 +173,7 @@ mod easy_connector {
         EstablishedClientConnection,
         pool::{
             FiFoReuseLruDropPool, PooledConnector,
-            http::{
-                BasicHttpConId, BasicHttpConnIdentifier, HttpPooledConnectorBuilder,
-                HttpPooledConnectorConfig,
-            },
+            http::{BasicHttpConId, BasicHttpConnIdentifier, HttpPooledConnectorConfig},
         },
     };
     use rama_tcp::client::service::TcpConnector;
@@ -478,11 +475,7 @@ mod easy_connector {
             self,
             config: HttpPooledConnectorConfig,
         ) -> Result<DefaultConnectionPoolBuilder<T, C>, OpaqueError> {
-            let connector = HttpPooledConnectorBuilder::new()
-                .max_active(config.max_active)
-                .max_total(config.max_total)
-                .maybe_with_wait_for_pool_timeout(config.wait_for_pool_timeout)
-                .build(self.connector)?;
+            let connector = config.build_connector(self.connector)?;
 
             Ok(EasyHttpWebClientBuilder {
                 connector,

--- a/rama-net/src/client/pool.rs
+++ b/rama-net/src/client/pool.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{future::Future, net::SocketAddr};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -128,6 +128,7 @@ struct PooledConnection<C, ID> {
     conn: C,
     id: ID,
     pool_slot: PoolSlot,
+    last_used: Instant,
 }
 
 /// Connection pool that uses FiFo for reuse and LRU to evict connections
@@ -135,6 +136,7 @@ pub struct FiFoReuseLruDropPool<C, ID> {
     storage: Arc<Mutex<VecDeque<PooledConnection<C, ID>>>>,
     total_slots: Arc<Semaphore>,
     active_slots: Arc<Semaphore>,
+    idle_timeout: Option<Duration>,
     returner: ConnReturner<C, ID>,
 }
 
@@ -151,8 +153,9 @@ impl<C, ID> Clone for ConnReturner<C, ID> {
 }
 
 impl<C, ID> ConnReturner<C, ID> {
-    fn return_conn(&self, conn: PooledConnection<C, ID>) {
+    fn return_conn(&self, mut conn: PooledConnection<C, ID>) {
         if let Some(storage) = self.weak_storage.upgrade() {
+            conn.last_used = Instant::now();
             storage.lock().push_front(conn)
         }
     }
@@ -165,6 +168,7 @@ impl<C, ID> Clone for FiFoReuseLruDropPool<C, ID> {
             total_slots: self.total_slots.clone(),
             active_slots: self.active_slots.clone(),
             returner: self.returner.clone(),
+            idle_timeout: self.idle_timeout,
         }
     }
 }
@@ -188,7 +192,20 @@ impl<C, ID> FiFoReuseLruDropPool<C, ID> {
             returner: ConnReturner { weak_storage },
             total_slots: Arc::new(Semaphore::const_new(max_total)),
             active_slots: Arc::new(Semaphore::const_new(max_active)),
+            idle_timeout: None,
         })
+    }
+
+    generate_set_and_with! {
+        /// If connections have been idle for longer then the provided timeout they
+        /// will be dropped and removed from the pool
+        ///
+        /// Note: timeout is only checked when a connection is requested from the pool,
+        /// it is not something that is done periodically
+        pub fn idle_timeout(mut self, timeout: Option<Duration>) -> Self {
+            self.idle_timeout = timeout;
+            self
+        }
     }
 }
 
@@ -213,20 +230,30 @@ where
         );
 
         let mut storage = self.storage.lock();
-        let pooled_conn = {
-            storage
-                .iter()
-                .position(|stored| &stored.id == id)
-                .and_then(|idx| storage.remove(idx))
-        };
 
-        if let Some(pooled_conn) = pooled_conn {
-            return Ok(ConnectionResult::Connection(LeasedConnection {
-                active_slot,
-                pooled_conn: Some(pooled_conn),
-                returner: self.returner.clone(),
-                failed: false.into(),
-            }));
+        let idx = storage.iter().position(|stored| &stored.id == id);
+        let pooled_conn = idx.and_then(|idx| storage.remove(idx));
+
+        if let (Some(idx), Some(pooled_conn)) = (idx, pooled_conn) {
+            let mut timeout_triggered = false;
+            if let Some(timeout) = self.idle_timeout {
+                if pooled_conn.last_used.elapsed() > timeout {
+                    timeout_triggered = true;
+                }
+            }
+
+            // Since we always insert in the beginning we can assume if this connection has been idle for too long
+            // all connections older then this one should also be evicted
+            if timeout_triggered {
+                storage.drain(idx..);
+            } else {
+                return Ok(ConnectionResult::Connection(LeasedConnection {
+                    active_slot,
+                    pooled_conn: Some(pooled_conn),
+                    returner: self.returner.clone(),
+                    failed: false.into(),
+                }));
+            }
         }
 
         let pool_slot = match self.total_slots.clone().try_acquire_owned() {
@@ -253,6 +280,7 @@ where
                 id,
                 conn,
                 pool_slot,
+                last_used: Instant::now(),
             }),
         }
     }
@@ -585,12 +613,11 @@ impl<S, P: Clone, R: Clone> Layer<S> for PooledConnectorLayer<P, R> {
 
 #[cfg(feature = "http")]
 pub mod http {
-    use std::time::Duration;
-
     use super::{FiFoReuseLruDropPool, PooledConnector, ReqToConnID};
     use crate::{Protocol, address::Authority, client::pool::OpaqueError, http::RequestContext};
     use rama_core::Context;
     use rama_http_types::Request;
+    use std::time::Duration;
 
     #[derive(Clone, Debug, Default)]
     #[non_exhaustive]
@@ -612,86 +639,63 @@ pub mod http {
         }
     }
 
-    #[derive(Clone, Default)]
-    /// Builder to help create a config for the default http connection pool or to
-    /// build the connector directly
-    pub struct HttpPooledConnectorBuilder {
-        config: HttpPooledConnectorConfig,
-    }
-
     #[derive(Clone)]
     /// Config used to create the default http connection pool
     pub struct HttpPooledConnectorConfig {
+        /// Set the max amount of connections that this connection pool will contain
+        ///
+        /// This is the sum of active connections and idle connections. When this limit
+        /// is hit idle connections will be replaced with new ones.
         pub max_total: usize,
+        /// Set the max amount of connections that can actively be used
+        ///
+        /// Requesting a connection from the pool will block until the pool
+        /// is below max capacity again.
         pub max_active: usize,
+        /// If connections have been idle for longer then the provided timeout they
+        /// will be dropped and removed from the pool
+        ///
+        /// Note: timeout is only checked when a connection is requested from the pool,
+        /// it is not something that is done periodically
+        pub idle_timeout: Option<Duration>,
+        /// When a pool is operating at max active capacity wait for this duration
+        /// to get a connection from the pool before the connector raises a timeout error
         pub wait_for_pool_timeout: Option<Duration>,
-    }
-
-    impl From<HttpPooledConnectorConfig> for HttpPooledConnectorBuilder {
-        fn from(config: HttpPooledConnectorConfig) -> Self {
-            Self { config }
-        }
     }
 
     impl Default for HttpPooledConnectorConfig {
         fn default() -> Self {
             Self {
-                max_total: 100,
+                max_total: 50,
                 max_active: 20,
-                wait_for_pool_timeout: None,
+                wait_for_pool_timeout: Some(Duration::from_secs(120)),
+                idle_timeout: Some(Duration::from_secs(300)),
             }
         }
     }
 
-    impl HttpPooledConnectorBuilder {
+    impl HttpPooledConnectorConfig {
         pub fn new() -> Self {
-            Self::default()
+            Self {
+                max_total: 50,
+                max_active: 20,
+                wait_for_pool_timeout: None,
+                idle_timeout: None,
+            }
         }
 
-        /// Set the max amount of connections that this connection pool will contain
-        ///
-        /// This is the sum of active connections and idle connections. When this limit
-        /// is hit idle connections will be replaced with new ones.
-        pub fn max_total(mut self, max: usize) -> Self {
-            self.config.max_total = max;
-            self
-        }
-
-        /// Set the max amount of connections that can actively be used
-        ///
-        /// Requesting a connection from the pool will block until the pool
-        /// is below max capacity again.
-        pub fn max_active(mut self, max: usize) -> Self {
-            self.config.max_active = max;
-            self
-        }
-
-        /// When a pool is operating at max active capacity wait for this duration
-        /// before the connector raises a timeout error
-        pub fn with_wait_for_pool_timeout(mut self, duration: Duration) -> Self {
-            self.config.wait_for_pool_timeout = Some(duration);
-            self
-        }
-
-        pub fn maybe_with_wait_for_pool_timeout(mut self, duration: Option<Duration>) -> Self {
-            self.config.wait_for_pool_timeout = duration;
-            self
-        }
-
-        pub fn build<C, S>(
+        pub fn build_connector<C, S>(
             self,
             inner: S,
         ) -> Result<
             PooledConnector<S, FiFoReuseLruDropPool<C, BasicHttpConId>, BasicHttpConnIdentifier>,
             OpaqueError,
         > {
-            let pool = FiFoReuseLruDropPool::new(self.config.max_active, self.config.max_total)?;
-            Ok(PooledConnector::new(inner, pool, BasicHttpConnIdentifier)
-                .maybe_with_wait_for_pool_timeout(self.config.wait_for_pool_timeout))
-        }
+            let pool = FiFoReuseLruDropPool::new(self.max_active, self.max_total)?
+                .maybe_with_idle_timeout(self.idle_timeout);
 
-        pub fn build_config(self) -> HttpPooledConnectorConfig {
-            self.config
+            Ok(PooledConnector::new(inner, pool, BasicHttpConnIdentifier)
+                .maybe_with_wait_for_pool_timeout(self.wait_for_pool_timeout))
         }
     }
 }
@@ -945,5 +949,31 @@ mod tests {
         assert_ok!(result);
 
         assert_eq!(svc.inner.created_connection.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn drop_idle_connections() {
+        let mut pool = FiFoReuseLruDropPool::new(5, 10).unwrap();
+        pool.set_idle_timeout(Duration::from_micros(1));
+
+        let svc = PooledConnector::new(TestService::default(), pool, StringRequestLengthID {});
+
+        let conn = svc
+            .connect(Context::default(), String::from(""))
+            .await
+            .unwrap()
+            .conn;
+
+        assert_eq!(svc.inner.created_connection.load(Ordering::Relaxed), 1);
+        drop(conn);
+
+        let conn = svc
+            .connect(Context::default(), String::from(""))
+            .await
+            .unwrap()
+            .conn;
+
+        assert_eq!(svc.inner.created_connection.load(Ordering::Relaxed), 2);
+        drop(conn);
     }
 }


### PR DESCRIPTION
Drop idle connection from pool to prevent using stale ones.

This + detecting broken connections should make the connection pool pretty robust to use. There is still room for improvements here and there, but this is now +- on par with connection pooling in hyper.

Part of: https://github.com/plabayo/rama/issues/581