### PR TITLE
feat: add `ends_with_ignore_ascii_case`

### DIFF
--- a/rama-utils/src/str/search.rs
+++ b/rama-utils/src/str/search.rs
@@ -83,13 +83,19 @@ mod tests {
     #[test]
     fn test_starts_with_ignore_ascii_case() {
         assert!(starts_with_ignore_ascii_case("user-agent", "user"));
+        assert!(starts_with_ignore_ascii_case("User-Agent", "user"));
+        assert!(starts_with_ignore_ascii_case("USER-AGENT", "user"));
         assert!(!starts_with_ignore_ascii_case("user-agent", "agent"));
+        assert!(!starts_with_ignore_ascii_case("User-Agent", "agent"));
     }
 
     #[test]
     fn test_ends_with_ignore_ascii_case() {
         assert!(ends_with_ignore_ascii_case("user-agent", "agent"));
+        assert!(ends_with_ignore_ascii_case("User-Agent", "agent"));
+        assert!(ends_with_ignore_ascii_case("USER-AGENT", "agent"));
         assert!(!ends_with_ignore_ascii_case("user-agent", "user"));
+        assert!(!ends_with_ignore_ascii_case("User-Agent", "user"));
     }
 
     #[test]


### PR DESCRIPTION
fixes #801 

I intentionally made the test fail during the debugging process.
The function snippet passes all test cases.