### PR TITLE
Issue 756/Rename AddExtension to AddInputExtension and add AddOutputExtension

### DIFF
--- a/examples/http_mitm_proxy_boring.rs
+++ b/examples/http_mitm_proxy_boring.rs
@@ -86,7 +86,7 @@ use rama::{
             protocol::{Role, WebSocketConfig},
         },
     },
-    layer::{AddExtensionLayer, ConsumeErrLayer},
+    layer::{AddInputExtensionLayer, ConsumeErrLayer},
     matcher::Matcher,
     net::{
         http::RequestContext,
@@ -179,7 +179,7 @@ async fn main() -> Result<(), BoxError> {
             .serve_graceful(
                 guard,
                 (
-                    AddExtensionLayer::new(state),
+                    AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
                     BodyLimitLayer::symmetric(2 * 1024 * 1024),
                 )

--- a/examples/http_mitm_proxy_rustls.rs
+++ b/examples/http_mitm_proxy_rustls.rs
@@ -52,7 +52,7 @@ use rama::{
         server::HttpServer,
         service::web::response::IntoResponse,
     },
-    layer::{AddExtensionLayer, ConsumeErrLayer},
+    layer::{AddInputExtensionLayer, ConsumeErrLayer},
     net::{
         http::RequestContext, proxy::ProxyTarget, stream::layer::http::BodyLimitLayer,
         tls::server::SelfSignedData, user::credentials::basic,
@@ -126,7 +126,7 @@ async fn main() -> Result<(), BoxError> {
             .serve_graceful(
                 guard,
                 (
-                    AddExtensionLayer::new(state),
+                    AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
                     BodyLimitLayer::symmetric(2 * 1024 * 1024),
                 )

--- a/examples/http_record_har.rs
+++ b/examples/http_record_har.rs
@@ -58,7 +58,7 @@ use rama::{
         server::HttpServer,
         service::web::{WebService, response::IntoResponse},
     },
-    layer::{AddExtensionLayer, ConsumeErrLayer, HijackLayer},
+    layer::{AddInputExtensionLayer, ConsumeErrLayer, HijackLayer},
     net::{
         http::RequestContext,
         proxy::ProxyTarget,
@@ -186,7 +186,7 @@ async fn main() -> Result<(), BoxError> {
             .serve_graceful(
                 guard,
                 (
-                    AddExtensionLayer::new(state),
+                    AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
                     BodyLimitLayer::symmetric(2 * 1024 * 1024),
                 )

--- a/examples/http_telemetry.rs
+++ b/examples/http_telemetry.rs
@@ -48,7 +48,7 @@ use rama::{
             web::{WebService, response::Html},
         },
     },
-    layer::AddExtensionLayer,
+    layer::AddInputExtensionLayer,
     net::stream::layer::opentelemetry::NetworkMetricsLayer,
     rt::Executor,
     tcp::server::TcpListener,
@@ -163,7 +163,7 @@ async fn main() {
             .serve_graceful(
                 guard,
                 (
-                    AddExtensionLayer::new(state),
+                    AddInputExtensionLayer::new(state),
                     NetworkMetricsLayer::default(),
                 )
                     .into_layer(http_service),

--- a/examples/tls_sni_proxy_mitm.rs
+++ b/examples/tls_sni_proxy_mitm.rs
@@ -100,7 +100,7 @@ use rama::{
         server::HttpServer,
         service::web::response::IntoResponse,
     },
-    layer::{AddExtensionLayer, ConsumeErrLayer},
+    layer::{AddInputExtensionLayer, ConsumeErrLayer},
     net::{
         Protocol,
         address::{Domain, HostWithPort, SocketAddress},
@@ -194,7 +194,7 @@ async fn main() -> Result<(), BoxError> {
                     .parse()
                     .context("parse raw addr as SocketAddress")?;
                 let connect_target = ConnectorTarget(addr.into());
-                Ok::<_, OpaqueError>(AddExtensionLayer::new(connect_target))
+                Ok::<_, OpaqueError>(AddInputExtensionLayer::new(connect_target))
             })
             .transpose()
             .context(

--- a/examples/unix_socket.rs
+++ b/examples/unix_socket.rs
@@ -27,7 +27,7 @@ mod unix_example {
         error::BoxError,
         extensions::ExtensionsRef,
         graceful::ShutdownGuard,
-        layer::AddExtensionLayer,
+        layer::AddInputExtensionLayer,
         service::service_fn,
         stream::Stream,
         telemetry::tracing::{
@@ -112,7 +112,7 @@ mod unix_example {
             listener
                 .serve_graceful(
                     guard.clone(),
-                    AddExtensionLayer::new(guard).into_layer(service_fn(handle)),
+                    AddInputExtensionLayer::new(guard).into_layer(service_fn(handle)),
                 )
                 .await;
         });

--- a/examples/ws_chat_server.rs
+++ b/examples/ws_chat_server.rs
@@ -26,7 +26,7 @@ use rama::{
             handshake::server::{ServerWebSocket, WebSocketAcceptor},
         },
     },
-    layer::AddExtensionLayer,
+    layer::AddInputExtensionLayer,
     service::service_fn,
     tcp::server::TcpListener,
     telemetry::tracing::{
@@ -124,7 +124,7 @@ async fn main() {
         TcpListener::bind("127.0.0.1:62033")
             .await
             .expect("bind TCP Listener")
-            .serve_graceful(guard, AddExtensionLayer::new(State::default()).into_layer(server))
+            .serve_graceful(guard, AddInputExtensionLayer::new(State::default()).into_layer(server))
             .await;
     });
 

--- a/rama-core/src/layer/add_extension.rs
+++ b/rama-core/src/layer/add_extension.rs
@@ -1,4 +1,4 @@
-//! Middleware that clones a value into the incoming input extensions
+//! Middleware that clones a value into an incoming input's or an output's extensions
 //!
 //! # Example
 //!
@@ -6,7 +6,7 @@
 //! use std::{sync::Arc, convert::Infallible};
 //!
 //! use rama_core::{extensions::{Extensions, ExtensionsRef}, Service, Layer, service::service_fn};
-//! use rama_core::layer::add_extension::AddExtensionLayer;
+//! use rama_core::layer::add_extension::AddInputExtensionLayer;
 //! use rama_core::error::BoxError;
 //! # #[derive(Debug)]
 //! # struct DatabaseConnectionPool;
@@ -38,13 +38,61 @@
 //!
 //! let mut service = (
 //!     // Share an `Arc<State>` with all requests.
-//!     AddExtensionLayer::new(Arc::new(state)),
+//!     AddInputExtensionLayer::new(Arc::new(state)),
 //! ).into_layer(service_fn(handle));
 //!
 //! // Call the service.
 //! let response = service
 //!     .serve(Extensions::new())
 //!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use std::{sync::Arc, convert::Infallible};
+//!
+//! use rama_core::{extensions::{Extensions, ExtensionsRef}, Service, Layer, service::service_fn};
+//! use rama_core::layer::add_extension::AddOutputExtensionLayer;
+//! use rama_core::error::BoxError;
+//! # #[derive(Debug)]
+//! # struct ResponseCounter;
+//! # impl ResponseCounter {
+//! #     fn new() -> ResponseCounter { ResponseCounter }
+//! # }
+//! #
+//! // Shared state across all responses --- in this case, a counter of handled requests.
+//! #[derive(Debug)]
+//! struct State {
+//!     counter: ResponseCounter,
+//! }
+//!
+//! // Response can be any type that implements [`ExtensionsMut`]
+//! async fn handle(req: ()) -> Result<Extensions, Infallible>
+//! {
+//!     Ok(Extensions::new())
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), BoxError> {
+//! // Construct the shared state.
+//! let state = State {
+//!     counter: ResponseCounter::new(),
+//! };
+//!
+//! let mut service = (
+//!     // Add an `Arc<State>` to all responses.
+//!     AddOutputExtensionLayer::new(Arc::new(state)),
+//! ).into_layer(service_fn(handle));
+//!
+//! // Call the service.
+//! let response = service
+//!     .serve(())
+//!     .await?;
+//! // Retrieve state from response
+//! let counter_state = response.extensions().get::<Arc<State>>().unwrap();
 //! # Ok(())
 //! # }
 //! ```
@@ -58,19 +106,19 @@ use rama_utils::macros::define_inner_service_accessors;
 use std::fmt;
 
 /// [`Layer`] for adding some shareable value to incoming input's extensions.
-pub struct AddExtensionLayer<T> {
+pub struct AddInputExtensionLayer<T> {
     value: T,
 }
 
-impl<T: fmt::Debug> std::fmt::Debug for AddExtensionLayer<T> {
+impl<T: fmt::Debug> std::fmt::Debug for AddInputExtensionLayer<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AddExtensionLayer")
+        f.debug_struct("AddInputExtensionLayer")
             .field("value", &self.value)
             .finish()
     }
 }
 
-impl<T> Clone for AddExtensionLayer<T>
+impl<T> Clone for AddInputExtensionLayer<T>
 where
     T: Clone,
 {
@@ -81,28 +129,28 @@ where
     }
 }
 
-impl<T> AddExtensionLayer<T> {
-    /// Create a new [`AddExtensionLayer`].
+impl<T> AddInputExtensionLayer<T> {
+    /// Create a new [`AddInputExtensionLayer`].
     pub const fn new(value: T) -> Self {
         Self { value }
     }
 }
 
-impl<S, T> Layer<S> for AddExtensionLayer<T>
+impl<S, T> Layer<S> for AddInputExtensionLayer<T>
 where
     T: Clone,
 {
-    type Service = AddExtension<S, T>;
+    type Service = AddInputExtension<S, T>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        AddExtension {
+        AddInputExtension {
             inner,
             value: self.value.clone(),
         }
     }
 
     fn into_layer(self, inner: S) -> Self::Service {
-        AddExtension {
+        AddInputExtension {
             inner,
             value: self.value,
         }
@@ -110,21 +158,21 @@ where
 }
 
 /// Middleware for adding some shareable value to incoming input's extensions.
-pub struct AddExtension<S, T> {
+pub struct AddInputExtension<S, T> {
     inner: S,
     value: T,
 }
 
-impl<S: fmt::Debug, T: fmt::Debug> std::fmt::Debug for AddExtension<S, T> {
+impl<S: fmt::Debug, T: fmt::Debug> std::fmt::Debug for AddInputExtension<S, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AddExtension")
+        f.debug_struct("AddInputExtension")
             .field("inner", &self.inner)
             .field("value", &self.value)
             .finish()
     }
 }
 
-impl<S, T> Clone for AddExtension<S, T>
+impl<S, T> Clone for AddInputExtension<S, T>
 where
     S: Clone,
     T: Clone,
@@ -137,8 +185,8 @@ where
     }
 }
 
-impl<S, T> AddExtension<S, T> {
-    /// Create a new [`AddExtension`].
+impl<S, T> AddInputExtension<S, T> {
+    /// Create a new [`AddInputExtension`].
     pub const fn new(inner: S, value: T) -> Self {
         Self { inner, value }
     }
@@ -146,7 +194,7 @@ impl<S, T> AddExtension<S, T> {
     define_inner_service_accessors!();
 }
 
-impl<Input, S, T> Service<Input> for AddExtension<S, T>
+impl<Input, S, T> Service<Input> for AddInputExtension<S, T>
 where
     Input: Send + ExtensionsMut + 'static,
     S: Service<Input>,
@@ -155,12 +203,114 @@ where
     type Output = S::Output;
     type Error = S::Error;
 
-    fn serve(
-        &self,
-        mut input: Input,
-    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send + '_ {
+    async fn serve(&self, mut input: Input) -> Result<Self::Output, Self::Error> {
         input.extensions_mut().insert(self.value.clone());
-        self.inner.serve(input)
+        self.inner.serve(input).await
+    }
+}
+
+/// [`Layer`] for adding some shareable value to an output's extensions.
+pub struct AddOutputExtensionLayer<T> {
+    value: T,
+}
+
+impl<T: fmt::Debug> std::fmt::Debug for AddOutputExtensionLayer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddOutputExtensionLayer")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl<T> Clone for AddOutputExtensionLayer<T>
+where
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+        }
+    }
+}
+
+impl<T> AddOutputExtensionLayer<T> {
+    /// Create a new [`AddOutputExtensionLayer`].
+    pub const fn new(value: T) -> Self {
+        Self { value }
+    }
+}
+
+impl<S, T> Layer<S> for AddOutputExtensionLayer<T>
+where
+    T: Clone,
+{
+    type Service = AddOutputExtension<S, T>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AddOutputExtension {
+            inner,
+            value: self.value.clone(),
+        }
+    }
+
+    fn into_layer(self, inner: S) -> Self::Service {
+        AddOutputExtension {
+            inner,
+            value: self.value,
+        }
+    }
+}
+
+/// Middleware for adding some shareable value to an output's extensions.
+pub struct AddOutputExtension<S, T> {
+    inner: S,
+    value: T,
+}
+
+impl<S: fmt::Debug, T: fmt::Debug> std::fmt::Debug for AddOutputExtension<S, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AddOutputExtension")
+            .field("inner", &self.inner)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl<S, T> Clone for AddOutputExtension<S, T>
+where
+    S: Clone,
+    T: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            value: self.value.clone(),
+        }
+    }
+}
+
+impl<S, T> AddOutputExtension<S, T> {
+    /// Create a new [`AddOutputExtension`].
+    pub const fn new(inner: S, value: T) -> Self {
+        Self { inner, value }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<Input, S, T> Service<Input> for AddOutputExtension<S, T>
+where
+    Input: Send + 'static,
+    S: Service<Input, Output: Send + ExtensionsMut + 'static>,
+    T: Clone + Send + Sync + std::fmt::Debug + 'static,
+{
+    type Output = S::Output;
+    type Error = S::Error;
+
+    async fn serve(&self, input: Input) -> Result<Self::Output, Self::Error> {
+        let mut res = self.inner.serve(input).await?;
+        res.extensions_mut().insert(self.value.clone());
+        Ok(res)
     }
 }
 
@@ -174,17 +324,31 @@ mod tests {
     struct State(i32);
 
     #[tokio::test]
-    async fn basic() {
+    async fn basic_input() {
         let state = Arc::new(State(1));
 
-        let svc =
-            AddExtensionLayer::new(state).into_layer(service_fn(async |req: ServiceInput<()>| {
+        let svc = AddInputExtensionLayer::new(state).into_layer(service_fn(
+            async |req: ServiceInput<()>| {
                 let state = req.extensions().get::<Arc<State>>().unwrap();
                 Ok::<_, Infallible>(state.0)
-            }));
+            },
+        ));
 
         let res = svc.serve(ServiceInput::new(())).await.unwrap();
 
         assert_eq!(1, res);
+    }
+
+    #[tokio::test]
+    async fn basic_output() {
+        let state = Arc::new(State(1));
+
+        let svc = AddOutputExtensionLayer::new(state).into_layer(service_fn(
+            async |req: ServiceInput<()>| Ok::<_, Infallible>(req),
+        ));
+
+        let res = svc.serve(ServiceInput::new(())).await.unwrap();
+
+        assert_eq!(1, res.extensions().get::<Arc<State>>().unwrap().0);
     }
 }

--- a/rama-core/src/layer/mod.rs
+++ b/rama-core/src/layer/mod.rs
@@ -945,7 +945,9 @@ pub mod limit;
 pub use limit::{Limit, LimitLayer};
 
 pub mod add_extension;
-pub use add_extension::{AddExtension, AddExtensionLayer};
+pub use add_extension::{
+    AddInputExtension, AddInputExtensionLayer, AddOutputExtension, AddOutputExtensionLayer,
+};
 
 pub mod get_extension;
 pub use get_extension::{GetExtension, GetExtensionLayer};


### PR DESCRIPTION
Couple of thoughts I had while doing this one:
*  I am not sure if my example at the top of `add_extension` with the `ResponseCounter` is a good one, happy to change it/remove it if we don't need an example
* The `serve` function for `AddInputExtension` used to return a `Future<>` but for `AddOutputExtension` I needed to await to get the response, so I made both of them consistent and converted them into `async fn`s. This is also consistent with `GetInputExtension` and `GetOutputExtension`. I am not super familiar with async rust (let alone rust) so I am not 100% sure about the implications of this change but I have done a bit of looking into it so `async fn` is the same as returning a `Future<>` from a function that wraps the original function body in an `async move`. The things im not sure about are:
    * `'_` - im not sure we need this, presumably we want the returned value to live as long as the args, is that the default for async functions?
    * `Send` - not sure if we need to enforce it on the return here, `Input` has the trait enforced and its the only one we take a mutable reference to

Relates to #759