### PR TITLE
Fix incorrect FQDN handling in Hickory DNS resolver

### DIFF
--- a/rama-dns/src/hickory.rs
+++ b/rama-dns/src/hickory.rs
@@ -241,7 +241,8 @@ impl DnsResolver for HickoryDns {
 }
 
 fn fqdn_from_domain(domain: Domain) -> Result<Name, OpaqueError> {
+    let is_fqdn = domain.is_fqdn();
     let mut name = Name::from_utf8(domain).context("try to consume a Domain as a Dns Name")?;
-    name.set_fqdn(true);
+    name.set_fqdn(is_fqdn);
     Ok(name)
 }


### PR DESCRIPTION
 HickoryDns currently forces set_fqdn(true) for all domains, which incorrectly marks non‑FQDN inputs as FQDN.
This change sets FQDN only when the input domain is already FQDN, preserving correct DNS resolution behavior (e.g. short service names in Kubernetes).
