### PR TITLE
Flacky http client test

### DIFF
--- a/tests/integration/client/mod.rs
+++ b/tests/integration/client/mod.rs
@@ -126,7 +126,7 @@ async fn connection_pooling_detects_closed_connections(version: Version, delay: 
         let token = CancellationToken::new();
         let shutdown = Shutdown::new(token.clone().cancelled_owned());
 
-        let executor = Executor::graceful(shutdown.guard());
+        let executor: Executor = Executor::graceful(shutdown.guard());
         let http_server =
             HttpServer::auto(executor.clone()).service(service_fn(move |_req: Request| {
                 // Trigger graceful shutdown after single response
@@ -193,7 +193,7 @@ async fn connection_pooling_detects_closed_connections(version: Version, delay: 
 
     // Make sure we are slower then breaking the connection and give internal state machine some
     // time to handle this.
-    sleep(Duration::from_millis(10)).await;
+    sleep(Duration::from_millis(100)).await;
     if let Some(delay) = delay {
         sleep(delay).await;
     }


### PR DESCRIPTION
Increase sleep duration in test to avoid flacky test

Was expecting that this could happen but wanted to try first with only 10ms sleep. Sleep is needed here since we are mimicking real world usage. 100 should be more then fine, we could also try 50 or something else first