### PR TITLE
update README forks + sync with fork upstreams

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -45,7 +45,7 @@ jobs:
           env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN_MSRV}}"
       - name: Generate Rust Docs
         env:
-          RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links"
+          RUSTDOCFLAGS: "-D rustdoc::broken_intra_doc_links --cfg docsrs"
         run: cargo doc --all-features --no-deps
       - name: Install Graphviz
         run: sudo apt-get install graphviz

--- a/docs/thirdparty/fork/README.md
+++ b/docs/thirdparty/fork/README.md
@@ -14,9 +14,9 @@ as a distant relative.
     - Original: <https://github.com/hyperium/h2/blob/b9d5397bd751633f676b3164ebe03cb3c4534a75/LICENSE>
     - Type: MIT
     - Copy: [./licenses/h2](./licenses/h2)
-- hyper: <https://github.com/hyperium/hyper/tree/b8affd8a2ee5d77dec0c32050a7234e4f2f3751b>
+- hyper: <https://github.com/hyperium/hyper/tree/f9f8f44058745d23fa52abf51b96b61ee7665642>
   - License:
-    - Original: <https://github.com/hyperium/hyper/blob/b8affd8a2ee5d77dec0c32050a7234e4f2f3751b/LICENSE>
+    - Original: <https://github.com/hyperium/hyper/blob/f9f8f44058745d23fa52abf51b96b61ee7665642/LICENSE>
     - Type: MIT
     - Copy: [./licenses/hyper](./licenses/hyper)
 - hyper-util: <https://github.com/hyperium/hyper-util/tree/66afc93debef02548c86e8454e6bc01cf4fca280>
@@ -39,15 +39,40 @@ as a distant relative.
     - Original: <https://github.com/tower-rs/tower/blob/21e01e977e97a7025ff4beb00b2acd79eadf7285/LICENSE>
     - Type: MIT
     - Copy: [./licenses/tower](./licenses/tower)
-- <https://github.com/tower-rs/tower-http/tree/35740decc663f4921b85b234ae33580f40fcbb31>
+- <https://github.com/tower-rs/tower-http/tree/7cfdf76723415faf12e3dfdfdf1d1c93a2e31cab>
   - pretty much everything
   - now kept directly in sync "conceptual logic wise",
     but originally forked as an actual `tower-async` package as found in
     <https://github.com/plabayo/tower-async/tree/57798b7baea8e212197a226a2481fa282591dda4>
   - License:
-    - Original: <https://github.com/tower-rs/tower-http/blob/35740decc663f4921b85b234ae33580f40fcbb31/tower-http/LICENSE>
+    - Original: <https://github.com/tower-rs/tower-http/blob/7cfdf76723415faf12e3dfdfdf1d1c93a2e31cab/tower-http/LICENSE>
     - Type: MIT
     - Copy: [./licenses/tower-http](./licenses/tower-http)
+
+## External Forks
+
+These are forks made within other code repositories,
+but still directly in function of Rama.
+
+- <https://github.com/cloudflare/boring/tree/47c33f64284a905bd1c26dc59c5eec6f5f38bf8b>
+  - boring:
+    - Fork: <https://github.com/plabayo/rama-boring/tree/7b3fb171483c6250dc607520cd7cc71c85843ee1/boring>
+    - License:
+      - Original: <https://github.com/cloudflare/boring/blob/47c33f64284a905bd1c26dc59c5eec6f5f38bf8b/boring/LICENSE>
+      - Type: Apache 2.0
+      - Copy: [./licenses/boring](./licenses/boring)
+  - boring-sys:
+    - Fork: <https://github.com/plabayo/rama-boring/tree/7b3fb171483c6250dc607520cd7cc71c85843ee1/boring-sys>
+    - License:
+      - Original: <https://github.com/cloudflare/boring/blob/47c33f64284a905bd1c26dc59c5eec6f5f38bf8b/boring-sys/LICENSE-MIT>
+      - Type: MIT
+      - Copy: [./licenses/boring-sys](./licenses/boring-sys)
+  - tokio-boring:
+    - Fork: <https://github.com/plabayo/rama-boring/tree/7b3fb171483c6250dc607520cd7cc71c85843ee1/tokio-boring>
+    - License:
+      - Original: <https://github.com/cloudflare/boring/blob/47c33f64284a905bd1c26dc59c5eec6f5f38bf8b/tokio-boring/LICENSE-MIT>
+      - Type: MIT
+      - Copy: [./licenses/tokio-boring](./licenses/tokio-boring)
 
 ## Relative Forks
 

--- a/docs/thirdparty/fork/licenses/boring
+++ b/docs/thirdparty/fork/licenses/boring
@@ -1,0 +1,16 @@
+Copyright 2011-2017 Google Inc.
+          2013 Jack Lloyd
+          2013-2014 Steven Fackler
+          2020 Ivan Nikulin <ifaaan@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/docs/thirdparty/fork/licenses/boring-sys
+++ b/docs/thirdparty/fork/licenses/boring-sys
@@ -1,0 +1,26 @@
+Copyright (c) 2014 Alex Crichton
+Copyright (c) 2020 Ivan Nikulin <ifaaan@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/docs/thirdparty/fork/licenses/tokio-boring
+++ b/docs/thirdparty/fork/licenses/tokio-boring
@@ -1,0 +1,26 @@
+Copyright (c) 2016 Tokio contributors
+Copyright (c) 2020 Ivan Nikulin <ifaaan@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rama-core/src/stream/read.rs
+++ b/rama-core/src/stream/read.rs
@@ -215,7 +215,6 @@ impl<const N: usize> Read for StackReader<N> {
 pin_project! {
     /// Reader that can be used to chain two readers together.
     #[must_use = "streams do nothing unless polled"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
     pub struct ChainReader<T, U> {
         #[pin]
         first: T,

--- a/rama-core/src/stream/rewind.rs
+++ b/rama-core/src/stream/rewind.rs
@@ -161,5 +161,7 @@ mod tests {
 
         let mut buf = [0; 5];
         stream.read_exact(&mut buf).await.expect("read1");
+
+        assert_eq!(&buf, &underlying);
     }
 }

--- a/rama-core/src/telemetry/mod.rs
+++ b/rama-core/src/telemetry/mod.rs
@@ -1,6 +1,7 @@
 //! Rama telemetry modules.
 
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(target_os = "opentelemetry")))]
 pub mod opentelemetry;
 
 #[macro_use]

