### PR TITLE
Patch/docs netstack fm

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,3 +634,6 @@ Available at <https://ramaproxy.org/book/faq.html>.
 [![Star History Chart](https://api.star-history.com/svg?repos=plabayo/rama&type=Date)](https://star-history.com/#plabayo/rama&Date)
 
 [![original (OG) rama logo](./docs/book/src/img/old_logo.png)](https://ramaproxy.org/)
+
+📚 Want to know why we built Rama?  
+Check out the [NetstackFM podcast →](docs/netstackfm.md)

--- a/docs/book/src/preface.md
+++ b/docs/book/src/preface.md
@@ -1,3 +1,5 @@
+🎧 **New! Listen to [Netstack.FM Episode 1](https://netstack.fm/#episode-1)** — the podcast about building Rama and rethinking networking with Rust.
+
 ![rama banner](https://raw.githubusercontent.com/plabayo/rama/main/docs/img/rama_banner.jpeg)
 
 [![Crates.io][crates-badge]][crates-url]

--- a/docs/netstackfm
+++ b/docs/netstackfm
@@ -1,0 +1,13 @@
+# Netstack.FM – A podcast about networking, Rust, and everything in between.
+
+🎧 [Listen to Episode 1](https://netstack.fm/#episode-1)
+
+In this first episode, we discuss:
+- Why Rama was built
+- Why we chose Rust for packet infrastructure
+- What’s broken in traditional networking
+- What CTOs and developers can expect from Rama
+
+🔗 All episodes: https://netstack.fm
+
+Brought to you by the creators of Rama.


### PR DESCRIPTION
add netstack fm links to the rama docs,
to aid new rama visitors to also discover our podcast about networking and rust