### PR TITLE
rama-cli windows support: pre-built binaries + package publication (winget)

### DIFF
--- a/.github/workflows/RamaCLIRelease.yaml
+++ b/.github/workflows/RamaCLIRelease.yaml
@@ -139,6 +139,7 @@ jobs:
           - x86_64-pc-windows-msvc
 
     steps:
+      - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/RamaCLIRelease.yaml
+++ b/.github/workflows/RamaCLIRelease.yaml
@@ -127,3 +127,57 @@ jobs:
             target/${{ matrix.target }}/release/*.sha256
           prerelease: ${{ contains(github.ref_name, '-') }}
           tag_name: ${{ inputs.tag || github.ref_name }}
+
+  build-release-windows:
+    runs-on: windows-latest
+    env:
+      RUST_BACKTRACE: full
+    strategy:
+      fail-fast: true
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          env-vars: "RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}"
+
+      - name: Build release (Windows)
+        shell: bash
+        run: |
+          cargo build --release -p rama-cli --target ${{ matrix.target }}
+
+      - name: Package (zip)
+        shell: pwsh
+        run: |
+          $BinPath = "target/${{ matrix.target }}/release"
+          $Exe     = Join-Path $BinPath "rama.exe"
+          if (!(Test-Path $Exe)) { throw "Binary not found: $Exe" }
+          $Zip = Join-Path $BinPath "rama.${{ matrix.target }}.zip"
+          if (Test-Path $Zip) { Remove-Item $Zip }
+          Compress-Archive -Path $Exe -DestinationPath $Zip -Force
+
+      - name: Generate checksums
+        shell: pwsh
+        run: |
+          $BinPath = "target/${{ matrix.target }}/release"
+          $Zip     = Join-Path $BinPath "rama.${{ matrix.target }}.zip"
+          $Hash    = (Get-FileHash -Path $Zip -Algorithm SHA256).Hash.ToLower()
+          Set-Content -NoNewline -Path "$Zip.sha256" -Value "$Hash  $(Split-Path -Leaf $Zip)`n"
+
+      - name: Upload Github Assets
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            target/${{ matrix.target }}/release/*.zip
+            target/${{ matrix.target }}/release/*.sha256
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          tag_name: ${{ inputs.tag || github.ref_name }}

--- a/justfile
+++ b/justfile
@@ -202,6 +202,10 @@ publish:
     cargo publish -p rama
     cargo publish -p rama-cli
 
+[working-directory: './rama-cli/manifests/winget/Plabayo/Rama/Preview']
+@submit-rama-cli-winget-preview:
+    wingetcreate submit -p 'Plabayo.Rama.Preview version bump' .
+
 update-deps:
     cargo upgrade
     cargo upgrades

--- a/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.installer.yaml
+++ b/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.installer.yaml
@@ -1,0 +1,16 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: Plabayo.Rama.Preview
+PackageVersion: 0.3.0-alpha.2
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rama.exe
+  PortableCommandAlias: rama
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/plabayo/rama/releases/download/rama-0.3.0-alpha.2/rama.x86_64-pc-windows-msvc.zip
+  InstallerSha256: 3E86D9EDD2763185B2E1CD714BEB4D5DD003FF560D39254EB12659AEF5FC7B6C
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.locale.en-US.yaml
+++ b/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: Plabayo.Rama.Preview
+PackageVersion: 0.3.0-alpha.2
+PackageLocale: en-US
+Publisher: Plabayo
+PackageName: Rama CLI
+License: MIT License
+ShortDescription: rama cli to move and transform network packets
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.yaml
+++ b/rama-cli/manifests/winget/Plabayo/Rama/Preview/Plabayo.Rama.Preview.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.10.3.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: Plabayo.Rama.Preview
+PackageVersion: 0.3.0-alpha.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0


### PR DESCRIPTION
- [x] add windows target to RamaCLIRelease.yaml
- [x] winget package support
- [x] package submission: https://github.com/microsoft/winget-pkgs/pull/287304 (`Plabayo.Rama.Preview` ; we'll make the non-preview once we release 0.3 :))
- [x] requested OSS signing cert with signpath.io
- ~~auto package updates and publication~~

This way it is ready for the full windows support part of rama 0.3.0-alpha.3