### PR TITLE
use new cli interface for comment for stunnel cli

### DIFF
--- a/rama-cli/src/cmd/serve/stunnel/mod.rs
+++ b/rama-cli/src/cmd/serve/stunnel/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! Test:
 //!
-//! 4. rama send 127.0.0.1:8003
+//! 4. rama :8003
 
 use rama::{
     Layer,


### PR DESCRIPTION
just noticed that the stunnel comment is not up to date with new cli interface.