### PR TITLE
Fix missing `listen()` call in `TcpListener::build()` for `SocketOptions` and `DeviceName`

### DIFF
--- a/rama-tcp/src/server/listener.rs
+++ b/rama-tcp/src/server/listener.rs
@@ -145,6 +145,9 @@ where
             }
             .try_build_socket()
             .context("create tcp ipv4 socket attached to device")?;
+            socket
+                .listen(4096)
+                .context("mark the socket as ready to accept incoming connection requests")?;
             bind_socket_internal(self.state, socket)
         })
         .await
@@ -166,6 +169,9 @@ where
                 let socket = opts
                     .try_build_socket()
                     .context("build socket from options")?;
+                socket
+                    .listen(4096)
+                    .context("mark the socket as ready to accept incoming connection requests")?;
                 self.bind_socket(socket).await
             }
         }


### PR DESCRIPTION
**Title:**  Fix missing `listen()` call in `TcpListener::build()` for `SocketOptions` and `DeviceName`

#### Description
This PR fixes an issue where `TcpListener::build()` would not work correctly when using either `SocketOptions` or `DeviceName`, due to a missing `listen()` system call.

#### Problem
When using `SocketOptions` or `DeviceName`, the socket was being created and bound, but never marked as a listening socket (i.e., `listen(fd, backlog)` was not called). This resulted in the listener not accepting connections. In contrast, using a plain `SocketAddress` worked correctly.

Using `strace`, it was observed that the `listen()` syscall was missing in these code paths.

#### Solution
Added a call to `socket.listen(4096)` in the following locations:

* `bind_device`: before calling `bind_socket_internal()`

https://github.com/plabayo/rama/blob/a53aaf613b9b746a0312ac383e877046e0e956a2/rama-tcp/src/server/listener.rs#L136
```rust
socket.listen(4096).context("mark the socket as ready to accept incoming connection requests")?;
```
https://github.com/plabayo/rama/blob/a53aaf613b9b746a0312ac383e877046e0e956a2/rama-tcp/src/server/listener.rs#L148

* `bind`: in the `Interface::Socket(opts)` branch, before calling `bind_socket()`

https://github.com/plabayo/rama/blob/a53aaf613b9b746a0312ac383e877046e0e956a2/rama-tcp/src/server/listener.rs#L157
```rust
socket.listen(4096).context("mark the socket as ready to accept incoming connection requests")?;
```
https://github.com/plabayo/rama/blob/a53aaf613b9b746a0312ac383e877046e0e956a2/rama-tcp/src/server/listener.rs#L169

#### Updated methods

```rust
    #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
    /// Creates a new TcpListener, which will be bound to the specified (interface) device name).
    ///
    /// The returned listener is ready for accepting connections.
    pub async fn bind_device<N: TryInto<DeviceName, Error: Into<BoxError>> + Send + 'static>(
        self,
        name: N,
    ) -> Result<TcpListener<S>, BoxError> {
        tokio::task::spawn_blocking(|| {
            let name = name.try_into().map_err(Into::<BoxError>::into)?;
            let socket = SocketOptions {
                device: Some(name),
                ..SocketOptions::default_tcp()
            }
            .try_build_socket()
            .context("create tcp ipv4 socket attached to device")?;
            socket
                .listen(4096)
                .context("mark the socket as ready to accept incoming connection requests")?;
            bind_socket_internal(self.state, socket)
        })
        .await
        .context("await blocking bind socket task")?
    }

    /// Creates a new TcpListener, which will be bound to the specified interface.
    ///
    /// The returned listener is ready for accepting connections.
    pub async fn bind<I: TryInto<Interface, Error: Into<BoxError>>>(
        self,
        interface: I,
    ) -> Result<TcpListener<S>, BoxError> {
        match interface.try_into().map_err(Into::<BoxError>::into)? {
            Interface::Address(addr) => self.bind_address(addr).await,
            #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
            Interface::Device(name) => self.bind_device(name).await,
            Interface::Socket(opts) => {
                let socket = opts
                    .try_build_socket()
                    .context("build socket from options")?;
                socket
                    .listen(4096)
                    .context("mark the socket as ready to accept incoming connection requests")?;
                self.bind_socket(socket).await
            }
        }
    }
}
```

#### Note

* The backlog value is set to `4096`, as suggested by @glendc, which is a more appropriate default.
* This change ensures consistent behavior across all binding methods.