### PR TITLE
add http peek router implementation + proxy connectivity example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,6 +601,10 @@ name = "http_https_socks5_and_socks5h_connect_proxy"
 required-features = ["dns", "socks5", "http-full", "boring"]
 
 [[example]]
+name = "proxy_connectivity_check"
+required-features = ["socks5", "http-full", "tls"]
+
+[[example]]
 name = "haproxy_client_ip"
 required-features = ["haproxy", "http-full"]
 

--- a/docs/book/src/proxies/protocol_inspection.md
+++ b/docs/book/src/proxies/protocol_inspection.md
@@ -126,9 +126,18 @@ This pattern allows for flexible protocol handling while maintaining clean separ
 - Handle protocol-specific processing
 - Integrate with MITM capabilities when needed
 
-[`socks5_and_http_proxy.rs`](https://github.com/plabayo/rama/tree/main/examples/socks5_and_http_proxy.rs) is another example of such protocol inspection. This code is used to be able to support a socks5 proxy that can also be something else next to it(e.g. an http proxy).
-
-[`http_https_socks5_and_socks5h_connect_proxy.rs`](https://github.com/plabayo/rama/tree/main/examples/http_https_socks5_and_socks5h_connect_proxy.rs) is another advanced demonstration of Rama's protocol inspection and routing capabilities. This example showcases how to build a **single, unified proxy server** that intelligently handles HTTP, HTTPS (via CONNECT), SOCKS5, and SOCKS5H traffic all within the same listener, leveraging various `PeekRouter` and service composition patterns for robust multi-protocol support.
+Some rama examples that built on top of protocol inspection:
+- [`socks5_and_http_proxy.rs`](https://github.com/plabayo/rama/tree/main/examples/socks5_and_http_proxy.rs)
+  is an example of such protocol inspection.This code is used to be able to support
+  a socks5 proxy that can also be something else next to it (e.g. an http proxy).
+- [`http_https_socks5_and_socks5h_connect_proxy.rs`](https://github.com/plabayo/rama/tree/main/examples/http_https_socks5_and_socks5h_connect_proxy.rs)
+  is another advanced demonstration of Rama's protocol inspection and routing capabilities.
+  This example showcases how to build a **single, unified proxy server** that intelligently handles
+  HTTP, HTTPS (HTTP within TLS) and SOCKS5 traffic all within the same listener,
+  leveraging various `PeekRouter` and service composition patterns for robust multi-protocol support.
+- [`proxy_connectivity_check.rs`](https://github.com/plabayo/rama/tree/main/examples/proxy_connectivity_check.rs)
+  is not about protocool inspection but does leverage socks5 and http protocol inspections for various purposes,
+  including to hijack very specific http data without forcing all socks5 proxy traffic to be http.
 
 ## Best Practices
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -62,6 +62,9 @@ This directory contains example implementations demonstrating various features a
   combines `http_connect_proxy` and `socks5_connect_proxy` into a single server.
 - [`http_https_socks5_and_socks5h_connect_proxy.rs`](./http_https_socks5_and_socks5h_connect_proxy.rs) -
   combines `http_connect_proxy`, `https_connect_proxy` and `socks5_connect_proxy` into a single server.
+- [`proxy_connectivity_check.rs`](./proxy_connectivity_check.rs) -
+  combines an http and socks5 proxy, but mostly is about how you can add a connectivity check,
+  used by humans as a sanity check for whether or not they are connected (via) "the" proxy.
 
 ### HaProxy
 

--- a/examples/proxy_connectivity_check.rs
+++ b/examples/proxy_connectivity_check.rs
@@ -1,0 +1,243 @@
+//! An example to showcase how you can provide a kind of connectivity check
+//! using protocol inspection and hijacking utilities provided by rama
+//! for both http and socks5 proxies. We do not showcase it for all possible
+//! proxy flows and protocols, neither for MITM proxies. You can however
+//! apply the techniques demonstrated here there as well.
+//!
+//! # Run the example
+//!
+//! ```sh
+//! cargo run --example proxy_connectivity_check --features=socks5,http-full,tls
+//! ```
+//!
+//! # Expected output
+//!
+//! The server will start and listen on `:62030`. You can use `curl` to interact with the service:
+//!
+//! ```
+//! curl -v -x http://127.0.0.1:62030 --proxy-user 'tom:clancy' http://example.com/
+//! curl -v -x socks5://127.0.0.1:62030 --proxy-user 'john:secret' http://example.com/
+//! ```
+//!
+//! You should see in all the above examples the hijacked page by rama
+//! proving you are correctly connected via a proxy built with rama.
+//!
+//! If you instead go to the example website directly you'll see the
+//! original example site:
+//!
+//! ```sh
+//! curl -v http://example.com/
+//! ```
+//!
+//! Note that in an actual production setting you would usually do this with a (sub)domain
+//! that you control rather than a thirdparty external web service.
+
+use rama::{
+    Context, Layer, Service,
+    context::RequestContextExt,
+    http::{
+        Body, Request, Response, StatusCode,
+        client::EasyHttpWebClient,
+        layer::{
+            proxy_auth::ProxyAuthLayer,
+            remove_header::{RemoveRequestHeaderLayer, RemoveResponseHeaderLayer},
+            trace::TraceLayer,
+            upgrade::UpgradeLayer,
+        },
+        matcher::{DomainMatcher, MethodMatcher},
+        server::HttpServer,
+        service::web::{
+            StaticService,
+            response::{Html, IntoResponse},
+        },
+    },
+    layer::{ConsumeErrLayer, HijackLayer},
+    net::{
+        address::{Domain, SocketAddress},
+        http::{RequestContext, server::HttpPeekRouter},
+        proxy::ProxyTarget,
+        stream::ClientSocketInfo,
+        tls::SecureTransport,
+        user::Basic,
+    },
+    proxy::socks5::{
+        Socks5Acceptor, Socks5Auth,
+        server::{LazyConnector, Socks5PeekRouter},
+    },
+    rt::Executor,
+    service::service_fn,
+    tcp::{client::service::Forwarder, server::TcpListener},
+};
+
+use std::{convert::Infallible, time::Duration};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+fn new_example_hijack_svc()
+-> impl Clone + Service<(), Request, Response = Response, Error = Infallible> {
+    StaticService::new(Html(
+        r##"<!doctype html>
+<html>
+<head>
+    <title>Connectivity Example</title>
+
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style type="text/css">
+    body {
+        background-color: #f0f0f2;
+        margin: 0;
+        padding: 0;
+        font-family: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+
+    }
+    div {
+        width: 600px;
+        margin: 5em auto;
+        padding: 2em;
+        background-color: #fdfdff;
+        border-radius: 0.5em;
+        box-shadow: 2px 3px 7px 2px rgba(0,0,0,0.02);
+    }
+    a:link, a:visited {
+        color: #38488f;
+        text-decoration: none;
+    }
+    @media (max-width: 700px) {
+        div {
+            margin: 0 auto;
+            width: auto;
+        }
+    }
+    </style>
+</head>
+
+<body>
+<div>
+    <h1>Connectivity Example</h1>
+    <p>This example demonstrates how you can provide a kind of connectivity check
+    using protocol inspection and hijacking utilities provided by rama
+    for both http and socks5 proxies.</p>
+    <p><a href="https://ramaproxy.org">More information...</a></p>
+</div>
+</body>
+</html>
+"##,
+    ))
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let graceful = rama::graceful::Shutdown::default();
+
+    let tcp_service = TcpListener::bind(SocketAddress::default_ipv4(62030))
+        .await
+        .expect("bind tcp interface for connectivity example");
+
+    let proxy_service = (
+        RemoveResponseHeaderLayer::hop_by_hop(),
+        RemoveRequestHeaderLayer::hop_by_hop(),
+        HijackLayer::new(
+            DomainMatcher::exact(Domain::from_static("example.com")),
+            new_example_hijack_svc(),
+        ),
+    )
+        .into_layer(service_fn(http_plain_proxy));
+
+    let http_service = HttpServer::auto(Executor::graceful(graceful.guard())).service(
+        (
+            TraceLayer::new_for_http(),
+            ProxyAuthLayer::new(Basic::new("tom", "clancy")),
+            UpgradeLayer::new(
+                MethodMatcher::CONNECT,
+                service_fn(http_connect_accept),
+                ConsumeErrLayer::default().into_layer(Forwarder::ctx()),
+            ),
+        )
+            .into_layer(proxy_service.clone()),
+    );
+
+    let exec = Executor::graceful(graceful.guard());
+    let socks5_svc = HttpPeekRouter::new(HttpServer::auto(exec).service(proxy_service))
+        .with_fallback(Forwarder::ctx());
+    let socks5_acceptor = Socks5Acceptor::new()
+        .with_auth(Socks5Auth::username_password("john", "secret"))
+        .with_connector(LazyConnector::new(socks5_svc));
+
+    let auto_socks5_acceptor = Socks5PeekRouter::new(socks5_acceptor).with_fallback(http_service);
+
+    graceful.spawn_task_fn(|guard| tcp_service.serve_graceful(guard, auto_socks5_acceptor));
+
+    graceful
+        .shutdown_with_limit(Duration::from_secs(30))
+        .await
+        .expect("graceful shutdown");
+}
+
+async fn http_connect_accept(
+    mut ctx: Context<()>,
+    req: Request,
+) -> Result<(Response, Context<()>, Request), Response> {
+    match ctx
+        .get_or_try_insert_with_ctx::<RequestContext, _>(|ctx| (ctx, &req).try_into())
+        .map(|ctx| ctx.authority.clone())
+    {
+        Ok(authority) => {
+            tracing::info!(%authority, "accept CONNECT (lazy): insert proxy target into context");
+            ctx.insert(ProxyTarget(authority));
+        }
+        Err(err) => {
+            tracing::error!(err = %err, "error extracting authority");
+            return Err(StatusCode::BAD_REQUEST.into_response());
+        }
+    }
+
+    tracing::info!(
+        "proxy secure transport ingress: {:?}",
+        ctx.get::<SecureTransport>()
+    );
+
+    Ok((StatusCode::OK.into_response(), ctx, req))
+}
+
+async fn http_plain_proxy(ctx: Context<()>, req: Request) -> Result<Response, Infallible> {
+    let client = EasyHttpWebClient::default();
+    match client.serve(ctx, req).await {
+        Ok(resp) => {
+            match resp
+                .extensions()
+                .get::<RequestContextExt>()
+                .and_then(|ext| ext.get::<ClientSocketInfo>())
+            {
+                Some(client_socket_info) => tracing::info!(
+                    status = %resp.status(),
+                    local_addr = ?client_socket_info.local_addr(),
+                    server_addr = %client_socket_info.peer_addr(),
+                    "http plain text proxy received response",
+                ),
+                None => tracing::info!(
+                    status = %resp.status(),
+                    "http plain text proxy received response, IP info unknown",
+                ),
+            };
+            Ok(resp)
+        }
+        Err(err) => {
+            tracing::error!(error = %err, "error in client request");
+            Ok(Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .unwrap())
+        }
+    }
+}

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -19,6 +19,28 @@ pub enum Host {
 }
 
 impl Host {
+    /// Returns `true` if [`host`] is a [`Domain`].
+    pub fn is_domain(&self) -> bool {
+        matches!(self, Host::Name(_))
+    }
+
+    /// Returns `true` if [`host`] is a [`IpAddr`].
+    pub fn is_ip(&self) -> bool {
+        matches!(self, Host::Address(_))
+    }
+
+    /// Returns `true` if [`host`] is a [`IpAddr::V4`].
+    pub fn is_ipv4(&self) -> bool {
+        matches!(self, Host::Address(IpAddr::V4(_)))
+    }
+
+    /// Returns `true` if [`host`] is a [`IpAddr::V6`].
+    pub fn is_ipv6(&self) -> bool {
+        matches!(self, Host::Address(IpAddr::V4(_)))
+    }
+}
+
+impl Host {
     /// Local loopback address (IPv4)
     pub const LOCALHOST_IPV4: Self = Self::Address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 

--- a/rama-net/src/http/mod.rs
+++ b/rama-net/src/http/mod.rs
@@ -7,3 +7,5 @@
 mod request_context;
 #[doc(inline)]
 pub use request_context::RequestContext;
+
+pub mod server;

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -77,7 +77,10 @@ impl<T: HttpRequestParts, State> TryFrom<(&Context<State>, &T)> for RequestConte
             .unwrap_or_else(|| protocol.default_port().unwrap_or(80));
         tracing::trace!(uri = %uri, "request context: detected default port: {default_port}");
 
-        let proxy_authority_opt: Option<Authority> = ctx.get::<ProxyTarget>().map(|t| t.0.clone());
+        let proxy_authority_opt: Option<Authority> = ctx
+            .get::<ProxyTarget>()
+            .and_then(|t| t.0.host().is_domain().then(|| t.0.clone()));
+
         let sni_host_opt = ctx.get().and_then(try_get_host_from_secure_transport);
         let authority = match (proxy_authority_opt, sni_host_opt) {
             (Some(authority), _) => {

--- a/rama-net/src/http/server/mod.rs
+++ b/rama-net/src/http/server/mod.rs
@@ -1,0 +1,7 @@
+//! Http server utility types and services.
+//!
+//! - [`HttpPeekRouter`] allows you to detect http/1x and h2 traffic. H3 traffic
+//!   is not covered by this router as this is done via sidechannel information instead (e.g. ALPN in TLS).
+
+pub mod peek;
+pub use peek::{HttpPeekRouter, HttpPeekStream, NoHttpRejectError};

--- a/rama-net/src/http/server/peek.rs
+++ b/rama-net/src/http/server/peek.rs
@@ -1,0 +1,662 @@
+//! types and logic for [`HttpPeekRouter`]
+
+use std::fmt;
+
+use rama_core::{
+    Context, Service,
+    error::{BoxError, ErrorContext},
+    service::RejectService,
+};
+use tokio::io::AsyncReadExt;
+
+use crate::stream::{PeekStream, StackReader};
+
+/// A [`Service`] router that can be used to support
+/// http/1x and h2 traffic as well as non-tls traffic.
+///
+/// By default non-tls traffic is rejected using [`RejectService`].
+/// Use [`TlsPeekRouter::with_fallback`] to configure the fallback service.
+pub struct HttpPeekRouter<T, F = RejectService<(), NoHttpRejectError>> {
+    http_acceptor: T,
+    fallback: F,
+}
+
+/// Type wrapper used by [`HttpPeekRouter::new_dual`]
+/// to serve http/1x and h2 separately.
+pub struct HttpDualAcceptor<T, U> {
+    http1: T,
+    h2: U,
+}
+
+impl<T: Clone, U: Clone> Clone for HttpDualAcceptor<T, U> {
+    fn clone(&self) -> Self {
+        Self {
+            http1: self.http1.clone(),
+            h2: self.h2.clone(),
+        }
+    }
+}
+
+impl<T: fmt::Debug, U: fmt::Debug> fmt::Debug for HttpDualAcceptor<T, U> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpDualAcceptor")
+            .field("http1", &self.http1)
+            .field("h2", &self.h2)
+            .finish()
+    }
+}
+
+/// Type wrapper used by [`HttpPeekRouter::new`]
+/// to serve http/1x and h2 with a single service.
+pub struct HttpAutoAcceptor<T>(T);
+
+impl<T: Clone> Clone for HttpAutoAcceptor<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for HttpAutoAcceptor<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HttpAutoAcceptor").field(&self.0).finish()
+    }
+}
+
+/// Type wrapper used by [`HttpPeekRouter::new_http1`]
+/// to only serve http/1x, and send h2 to the fallback.
+pub struct Http1Acceptor<T>(T);
+
+impl<T: Clone> Clone for Http1Acceptor<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for Http1Acceptor<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Http1Acceptor").field(&self.0).finish()
+    }
+}
+
+/// Type wrapper used by [`HttpPeekRouter::new_h2`]
+/// to only serve h2, and send http/1x to the fallback.
+pub struct H2Acceptor<T>(T);
+
+impl<T: Clone> Clone for H2Acceptor<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for H2Acceptor<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("H2Acceptor").field(&self.0).finish()
+    }
+}
+rama_utils::macros::error::static_str_error! {
+    #[doc = "non-http connection is rejected"]
+    pub struct NoHttpRejectError;
+}
+
+impl<T> HttpPeekRouter<HttpAutoAcceptor<T>> {
+    /// Create a new [`HttpPeekRouter`] using a service
+    /// which can handle h2 and http/1x versions alike.
+    pub fn new(auto_acceptor: T) -> Self {
+        Self {
+            http_acceptor: HttpAutoAcceptor(auto_acceptor),
+            fallback: RejectService::new(NoHttpRejectError),
+        }
+    }
+}
+
+impl<T> HttpPeekRouter<Http1Acceptor<T>> {
+    /// Create a new [`HttpPeekRouter`] using a service
+    /// which handles http/1x traffic but forwards h2 traffic to fallback.
+    pub fn new_http1(http1_acceptor: T) -> Self {
+        Self {
+            http_acceptor: Http1Acceptor(http1_acceptor),
+            fallback: RejectService::new(NoHttpRejectError),
+        }
+    }
+}
+
+impl<T> HttpPeekRouter<H2Acceptor<T>> {
+    /// Create a new [`HttpPeekRouter`] using a service
+    /// which handles h2 traffic but forwards http/1x traffic to fallback.
+    pub fn new_h2(h2_acceptor: T) -> Self {
+        Self {
+            http_acceptor: H2Acceptor(h2_acceptor),
+            fallback: RejectService::new(NoHttpRejectError),
+        }
+    }
+}
+
+impl<T> HttpPeekRouter<T> {
+    /// Attach a fallback [`Service`] tp this [`HttpPeekRouter`].
+    pub fn with_fallback<F>(self, fallback: F) -> HttpPeekRouter<T, F> {
+        HttpPeekRouter {
+            http_acceptor: self.http_acceptor,
+            fallback,
+        }
+    }
+}
+
+impl<T, U> HttpPeekRouter<HttpDualAcceptor<T, U>> {
+    /// Create a new [`HttpPeekRouter`] using a service
+    /// which handles http/1x and h2 in two separate services.
+    pub fn new_dual(http1_acceptor: T, h2_acceptor: U) -> Self {
+        Self {
+            http_acceptor: HttpDualAcceptor {
+                http1: http1_acceptor,
+                h2: h2_acceptor,
+            },
+            fallback: RejectService::new(NoHttpRejectError),
+        }
+    }
+}
+
+impl<T: Clone, F: Clone> Clone for HttpPeekRouter<T, F> {
+    fn clone(&self) -> Self {
+        Self {
+            http_acceptor: self.http_acceptor.clone(),
+            fallback: self.fallback.clone(),
+        }
+    }
+}
+
+impl<T: fmt::Debug, F: fmt::Debug> fmt::Debug for HttpPeekRouter<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpPeekRouter")
+            .field("http_acceptor", &self.http_acceptor)
+            .field("fallback", &self.fallback)
+            .finish()
+    }
+}
+
+impl<State, Stream, Response, T, F> Service<State, Stream>
+    for HttpPeekRouter<HttpAutoAcceptor<T>, F>
+where
+    State: Clone + Send + Sync + 'static,
+    Stream: crate::stream::Stream + Unpin,
+    Response: Send + 'static,
+    T: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    F: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+{
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        ctx: Context<State>,
+        stream: Stream,
+    ) -> Result<Self::Response, Self::Error> {
+        let (version, stream) = peek_http_stream(stream).await?;
+        if version.is_some() {
+            tracing::trace!(?version, "http peek: serve[auto]: http acceptor");
+            self.http_acceptor
+                .0
+                .serve(ctx, stream)
+                .await
+                .map_err(Into::into)
+        } else {
+            tracing::trace!(?version, "http peek: serve[auto]: fallback");
+            self.fallback.serve(ctx, stream).await.map_err(Into::into)
+        }
+    }
+}
+
+impl<State, Stream, Response, T, F> Service<State, Stream> for HttpPeekRouter<Http1Acceptor<T>, F>
+where
+    State: Clone + Send + Sync + 'static,
+    Stream: crate::stream::Stream + Unpin,
+    Response: Send + 'static,
+    T: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    F: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+{
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        ctx: Context<State>,
+        stream: Stream,
+    ) -> Result<Self::Response, Self::Error> {
+        let (version, stream) = peek_http_stream(stream).await?;
+        if version == Some(HttpPeekVersion::Http1x) {
+            tracing::trace!(?version, "http peek: serve[http1]: http/1x acceptor");
+            self.http_acceptor
+                .0
+                .serve(ctx, stream)
+                .await
+                .map_err(Into::into)
+        } else {
+            tracing::trace!(?version, "http peek: serve[http1]: fallback");
+            self.fallback.serve(ctx, stream).await.map_err(Into::into)
+        }
+    }
+}
+
+impl<State, Stream, Response, T, F> Service<State, Stream> for HttpPeekRouter<H2Acceptor<T>, F>
+where
+    State: Clone + Send + Sync + 'static,
+    Stream: crate::stream::Stream + Unpin,
+    Response: Send + 'static,
+    T: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    F: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+{
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        ctx: Context<State>,
+        stream: Stream,
+    ) -> Result<Self::Response, Self::Error> {
+        let (version, stream) = peek_http_stream(stream).await?;
+        if version == Some(HttpPeekVersion::H2) {
+            tracing::trace!(?version, "http peek: serve[h2]: http acceptor");
+            self.http_acceptor
+                .0
+                .serve(ctx, stream)
+                .await
+                .map_err(Into::into)
+        } else {
+            tracing::trace!(?version, "http peek: serve[h2]: fallback");
+            self.fallback.serve(ctx, stream).await.map_err(Into::into)
+        }
+    }
+}
+
+impl<State, Stream, Response, T, U, F> Service<State, Stream>
+    for HttpPeekRouter<HttpDualAcceptor<T, U>, F>
+where
+    State: Clone + Send + Sync + 'static,
+    Stream: crate::stream::Stream + Unpin,
+    Response: Send + 'static,
+    T: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    U: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+    F: Service<State, HttpPeekStream<Stream>, Response = Response, Error: Into<BoxError>>,
+{
+    type Response = Response;
+    type Error = BoxError;
+
+    async fn serve(
+        &self,
+        ctx: Context<State>,
+        stream: Stream,
+    ) -> Result<Self::Response, Self::Error> {
+        let (version, stream) = peek_http_stream(stream).await?;
+        match version {
+            Some(HttpPeekVersion::H2) => {
+                tracing::trace!(?version, "http peek: serve[dual]: h2 acceptor");
+                self.http_acceptor
+                    .h2
+                    .serve(ctx, stream)
+                    .await
+                    .map_err(Into::into)
+            }
+            Some(HttpPeekVersion::Http1x) => {
+                tracing::trace!(?version, "http peek: serve[dual]: http/1x acceptor");
+                self.http_acceptor
+                    .http1
+                    .serve(ctx, stream)
+                    .await
+                    .map_err(Into::into)
+            }
+            None => {
+                tracing::trace!(?version, "http peek: serve[dual]: fallback");
+                self.fallback.serve(ctx, stream).await.map_err(Into::into)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpPeekVersion {
+    Http1x,
+    H2,
+}
+
+async fn peek_http_stream<Stream: crate::stream::Stream + Unpin>(
+    mut stream: Stream,
+) -> Result<(Option<HttpPeekVersion>, HttpPeekStream<Stream>), BoxError> {
+    let mut peek_buf = [0u8; HTTP_HEADER_PEEK_LEN];
+    let n = stream
+        .read(&mut peek_buf)
+        .await
+        .context("try to read http prefix")?;
+
+    const HTTP_METHODS: &[&[u8]] = &[
+        b"GET ",
+        b"POST ",
+        b"PUT ",
+        b"DELETE ",
+        b"HEAD ",
+        b"OPTIONS ",
+        b"CONNECT ",
+        b"TRACE ",
+        b"PATCH ",
+    ];
+
+    let http_version = if n == H2_MAGIC_PREFIX.len() && peek_buf.eq(H2_MAGIC_PREFIX) {
+        Some(HttpPeekVersion::H2)
+    } else if HTTP_METHODS
+        .iter()
+        .any(|method| peek_buf.starts_with(method))
+    {
+        Some(HttpPeekVersion::Http1x)
+    } else {
+        None
+    };
+
+    tracing::trace!(?http_version, "http prefix header read");
+
+    let offset = HTTP_HEADER_PEEK_LEN - n;
+    if offset > 0 {
+        tracing::trace!(
+            %n,
+            "move http peek buffer cursor due to reading not enough"
+        );
+        for i in (0..n).rev() {
+            peek_buf[i + offset] = peek_buf[i];
+        }
+    }
+
+    let mut peek = StackReader::new(peek_buf);
+    peek.skip(offset);
+
+    let stream = PeekStream::new(peek, stream);
+
+    Ok((http_version, stream))
+}
+
+const H2_MAGIC_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+const HTTP_HEADER_PEEK_LEN: usize = H2_MAGIC_PREFIX.len();
+
+/// [`PeekStream`] alias used by [`HttpPeekRouter`].
+pub type HttpPeekStream<S> = PeekStream<StackReader<HTTP_HEADER_PEEK_LEN>, S>;
+
+#[cfg(test)]
+mod test {
+    use rama_core::service::{RejectError, service_fn};
+    use std::convert::Infallible;
+
+    use crate::stream::Stream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_peek_router() {
+        let http_service = service_fn(async |_, _| Ok::<_, Infallible>("http"));
+        let fallback_service = service_fn(async |_, _| Ok::<_, Infallible>("other"));
+
+        let peek_http_svc = HttpPeekRouter::new(http_service).with_fallback(fallback_service);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("http", response);
+
+        let response = peek_http_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nfoo".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("http", response);
+
+        const HTTP_METHODS: &[&str] = &[
+            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+        ];
+        for method in HTTP_METHODS {
+            let response = peek_http_svc
+                .serve(
+                    Context::default(),
+                    std::io::Cursor::new(format!("{method} /foobar HTTP/1.1").into_bytes()),
+                )
+                .await
+                .unwrap();
+            assert_eq!("http", response);
+        }
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foo".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foobar".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_http1_router() {
+        let http_service = service_fn(async |_, _| Ok::<_, Infallible>("http1"));
+        let fallback_service = service_fn(async |_, _| Ok::<_, Infallible>("other"));
+
+        let peek_http_svc = HttpPeekRouter::new_http1(http_service).with_fallback(fallback_service);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nfoo".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        const HTTP_METHODS: &[&str] = &[
+            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+        ];
+        for method in HTTP_METHODS {
+            let response = peek_http_svc
+                .serve(
+                    Context::default(),
+                    std::io::Cursor::new(format!("{method} /foobar HTTP/1.1").into_bytes()),
+                )
+                .await
+                .unwrap();
+            assert_eq!("http1", response);
+        }
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foo".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foobar".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_h2_router() {
+        let http_service = service_fn(async |_, _| Ok::<_, Infallible>("h2"));
+        let fallback_service = service_fn(async |_, _| Ok::<_, Infallible>("other"));
+
+        let peek_http_svc = HttpPeekRouter::new_h2(http_service).with_fallback(fallback_service);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nfoo".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("h2", response);
+
+        const HTTP_METHODS: &[&str] = &[
+            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+        ];
+        for method in HTTP_METHODS {
+            let response = peek_http_svc
+                .serve(
+                    Context::default(),
+                    std::io::Cursor::new(format!("{method} /foobar HTTP/1.1").into_bytes()),
+                )
+                .await
+                .unwrap();
+            assert_eq!("other", response);
+        }
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foo".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foobar".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_dual_router() {
+        let http1_service = service_fn(async |_, _| Ok::<_, Infallible>("http1"));
+        let h2_service = service_fn(async |_, _| Ok::<_, Infallible>("h2"));
+        let fallback_service = service_fn(async |_, _| Ok::<_, Infallible>("other"));
+
+        let peek_http_svc =
+            HttpPeekRouter::new_dual(http1_service, h2_service).with_fallback(fallback_service);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(
+                Context::default(),
+                std::io::Cursor::new(b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nfoo".to_vec()),
+            )
+            .await
+            .unwrap();
+        assert_eq!("h2", response);
+
+        const HTTP_METHODS: &[&str] = &[
+            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+        ];
+        for method in HTTP_METHODS {
+            let response = peek_http_svc
+                .serve(
+                    Context::default(),
+                    std::io::Cursor::new(format!("{method} /foobar HTTP/1.1").into_bytes()),
+                )
+                .await
+                .unwrap();
+            assert_eq!("http1", response);
+        }
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foo".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(b"foobar".to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("other", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_router_read_eof() {
+        const CONTENT: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nfoobar";
+
+        async fn http_service_fn(
+            mut stream: impl Stream + Unpin,
+        ) -> Result<&'static str, BoxError> {
+            let mut v = Vec::default();
+            let _ = stream.read_to_end(&mut v).await?;
+            assert_eq!(CONTENT, v);
+
+            Ok("ok")
+        }
+        let http_service = service_fn(http_service_fn);
+
+        let peek_http_svc = HttpPeekRouter::new(http_service).with_fallback(RejectService::<
+            &'static str,
+            RejectError,
+        >::new(
+            RejectError::default(),
+        ));
+
+        let response = peek_http_svc
+            .serve(Context::default(), std::io::Cursor::new(CONTENT.to_vec()))
+            .await
+            .unwrap();
+        assert_eq!("ok", response);
+    }
+
+    #[tokio::test]
+    async fn test_peek_router_read_no_http_eof() {
+        let cases = [
+            "",
+            "foo",
+            "abcd",
+            "abcde",
+            "foobarbazbananas",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula turpis nibh, eget euismod enim elementum et.",
+        ];
+        for content in cases {
+            async fn http_service_fn() -> Result<Vec<u8>, BoxError> {
+                Ok("http".as_bytes().to_vec())
+            }
+            let http_service = service_fn(http_service_fn);
+
+            async fn other_service_fn(
+                mut stream: impl Stream + Unpin,
+            ) -> Result<Vec<u8>, BoxError> {
+                let mut v = Vec::default();
+                let _ = stream.read_to_end(&mut v).await?;
+                Ok(v)
+            }
+            let other_service = service_fn(other_service_fn);
+
+            let peek_http_svc = HttpPeekRouter::new(http_service).with_fallback(other_service);
+
+            let response = peek_http_svc
+                .serve(
+                    Context::default(),
+                    std::io::Cursor::new(content.as_bytes().to_vec()),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(content.as_bytes(), &response[..]);
+        }
+    }
+}

--- a/rama-socks5/src/server/connect.rs
+++ b/rama-socks5/src/server/connect.rs
@@ -2,7 +2,7 @@ use rama_core::{Context, Service, error::BoxError};
 use rama_net::{
     address::Authority,
     client::EstablishedClientConnection,
-    proxy::{ProxyRequest, StreamForwardService},
+    proxy::{ProxyRequest, ProxyTarget, StreamForwardService},
     stream::{Socket, Stream},
 };
 use rama_tcp::client::{
@@ -389,7 +389,7 @@ where
 {
     async fn accept_connect(
         &self,
-        ctx: Context<State>,
+        mut ctx: Context<State>,
         mut stream: S,
         destination: Authority,
     ) -> Result<(), Error> {
@@ -407,6 +407,8 @@ where
             %destination,
             "socks5 server: lazy connect: reply sent, delegate to inner stream service",
         );
+
+        ctx.insert(ProxyTarget(destination));
 
         self.service
             .serve(ctx, stream)

--- a/tests/integration/examples/example_tests/http_https_socks5_and_socks5h_connect_proxy.rs
+++ b/tests/integration/examples/example_tests/http_https_socks5_and_socks5h_connect_proxy.rs
@@ -126,7 +126,7 @@ async fn test_http_client_over_socks5_proxy_connect(
     for uri in test_uris {
         tracing::info!(
             %uri,
-            "try to establish proxied connection over SOCKS5 within a TLS Tunnel",
+            "try to establish proxied connection over SOCKS5",
         );
 
         let request = Request::builder()
@@ -159,7 +159,6 @@ async fn test_http_client_over_socks5_proxy_connect(
         assert_eq!("pong", resp);
         tracing::info!("socks5 ping-pong succeeded")
     }
-    println!("bye now!");
     tracing::info!("bye now!");
 }
 

--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -57,6 +57,8 @@ mod http_web_service_dir_and_api;
 mod https_connect_proxy;
 #[cfg(all(feature = "http-full", feature = "rustls"))]
 mod mtls_tunnel_and_service;
+#[cfg(all(feature = "tls", feature = "socks5", feature = "http-full",))]
+mod proxy_connectivity_check;
 #[cfg(feature = "tcp")]
 mod tcp_listener_hello;
 #[cfg(feature = "tcp")]

--- a/tests/integration/examples/example_tests/proxy_connectivity_check.rs
+++ b/tests/integration/examples/example_tests/proxy_connectivity_check.rs
@@ -1,0 +1,89 @@
+use super::utils;
+
+use rama::{
+    Context, Service,
+    http::{Body, BodyExtractExt, Request, client::HttpConnector},
+    net::{
+        Protocol,
+        address::{ProxyAddress, SocketAddress},
+        client::{ConnectorService, EstablishedClientConnection},
+        user::{Basic, ProxyCredential},
+    },
+    proxy::socks5::Socks5ProxyConnector,
+    tcp::client::service::TcpConnector,
+};
+
+#[tokio::test]
+#[ignore]
+async fn test_proxy_connectivity_check() {
+    utils::init_tracing();
+
+    let runner = utils::ExampleRunner::interactive("proxy_connectivity_check", Some("socks5,tls"));
+
+    let mut ctx = Context::default();
+    ctx.insert(ProxyAddress::try_from("http://tom:clancy@127.0.0.1:62030").unwrap());
+    // test regular proxy flow
+    let result = runner
+        .get("http://example.com")
+        .send(ctx.clone())
+        .await
+        .unwrap()
+        .try_into_string()
+        .await
+        .unwrap();
+    assert!(result.contains("Connectivity Example"));
+    tracing::info!("http proxy: connectivity check succeeded");
+
+    test_http_client_over_socks5_proxy_connect().await;
+}
+
+async fn test_http_client_over_socks5_proxy_connect() {
+    let proxy_socket_addr = SocketAddress::local_ipv4(62030);
+
+    tracing::info!(
+        %proxy_socket_addr,
+        "local servers up and running",
+    );
+
+    // TODO: once we have socks5 support in Easy http web client
+    // we can probably simplify this by using the interactive runner client
+    // instead of having to do this manually...
+
+    let client = HttpConnector::new(Socks5ProxyConnector::required(TcpConnector::new()));
+
+    let mut ctx = Context::default();
+    ctx.insert(ProxyAddress {
+        protocol: Some(Protocol::SOCKS5),
+        authority: proxy_socket_addr.into(),
+        credential: Some(ProxyCredential::Basic(Basic::new("john", "secret"))),
+    });
+
+    tracing::info!("try to establish proxied connection over SOCKS5");
+
+    let request = Request::builder()
+        .uri("http://example.com")
+        .body(Body::empty())
+        .expect("build simple GET request");
+
+    let EstablishedClientConnection {
+        ctx,
+        req,
+        conn: http_service,
+    } = client
+        .connect(ctx.clone(), request)
+        .await
+        .expect("establish a proxied connection ready to make http requests");
+
+    tracing::info!("try to make GET http request and try to receive response text",);
+
+    let resp = http_service
+        .serve(ctx, req)
+        .await
+        .expect("make http request via socks5 proxy")
+        .try_into_string()
+        .await
+        .expect("get response text");
+
+    assert!(resp.contains("Connectivity Example"));
+    tracing::info!("socks5 proxy: connectivity check succeeded");
+}


### PR DESCRIPTION
- http peek router allows you to serve http/1x, h2 or both if detected
- proxy connectivity shows how you can use peeking and/or hijacking to easily
  support proxy connectivity checks within a rama stack
