### PR TITLE
Move executor to extensions

### DIFF
--- a/examples/http_mitm_proxy_rustls.rs
+++ b/examples/http_mitm_proxy_rustls.rs
@@ -177,7 +177,12 @@ async fn http_connect_proxy(ctx: Context, upgraded: Upgraded) -> Result<(), Infa
 
     let http_service = new_http_mitm_proxy();
 
-    let http_transport_service = HttpServer::auto(ctx.executor().clone()).service(http_service);
+    let executor = upgraded
+        .extensions()
+        .get::<Executor>()
+        .cloned()
+        .unwrap_or_default();
+    let http_transport_service = HttpServer::auto(executor).service(http_service);
 
     let https_service = TlsAcceptorLayer::new(
         upgraded

--- a/examples/http_record_har.rs
+++ b/examples/http_record_har.rs
@@ -238,7 +238,13 @@ async fn http_connect_proxy(ctx: Context, upgraded: Upgraded) -> Result<(), Infa
     let state = upgraded.extensions().get::<State>().unwrap();
     let http_service = new_http_mitm_proxy(state);
 
-    let mut http_tp = HttpServer::auto(ctx.executor().clone());
+    let executor = upgraded
+        .extensions()
+        .get::<Executor>()
+        .cloned()
+        .unwrap_or_default();
+
+    let mut http_tp = HttpServer::auto(executor);
     http_tp.h2_mut().enable_connect_protocol();
 
     let http_transport_service = http_tp.service(http_service);

--- a/examples/socks5_connect_proxy_mitm_proxy.rs
+++ b/examples/socks5_connect_proxy_mitm_proxy.rs
@@ -135,6 +135,12 @@ async fn http_mitm_proxy(ctx: Context, req: Request) -> Result<Response, Infalli
         .with_server_verify_mode(ServerVerifyMode::Disable)
         .into_shared_builder();
 
+    let executor = req
+        .extensions()
+        .get::<Executor>()
+        .cloned()
+        .unwrap_or_default();
+
     let client = EasyHttpWebClient::builder()
         .with_default_transport_connector()
         .with_tls_proxy_support_using_boringssl()
@@ -148,7 +154,7 @@ async fn http_mitm_proxy(ctx: Context, req: Request) -> Result<Response, Infalli
             // you also usually do not want it as a layer, but instead plug the inspector
             // directly JIT-style into your http (client) connector.
             RequestWriterInspector::stdout_unbounded(
-                ctx.executor(),
+                &executor,
                 Some(traffic_writer::WriterMode::Headers),
             ),
         ))

--- a/rama-core/src/context/mod.rs
+++ b/rama-core/src/context/mod.rs
@@ -1,75 +1,16 @@
 //! Context passed to and between services as input.
-use crate::graceful::ShutdownGuard;
-use crate::rt::Executor;
-use tokio::task::JoinHandle;
 
+#[non_exhaustive]
 #[derive(Debug, Default, Clone)]
 /// Context passed to and between services as input.
 ///
 /// See [`crate::context`] for more information.