--- a/rama-dns/src/hickory.rs
+++ b/rama-dns/src/hickory.rs
@@ -22,7 +22,7 @@ pub use hickory_resolver as resolver;
 pub struct HickoryDns(Arc<TokioResolver>);
 
 impl Default for HickoryDns {
-    #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(any(target_family = "unix", target_os = "windows"))]
     fn default() -> Self {
         Self::try_new_system().unwrap_or_else(|err| {
             tracing::warn!(
@@ -32,7 +32,7 @@ impl Default for HickoryDns {
         })
     }
 
-    #[cfg(not(any(unix, target_os = "windows")))]
+    #[cfg(not(any(target_family = "unix", target_os = "windows")))]
     fn default() -> Self {
         Self::new_cloudflare()
     }
@@ -101,7 +101,7 @@ impl HickoryDns {
         Self::builder().with_config(ResolverConfig::quad9()).build()
     }
 
-    #[cfg(any(unix, target_os = "windows"))]
+    #[cfg(any(target_family = "unix", target_os = "windows"))]
     /// Construct a new [`HickoryDns`] with the system configuration.
     ///
     /// This will use `/etc/resolv.conf` on Unix OSes and the registry on Windows.

--- a/rama-http-backend/src/client/http_inspector/mod.rs
+++ b/rama-http-backend/src/client/http_inspector/mod.rs
@@ -4,6 +4,7 @@
 #[cfg(feature = "tls")]
 mod tls_alpn;
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use tls_alpn::HttpsAlpnModifier;
 
 mod version_adapter;

--- a/rama-http-backend/src/server/service.rs
+++ b/rama-http-backend/src/server/service.rs
@@ -182,6 +182,7 @@ where
     }
 
     #[cfg(target_family = "unix")]
+    #[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
     /// Listen for connections on the given [`Path`], using a unix (domain) socket, serving HTTP connections.
     ///
     /// It's a shortcut in case you don't need to operate on the unix transport layer directly.
@@ -191,11 +192,11 @@ where
         Response: IntoResponse + Send + 'static,
         P: AsRef<Path>,
     {
-        let unix = UnixListener::bind_path(path).await?;
+        let socket = UnixListener::bind_path(path).await?;
         let service = HttpService::new(self.builder, service);
         match self.guard {
-            Some(guard) => unix.serve_graceful(guard, service).await,
-            None => unix.serve(service).await,
+            Some(guard) => socket.serve_graceful(guard, service).await,
+            None => socket.serve(service).await,
         };
         Ok(())
     }

--- a/rama-http-core/src/client/conn/http1.rs
+++ b/rama-http-core/src/client/conn/http1.rs
@@ -318,7 +318,7 @@ impl Builder {
 
     /// Set whether HTTP/0.9 responses should be tolerated.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn http09_responses(&mut self, enabled: bool) -> &mut Self {
         self.h09_responses = enabled;
         self
@@ -338,7 +338,7 @@ impl Builder {
     /// > of 400 (Bad Request). A proxy MUST remove any such whitespace from a
     /// > response message before forwarding the message downstream.
     ///
-    /// Default is false.
+    /// Default is `false`.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
     pub fn allow_spaces_after_header_name_in_responses(&mut self, enabled: bool) -> &mut Self {
@@ -376,7 +376,7 @@ impl Builder {
     /// > obs-fold with one or more SP octets prior to interpreting the field
     /// > value.
     ///
-    /// Default is false.
+    /// Default is `false`.
     ///
     /// [RFC 7230 Section 3.2.4.]: https://tools.ietf.org/html/rfc7230#section-3.2.4
     pub fn allow_obsolete_multiline_headers_in_responses(&mut self, enabled: bool) -> &mut Self {
@@ -391,7 +391,7 @@ impl Builder {
     /// name, or does not include a colon at all, the line will be silently ignored
     /// and no error will be reported.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn ignore_invalid_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_parser_config
             .ignore_invalid_headers_in_responses(enabled);
@@ -418,7 +418,7 @@ impl Builder {
     /// Set whether HTTP/1 connections will write header names as title case at
     /// the socket level.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn title_case_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_title_case_headers = enabled;
         self

--- a/rama-http-core/src/ext/mod.rs
+++ b/rama-http-core/src/ext/mod.rs
@@ -1,4 +1,45 @@
-//! HTTP extensions.
+//! Extensions for HTTP messages in Rama.
+//!
+//! This module provides types and utilities that extend the capabilities of HTTP requests and responses
+//! in Rama. Extensions are additional pieces of information or features that can be attached to HTTP
+//! messages via the [`rama_core::extensions::Extensions`] map, which is
+//! accessible through the methods provided by the
+//! [`rama_core::extensions::ExtensionsRef`] and [`rama_core::extensions::ExtensionsMut`]
+//! traits implemented for [`rama_http_types::Request`] and [`rama_http_types::Response`].
+//!
+//! # What are extensions?
+//!
+//! Extensions allow Rama to associate extra metadata or behaviors with HTTP messages, beyond the standard
+//! headers and body. These can be used by advanced users and library authors to access protocol-specific
+//! features, track original header casing, handle informational responses, and more.
+//!
+//! See for more information the rama book:
+//! <https://ramaproxy.org/book/intro/state.html#extensions>
+//!
+//! # How to access extensions
+//!
+//! Extensions are stored in the `Extensions` map of a request or response. You can access them using:
+//!
+//! ```rust
+//! # use rama_core::extensions::ExtensionsRef;
+//! # let response = rama_http_types::Response::new(());
+//! if let Some(ext) = response.extensions().get::<rama_http_core::ext::ReasonPhrase>() {
+//!     // use the extension
+//! }
+//! ```
+//!
+//! # Extension Groups
+//!
+//! The extensions in this module can be grouped as follows:
+//!
+//! - **HTTP/1 Reason Phrase**: [`ReasonPhrase`] — Access non-canonical reason phrases in HTTP/1 responses.
+//! - **Informational Responses**: [`on_informational`] — Register callbacks for 1xx HTTP/1 responses on the client.
+//!
+//! Some other crates such as [`rama_http_types`] also provide extension types used by this crate:
+//! - **Header Case Tracking**: Internal types for tracking the original casing and order of headers as received.
+//! - **HTTP/2 Protocol Extensions**: Access the `:protocol` pseudo-header for Extended CONNECT in HTTP/2.
+//!
+//! See the documentation on each item for details about its usage and requirements.
 
 mod h1_reason_phrase;
 pub use h1_reason_phrase::ReasonPhrase;

--- a/rama-http-core/src/h2/codec/mod.rs
+++ b/rama-http-core/src/h2/codec/mod.rs
@@ -78,6 +78,7 @@ impl<T, B> Codec<T, B> {
     /// frames will be rejected.
     #[cfg(feature = "unstable")]
     #[inline]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub fn max_recv_frame_size(&self) -> usize {
         self.inner.max_frame_size()
     }
@@ -109,6 +110,7 @@ impl<T, B> Codec<T, B> {
 
     /// Get a reference to the inner stream.
     #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub fn get_ref(&self) -> &T {
         self.inner.get_ref().get_ref()
     }

--- a/rama-http-core/src/h2/mod.rs
+++ b/rama-http-core/src/h2/mod.rs
@@ -110,6 +110,7 @@ mod proto;
 
 #[cfg(feature = "unstable")]
 #[allow(missing_docs)]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub mod proto;
 
 pub mod client;
@@ -128,6 +129,7 @@ pub use crate::h2::error::{Error, Reason};
 pub use crate::h2::share::{FlowControl, Ping, PingPong, Pong, RecvStream, SendStream};
 
 #[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub use codec::{Codec, SendError};
 
 use std::pin::Pin;

--- a/rama-http-core/src/h2/server.rs
+++ b/rama-http-core/src/h2/server.rs
@@ -604,6 +604,7 @@ where
     // Could disappear at anytime.
     #[doc(hidden)]
     #[cfg(feature = "unstable")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
     pub fn num_wired_streams(&self) -> usize {
         self.connection.num_wired_streams()
     }

--- a/rama-http-core/src/server/conn/auto.rs
+++ b/rama-http-core/src/server/conn/auto.rs
@@ -511,7 +511,7 @@ impl Http1Builder<'_> {
     ///
     /// Note that including the `date` header is recommended by RFC 7231.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
         self.inner.http1.auto_date_header(enabled);
         self
@@ -532,7 +532,7 @@ impl Http1Builder<'_> {
 
     /// Enables or disables HTTP/1 keep-alive.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn keep_alive(&mut self, val: bool) -> &mut Self {
         self.inner.http1.keep_alive(val);
         self
@@ -543,7 +543,7 @@ impl Http1Builder<'_> {
     ///
     /// Note that this setting does not affect HTTP/2.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn title_case_headers(&mut self, enabled: bool) -> &mut Self {
         self.inner.http1.title_case_headers(enabled);
         self
@@ -555,7 +555,7 @@ impl Http1Builder<'_> {
     /// name, or does not include a colon at all, the line will be silently ignored
     /// and no error will be reported.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn ignore_invalid_headers(&mut self, enabled: bool) -> &mut Self {
         self.inner.http1.ignore_invalid_headers(enabled);
         self
@@ -623,7 +623,7 @@ impl Http1Builder<'_> {
     ///
     /// Experimental, may have bugs.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn pipeline_flush(&mut self, enabled: bool) -> &mut Self {
         self.inner.http1.pipeline_flush(enabled);
         self
@@ -803,7 +803,7 @@ impl Http2Builder<'_> {
     ///
     /// Note that including the `date` header is recommended by RFC 7231.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
         self.inner.http2.auto_date_header(enabled);
         self

--- a/rama-http-core/src/server/conn/http1.rs
+++ b/rama-http-core/src/server/conn/http1.rs
@@ -253,7 +253,7 @@ impl Builder {
 
     /// Enables or disables HTTP/1 keep-alive.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn keep_alive(&mut self, val: bool) -> &mut Self {
         self.h1_keep_alive = val;
         self
@@ -262,9 +262,18 @@ impl Builder {
     /// Set whether HTTP/1 connections will write header names as title case at
     /// the socket level.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn title_case_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_title_case_headers = enabled;
+        self
+    }
+
+    /// Set whether multiple spaces are allowed as delimiters in request lines.
+    ///
+    /// Default is `false`.
+    pub fn allow_multiple_spaces_in_request_line_delimiters(&mut self, enabled: bool) -> &mut Self {
+        self.h1_parser_config
+            .allow_multiple_spaces_in_request_line_delimiters(enabled);
         self
     }
 
@@ -274,7 +283,7 @@ impl Builder {
     /// name, or does not include a colon at all, the line will be silently ignored
     /// and no error will be reported.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn ignore_invalid_headers(&mut self, enabled: bool) -> &mut Self {
         self.h1_parser_config
             .ignore_invalid_headers_in_requests(enabled);
@@ -350,7 +359,7 @@ impl Builder {
     ///
     /// Note that including the `date` header is recommended by RFC 7231.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
         self.date_header = enabled;
         self
@@ -360,7 +369,7 @@ impl Builder {
     ///
     /// Experimental, may have bugs.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub fn pipeline_flush(&mut self, enabled: bool) -> &mut Self {
         self.pipeline_flush = enabled;
         self

--- a/rama-http-core/src/server/conn/http2.rs
+++ b/rama-http-core/src/server/conn/http2.rs
@@ -253,7 +253,7 @@ impl Builder {
     ///
     /// Note that including the `date` header is recommended by RFC 7231.
     ///
-    /// Default is true.
+    /// Default is `true`.
     pub fn auto_date_header(&mut self, enabled: bool) -> &mut Self {
         self.h2_builder.date_header = enabled;
         self

--- a/rama-http-types/src/conn.rs
+++ b/rama-http-types/src/conn.rs
@@ -13,7 +13,7 @@ pub struct Http1ClientContextParams {
     /// Set whether HTTP/1 connections will write header names as title case at
     /// the socket level.
     ///
-    /// Default is false.
+    /// Default is `false`.
     pub title_header_case: bool,
 }
 

--- a/rama-http-types/src/proto/h2/ext.rs
+++ b/rama-http-types/src/proto/h2/ext.rs
@@ -5,10 +5,23 @@ use crate::proto::h2::hpack::BytesStr;
 use rama_core::bytes::Bytes;
 use std::fmt;
 
-/// Represents the `:protocol` pseudo-header used by
-/// the [Extended CONNECT Protocol].
+/// The `Protocol` extension allows access to the value of the `:protocol` pseudo-header
+/// used by the [Extended CONNECT Protocol](https://datatracker.ietf.org/doc/html/rfc8441#section-4).
+/// This extension is only sent on HTTP/2 CONNECT requests, most commonly with the value `websocket`.
 ///
-/// [Extended CONNECT Protocol]: https://datatracker.ietf.org/doc/html/rfc8441#section-4
+/// # Example
+///
+/// ```rust
+/// use rama_core::extensions::ExtensionsMut;
+/// use rama_http_types::proto::h2::ext::Protocol;
+/// use rama_http_types::{Request, Method, Version};
+///
+/// let mut req = Request::new(());
+/// *req.method_mut() = Method::CONNECT;
+/// *req.version_mut() = Version::HTTP_2;
+/// req.extensions_mut().insert(Protocol::from_static("websocket"));
+/// // Now the request will include the `:protocol` pseudo-header with value "websocket"
+/// ```
 #[derive(Clone, Eq, PartialEq)]
 pub struct Protocol {
     value: BytesStr,

--- a/rama-http/src/layer/har/spec.md
+++ b/rama-http/src/layer/har/spec.md
@@ -13,7 +13,7 @@ One of the goals of the HTTP Archive format is to be flexible enough so, it can 
 - The format is based on [JSON](http://www.ietf.org/rfc/rfc4627.txt).
 - Please follow-up in the [newsgroup](http://groups.google.com/group/http-archive-specification?hl=en).
 - An online [HAR viewer](http://www.softwareishard.com/blog/har-viewer/) is available.
-- Report any problems in the [issue list](http://code.google.com/p/http-archive-specification/issues/list).
+- Report any problems in the [issue list](https://code.google.com/archive/p/http-archive-specification/issues).
 - See [list of tools](http://www.softwareishard.com/blog/har-adopters/) supporting HAR.
 
 ### HAR Data Structure

--- a/rama-http/src/layer/har/toggle.rs
+++ b/rama-http/src/layer/har/toggle.rs
@@ -148,6 +148,7 @@ where
 }
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 pub fn mpsc_toggle_for_unix_signal<C>(
     signal: tokio::signal::unix::SignalKind,
     cancel: C,

--- a/rama-http/src/layer/mod.rs
+++ b/rama-http/src/layer/mod.rs
@@ -50,13 +50,17 @@ pub mod traffic_writer;
 pub mod validate_request;
 
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub mod opentelemetry;
 
 pub(crate) mod util;
 
 #[cfg(feature = "compression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 pub mod compress_adapter;
 #[cfg(feature = "compression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 pub mod compression;
 #[cfg(feature = "compression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 pub mod decompression;

--- a/rama-http/src/layer/timeout/mod.rs
+++ b/rama-http/src/layer/timeout/mod.rs
@@ -1,7 +1,7 @@
 //! Middleware that applies a timeout to requests.
 //!
-//! If the request does not complete within the specified timeout it will be aborted and a `408
-//! Request Timeout` response will be sent.
+//! If the request does not complete within the specified timeout, it will be aborted and a
+//! response with an empty body and a custom status code will be returned.
 //!
 //! # Differences from `rama_core::service::layer::Timeout`
 //!
@@ -9,9 +9,9 @@
 //! it changes the error type to [`BoxError`](rama_core::error::BoxError). For HTTP services that is rarely
 //! what you want as returning errors will terminate the connection without sending a response.
 //!
-//! This middleware won't change the error type and instead return a `408 Request Timeout`
-//! response. That means if your service's error type is [`Infallible`] it will still be
-//! [`Infallible`] after applying this middleware.
+//! This middleware won't change the error type and instead returns a response with an empty body
+//! and the specified status code. That means if your service's error type is [`Infallible`], it will
+//! still be [`Infallible`] after applying this middleware.
 //!
 //! # Example
 //!
@@ -20,7 +20,7 @@
 //!
 //! use rama_core::Layer;
 //! use rama_core::service::service_fn;
-//! use rama_http::{Body, Request, Response};
+//! use rama_http::{Body, Request, Response, StatusCode};
 //! use rama_http::layer::timeout::TimeoutLayer;
 //! use rama_core::error::BoxError;
 //!
@@ -32,8 +32,8 @@
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), BoxError> {
 //! let svc = (
-//!     // Timeout requests after 30 seconds
-//!     TimeoutLayer::new(Duration::from_secs(30)),
+//!     // Timeout requests after 30 seconds with the specified status code
+//!     TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, Duration::from_secs(30)),
 //! ).into_layer(service_fn(handle));
 //! # Ok(())
 //! # }

--- a/rama-http/src/service/mod.rs
+++ b/rama-http/src/service/mod.rs
@@ -6,4 +6,5 @@ pub mod redirect;
 pub mod web;
 
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub mod opentelemetry;

--- a/rama-net/src/client/pool/mod.rs
+++ b/rama-net/src/client/pool/mod.rs
@@ -282,6 +282,7 @@ impl<C, ID> LruDropPool<C, ID> {
 
     #[cfg(feature = "opentelemetry")]
     generate_set_and_with! {
+        #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
         pub fn metrics(mut self, metrics: Option<Arc<metrics::PoolMetrics>>) -> Self {
             self.metrics = metrics;
             self

--- a/rama-net/src/fingerprint/akamai/mod.rs
+++ b/rama-net/src/fingerprint/akamai/mod.rs
@@ -2,4 +2,5 @@
 mod h2;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use h2::{AkamaiH2, AkamaiH2ComputeError};

--- a/rama-net/src/fingerprint/ja4/mod.rs
+++ b/rama-net/src/fingerprint/ja4/mod.rs
@@ -2,10 +2,12 @@
 mod http;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use http::{Ja4H, Ja4HComputeError};
 
 #[cfg(feature = "tls")]
 mod tls;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use tls::{Ja4, Ja4ComputeError};

--- a/rama-net/src/fingerprint/mod.rs
+++ b/rama-net/src/fingerprint/mod.rs
@@ -4,27 +4,32 @@
 mod akamai;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use akamai::{AkamaiH2, AkamaiH2ComputeError};
 
 #[cfg(any(feature = "tls", feature = "http"))]
 mod ja4;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use ja4::{Ja4H, Ja4HComputeError};
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use ja4::{Ja4, Ja4ComputeError};
 
 #[cfg(feature = "tls")]
 mod peet;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use peet::{PeetComputeError, PeetPrint};
 
 #[cfg(feature = "tls")]
 mod ja3;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use ja3::{Ja3, Ja3ComputeError};
 
 #[cfg(feature = "tls")]
@@ -89,6 +94,7 @@ mod tls_utils {
 }
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use tls_utils::ClientHelloProvider;
 
 #[cfg(feature = "http")]
@@ -140,4 +146,5 @@ mod http_utils {
 }
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub use http_utils::{HttpRequestInput, HttpRequestProvider};

--- a/rama-net/src/fingerprint/peet/mod.rs
+++ b/rama-net/src/fingerprint/peet/mod.rs
@@ -2,4 +2,5 @@
 mod tls;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use tls::{PeetComputeError, PeetPrint};

--- a/rama-net/src/lib.rs
+++ b/rama-net/src/lib.rs
@@ -32,18 +32,23 @@ pub(crate) mod proto;
 pub use proto::Protocol;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod transport;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod http;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub mod tls;
 
 #[cfg(any(feature = "tls", feature = "http"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "tls", feature = "http"))))]
 pub mod fingerprint;
 
 #[cfg(all(feature = "tls", feature = "http"))]
+#[cfg_attr(docsrs, doc(cfg(all(feature = "tls", feature = "http"))))]
 pub mod https;
 
 pub mod socket;

--- a/rama-net/src/socket/interface.rs
+++ b/rama-net/src/socket/interface.rs
@@ -17,6 +17,10 @@ pub enum Interface {
     /// [`Socket`]: super::core::Socket
     Address(SocketAddress),
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Bind to a network device interface name, using IPv4/TCP.
     ///
     /// Use [`SocketOptions`] if you want more finegrained control,
@@ -36,6 +40,10 @@ impl Interface {
 }
 
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+)]
 pub use device::DeviceName;
 
 use super::SocketOptions;

--- a/rama-net/src/socket/mod.rs
+++ b/rama-net/src/socket/mod.rs
@@ -5,6 +5,10 @@ mod interface;
 pub use interface::Interface;
 
 #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+)]
 #[doc(inline)]
 pub use interface::DeviceName;
 

--- a/rama-net/src/socket/opts.rs
+++ b/rama-net/src/socket/opts.rs
@@ -56,12 +56,15 @@ pub enum Protocol {
     /// Protocol corresponding to `UDP` (`sys::IPPROTO_UDP`)
     UDP,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Protocol corresponding to `MPTCP` (`sys::IPPROTO_MPTCP`)
     MPTCP,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Protocol corresponding to `DCCP` (`sys::IPPROTO_DCCP`)
     DCCP,
     #[cfg(any(target_os = "freebsd", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "freebsd", target_os = "linux"))))]
     /// Protocol corresponding to `SCTP` (`sys::IPPROTO_SCTP`)
     SCTP,
 }
@@ -82,10 +85,13 @@ impl From<Protocol> for SocketProtocol {
             Protocol::TCP => Self::TCP,
             Protocol::UDP => Self::UDP,
             #[cfg(target_os = "linux")]
+            #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
             Protocol::MPTCP => Self::MPTCP,
             #[cfg(target_os = "linux")]
+            #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
             Protocol::DCCP => Self::DCCP,
             #[cfg(any(target_os = "freebsd", target_os = "linux"))]
+            #[cfg_attr(docsrs, doc(cfg(any(target_os = "freebsd", target_os = "linux"))))]
             Protocol::SCTP => Self::SCTP,
         }
     }
@@ -104,11 +110,13 @@ pub enum Type {
     /// Used for protocols such as [`Protocol::UDP`].
     Datagram,
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Type corresponding to `SOCK_DCCP`.
     ///
     /// Used for the [`Protocol::DCCP`].
     DCCP,
     #[cfg(not(target_os = "espidf"))]
+    #[cfg_attr(docsrs, doc(cfg(not(target_os = "espidf"))))]
     /// Type corresponding to `SOCK_SEQPACKET`.
     SequencePacket,
     #[cfg(not(any(target_os = "redox", target_os = "espidf")))]
@@ -130,10 +138,13 @@ impl From<Type> for SocketType {
             Type::Stream => Self::STREAM,
             Type::Datagram => Self::DGRAM,
             #[cfg(target_os = "linux")]
+            #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
             Type::DCCP => Self::DCCP,
             #[cfg(not(target_os = "espidf"))]
+            #[cfg_attr(docsrs, doc(cfg(not(target_os = "espidf"))))]
             Type::SequencePacket => Self::SEQPACKET,
             #[cfg(not(any(target_os = "redox", target_os = "espidf")))]
+            #[cfg_attr(docsrs, doc(cfg(any(target_os = "redox", target_os = "espidf"))))]
             Type::Raw => Self::RAW,
         }
     }
@@ -166,6 +177,18 @@ pub struct TcpKeepAlive {
         target_os = "vita",
         target_os = "haiku",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "nto",
+            target_os = "espidf",
+            target_os = "vita",
+            target_os = "haiku",
+        ))))
+    )]
     /// Set the value of the `TCP_KEEPINTVL` option. On Windows, this sets the
     /// value of the `tcp_keepalive` struct's `keepaliveinterval` field.
     ///
@@ -185,6 +208,19 @@ pub struct TcpKeepAlive {
         target_os = "vita",
         target_os = "haiku",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "windows",
+            target_os = "nto",
+            target_os = "espidf",
+            target_os = "vita",
+            target_os = "haiku",
+        ))))
+    )]
     /// Set the value of the `TCP_KEEPCNT` option.
     ///
     /// Set the maximum number of TCP keepalive probes that will be sent before
@@ -387,6 +423,10 @@ pub struct SocketOptions {
     pub address: Option<SocketAddress>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Bind the [`Socket`] to the specified device.
     ///
     /// Sets the value for the `SO_BINDTODEVICE` option on this [`Socket`]].
@@ -423,6 +463,7 @@ pub struct SocketOptions {
     pub linger: Option<Duration>,
 
     #[cfg(not(target_os = "redox"))]
+    #[cfg_attr(docsrs, doc(cfg(not(target_os = "redox"))))]
     /// Set value for the SO_OOBINLINE option on this [`Socket`].
     ///
     /// If this option is enabled,
@@ -434,7 +475,8 @@ pub struct SocketOptions {
     /// [RFC6093]: https://datatracker.ietf.org/doc/html/rfc6093
     pub out_of_band_inline: Option<bool>,
 
-    #[cfg(all(unix, target_os = "linux"))]
+    #[cfg(all(target_family = "unix", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all(target_family = "unix", target_os = "linux"))))]
     /// Set value for the `SO_PASSCRED` option on this [`Socket`].
     ///
     /// If this option is enabled, enables the receiving of the `SCM_CREDENTIALS` control messages.
@@ -469,6 +511,7 @@ pub struct SocketOptions {
     pub write_timeout: Option<Duration>,
 
     #[cfg(not(any(target_os = "redox", target_os = "espidf")))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "redox", target_os = "espidf"))))]
     /// Set the value of the `IP_HDRINCL` option on this [`Socket`].
     ///
     /// If enabled, the user supplies an IP header in front of the user data.
@@ -490,6 +533,17 @@ pub struct SocketOptions {
         target_os = "dragonfly",
         target_os = "netbsd"
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "redox",
+            target_os = "espidf",
+            target_os = "openbsd",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "netbsd"
+        ))))
+    )]
     /// Set the value of the `IP_HDRINCL` option on this [`Socket`].
     ///
     /// If enabled, the user supplies an IP header in front of the user data.
@@ -501,6 +555,7 @@ pub struct SocketOptions {
     pub header_included_v6: Option<bool>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set the value of the `IP_TRANSPARENT` option on this [`Socket`].
     ///
     /// Setting this boolean option enables transparent proxying on this [`Socket`].
@@ -533,6 +588,16 @@ pub struct SocketOptions {
         target_os = "illumos",
         target_os = "haiku",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "fuchsia",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "haiku",
+        ))))
+    )]
     /// Set the value of the `IP_TOS` option for this [`Socket`].
     ///
     /// This value sets the type-of-service field that is used in every packet sent from this [`Socket`].
@@ -558,6 +623,24 @@ pub struct SocketOptions {
         target_os = "espidf",
         target_os = "vita",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "aix",
+            target_os = "dragonfly",
+            target_os = "fuchsia",
+            target_os = "hurd",
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "nto",
+            target_os = "espidf",
+            target_os = "vita",
+        ))))
+    )]
     /// Set the value of the `IP_RECVTOS` option for this [`Socket`].
     ///
     /// If enabled, the `IP_TOS` ancillary message is passed with incoming packets.
@@ -572,6 +655,7 @@ pub struct SocketOptions {
     pub multicast_hops_v6: Option<u32>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set the value of the `IP_MULTICAST_ALL` option for this [`Socket`].
     ///
     /// This option can be used to modify the delivery policy of
@@ -585,6 +669,7 @@ pub struct SocketOptions {
     pub multicast_all_v4: Option<bool>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set the value of the `IPV6_MULTICAST_ALL` option for this [`Socket`].
     ///
     /// This option can be used to modify the delivery policy of multicast messages.
@@ -657,6 +742,22 @@ pub struct SocketOptions {
         target_os = "espidf",
         target_os = "vita",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "dragonfly",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "hurd",
+            target_os = "espidf",
+            target_os = "vita",
+        ))))
+    )]
     /// Set the value of the `IPV6_RECVTCLASS` option for this [`Socket`].
     ///
     /// If enabled, the `IPV6_TCLASS` ancillary message is passed
