### PR TITLE
Extension trait for individual extensions

### DIFF
--- a/rama-core/src/layer/add_extension.rs
+++ b/rama-core/src/layer/add_extension.rs
@@ -4,7 +4,10 @@
 //! but instead use extensions for optional behaviour to change. Static typed state
 //! is better embedded in service structs or as state for routers.
 
-use crate::{Layer, Service, extensions::ExtensionsMut};
+use crate::{
+    Layer, Service,
+    extensions::{Extension, ExtensionsMut},
+};
 use rama_utils::macros::define_inner_service_accessors;
 
 /// [`Layer`] for adding some shareable value to incoming input's extensions.
@@ -61,7 +64,7 @@ impl<Input, S, T> Service<Input> for AddInputExtension<S, T>
 where
     Input: Send + ExtensionsMut + 'static,
     S: Service<Input>,
-    T: Clone + Send + Sync + std::fmt::Debug + 'static,
+    T: Extension + Clone,
 {
     type Output = S::Output;
     type Error = S::Error;
@@ -126,7 +129,7 @@ impl<Input, S, T> Service<Input> for AddOutputExtension<S, T>
 where
     Input: Send + 'static,
     S: Service<Input, Output: Send + ExtensionsMut + 'static>,
-    T: Clone + Send + Sync + std::fmt::Debug + 'static,
+    T: Extension + Clone,
 {
     type Output = S::Output;
     type Error = S::Error;

--- a/rama-core/src/layer/get_extension.rs
+++ b/rama-core/src/layer/get_extension.rs
@@ -1,7 +1,10 @@
 //! Middleware that gets called with a clone of the value of to given type
 //! if it is available in the current input/output extensions.
 
-use crate::{Layer, Service, extensions::ExtensionsRef};
+use crate::{
+    Layer, Service,
+    extensions::{Extension, ExtensionsRef},
+};
 use rama_utils::macros::define_inner_service_accessors;
 use std::{fmt, marker::PhantomData};
 
@@ -127,7 +130,7 @@ impl<Input, S, T, Fut, F> Service<Input> for GetInputExtension<S, T, Fut, F>
 where
     Input: Send + ExtensionsRef + 'static,
     S: Service<Input>,
-    T: Clone + Send + Sync + 'static,
+    T: Extension + Clone,
     F: Fn(T) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = ()> + Send + 'static,
 {
@@ -265,7 +268,7 @@ impl<Input, S, T, Fut, F> Service<Input> for GetOutputExtension<S, T, Fut, F>
 where
     Input: Send + 'static,
     S: Service<Input, Output: Send + ExtensionsRef + 'static>,
-    T: Clone + Send + Sync + 'static,
+    T: Extension + Clone,
     F: Fn(T) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = ()> + Send + 'static,
 {

--- a/rama-core/src/matcher/ext.rs
+++ b/rama-core/src/matcher/ext.rs
@@ -1,5 +1,5 @@
 use crate::{
-    extensions::ExtensionsRef,
+    extensions::{Extension, ExtensionsRef},
     matcher::{Extensions, Matcher},
 };
 
@@ -45,7 +45,7 @@ where
 impl<Request, P, T> Matcher<Request> for ExtensionMatcher<P, T>
 where
     Request: Send + ExtensionsRef + 'static,
-    T: Clone + Send + Sync + 'static,
+    T: Extension + Clone,
     P: private::ExtensionPredicate<T>,
 {
     fn matches(&self, _ext: Option<&mut Extensions>, req: &Request) -> bool {

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -1,11 +1,10 @@
-use std::any::Any;
 use std::fmt;
 
 use crate::Result;
 use crate::dep::hyperium::http::Extensions as HyperExtensions;
 use crate::dep::hyperium::http::request::{Parts as HyperiumParts, Request as HyperiumRequest};
 use crate::{HeaderMap, HeaderName, HeaderValue, Method, Uri, Version, body::Body};
-use rama_core::extensions::{Extensions, ExtensionsMut, ExtensionsRef};
+use rama_core::extensions::{Extension, Extensions, ExtensionsMut, ExtensionsRef};
 
 /// Represents an HTTP request.
 ///
@@ -976,7 +975,7 @@ impl Builder {
     /// ```
     pub fn extension<T>(self, extension: T) -> Self
     where
-        T: Clone + Any + Send + Sync + std::fmt::Debug + 'static,
+        T: Extension + Clone,
     {
         self.and_then(move |mut head| {
             head.extensions.insert(extension);

--- a/rama-http-types/src/response.rs
+++ b/rama-http-types/src/response.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::fmt::{self, Display};
@@ -10,7 +9,7 @@ use crate::proto::h1::ext::ReasonPhrase;
 use crate::status::StatusCode;
 use crate::version::Version;
 use crate::{Body, Result};
-use rama_core::extensions::{Extensions, ExtensionsMut, ExtensionsRef};
+use rama_core::extensions::{Extension, Extensions, ExtensionsMut, ExtensionsRef};
 
 /// Represents an HTTP response
 ///
@@ -815,7 +814,7 @@ impl Builder {
     /// ```
     pub fn extension<T>(self, extension: T) -> Self
     where
-        T: Clone + Any + Send + Sync + std::fmt::Debug + 'static,
+        T: Extension + Clone,
     {
         self.and_then(move |mut head| {
             head.extensions.insert(extension);

--- a/rama-http/src/layer/header_config.rs
+++ b/rama-http/src/layer/header_config.rs
@@ -47,7 +47,7 @@ use crate::{
     Request,
     utils::{HeaderValueErr, HeaderValueGetter},
 };
-use rama_core::extensions::ExtensionsMut;
+use rama_core::extensions::{Extension, ExtensionsMut};
 use rama_core::telemetry::tracing;
 use rama_core::{Layer, Service, error::BoxError};
 use rama_utils::macros::define_inner_service_accessors;
@@ -140,7 +140,7 @@ where
 impl<T, S, Body, E> Service<Request<Body>> for HeaderConfigService<T, S>
 where
     S: Service<Request<Body>, Error = E>,
-    T: DeserializeOwned + Clone + Send + Sync + std::fmt::Debug + 'static,
+    T: DeserializeOwned + Extension + Clone,
     Body: Send + Sync + 'static,
     E: Into<BoxError> + Send + Sync + 'static,
 {

--- a/rama-http/src/layer/header_option_value.rs
+++ b/rama-http/src/layer/header_option_value.rs
@@ -7,7 +7,7 @@ use crate::{HeaderName, Request, utils::HeaderValueGetter};
 use rama_core::{
     Layer, Service,
     error::{BoxError, ErrorExt, OpaqueError},
-    extensions::ExtensionsMut,
+    extensions::{Extension, ExtensionsMut},
     telemetry::tracing,
 };
 use rama_utils::macros::define_inner_service_accessors;
@@ -85,7 +85,7 @@ where
 impl<T, S, Body, E> Service<Request<Body>> for HeaderOptionValueService<T, S>
 where
     S: Service<Request<Body>, Error = E>,
-    T: Default + Clone + Send + Sync + std::fmt::Debug + 'static,
+    T: Default + Extension + Clone,
     Body: Send + Sync + 'static,
     E: Into<BoxError> + Send + Sync + 'static,
 {

--- a/rama-http/src/layer/proxy_auth.rs
+++ b/rama-http/src/layer/proxy_auth.rs
@@ -6,7 +6,7 @@ use crate::header::PROXY_AUTHENTICATE;
 use crate::headers::authorization::Authority;
 use crate::headers::{HeaderMapExt, ProxyAuthorization, authorization::Credentials};
 use crate::{Request, Response, StatusCode};
-use rama_core::extensions::{ExtensionsMut, ExtensionsRef};
+use rama_core::extensions::{Extension, ExtensionsMut, ExtensionsRef};
 use rama_core::{Layer, Service};
 use rama_error::{BoxError, ErrorContext as _, OpaqueError};
 use rama_http_types::body::OptionalBody;
@@ -165,7 +165,7 @@ impl<A: Clone, C, S: Clone, L> Clone for ProxyAuthService<A, C, S, L> {
 impl<A, C, L, S, ReqBody, ResBody> Service<Request<ReqBody>> for ProxyAuthService<A, C, S, L>
 where
     A: Authority<C, L>,
-    C: Credentials + Clone + Send + Sync + 'static,
+    C: Credentials + Extension + Clone,
     S: Service<Request<ReqBody>, Output = Response<ResBody>, Error: Into<BoxError>>,
     L: 'static,
     ReqBody: Send + 'static,

--- a/rama-http/src/service/client/ext.rs
+++ b/rama-http/src/service/client/ext.rs
@@ -2,8 +2,7 @@ use crate::{Method, Request, Response, Uri};
 use rama_core::{
     Service,
     error::{BoxError, ErrorExt, OpaqueError},
-    extensions::Extensions,
-    extensions::ExtensionsMut,
+    extensions::{Extension, Extensions, ExtensionsMut},
 };
 use rama_http_headers::authorization::Credentials;
 
@@ -573,7 +572,7 @@ where
     #[must_use]
     pub fn extension<T>(mut self, extension: T) -> Self
     where
-        T: Clone + Send + Sync + std::fmt::Debug + 'static,
+        T: Extension + Clone,
     {
         match self.state {
             RequestBuilderState::PreBody(builder) => {

--- a/rama-http/src/service/web/endpoint/extract/extension.rs
+++ b/rama-http/src/service/web/endpoint/extract/extension.rs
@@ -21,7 +21,7 @@ define_http_rejection! {
 impl<State, T> FromPartsStateRefPair<State> for Extension<T>
 where
     State: Send + Sync,
-    T: Send + Sync + Clone + 'static,
+    T: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
     type Rejection = MissingExtension;
 
@@ -38,7 +38,7 @@ where
 impl<State, T> OptionalFromPartsStateRefPair<State> for Extension<T>
 where
     State: Send + Sync,
-    T: Send + Sync + Clone + 'static,
+    T: Send + Sync + Clone + std::fmt::Debug + 'static,
 {
     type Rejection = Infallible;
 

--- a/rama-net/src/client/pool/mod.rs
+++ b/rama-net/src/client/pool/mod.rs
@@ -4,7 +4,7 @@ use crate::conn::{ConnectionHealth, ConnectionHealthStatus};
 use crate::stream::Socket;
 use parking_lot::Mutex;
 use rama_core::error::{BoxError, ErrorContext, OpaqueError};
-use rama_core::extensions::{Extensions, ExtensionsMut, ExtensionsRef};
+use rama_core::extensions::{Extension, Extensions, ExtensionsMut, ExtensionsRef};
 use rama_core::telemetry::tracing::trace;
 use rama_core::{Layer, Service};
 use rama_utils::macros::generate_set_and_with;
@@ -723,7 +723,7 @@ impl<Input, S, P, R> Service<Input> for PooledConnector<S, P, R>
 where
     S: ConnectorService<Input>,
     Input: Send + ExtensionsRef + 'static,
-    P: Pool<S::Connection, R::ID>,
+    P: Pool<S::Connection, R::ID> + Extension + Clone,
     R: ReqToConnID<Input>,
 {
     type Output = EstablishedClientConnection<P::Connection, Input>;


### PR DESCRIPTION
`Extension` trait and some changes to prepare for "new-extensions" (eg Extension + Clone is needed for the current setup, but in a lot of places we will be able to remove Clone bound)

I will be adding limited support for new extensions behind a flag so we personally can test it for a while. It will be less powerful then the complete switch, but should allow use to test this extensively. 