-pub struct Context {
-    executor: Executor,
-}
-
-#[derive(Debug)]
-/// Component parts of [`Context`].
-pub struct Parts {
-    pub executor: Executor,
-}
+pub struct Context;
 
 impl Context {
     #[must_use]
     /// Create a new [`Context`] with the given state.
-    pub fn new(executor: Executor) -> Self {
-        Self { executor }
-    }
-
-    #[must_use]
-    pub fn from_parts(parts: Parts) -> Self {
-        Self {
-            executor: parts.executor,
-        }
-    }
-
-    #[must_use]
-    pub fn into_parts(self) -> Parts {
-        Parts {
-            executor: self.executor,
-        }
-    }
-
-    #[must_use]
-    /// Get a reference to the executor.
-    pub fn executor(&self) -> &Executor {
-        &self.executor
-    }
-
-    /// Set a new [`Executor`] to the [`Context`].
-    pub fn set_executor(&mut self, exec: Executor) -> &mut Self {
-        self.executor = exec;
-        self
-    }
-
-    /// Set a new [`Executor`] to the [`Context`].
-    #[must_use]
-    pub fn with_executor(mut self, exec: Executor) -> Self {
-        self.executor = exec;
-        self
-    }
-
-    /// Spawn a future on the current executor,
-    /// this is spawned gracefully in case a shutdown guard has been registered.
-    pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
-    where
-        F: Future<Output: Send + 'static> + Send + 'static,
-    {
-        self.executor.spawn_task(future)
-    }
-
-    #[must_use]
-    /// Get a reference to the shutdown guard,
-    /// if and only if the context was created within a graceful environment.
-    pub fn guard(&self) -> Option<&ShutdownGuard> {
-        self.executor.guard()
+    pub fn new() -> Self {
+        Self {}
     }
 }

--- a/rama-http-backend/src/server/hyper_conn.rs
+++ b/rama-http-backend/src/server/hyper_conn.rs
@@ -70,6 +70,7 @@ mod private {
     use crate::server::hyper_conn::{map_boxed_http_core_result, map_http_core_result};
     use rama_core::extensions::ExtensionsMut;
     use rama_core::futures::FutureExt;
+    use rama_core::rt::Executor;
     use rama_core::stream::Stream;
     use rama_core::telemetry::tracing;
     use rama_core::{Context, Service};
@@ -106,7 +107,11 @@ mod private {
             S: Service<Request, Response = Response, Error = Infallible> + Clone,
             Response: IntoResponse + Send + 'static,
         {
-            let guard = ctx.guard().cloned();
+            let guard = io
+                .extensions()
+                .get::<Executor>()
+                .and_then(|exec| exec.guard())
+                .cloned();
             let extensions = io.take_extensions();
             let service = RamaHttpService::new(ctx, extensions, service);
 
@@ -152,7 +157,10 @@ mod private {
         {
             let extensions = io.take_extensions();
             let stream = Box::pin(io);
-            let guard = ctx.guard().cloned();
+            let guard = extensions
+                .get::<Executor>()
+                .and_then(|exec| exec.guard())
+                .cloned();
 
             let service = RamaHttpService::new(ctx, extensions, service);
 
@@ -196,7 +204,10 @@ mod private {
         {
             let extensions = io.take_extensions();
             let stream = Box::pin(io);
-            let guard = ctx.guard().cloned();
+            let guard = extensions
+                .get::<Executor>()
+                .and_then(|exec| exec.guard())
+                .cloned();
 
             let service = RamaHttpService::new(ctx, extensions, service);
 

--- a/rama-http/src/service/opentelemetry.rs
+++ b/rama-http/src/service/opentelemetry.rs
@@ -4,7 +4,6 @@ use rama_core::{
     Context, Service,
     bytes::Bytes,
     error::{BoxError, ErrorContext},
-    rt::Executor,
 };
 use std::{fmt, pin::Pin};
 
@@ -50,27 +49,6 @@ impl<S> OtelExporter<S> {
             ctx: Context::default(),
             handle: tokio::runtime::Handle::current(),
         }
-    }
-
-    /// Set a new [`Executor`] to the [`OtelExporter`].
-    ///
-    /// Useful in acse you want to make it graceful,
-    /// most likely it is however not what you really want to do,
-    /// given most exporters live on their own island.
-    pub fn set_executor(&mut self, exec: Executor) -> &mut Self {
-        self.ctx.set_executor(exec);
-        self
-    }
-
-    /// Set a new [`Executor`] to the [`OtelExporter`].
-    ///
-    /// Useful in acse you want to make it graceful,
-    /// most likely it is however not what you really want to do,
-    /// given most exporters live on their own island.
-    #[must_use]
-    pub fn with_executor(mut self, exec: Executor) -> Self {
-        self.ctx.set_executor(exec);
-        self
     }
 }
 

--- a/rama-unix/src/unix/server/listener.rs
+++ b/rama-unix/src/unix/server/listener.rs
@@ -219,7 +219,6 @@ impl UnixListener {
     where
         S: Service<UnixStream>,
     {
-        let ctx = Context::new(Executor::new());
         let service = Arc::new(service);
 
         loop {
@@ -232,7 +231,7 @@ impl UnixListener {
             };
 
             let service = service.clone();
-            let ctx = ctx.clone();
+            let ctx = Context::default();
 
             let peer_addr: UnixSocketAddress = peer_addr.into();
             let local_addr: Option<UnixSocketAddress> = socket.local_addr().ok().map(Into::into);
@@ -249,6 +248,7 @@ impl UnixListener {
             socket
                 .extensions_mut()
                 .insert(UnixSocketInfo::new(local_addr, peer_addr));
+            socket.extensions_mut().insert(Executor::new());
 
             tokio::spawn(
                 async move {
@@ -268,7 +268,6 @@ impl UnixListener {
     where
         S: Service<UnixStream>,
     {
-        let ctx: Context = Context::new(Executor::graceful(guard.clone()));
         let service = Arc::new(service);
         let mut cancelled_fut = pin!(guard.cancelled());
 
@@ -282,7 +281,7 @@ impl UnixListener {
                     match result {
                         Ok((socket, peer_addr)) => {
                             let service = service.clone();
-                            let ctx = ctx.clone();
+                            let ctx = Context::default();
 
                             let peer_addr: UnixSocketAddress = peer_addr.into();
                             let local_addr: Option<UnixSocketAddress> = socket.local_addr().ok().map(Into::into);
@@ -297,6 +296,7 @@ impl UnixListener {
 
                             let mut socket = UnixStream::new(socket);
                             socket.extensions_mut().insert(UnixSocketInfo::new(local_addr, peer_addr));
+                            socket.extensions_mut().insert(Executor::graceful(guard.clone()));
 
                             guard.spawn_task(async move {
                                 let _ = service.serve(ctx, socket).await;

--- a/rama-ws/src/handshake/server.rs
+++ b/rama-ws/src/handshake/server.rs
@@ -8,10 +8,10 @@ use std::{
 use rama_core::{
     Context, Service,
     error::{ErrorContext, OpaqueError},
-    extensions::Extensions,
-    extensions::{ExtensionsMut, ExtensionsRef},
+    extensions::{Extensions, ExtensionsMut, ExtensionsRef},
     futures::{StreamExt, TryStreamExt},
     matcher::Matcher,
+    rt::Executor,
     telemetry::tracing::{self, Instrument},
 };
 #[cfg(feature = "compression")]
@@ -763,7 +763,11 @@ where
                     network.protocol.name = "ws",
                 );
 
-                let exec = ctx.executor().clone();
+                let exec = req
+                    .extensions()
+                    .get::<Executor>()
+                    .cloned()
+                    .unwrap_or_default();
 
                 exec.spawn_task(
                     async move {


### PR DESCRIPTION
This is the last piece that needs to move to extensions.

Next PR will completely remove context