@@ -674,6 +775,19 @@ pub struct SocketOptions {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd"
+        )))
+    )]
     /// Set the value of the `IPV6_TCLASS` option for this [`Socket`].
     ///
     /// Specifies the traffic class field that is used in every packets
@@ -681,7 +795,7 @@ pub struct SocketOptions {
     pub tclass_v6: Option<u32>,
 
     #[cfg(not(any(
-        windows,
+        target_os = "windows",
         target_os = "dragonfly",
         target_os = "fuchsia",
         target_os = "illumos",
@@ -694,6 +808,23 @@ pub struct SocketOptions {
         target_os = "espidf",
         target_os = "vita",
     )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(not(any(
+            target_os = "windows",
+            target_os = "dragonfly",
+            target_os = "fuchsia",
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "haiku",
+            target_os = "hurd",
+            target_os = "espidf",
+            target_os = "vita",
+        ))))
+    )]
     /// Set the value of the `IPV6_RECVHOPLIMIT` option for this [`Socket`].
     ///
     /// The received hop limit is returned as ancillary data by `recvmsg()`
@@ -729,7 +860,11 @@ pub struct SocketOptions {
     /// thereby avoiding the frequent sending of small packets.
     pub tcp_no_delay: Option<bool>,
 
-    #[cfg(all(unix, not(target_os = "redox")))]
+    #[cfg(all(target_family = "unix", not(target_os = "redox")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(target_family = "unix", not(target_os = "redox"))))
+    )]
     /// Sets the value of the `TCP_MAXSEG` option on this [`Socket`].
     ///
     /// The `TCP_MAXSEG` option denotes the TCP Maximum Segment Size
