### PR TITLE
docs: fix small typos

### DIFF
--- a/docs/book/src/intro/errors.md
+++ b/docs/book/src/intro/errors.md
@@ -55,7 +55,7 @@ that implements the [`std::error::Error`] trait. Using the [`OpaqueError::from_d
 you can even create errors from a displayable type.
 
 The other advantage of [`OpaqueError`] over [`BoxError`]
-is that it is Sized and can be used in places where a `Sized`` type is required,
+is that it is Sized and can be used in places where a `Sized` type is required,
 while [`BoxError`] is `?Sized` and can give you a hard time in certain scenarios.
 
 ## Error Context

--- a/docs/book/src/intro/terminology.md
+++ b/docs/book/src/intro/terminology.md
@@ -45,5 +45,5 @@ Depending on a combination of how you learn/reason and how well I explained this
 this may or may not make sense. Please consult
 [the examples found in the `/examples` dir](https://github.com/plabayo/rama/tree/main/examples)
 to see this in action in actual Rust code. GitHub should allow you to even click through
-the synbols, but this might be even easier if you clone the repo and go through them
+the symbols, but this might be even easier if you clone the repo and go through them
 in your preferred IDE.


### PR DESCRIPTION
Just some typos I found while reading the doc a few weeks ago