### PR TITLE
Fix broken tracing with multiple layers

### DIFF
--- a/rama-http-types/src/proto/h2/frame/setting.rs
+++ b/rama-http-types/src/proto/h2/frame/setting.rs
@@ -213,10 +213,9 @@ impl SettingOrder {
         if self.mask & mask_id == 0 {
             self.mask |= mask_id;
             self.ids.push(id);
+        } else {
+            tracing::trace!("ignore duplicate setting id: {id:?}")
         }
-        // else {
-        //     tracing::trace!("ignore duplicate setting id: {id:?}")
-        // }
     }
 
     pub fn extend(&mut self, iter: impl IntoIterator<Item = SettingId>) {

--- a/rama-http-types/src/proto/h2/frame/setting.rs
+++ b/rama-http-types/src/proto/h2/frame/setting.rs
@@ -213,9 +213,10 @@ impl SettingOrder {
         if self.mask & mask_id == 0 {
             self.mask |= mask_id;
             self.ids.push(id);
-        } else {
-            tracing::trace!("ignore duplicate setting id: {id:?}")
         }
+        // else {
+        //     tracing::trace!("ignore duplicate setting id: {id:?}")
+        // }
     }
 
     pub fn extend(&mut self, iter: impl IntoIterator<Item = SettingId>) {

--- a/rama-http-types/src/proto/h2/frame/settings.rs
+++ b/rama-http-types/src/proto/h2/frame/settings.rs
@@ -318,11 +318,6 @@ impl fmt::Debug for Settings {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut builder = f.debug_struct("Settings");
         builder.field("flags", &self.flags);
-        builder.field("setting_order", &self.config.setting_order);
-        builder.field(
-            "setting_order defaults (appended if not present)",
-            &SettingOrder::default_settings(),
-        );
         builder.field("config", &self.config);
         builder.finish()
     }

--- a/rama-http-types/src/proto/h2/frame/settings.rs
+++ b/rama-http-types/src/proto/h2/frame/settings.rs
@@ -319,37 +319,11 @@ impl fmt::Debug for Settings {
         let mut builder = f.debug_struct("Settings");
         builder.field("flags", &self.flags);
         builder.field("setting_order", &self.config.setting_order);
-
-        self.for_each(|setting| match setting.id {
-            SettingId::EnablePush => {
-                builder.field("enable_push", &setting.value);
-            }
-            SettingId::HeaderTableSize => {
-                builder.field("header_table_size", &setting.value);
-            }
-            SettingId::InitialWindowSize => {
-                builder.field("initial_window_size", &setting.value);
-            }
-            SettingId::MaxConcurrentStreams => {
-                builder.field("max_concurrent_streams", &setting.value);
-            }
-            SettingId::MaxFrameSize => {
-                builder.field("max_frame_size", &setting.value);
-            }
-            SettingId::MaxHeaderListSize => {
-                builder.field("max_header_list_size", &setting.value);
-            }
-            SettingId::EnableConnectProtocol => {
-                builder.field("enable_connect_protocol", &setting.value);
-            }
-            SettingId::NoRfc7540Priorities => {
-                builder.field("no_rfc7540_priorities", &setting.value);
-            }
-            SettingId::Unknown(id) => {
-                builder.field(&format!("unknown_unknown_setting_{id}"), &setting.value);
-            }
-        });
-
+        builder.field(
+            "setting_order defaults (appended if not present)",
+            &SettingOrder::default_settings(),
+        );
+        builder.field("config", &self.config);
         builder.finish()
     }
 }


### PR DESCRIPTION
Tracing doesn't really support trace events inside Debug implementations. This debug impl has a trace event quite deep in the debug logic. Easy option is to remove that trace event in `SettingOrder::push` but to me this shows that this Debug impl was too complex, so I simplified it. It should still contain all the necessary info, just a bit more manual when you need to interpret it