### PR TITLE
fix flacky cli ip test

### DIFF
--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -115,6 +115,10 @@ impl BidirectionalWriter<UnboundedSender<BidirectionalMessage>> {
                     tracing::error!("failed to write separator to writer: {err:?}")
                 }
             }
+
+            if let Err(err) = writer.flush().await {
+                tracing::error!("failed to flush writer: {err:?}")
+            }
         });
 
         Self { sender: tx }
@@ -208,6 +212,10 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
                         tracing::error!("failed to write separator to writer: {err:?}")
                     }
                 }
+
+                if let Err(err) = writer.flush().await {
+                    tracing::error!("failed to flush writer: {err:?}")
+                }
             }
             .instrument(span),
         );
@@ -287,6 +295,10 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
                     if let Err(err) = writer.write_all(b"\r\n").await {
                         tracing::error!("failed to write separator to writer: {err:?}")
                     }
+                }
+
+                if let Err(err) = writer.flush().await {
+                    tracing::error!("failed to flush writer: {err:?}")
                 }
             }
             .instrument(span),


### PR DESCRIPTION
Failing tests all have this line as txt output, seems like it didnt write `/r/n` fast enough
```
2025-11-02T16:35:42.9754896Z 127.0.0.1[2m2025-11-02T16:28:20.441346Z[0m [32m INFO[0m [2mtokio_graceful::shutdown[0m[2m:[0m ::shutdown: ready after 0.001926691s

```