@@ -737,6 +872,7 @@ pub struct SocketOptions {
     pub tcp_max_segments: Option<u32>,
 
     #[cfg(any(target_os = "freebsd", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "freebsd", target_os = "linux"))))]
     /// Set the value of the `TCP_CONGESTION` option for this [`Socket`].
     ///
     /// Specifies the TCP congestion control algorithm to use for this socket.
@@ -746,6 +882,10 @@ pub struct SocketOptions {
     pub tcp_congestion: Option<String>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Sets the value for the `SO_MARK` option on this [`Socket`].
     ///
     /// This value sets the socket mark field for each packet sent through this [`Socket`].
@@ -755,6 +895,10 @@ pub struct SocketOptions {
     pub mark: Option<u32>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set the value of the `TCP_CORK` option on this [`Socket`].
     ///
     /// If set, don't send out partial frames. All queued partial frames are
@@ -764,6 +908,10 @@ pub struct SocketOptions {
     pub tcp_cork: Option<bool>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set the value of the `TCP_QUICKACK` option on this [`Socket`].
     ///
     /// If set, acks are sent immediately, rather than delayed if needed in accordance to normal
@@ -773,6 +921,10 @@ pub struct SocketOptions {
     pub tcp_quick_ack: Option<bool>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set the value of the `TCP_THIN_LINEAR_TIMEOUTS` option on this [`Socket`].
     ///
     /// If set, the kernel will dynamically detect a thin-stream connection
@@ -783,6 +935,10 @@ pub struct SocketOptions {
     pub tcp_thin_linear_timeouts: Option<bool>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set the value of the `TCP_USER_TIMEOUT` option on this [`Socket`].
     ///
     /// If set, this specifies the maximum amount of time that transmitted data may remain
@@ -796,6 +952,10 @@ pub struct SocketOptions {
     pub tcp_user_timeout: Option<Duration>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set value for the `IP_FREEBIND` option on this [`Socket`].
     ///
     /// If enabled, this boolean option allows binding to an IP address that is
@@ -806,6 +966,10 @@ pub struct SocketOptions {
     pub freebind: Option<bool>,
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Set value for the `IPV6_FREEBIND` option on this [`Socket`].
     ///
     /// This is an IPv6 counterpart of `IP_FREEBIND` [`Socket`] option on
@@ -816,12 +980,23 @@ pub struct SocketOptions {
     pub freebind_ipv6: Option<bool>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `SO_INCOMING_CPU` option on this [`Socket`].
     ///
     /// Sets the CPU affinity of the [`Socket`].
     pub cpu_affinity: Option<usize>,
 
-    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+    #[cfg(all(
+        target_family = "unix",
+        not(any(target_os = "solaris", target_os = "illumos"))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            target_family = "unix",
+            not(any(target_os = "solaris", target_os = "illumos"))
+        )))
+    )]
     /// Set value for the `SO_REUSEPORT` option on this [`Socket`].
     ///
     /// This indicates that further calls to `bind` may allow reuse of local
@@ -830,6 +1005,7 @@ pub struct SocketOptions {
     pub reuse_port: Option<bool>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `DCCP_SOCKOPT_SERVICE` option on this [`Socket`].
     ///
     /// Sets the DCCP service. The specification mandates use of service codes.
@@ -843,12 +1019,14 @@ pub struct SocketOptions {
     pub dccp_service: Option<u32>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `DCCP_SOCKOPT_CCID` option on this [`Socket`].
     ///
     /// This option sets both the TX and RX CCIDs at the same time.
     pub dccp_ccid: Option<u8>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `DCCP_SOCKOPT_SERVER_TIMEWAIT` option on this [`Socket`].
     ///
     /// Enables a listening [`Socket`] to hold timewait state when closing the
@@ -856,6 +1034,7 @@ pub struct SocketOptions {
     pub dccp_server_timewait: Option<bool>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `DCCP_SOCKOPT_SEND_CSCOV` option on this [`Socket`].
     ///
     /// Both this option and `DCCP_SOCKOPT_RECV_CSCOV` are used for setting the
@@ -866,6 +1045,7 @@ pub struct SocketOptions {
     pub dccp_send_cscov: Option<u32>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set the value of the `DCCP_SOCKOPT_RECV_CSCOV` option on this [`Socket`].
     ///
     /// This option is only useful when combined with [`dccp_send_cscov`].
@@ -874,6 +1054,7 @@ pub struct SocketOptions {
     pub dccp_recv_cscov: Option<u32>,
 
     #[cfg(target_os = "linux")]
+    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
     /// Set value for the `DCCP_SOCKOPT_QPOLICY_TXQLEN` option on this [`Socket`].
     ///
     /// This option sets the maximum length of the output queue. A zero value is
@@ -913,7 +1094,7 @@ impl SocketOptions {
         if let Some(oob) = self.out_of_band_inline {
             socket.set_out_of_band_inline(oob)?;
         }
-        #[cfg(all(unix, target_os = "linux"))]
+        #[cfg(all(target_family = "unix", target_os = "linux"))]
         if let Some(passcred) = self.passcred {
             socket.set_passcred(passcred)?;
         }
@@ -1016,7 +1197,7 @@ impl SocketOptions {
         }
 
         #[cfg(not(any(
-            windows,
+            target_os = "windows",
             target_os = "dragonfly",
             target_os = "fuchsia",
             target_os = "illumos",
@@ -1034,7 +1215,7 @@ impl SocketOptions {
         }
 
         #[cfg(not(any(
-            windows,
+            target_os = "windows",
             target_os = "dragonfly",
             target_os = "fuchsia",
             target_os = "illumos",
@@ -1072,7 +1253,7 @@ impl SocketOptions {
             socket.set_tcp_nodelay(no_delay)?;
         }
 
-        #[cfg(all(unix, not(target_os = "redox")))]
+        #[cfg(all(target_family = "unix", not(target_os = "redox")))]
         if let Some(mss) = self.tcp_max_segments {
             socket.set_tcp_mss(mss)?;
         }
@@ -1112,7 +1293,10 @@ impl SocketOptions {
             socket.set_cpu_affinity(cpu)?;
         }
 
-        #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+        #[cfg(all(
+            target_family = "unix",
+            not(any(target_os = "solaris", target_os = "illumos"))
+        ))]
         if let Some(reuse) = self.reuse_port {
             socket.set_reuse_port(reuse)?;
         }

--- a/rama-net/src/stream/layer/mod.rs
+++ b/rama-net/src/stream/layer/mod.rs
@@ -10,7 +10,9 @@ pub use tracker::{
 };
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod http;
 
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub mod opentelemetry;

--- a/rama-proxy/src/lib.rs
+++ b/rama-proxy/src/lib.rs
@@ -259,10 +259,12 @@ pub use proxydb::{
 pub use proxydb::layer::{ProxyDBLayer, ProxyDBService, ProxyFilterMode, UsernameFormatter};
 
 #[cfg(feature = "live-update")]
+#[cfg_attr(docsrs, doc(cfg(feature = "live-update")))]
 #[doc(inline)]
 pub use proxydb::{LiveUpdateProxyDB, LiveUpdateProxyDBSetter, proxy_db_updater};
 
 #[cfg(feature = "memory-db")]
+#[cfg_attr(docsrs, doc(cfg(feature = "memory-db")))]
 #[doc(inline)]
 pub use proxydb::{
     MemoryProxyDB, MemoryProxyDBInsertError, MemoryProxyDBInsertErrorKind, MemoryProxyDBQueryError,
@@ -270,5 +272,6 @@ pub use proxydb::{
 };
 
 #[cfg(feature = "csv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "csv")))]
 #[doc(inline)]
 pub use proxydb::{ProxyCsvRowReader, ProxyCsvRowReaderError, ProxyCsvRowReaderErrorKind};

--- a/rama-proxy/src/proxydb/mod.rs
+++ b/rama-proxy/src/proxydb/mod.rs
@@ -7,6 +7,7 @@ use std::fmt;
 #[cfg(feature = "live-update")]
 mod update;
 #[cfg(feature = "live-update")]
+#[cfg_attr(docsrs, doc(cfg(feature = "live-update")))]
 #[doc(inline)]
 pub use update::{LiveUpdateProxyDB, LiveUpdateProxyDBSetter, proxy_db_updater};
 
@@ -21,6 +22,7 @@ pub use internal::Proxy;
 mod csv;
 
 #[cfg(feature = "csv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "csv")))]
 #[doc(inline)]
 pub use csv::{ProxyCsvRowReader, ProxyCsvRowReaderError, ProxyCsvRowReaderErrorKind};
 
@@ -1328,6 +1330,7 @@ mod memdb {
 }
 
 #[cfg(feature = "memory-db")]
+#[cfg_attr(docsrs, doc(cfg(feature = "memory-db")))]
 pub use memdb::{
     MemoryProxyDB, MemoryProxyDBInsertError, MemoryProxyDBInsertErrorKind, MemoryProxyDBQueryError,
     MemoryProxyDBQueryErrorKind,

--- a/rama-socks5/src/client/proxy_connector.rs
+++ b/rama-socks5/src/client/proxy_connector.rs
@@ -80,6 +80,7 @@ impl Socks5ProxyConnectorLayer {
         ///
         /// In case of an error with resolving the domain address the connector
         /// will anyway use the domain instead of the ip.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
         pub fn default_dns_resolver(mut self) -> Self {
             self.dns_resolver = Some(rama_dns::global_dns_resolver());
             self
@@ -94,6 +95,7 @@ impl Socks5ProxyConnectorLayer {
         ///
         /// In case of an error with resolving the domain address the connector
         /// will anyway use the domain instead of the ip.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
         pub fn dns_resolver(mut self, resolver: impl DnsResolver) -> Self {
             self.dns_resolver = Some(resolver.boxed());
             self
@@ -192,6 +194,7 @@ impl<S> Socks5ProxyConnector<S> {
         ///
         /// In case of an error with resolving the domain address the connector
         /// will anyway use the domain instead of the ip.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
         pub fn default_dns_resolver(mut self) -> Self {
             self.dns_resolver = Some(rama_dns::global_dns_resolver());
             self
@@ -206,6 +209,7 @@ impl<S> Socks5ProxyConnector<S> {
         ///
         /// In case of an error with resolving the domain address the connector
         /// will anyway use the domain instead of the ip.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
         pub fn dns_resolver(mut self, resolver: impl DnsResolver) -> Self {
             self.dns_resolver = Some(resolver.boxed());
             self

--- a/rama-socks5/src/server/udp/mod.rs
+++ b/rama-socks5/src/server/udp/mod.rs
@@ -351,6 +351,7 @@ impl<B, I> UdpRelay<B, I> {
     /// It will be used to best-effort resolve the domain name,
     /// in case a domain name is passed to forward to the target server.
     #[must_use]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
     pub fn with_default_dns_resolver(mut self) -> Self {
         self.dns_resolver = None;
         self
@@ -360,6 +361,7 @@ impl<B, I> UdpRelay<B, I> {
     ///
     /// It will be used to best-effort resolve the domain name,
     /// in case a domain name is passed to forward to the target server.
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
     pub fn set_default_dns_resolver(&mut self) -> &mut Self {
         self.dns_resolver = None;
         self
@@ -370,6 +372,7 @@ impl<B, I> UdpRelay<B, I> {
     /// It will be used to best-effort resolve the domain name,
     /// in case a domain name is passed to forward to the target server.
     #[must_use]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
     pub fn with_dns_resolver(mut self, resolver: impl DnsResolver<Error = OpaqueError>) -> Self {
         self.dns_resolver = Some(resolver.boxed());
         self
@@ -379,6 +382,7 @@ impl<B, I> UdpRelay<B, I> {
     ///
     /// It will be used to best-effort resolve the domain name,
     /// in case a domain name is passed to forward to the target server.
+    #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
     pub fn set_dns_resolver(
         &mut self,
         resolver: impl DnsResolver<Error = OpaqueError>,

--- a/rama-tcp/src/client/mod.rs
+++ b/rama-tcp/src/client/mod.rs
@@ -1,6 +1,7 @@
 //! Rama TCP Client module.
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod service;
 
 mod connect;

--- a/rama-tcp/src/server/listener.rs
+++ b/rama-tcp/src/server/listener.rs
@@ -77,7 +77,8 @@ impl TcpListenerBuilder {
         Ok(TcpListener { inner })
     }
 
-    #[cfg(any(windows, unix))]
+    #[cfg(any(target_os = "windows", target_family = "unix"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "windows", target_family = "unix"))))]
     /// Creates a new TcpListener, which will be bound to the specified socket.
     ///
     /// The returned listener is ready for accepting connections.
@@ -91,6 +92,10 @@ impl TcpListenerBuilder {
     }
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Creates a new TcpListener, which will be bound to the specified (interface) device name).
     ///
     /// The returned listener is ready for accepting connections.
@@ -167,7 +172,8 @@ impl TcpListener {
         TcpListenerBuilder::default().bind_address(addr).await
     }
 
-    #[cfg(any(windows, unix))]
+    #[cfg(any(target_os = "windows", target_family = "unix"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "windows", target_family = "unix"))))]
     /// Creates a new TcpListener, which will be bound to the specified socket.
     ///
     /// The returned listener is ready for accepting connections.
@@ -176,6 +182,10 @@ impl TcpListener {
     }
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Creates a new TcpListener, which will be bound to the specified (interface) device name.
     ///
     /// The returned listener is ready for accepting connections.
@@ -230,7 +240,7 @@ impl From<TokioTcpListener> for TcpListener {
     }
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(target_os = "windows", target_family = "unix"))]
 impl TryFrom<rama_net::socket::core::Socket> for TcpListener {
     type Error = std::io::Error;
 

--- a/rama-tls-boring/src/client/mod.rs
+++ b/rama-tls-boring/src/client/mod.rs
@@ -27,4 +27,5 @@ mod emulate_ua;
 
 #[cfg(feature = "ua")]
 #[doc(inline)]
+#[cfg_attr(docsrs, doc(cfg(feature = "ua")))]
 pub use emulate_ua::{EmulateTlsProfileLayer, EmulateTlsProfileService};

--- a/rama-ua/src/profile/db.rs
+++ b/rama-ua/src/profile/db.rs
@@ -33,6 +33,7 @@ impl UserAgentDatabase {
     /// This function is only available if the `embed-profiles` feature is enabled.
     #[cfg(feature = "embed-profiles")]
     #[must_use]
+    #[cfg_attr(docsrs, doc(cfg(feature = "embed-profiles")))]
     pub fn embedded() -> Self {
         let profiles = crate::profile::load_embedded_profiles();
         Self::from_iter(profiles)

--- a/rama-ua/src/profile/mod.rs
+++ b/rama-ua/src/profile/mod.rs
@@ -17,6 +17,7 @@ pub use http::*;
 #[cfg(feature = "tls")]
 mod tls;
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub use tls::*;
 
 mod js;
@@ -34,4 +35,5 @@ pub use runtime_hints::*;
 #[cfg(feature = "embed-profiles")]
 mod embedded_profiles;
 #[cfg(feature = "embed-profiles")]
+#[cfg_attr(docsrs, doc(cfg(feature = "embed-profiles")))]
 pub use embedded_profiles::*;

--- a/rama-ua/src/profile/ua.rs
+++ b/rama-ua/src/profile/ua.rs
@@ -36,6 +36,7 @@ pub struct UserAgentProfile {
     pub http: super::HttpProfile,
 
     #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     /// The profile information regarding the tls implementation of the [`crate::UserAgent`].
     pub tls: super::TlsProfile,
 

--- a/rama-udp/src/socket.rs
+++ b/rama-udp/src/socket.rs
@@ -56,7 +56,8 @@ impl UdpSocket {
         Ok(Self { inner })
     }
 
-    #[cfg(any(windows, unix))]
+    #[cfg(any(target_os = "windows", target_family = "unix"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "windows", target_family = "unix"))))]
     /// Creates a new [`UdpSocket`], which will be bound to the specified socket.
     ///
     /// The returned socket is ready for accepting connections and connecting to others.
@@ -67,6 +68,10 @@ impl UdpSocket {
     }
 
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux")))
+    )]
     /// Creates a new [`UdpSocket`], which will be bound to the specified (interface) device name).
     ///
     /// The returned socket is ready for accepting connections and connecting to others.
@@ -172,7 +177,8 @@ impl UdpSocket {
     }
 
     /// Expose a reference to `self` as a [`rama_net::socket::core::SockRef`].
-    #[cfg(any(windows, unix))]
+    #[cfg(any(target_os = "windows", target_family = "unix"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "windows", target_family = "unix"))))]
     #[inline]
     pub fn as_socket(&self) -> rama_net::socket::core::SockRef<'_> {
         rama_net::socket::core::SockRef::from(self)
@@ -923,7 +929,7 @@ fn bind_socket_internal(socket: rama_net::socket::core::Socket) -> Result<UdpSoc
     })
 }
 
-#[cfg(any(windows, unix))]
+#[cfg(any(target_os = "windows", target_family = "unix"))]
 impl TryFrom<rama_net::socket::core::Socket> for UdpSocket {
     type Error = std::io::Error;
 

--- a/rama-unix/src/lib.rs
+++ b/rama-unix/src/lib.rs
@@ -21,5 +21,6 @@
 mod unix;
 
 #[cfg(target_family = "unix")]
+#[cfg_attr(docsrs, doc(cfg(target_family = "unix")))]
 #[doc(inline)]
 pub use unix::*;

--- a/rama-ws/src/handshake/client.rs
+++ b/rama-ws/src/handshake/client.rs
@@ -667,6 +667,7 @@ where
         /// Set/add deflate ext and also apply it to the [`WebSocketConfig`],
         /// using the default [`crate::protocol::PerMessageDeflateConfig`].
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate(mut self) -> Self {
             self.extensions = match self.extensions.take() {
                 Some(ext) => {
@@ -686,6 +687,7 @@ where
         ///
         /// Overwrites existing extensions if already existed.
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_overwrite_extensions(mut self) -> Self {
             self.extensions = Some(SecWebSocketExtensions::per_message_deflate());
             self.inner.config = Some(self.inner.config.take().unwrap_or_default().with_per_message_deflate_default());
@@ -698,6 +700,7 @@ where
         /// Set/add deflate ext and also apply it to the [`WebSocketConfig`],
         /// using the default [`crate::protocol::PerMessageDeflateConfig`].
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_with_config(mut self, config: impl Into<crate::protocol::PerMessageDeflateConfig>) -> Self {
             let config = config.into();
             self.extensions = match self.extensions.take() {
@@ -724,6 +727,7 @@ where
         ///
         /// Overwrites existing extensions if already existed.
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_with_config_overwrite_extensions(mut self, config: impl Into<crate::protocol::PerMessageDeflateConfig>) -> Self {
             let config = config.into();
             self.extensions = Some(SecWebSocketExtensions::per_message_deflate_with_config((&config).into()));

--- a/rama-ws/src/handshake/server.rs
+++ b/rama-ws/src/handshake/server.rs
@@ -361,6 +361,7 @@ impl WebSocketAcceptor {
     #[cfg(feature = "compression")]
     rama_utils::macros::generate_set_and_with! {
         /// Set or add the deflate WebSocket extension with the default config
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate(mut self) -> Self {
             self.extensions = match self.extensions.take() {
                 Some(ext) => {
@@ -376,6 +377,7 @@ impl WebSocketAcceptor {
     rama_utils::macros::generate_set_and_with! {
         /// Set the deflate WebSocket extension with the default config,
         /// erasing existing if it already exists.
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_overwrite_extensions(mut self) -> Self {
             self.extensions = Some(headers::SecWebSocketExtensions::per_message_deflate());
             self
@@ -386,6 +388,7 @@ impl WebSocketAcceptor {
     rama_utils::macros::generate_set_and_with! {
         /// Set or add the deflate WebSocket extension with the given config,
         /// erasing existing if it already exists.
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_with_config(mut self, config: impl Into<sec_websocket_extensions::PerMessageDeflateConfig>) -> Self {
             self.extensions = match self.extensions.take() {
                 Some(ext) => {
@@ -401,6 +404,7 @@ impl WebSocketAcceptor {
     rama_utils::macros::generate_set_and_with! {
         /// Set or add the deflate WebSocket extension with the given config,
         /// erasing existing if it already exists.
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_with_config_overwrite_extensions(mut self, config: impl Into<sec_websocket_extensions::PerMessageDeflateConfig>) -> Self {
             self.extensions = Some(headers::SecWebSocketExtensions::per_message_deflate_with_config(config.into()));
             self

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -115,6 +115,7 @@ pub struct WebSocketConfig {
     pub accept_unmasked_frames: bool,
 
     #[cfg(feature = "compression")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
     /// Per-message-deflate configuration, specify it
     /// to enable per-message (de)compression using the Deflate algorithm
     /// as specified by [`RFC7692`].
@@ -124,6 +125,7 @@ pub struct WebSocketConfig {
 }
 
 #[cfg(feature = "compression")]
+#[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 /// Per-message-deflate configuration as specified in [`RFC7692`]
 ///
 /// [`RFC7692`]: https://datatracker.ietf.org/doc/html/rfc7692
@@ -329,6 +331,7 @@ impl WebSocketConfig {
     rama_utils::macros::generate_set_and_with! {
         /// Set [`Self::per_message_deflate`] with the default config..
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate_default(mut self) -> Self {
             self.per_message_deflate = Some(Default::default());
             self
@@ -339,6 +342,7 @@ impl WebSocketConfig {
     rama_utils::macros::generate_set_and_with! {
         /// Set [`Self::per_message_deflate`].
         #[must_use]
+        #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
         pub fn per_message_deflate(mut self, per_message_deflate: Option<PerMessageDeflateConfig>) -> Self {
             self.per_message_deflate = per_message_deflate;
             self

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,9 +1,14 @@
 //! rama cli utilities
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod args;
 
 #[cfg(all(feature = "http", feature = "net", feature = "haproxy"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "http", feature = "net", feature = "haproxy")))
+)]
 pub mod service;
 
 mod forward;

--- a/src/http/client/builder.rs
+++ b/src/http/client/builder.rs
@@ -112,6 +112,7 @@ impl<T> EasyHttpWebClientBuilder<T, TransportStage> {
     }
 
     #[cfg(feature = "boring")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "boring")))]
     /// Support a tls tunnel to the proxy itself using boringssl
     ///
     /// Note that a tls proxy is not needed to make a https connection
@@ -131,6 +132,7 @@ impl<T> EasyHttpWebClientBuilder<T, TransportStage> {
     }
 
     #[cfg(feature = "boring")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "boring")))]
     /// Support a tls tunnel to the proxy itself using boringssl and the provided config
     ///
     /// Note that a tls proxy is not needed to make a https connection
@@ -152,6 +154,7 @@ impl<T> EasyHttpWebClientBuilder<T, TransportStage> {
     }
 
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     /// Support a tls tunnel to the proxy itself using rustls
     ///
     /// Note that a tls proxy is not needed to make a https connection
@@ -172,6 +175,7 @@ impl<T> EasyHttpWebClientBuilder<T, TransportStage> {
     }
 
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     /// Support a tls tunnel to the proxy itself using rustls and the provided config
     ///
     /// Note that a tls proxy is not needed to make a https connection
@@ -223,6 +227,7 @@ impl<T> EasyHttpWebClientBuilder<T, ProxyTunnelStage> {
     }
 
     #[cfg(feature = "socks5")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "socks5")))]
     /// Add support for usage of a http(s) and socks5(h) [`ProxyAddress`] to this client
     ///
     /// Note that a tls proxy is not needed to make a https connection
@@ -281,6 +286,7 @@ impl<T> EasyHttpWebClientBuilder<T, ProxyTunnelStage> {
     }
 
     #[cfg(feature = "socks5")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "socks5")))]
     /// Add support for usage of a socks5(h) [`ProxyAddress`] to this client
     ///
     /// [`ProxyAddress`]: rama_net::address::ProxyAddress
@@ -341,6 +347,7 @@ impl<T> EasyHttpWebClientBuilder<T, ProxyStage> {
     }
 
     #[cfg(feature = "boring")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "boring")))]
     /// Support https connections by using boringssl for tls
     ///
     /// This will also add the [`HttpsAlpnModifier`] request inspector as that one is
@@ -374,6 +381,7 @@ impl<T> EasyHttpWebClientBuilder<T, ProxyStage> {
     }
 
     #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     /// Support https connections by using ruslts for tls
     ///
     /// This will also add the [`HttpsAlpnModifier`] request inspector as that one is

--- a/src/http/client/mod.rs
+++ b/src/http/client/mod.rs
@@ -24,6 +24,7 @@ pub use builder::EasyHttpWebClientBuilder;
 #[cfg(feature = "socks5")]
 mod proxy_connector;
 #[cfg(feature = "socks5")]
+#[cfg_attr(docsrs, doc(cfg(feature = "socks5")))]
 #[doc(inline)]
 pub use proxy_connector::{MaybeProxiedConnection, ProxyConnector, ProxyConnectorLayer};
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -12,6 +12,7 @@ pub use ::rama_http::{
 };
 
 #[cfg(feature = "http-full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
 #[doc(inline)]
 pub use ::rama_http_core as core;
 
@@ -25,20 +26,25 @@ pub mod layer {
     pub use ::rama_http::layer::*;
 
     #[cfg(feature = "http-full")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
     #[doc(inline)]
     pub use ::rama_http_backend::server::layer::*;
 }
 
 #[cfg(feature = "http-full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
 pub mod client;
 
 #[cfg(feature = "http-full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
 #[doc(inline)]
 pub use ::rama_http_backend::server;
 
 #[cfg(feature = "ws")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ws")))]
 #[doc(inline)]
 pub use ::rama_ws as ws;
 
 #[cfg(feature = "tls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
 pub mod tls;

--- a/src/http/tls.rs
+++ b/src/http/tls.rs
@@ -58,6 +58,7 @@ impl CertIssuerHttpClient {
     }
 
     #[cfg(feature = "boring")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "boring")))]
     pub fn try_from_env() -> Result<Self, OpaqueError> {
         use crate::{
             Layer as _,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -379,59 +379,79 @@ pub use ::rama_core::{
 };
 
 #[cfg(feature = "crypto")]
+#[cfg_attr(docsrs, doc(cfg(feature = "crypto")))]
 #[doc(inline)]
 pub use ::rama_crypto as crypto;
 
-#[cfg(all(unix, feature = "net"))]
+#[cfg(all(target_family = "unix", feature = "net"))]
+#[cfg_attr(docsrs, doc(cfg(all(target_family = "unix", feature = "net"))))]
 #[doc(inline)]
 pub use ::rama_unix as unix;
 
 #[cfg(feature = "tcp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tcp")))]
 #[doc(inline)]
 pub use ::rama_tcp as tcp;
 
 #[cfg(feature = "udp")]
+#[cfg_attr(docsrs, doc(cfg(feature = "udp")))]
 #[doc(inline)]
 pub use ::rama_udp as udp;
 
 pub mod telemetry;
 
 #[cfg(any(feature = "rustls", feature = "boring", feature = "acme"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "rustls", feature = "boring", feature = "acme")))
+)]
 pub mod tls;
 
 #[cfg(feature = "dns")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
 #[doc(inline)]
 pub use ::rama_dns as dns;
 
 #[cfg(feature = "net")]
+#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
 #[doc(inline)]
 pub use ::rama_net as net;
 
 #[cfg(feature = "http")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http")))]
 pub mod http;
 
 #[cfg(any(feature = "proxy", feature = "haproxy", feature = "socks5"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "proxy", feature = "haproxy", feature = "socks5")))
+)]
 pub mod proxy {
     //! rama proxy support
 
     #[cfg(feature = "proxy")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "proxy")))]
     #[doc(inline)]
     pub use ::rama_proxy::*;
 
     #[cfg(feature = "haproxy")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "haproxy")))]
     #[doc(inline)]
     pub use ::rama_haproxy as haproxy;
 
     #[cfg(feature = "socks5")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "socks5")))]
     #[doc(inline)]
     pub use ::rama_socks5 as socks5;
 }
 
 #[cfg(feature = "ua")]
+#[cfg_attr(docsrs, doc(cfg(feature = "ua")))]
 #[doc(inline)]
 pub use ::rama_ua as ua;
 
 #[cfg(feature = "cli")]
+#[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub mod cli;
 
 pub mod utils {
@@ -441,6 +461,7 @@ pub mod utils {
     pub use ::rama_utils::*;
 
     #[cfg(feature = "tower")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tower")))]
     #[doc(inline)]
     pub use ::rama_tower as tower;
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,6 +1,7 @@
 //! Rama telemetry modules.
 
 #[cfg(feature = "opentelemetry")]
+#[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub mod opentelemetry {
     //! openelemetry module re-exports
     //!

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -1,13 +1,16 @@
 #[cfg(feature = "boring")]
+#[cfg_attr(docsrs, doc(cfg(feature = "boring")))]
 #[doc(inline)]
 pub use rama_tls_boring as boring;
 
 #[cfg(feature = "rustls")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
 #[doc(inline)]
 pub use rama_tls_rustls as rustls;
 
 // TODO heavily extend the functionality in this module
 #[cfg(feature = "acme")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acme")))]
 pub mod acme {
     pub use ::rama_tls_acme::*;
 }

--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -94,9 +94,9 @@ mod ws_over_h2;
 #[cfg(all(feature = "http-full", feature = "boring"))]
 mod ws_tls_server;
 
-#[cfg(all(feature = "net", unix))]
+#[cfg(all(feature = "net", target_family = "unix"))]
 mod unix_datagram_codec;
-#[cfg(all(feature = "net", unix))]
+#[cfg(all(feature = "net", target_family = "unix"))]
 mod unix_socket;
 #[cfg(all(feature = "net", feature = "http-full", unix))]
 mod unix_socket_http;

--- a/tests/turmoil/main.rs
+++ b/tests/turmoil/main.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "http-full")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
 pub mod http;
 
 pub mod types;


### PR DESCRIPTION
- hyper@b8affd8a2ee5d77dec0c32050a7234e4f2f3751b (> 1.7.0) => hyper@f9f8f44058745d23fa52abf51b96b61ee7665642
- tower-http@35740decc663f4921b85b234ae33580f40fcbb31 => tower-http@7cfdf76723415faf12e3dfdfdf1d1c93a2e31cab

Also noticed we didn't add cfg tags yet to docs.rs, this commit alos tries to address those
and remove the magic cfg values unix/windows where still used.