### PR TITLE
[WIP] Implement rama-pac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rama-pac"
+version = "0.3.0-alpha.4"
+dependencies = [
+ "rama-core",
+ "rama-http",
+ "rama-net",
+]
+
+[[package]]
 name = "rama-proxy"
 version = "0.3.0-alpha.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "rama-macros",
     "rama-macros/tests/macros",
     "rama-net",
+    "rama-pac",
     "rama-proxy",
     "rama-socks5",
     "rama-tcp",

--- a/rama-pac/Cargo.toml
+++ b/rama-pac/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "rama-pac"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+authors.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+rama-http = { workspace = true }
+rama-net = { workspace = true }
+rama-core = { workspace = true }
+
+[lints]
+workspace = true

--- a/rama-pac/src/connector/mod.rs
+++ b/rama-pac/src/connector/mod.rs
@@ -1,0 +1,55 @@
+use crate::{pac_fetcher::fetch_pac, pac_parser::parse_pac_file};
+use rama_core::{Context, Service, error::BoxError};
+use rama_http::{Uri, service::client::HttpClientExt};
+use rama_net::{
+    client::{ConnectorService, EstablishedClientConnection},
+    stream::{Socket, Stream},
+};
+use std::fmt::Debug;
+
+pub struct PACConnector<S, W> {
+    pub service: S,
+    pub web_client: W,
+    pub pac_uri: Uri,
+}
+
+impl<S, W> PACConnector<S, W>
+where
+    W: HttpClientExt + Send + Sync + 'static,
+{
+    pub fn new(service: S, web_client: W, pac_uri: Uri) -> Self {
+        Self {
+            service,
+            web_client,
+            pac_uri,
+        }
+    }
+}
+
+impl<S, W, Request> Service<Request> for PACConnector<S, W>
+where
+    S: ConnectorService<Request, Connection: Stream + Socket + Unpin, Error: Into<BoxError>>
+        + Send
+        + Sync
+        + 'static,
+    W: HttpClientExt + Send + Sync + 'static,
+    Request: Send + 'static,
+    <W as HttpClientExt>::ExecuteResponse: Into<String>,
+    <W as HttpClientExt>::ExecuteError: Debug
+{
+    type Response = EstablishedClientConnection<S::Connection, Request>;
+    type Error = BoxError;
+
+    async fn serve(&self, ctx: Context, req: Request) -> Result<Self::Response, Self::Error> {
+        // first get the pac file
+        let pac_file = fetch_pac(&self.web_client, self.pac_uri.clone())
+            .await
+            .unwrap();
+
+        // parse and get back result for the uri form the pac file
+        let proxy_options = parse_pac_file(&pac_file);
+
+        // based on the result, either connect to the uri or return error
+        // Ok(self.service.connect(ctx, req).await.unwrap())
+    }
+}

--- a/rama-pac/src/lib.rs
+++ b/rama-pac/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod connector;
+pub mod pac_fetcher;
+pub mod pac_parser;

--- a/rama-pac/src/pac_fetcher/mod.rs
+++ b/rama-pac/src/pac_fetcher/mod.rs
@@ -1,0 +1,23 @@
+use std::fmt::Debug;
+
+use rama_core::{Context, error::BoxError};
+use rama_http::{Body, Uri, dep::http::Request, service::client::HttpClientExt};
+
+pub async fn fetch_pac<W>(web_client: &W, pac_uri: Uri) -> Result<String, BoxError>
+where
+    W: HttpClientExt + Send + Sync + 'static,
+    <W as HttpClientExt>::ExecuteResponse: Into<String>,
+    <W as HttpClientExt>::ExecuteError: Debug,
+{
+    let request = Request::builder()
+        .method("GET")
+        .uri(pac_uri)
+        .body(Body::empty())
+        .unwrap();
+    let response = web_client
+        .execute(Context::default(), request)
+        .await
+        .unwrap();
+    let pac_file = response.try_into().unwrap();
+    Ok(pac_file)
+}

--- a/rama-pac/src/pac_parser/mod.rs
+++ b/rama-pac/src/pac_parser/mod.rs
@@ -1,0 +1,5 @@
+use rama_core::error::BoxError;
+
+pub async fn parse_pac_file(pac_file: &str) -> Result<String, BoxError> {
+    todo!()
+}


### PR DESCRIPTION
# Details
## Issue number
#566 
## Summary
- Adds a `rama-pac` crate that will handle logic of creating a PAC Connector, getting and reading the PAC file for the outgoing request URL proxy options and route the request through first successful proxy.