### PR TITLE
Tags for extensions using traits

### DIFF
--- a/rama-core/src/extensions.rs
+++ b/rama-core/src/extensions.rs
@@ -312,6 +312,10 @@ pub struct Stream<T>(pub T);
 #[derive(Debug, Clone, Extension)]
 pub struct Input<T>(pub T);
 
+// We use this syntax: [`TlsExtension`] — TLS and secure transport
+// Instead of [`TlsExtension`]: TLS and secure transport
+// Because otherwise we hit `link definitions are not shown in rendered documentation`
+
 /// [`Extension`] is type which can be stored inside an [`Extensions`] store
 ///
 /// This is has to be manually implement or can be implemented using `#[derive(Extension)]`
@@ -323,7 +327,76 @@ pub struct Input<T>(pub T);
 ///
 /// There might be valid use cases for implementing it for other type of containers, so in case you run into these
 /// open a Github issue and we can see if implementing it makes sense
+///
+/// # Extension Tags
+///
+/// Extensions can be tagged with one or more categories using the `#[extension(tags(tag1, tag2))]`
+/// attribute on the derive macro. This generates implementations for the corresponding
+/// marker traits below, which groups them in rust docs
+///
+/// - [`TlsExtension`] — TLS and secure transport
+/// - [`HttpExtension`] — HTTP protocol
+/// - [`NetExtension`] — Network and connection level
+/// - [`UaExtension`] — User-agent emulation
+/// - [`ProxyExtension`] — Proxy
+/// - [`WsExtension`] — WebSocket
+/// - [`DnsExtension`] — DNS resolution
+/// - [`GrpcExtension`] — gRPC
+///
+/// ```rust,ignore
+/// #[derive(Debug, Clone, Extension)]
+/// #[extension(tags(tls, net))]
+/// pub struct SecureTransport(..);
+/// ```
+///
+/// Types that implement [`Extension`] manually can opt into tagged docs by implementing
+/// the marker trait(s) directly:
+///
+/// ```rust,ignore
+/// impl Extension for MyType {}
+/// impl HttpExtension for MyType {}
+/// ```
 pub trait Extension: Any + Send + Sync + std::fmt::Debug + 'static {}
+
+/// TLS and secure transport related extensions.
+///
+/// Derive with `#[extension(tags(tls))]`
+pub trait TlsExtension: Extension {}
+
+/// HTTP protocol related extensions.
+///
+/// Derive with `#[extension(tags(http))]`
+pub trait HttpExtension: Extension {}
+
+/// Network and connection level extensions.
+///
+/// Derive with `#[extension(tags(net))]`
+pub trait NetExtension: Extension {}
+
+/// User-agent emulation related extensions.
+///
+/// Derive with `#[extension(tags(ua))]`
+pub trait UaExtension: Extension {}
+
+/// Proxy related extensions.
+///
+/// Derive with `#[extension(tags(proxy))]`
+pub trait ProxyExtension: Extension {}
+
+/// WebSocket related extensions.
+///
+/// Derive with `#[extension(tags(ws))]`
+pub trait WsExtension: Extension {}
+
+/// DNS resolution related extensions.
+///
+/// Derive with `#[extension(tags(dns))]`
+pub trait DnsExtension: Extension {}
+
+/// gRPC related extensions.
+///
+/// Derive with `#[extension(tags(grpc))]`
+pub trait GrpcExtension: Extension {}
 
 pub trait ExtensionsRef {
     /// Get reference to the underlying [`Extensions`] store

--- a/rama-core/src/graceful.rs
+++ b/rama-core/src/graceful.rs
@@ -7,4 +7,5 @@ pub use ::tokio_graceful::{
     Shutdown, ShutdownBuilder, ShutdownGuard, WeakShutdownGuard, default_signal,
 };
 
+// TODO @glendc, remove usage from this in TransparentProxyEngine
 impl Extension for ShutdownGuard {}

--- a/rama-dns/src/client/resolver/address/overwrite.rs
+++ b/rama-dns/src/client/resolver/address/overwrite.rs
@@ -6,6 +6,7 @@ use rama_net::address::Domain;
 use super::{BoxDnsAddressResolver, DnsAddressResolver};
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(dns))]
 /// Wrapper struct that can be used to add
 /// dns address overwrites to an input as an extension.
 ///

--- a/rama-grpc/src/codec/compression.rs
+++ b/rama-grpc/src/codec/compression.rs
@@ -321,6 +321,7 @@ pub(crate) fn decompress(
 
 /// Controls compression behavior for individual messages within a stream.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Extension)]
+#[extension(tags(grpc))]
 pub enum SingleMessageCompressionOverride {
     /// Inherit whatever compression is already configured. If the stream is compressed this
     /// message will also be configured.

--- a/rama-grpc/src/status.rs
+++ b/rama-grpc/src/status.rs
@@ -44,7 +44,8 @@ const ENCODING_SET: &AsciiSet = &CONTROLS
 /// assert_eq!(status1.code(), Code::InvalidArgument);
 /// assert_eq!(status1.code(), status2.code());
 /// ```
-#[derive(Clone)]
+#[derive(Clone, Extension)]
+#[extension(tags(grpc))]
 pub struct Status(Box<StatusInner>);
 
 /// Box the contents of Status to avoid large error variants
@@ -69,8 +70,6 @@ impl StatusInner {
         Status(Box::new(self))
     }
 }
-
-impl Extension for Status {}
 
 /// gRPC status codes used by [`Status`].
 ///

--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
@@ -254,6 +254,7 @@ where
 }
 
 #[derive(Clone, Debug, Extension)]
+#[extension(tags(http, proxy))]
 /// Extension added to the [`Extensions`] by [`HttpProxyConnector`] to record the
 /// headers from a successful CONNECT response.
 ///

--- a/rama-http-headers/src/common/sec_websocket_protocol.rs
+++ b/rama-http-headers/src/common/sec_websocket_protocol.rs
@@ -12,6 +12,7 @@ derive_non_empty_flat_csv_header! {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(http, ws))]
 /// Utility type containing the accepted [`SecWebSocketProtocol`].
 pub struct AcceptedWebSocketProtocol(pub NonEmptyStr);
 

--- a/rama-http-headers/src/forwarded/std.rs
+++ b/rama-http-headers/src/forwarded/std.rs
@@ -10,6 +10,7 @@ use crate::{Error, HeaderDecode, HeaderEncode, TypedHeader};
 use super::ForwardHeader;
 
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(http))]
 /// Typed header wrapper for [`rama_net::forwarded::Forwarded`];
 pub struct Forwarded(rama_net::forwarded::Forwarded);
 

--- a/rama-http-types/src/body/limit.rs
+++ b/rama-http-types/src/body/limit.rs
@@ -2,6 +2,7 @@ use rama_core::extensions::Extension;
 
 /// Can be used to communicate the desire to limit the size of request/response bodies.
 #[derive(Debug, Clone, Copy, Extension)]
+#[extension(tags(http))]
 pub struct BodyLimit {
     kind: Option<BodyLimitKind>,
 }

--- a/rama-http-types/src/conn.rs
+++ b/rama-http-types/src/conn.rs
@@ -7,6 +7,7 @@ use crate::proto::h2::{PseudoHeaderOrder, frame::EarlyFrameCapture};
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 /// Optional parameters that can be set in the [`Extensions`] of a (h1) request
 /// to customise the connection of the h1 connection.
 ///
@@ -23,6 +24,7 @@ pub struct Http1ClientContextParams {
 }
 
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 /// Optional parameters that can be set in the [`Extensions`] of a (h2) request
 /// to customise the connection of the h2 connection.
 ///
@@ -62,6 +64,7 @@ pub struct H2ClientContextParams {
 }
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Extension)]
+#[extension(tags(http))]
 /// Target http version
 ///
 /// This can be set manually to enforce a specific version,

--- a/rama-http-types/src/lib.rs
+++ b/rama-http-types/src/lib.rs
@@ -51,6 +51,7 @@ pub use crate::status::StatusCode;
 pub use crate::version::Version;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 /// Extension type that can be inserted in case a Uri is modified as part of nested routers
 pub struct OriginalRouterUri(pub Arc<Uri>);
 

--- a/rama-http-types/src/proto/h1/ext/informational.rs
+++ b/rama-http-types/src/proto/h1/ext/informational.rs
@@ -4,6 +4,7 @@ use rama_core::extensions::Extension;
 use std::sync::Arc;
 
 #[derive(Clone, Extension)]
+#[extension(tags(http))]
 pub struct OnInformational(Arc<dyn OnInformationalCallback + Send + Sync>);
 
 impl OnInformational {

--- a/rama-http-types/src/proto/h1/ext/reason_phrase.rs
+++ b/rama-http-types/src/proto/h1/ext/reason_phrase.rs
@@ -16,6 +16,7 @@ use rama_core::extensions::Extension;
 /// When a `ReasonPhrase` is present in the extensions of the `http::Response` written by a server,
 /// its contents will be written in place of the canonical reason phrase when responding via HTTP/1.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Extension)]
+#[extension(tags(http))]
 pub struct ReasonPhrase(Bytes);
 
 impl ReasonPhrase {

--- a/rama-http-types/src/proto/h1/headers/original.rs
+++ b/rama-http-types/src/proto/h1/headers/original.rs
@@ -8,6 +8,7 @@ use super::{Http1HeaderName, IntoHttp1HeaderName};
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 // Keeps track of the order and casing
 // of the inserted header names, usually used in combination
 // with [`crate::proto::h1::Http1HeaderMap`].

--- a/rama-http-types/src/proto/h2/ext.rs
+++ b/rama-http-types/src/proto/h2/ext.rs
@@ -24,6 +24,7 @@ use std::fmt;
 /// // Now the request will include the `:protocol` pseudo-header with value "websocket"
 /// ```
 #[derive(Clone, Eq, PartialEq, Extension)]
+#[extension(tags(http))]
 pub struct Protocol {
     value: BytesStr,
 }

--- a/rama-http-types/src/proto/h2/frame/early_frame.rs
+++ b/rama-http-types/src/proto/h2/frame/early_frame.rs
@@ -161,6 +161,7 @@ struct EarlyFrameRecorder {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 pub struct EarlyFrameCapture(Arc<[EarlyFrame]>);
 
 impl EarlyFrameCapture {

--- a/rama-http-types/src/proto/h2/pseudo_header.rs
+++ b/rama-http-types/src/proto/h2/pseudo_header.rs
@@ -91,6 +91,7 @@ impl<'de> Deserialize<'de> for PseudoHeader {
 const PSEUDO_HEADERS_STACK_SIZE: usize = 5;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Extension)]
+#[extension(tags(http))]
 pub struct PseudoHeaderOrder {
     headers: SmallVec<[PseudoHeader; PSEUDO_HEADERS_STACK_SIZE]>,
     mask: u8,

--- a/rama-http-types/src/proto/mod.rs
+++ b/rama-http-types/src/proto/mod.rs
@@ -11,10 +11,12 @@ pub mod h1;
 pub mod h2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Extension)]
+#[extension(tags(http))]
 /// Byte length of the raw bytes of the request/response headers (excl. trailers).
 pub struct HeaderByteLength(pub usize);
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 /// Read-only copy of the parent request headers.
 ///
 /// This extension can be made available in [`RequestHeaders`].
@@ -35,6 +37,7 @@ impl Deref for RequestHeaders {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 /// Read-only copy of the parent request extensions.
 ///
 /// This extension can be made available as part of a response.

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -69,6 +69,7 @@ pub struct Upgraded {
 ///
 /// If no upgrade was available, or it doesn't succeed, yields an `Error`.
 #[derive(Clone, Extension)]
+#[extension(tags(http))]
 pub struct OnUpgrade {
     rx: Arc<Mutex<oneshot::Receiver<Result<Upgraded, BoxError>>>>,
 }

--- a/rama-http/src/layer/compression/predicate.rs
+++ b/rama-http/src/layer/compression/predicate.rs
@@ -196,6 +196,7 @@ impl Predicate for DefaultStreamPredicate {
 
 /// Preferred response encoding requested by a compression predicate.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(http))]
 pub enum PreferredEncoding {
     #[default]
     Gzip,

--- a/rama-http/src/layer/decompression/mod.rs
+++ b/rama-http/src/layer/decompression/mod.rs
@@ -106,6 +106,7 @@ mod service;
 /// Marker extension inserted into a response when [`Decompression`] unwraps a
 /// compressed response body.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(http))]
 pub enum DecompressedFrom {
     Gzip,
     Deflate,

--- a/rama-http/src/layer/dns/dns_resolve/mod.rs
+++ b/rama-http/src/layer/dns/dns_resolve/mod.rs
@@ -25,6 +25,7 @@ mod username_parser;
 pub use username_parser::DnsResolveModeUsernameParser;
 
 #[derive(Debug, Clone, Default, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Extension)]
+#[extension(tags(http, dns))]
 /// A vanity [`Extensions`] type for others to easily check if eager DNS resolution is enabled.
 ///
 /// [`Extensions`]: rama_core::extensions::Extensions

--- a/rama-http/src/layer/follow_redirect/mod.rs
+++ b/rama-http/src/layer/follow_redirect/mod.rs
@@ -310,6 +310,7 @@ where
 /// The value differs from the original request's effective URI if the middleware has followed
 /// redirections.
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 pub struct RequestUri(pub Uri);
 
 #[derive(Debug)]

--- a/rama-http/src/layer/har/extensions.rs
+++ b/rama-http/src/layer/har/extensions.rs
@@ -3,4 +3,5 @@ use rama_utils::str::arcstr::ArcStr;
 
 #[must_use]
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(http))]
 pub struct RequestComment(pub ArcStr);

--- a/rama-http/src/layer/har/recorder/fs.rs
+++ b/rama-http/src/layer/har/recorder/fs.rs
@@ -21,6 +21,7 @@ pub struct FileRecorder {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 /// Path to (HAR) file that the [`FileRecorder`] is recording into.
 ///
 /// Inserted into the response extensions.

--- a/rama-http/src/layer/request_id.rs
+++ b/rama-http/src/layer/request_id.rs
@@ -87,6 +87,7 @@ pub trait MakeRequestId: Send + Sync + 'static {
 
 /// An identifier for a request.
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(http))]
 pub struct RequestId(HeaderValue);
 
 impl RequestId {

--- a/rama-http/src/layer/retry/managed.rs
+++ b/rama-http/src/layer/retry/managed.rs
@@ -11,6 +11,7 @@ use rama_core::telemetry::tracing;
 use rama_utils::backoff::Backoff;
 
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 /// A metadata value that can be added to the [`Extensions`]
 /// of a [`Request`] to signal that the request should not be retried.
 ///

--- a/rama-http/src/layer/traffic_writer/request.rs
+++ b/rama-http/src/layer/traffic_writer/request.rs
@@ -19,6 +19,7 @@ pub trait RequestWriter: Send + Sync + 'static {
 
 /// Marker struct to indicate that the request should not be printed.
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 #[non_exhaustive]
 pub struct DoNotWriteRequest;
 

--- a/rama-http/src/layer/traffic_writer/response.rs
+++ b/rama-http/src/layer/traffic_writer/response.rs
@@ -42,6 +42,7 @@ pub trait ResponseWriter: Send + Sync + 'static {
 
 /// Marker struct to indicate that the response should not be printed.
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 #[non_exhaustive]
 pub struct DoNotWriteResponse;
 

--- a/rama-http/src/matcher/path/mod.rs
+++ b/rama-http/src/matcher/path/mod.rs
@@ -13,6 +13,7 @@ use rama_utils::str::starts_with_ignore_ascii_case;
 mod de;
 
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(http))]
 /// parameters that are inserted in the [`Extensions`],
 /// in case the [`PathMatcher`] found a match for the given [`Request`].
 pub struct UriParams {

--- a/rama-macros/src/extension_macro/extension.rs
+++ b/rama-macros/src/extension_macro/extension.rs
@@ -3,6 +3,22 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{DeriveInput, GenericParam, parse_quote};
 
+const KNOWN_TAGS: &[&str] = &["tls", "http", "net", "ua", "proxy", "ws", "dns", "grpc"];
+
+fn tag_to_trait_name(tag: &str) -> Option<&'static str> {
+    match tag {
+        "tls" => Some("TlsExtension"),
+        "http" => Some("HttpExtension"),
+        "net" => Some("NetExtension"),
+        "ua" => Some("UaExtension"),
+        "proxy" => Some("ProxyExtension"),
+        "ws" => Some("WsExtension"),
+        "dns" => Some("DnsExtension"),
+        "grpc" => Some("GrpcExtension"),
+        _ => None,
+    }
+}
+
 pub(crate) fn expand(mut item: DeriveInput) -> syn::Result<TokenStream> {
     for param in item.generics.params.iter() {
         if matches!(param, GenericParam::Lifetime(_)) {
@@ -12,6 +28,8 @@ pub(crate) fn expand(mut item: DeriveInput) -> syn::Result<TokenStream> {
             ));
         }
     }
+
+    let tags = parse_tags(&item)?;
 
     // This will go over all generics in the struct eg item: S, code: T
     // and will for each generic add these bound S: Any + Send + Sync + Debug + 'static
@@ -31,9 +49,20 @@ pub(crate) fn expand(mut item: DeriveInput) -> syn::Result<TokenStream> {
     let ident = item.ident;
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
-    Ok(quote! {
+    let mut output = quote! {
         impl #impl_generics #root_crate::extensions::Extension for #ident #ty_generics #where_clause {}
-    })
+    };
+
+    for tag in &tags {
+        let trait_name =
+            tag_to_trait_name(tag).expect("tag should have been validated during parsing");
+        let trait_ident = Ident::new(trait_name, Span::call_site());
+        output.extend(quote! {
+            impl #impl_generics #root_crate::extensions::#trait_ident for #ident #ty_generics #where_clause {}
+        });
+    }
+
+    Ok(output)
 }
 
 fn support_root_ts() -> proc_macro2::TokenStream {
@@ -62,5 +91,122 @@ fn support_root_ts() -> proc_macro2::TokenStream {
             "extension derive could not find Extension trait. \
              Add a dependency on `rama` or `rama-core`."
         ); }
+    }
+}
+
+fn parse_tags(item: &DeriveInput) -> syn::Result<Vec<String>> {
+    let mut tags = Vec::new();
+
+    for attr in &item.attrs {
+        if !attr.path().is_ident("extension") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("tags") {
+                // parse: tags(http, proxy)
+                meta.parse_nested_meta(|tag_meta| {
+                    let ident = tag_meta
+                        .path
+                        .get_ident()
+                        .ok_or_else(|| tag_meta.error("expected a tag name"))?;
+
+                    let tag = ident.to_string();
+                    if tag_to_trait_name(&tag).is_none() {
+                        return Err(syn::Error::new_spanned(
+                            ident,
+                            format!(
+                                "unknown extension tag `{tag}`. Known tags: {}",
+                                KNOWN_TAGS.join(", ")
+                            ),
+                        ));
+                    }
+
+                    if tags.contains(&tag) {
+                        return Err(syn::Error::new_spanned(
+                            ident,
+                            format!("duplicate extension tag `{tag}`"),
+                        ));
+                    }
+                    tags.push(tag);
+                    Ok(())
+                })?;
+            } else {
+                return Err(meta.error("unknown extension attribute, expected `tags`"));
+            }
+            Ok(())
+        })?;
+    }
+
+    Ok(tags)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_tags;
+    use syn::parse_quote;
+
+    #[test]
+    fn parse_tags_empty_when_attr_absent() {
+        let item: syn::DeriveInput = parse_quote! {
+            struct MyExt;
+        };
+
+        let tags = parse_tags(&item).unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn parse_tags_collects_valid_tags() {
+        let item: syn::DeriveInput = parse_quote! {
+            #[extension(tags(http, proxy))]
+            struct MyExt;
+        };
+
+        let tags = parse_tags(&item).unwrap();
+        assert_eq!(tags, vec!["http".to_owned(), "proxy".to_owned()]);
+    }
+
+    #[test]
+    fn parse_tags_rejects_unknown_tag() {
+        let item: syn::DeriveInput = parse_quote! {
+            #[extension(tags(http, banana))]
+            struct MyExt;
+        };
+
+        let err = parse_tags(&item).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown extension tag `banana`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_tags_rejects_duplicate_tags() {
+        let item: syn::DeriveInput = parse_quote! {
+            #[extension(tags(http, http))]
+            struct MyExt;
+        };
+
+        let err = parse_tags(&item).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate extension tag `http`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_tags_rejects_unknown_extension_attribute_field() {
+        let item: syn::DeriveInput = parse_quote! {
+            #[extension(foo(http))]
+            struct MyExt;
+        };
+
+        let err = parse_tags(&item).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unknown extension attribute, expected `tags`"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rama-macros/src/lib.rs
+++ b/rama-macros/src/lib.rs
@@ -190,7 +190,11 @@ pub fn derive_from_ref(item: TokenStream) -> TokenStream {
 ///
 /// Note that all type parameters of the derived type must satisfy:
 /// `Any + Send + Sync + Debug + 'static`.
-#[proc_macro_derive(Extension)]
+///
+/// Optional derive attributes:
+/// - `#[extension(tags(...))]`: implement one or more marker traits used to group
+///   extensions in rustdoc (`tls`, `http`, `net`, `ua`, `proxy`, `ws`, `dns`, `grpc`).
+#[proc_macro_derive(Extension, attributes(extension))]
 pub fn derive_extension(item: TokenStream) -> TokenStream {
     from_ref_macro::expand_with(item, extension_macro::extension::expand)
 }

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -13,6 +13,7 @@ use rama_core::{
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(net, proxy))]
 /// Address of a proxy that can be connected to.
 pub struct ProxyAddress {
     /// [`Protocol`] used by the proxy.

--- a/rama-net/src/client/mod.rs
+++ b/rama-net/src/client/mod.rs
@@ -22,6 +22,7 @@ use crate::address::HostWithPort;
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(net))]
 /// Target [`HostWithPort`] which if found in extensions
 /// is to be used by a connector such as a TCPConnector instead
 /// of the requested address, unless a proxy is requested in

--- a/rama-net/src/conn.rs
+++ b/rama-net/src/conn.rs
@@ -26,6 +26,7 @@ pub fn is_connection_error(e: &io::Error) -> bool {
 }
 
 #[derive(Clone, Default, Extension)]
+#[extension(tags(net))]
 /// Health of this connection
 ///
 /// Note: this should only be added once to extensions and

--- a/rama-net/src/forwarded/mod.rs
+++ b/rama-net/src/forwarded/mod.rs
@@ -34,6 +34,7 @@ pub use version::ForwardedVersion;
 use crate::address::SocketAddress;
 
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(net))]
 /// Forwarding information stored as a chain.
 ///
 /// This extension (which can be stored and modified via the [`Extensions`])

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -30,6 +30,7 @@ fn try_get_sni_from_secure_transport(t: &SecureTransport) -> Option<Domain> {
 
 #[cfg(not(feature = "tls"))]
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(tls))]
 #[non_exhaustive]
 struct SecureTransport;
 
@@ -39,6 +40,7 @@ fn try_get_sni_from_secure_transport(_: &SecureTransport) -> Option<Domain> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+#[extension(tags(http))]
 /// The context of the [`Request`].
 pub struct RequestContext {
     /// The HTTP Version.

--- a/rama-net/src/mode.rs
+++ b/rama-net/src/mode.rs
@@ -1,6 +1,7 @@
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Extension)]
+#[extension(tags(net))]
 /// Enum representing the IP modes that can be used by the DNS resolver.
 pub enum DnsResolveIpMode {
     #[default]
@@ -25,6 +26,7 @@ impl DnsResolveIpMode {
 }
 ///Mode for establishing a connection
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash, Extension)]
+#[extension(tags(net))]
 pub enum ConnectIpMode {
     #[default]
     Dual,

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -10,6 +10,7 @@ use rama_utils::str::smol_str::SmolStr;
 use rama_http_types::Scheme;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Extension)]
+#[extension(tags(net))]
 /// Web protocols that are relevant to Rama.
 ///
 /// Please [file an issue or open a PR][repo] if you need support for more protocols.

--- a/rama-net/src/proxy/mod.rs
+++ b/rama-net/src/proxy/mod.rs
@@ -8,5 +8,6 @@ mod forward;
 pub use forward::IoForwardService;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(net, proxy))]
 /// Target [`HostWithPort`] for a proxy/forwarder service.
 pub struct ProxyTarget(pub HostWithPort);

--- a/rama-net/src/stream/layer/tracker/bytes.rs
+++ b/rama-net/src/stream/layer/tracker/bytes.rs
@@ -191,6 +191,7 @@ where
 /// read and/or written even though the tracker is consumed by a protocol
 /// consumer.
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(net))]
 pub struct BytesRWTrackerHandle {
     read: Arc<AtomicUsize>,
     written: Arc<AtomicUsize>,

--- a/rama-net/src/stream/socket.rs
+++ b/rama-net/src/stream/socket.rs
@@ -79,6 +79,7 @@ impl<T: Socket> Socket for ServiceInput<T> {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(net))]
 /// Information about the socket on the egress end.
 pub struct ClientSocketInfo(pub SocketInfo);
 
@@ -108,6 +109,7 @@ impl DerefMut for ClientSocketInfo {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(net))]
 /// Connected socket information.
 pub struct SocketInfo {
     local_addr: Option<SocketAddress>,

--- a/rama-net/src/tls/client/mod.rs
+++ b/rama-net/src/tls/client/mod.rs
@@ -26,6 +26,7 @@ use super::{ApplicationProtocol, DataEncoding, ProtocolVersion};
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(tls))]
 /// Indicate (some) of the negotiated tls parameters that
 /// can be added to the input extensions by Tls implementations.
 pub struct NegotiatedTlsParameters {

--- a/rama-net/src/tls/mod.rs
+++ b/rama-net/src/tls/mod.rs
@@ -17,6 +17,7 @@ pub mod keylog;
 pub mod server;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(tls))]
 /// Context information that can be provided by `tls` connectors`,
 /// to configure the connection in function on an tls tunnel.
 pub struct TlsTunnel {
@@ -25,6 +26,7 @@ pub struct TlsTunnel {
 }
 
 #[derive(Debug, Clone, Default, Extension)]
+#[extension(tags(tls))]
 /// Metadata that can be added to the [`Extensions`]
 /// of a transport layer to signal that the transport is secure.
 ///

--- a/rama-net/src/user/credentials/basic.rs
+++ b/rama-net/src/user/credentials/basic.rs
@@ -7,6 +7,7 @@ use rama_utils::str::NonEmptyStr;
 use crate::user::authority::StaticAuthorizer;
 
 #[derive(Clone, PartialEq, Eq, Extension)]
+#[extension(tags(net))]
 /// Basic credentials.
 pub struct Basic {
     username: NonEmptyStr,

--- a/rama-net/src/user/credentials/proxy.rs
+++ b/rama-net/src/user/credentials/proxy.rs
@@ -4,6 +4,7 @@ use super::{Basic, Bearer};
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(net, proxy))]
 /// Extension wrapper that can be used by
 /// Deep Protocol Inspection (DPI) services which
 /// processed an exchanged [`ProxyCredential`].

--- a/rama-net/src/user/id.rs
+++ b/rama-net/src/user/id.rs
@@ -1,6 +1,7 @@
 use rama_core::extensions::Extension;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(net))]
 /// The identifier of a user.
 ///
 /// Usually created by the layer which authenticates the user.

--- a/rama-proxy/src/proxydb/internal.rs
+++ b/rama-proxy/src/proxydb/internal.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use venndb::VennDB;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Extension)]
+#[extension(tags(proxy))]
 #[cfg_attr(feature = "memory-db", derive(VennDB))]
 #[cfg_attr(feature = "memory-db", venndb(validator = proxydb_insert_validator))]
 /// The selected proxy to use to connect to the proxy.

--- a/rama-proxy/src/proxydb/mod.rs
+++ b/rama-proxy/src/proxydb/mod.rs
@@ -34,6 +34,7 @@ mod str;
 pub use str::StringFilter;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Extension)]
+#[extension(tags(proxy))]
 /// `ID` of the selected proxy. To be inserted into the `Context`,
 /// only if that proxy is selected.
 pub struct ProxyID(NonEmptyStr);
@@ -65,6 +66,7 @@ impl From<NonEmptyStr> for ProxyID {
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(proxy))]
 /// Filter to select a specific kind of proxy.
 ///
 /// If the `id` is specified the other fields are used

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -71,6 +71,7 @@ impl TlsConnectorData {
 }
 
 #[derive(Clone, Default, Extension)]
+#[extension(tags(tls))]
 /// Use [`TlsConnectorDataBuilder`] to build a [`TlsConnectorData`] in an ergonomic way
 ///
 /// This builder is very powerful and is capable of stacking other builders. Using it

--- a/rama-tls-boring/src/server/acceptor_data.rs
+++ b/rama-tls-boring/src/server/acceptor_data.rs
@@ -25,6 +25,7 @@ use rama_net::{
 use std::{sync::Arc, time::Duration};
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(tls))]
 /// Internal data used as configuration/input for the [`super::TlsAcceptorService`].
 ///
 /// Created by trying to turn the _rama_ opiniated [`rama_net::tls::server::ServerConfig`] into it.

--- a/rama-tls-rustls/src/client/connector_data.rs
+++ b/rama-tls-rustls/src/client/connector_data.rs
@@ -16,6 +16,7 @@ use crate::dep::pki_types::PrivatePkcs8KeyDer;
 use ::rama_core::error::ErrorContext;
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(tls))]
 /// Internal data used as configuration/input for the [`super::TlsConnector`].
 ///
 /// Created by converting a [`rustls::ClientConfig`] into it directly,

--- a/rama-tls-rustls/src/server/acceptor_data.rs
+++ b/rama-tls-rustls/src/server/acceptor_data.rs
@@ -14,6 +14,7 @@ use crate::dep::pki_types::PrivatePkcs8KeyDer;
 use ::rama_net::address::Domain;
 
 #[derive(Clone, Debug, Extension)]
+#[extension(tags(tls))]
 /// Internal data used as configuration/input for the [`super::TlsAcceptorService`].
 ///
 /// Created by converting a [`rustls::ServerConfig`] into it directly,

--- a/rama-ua/src/layer/emulate/provider.rs
+++ b/rama-ua/src/layer/emulate/provider.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Extension)]
+#[extension(tags(ua))]
 /// Extra information about the selected user agent profile,
 /// which isn't already injected. E.g. http and tls information
 /// is already injected separately.
@@ -40,6 +41,7 @@ impl From<&UserAgentProfile> for SelectedUserAgentProfile {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Extension)]
+#[extension(tags(ua))]
 /// Fallback strategy that can be injected into the context
 /// to customise what a provider can be requested to do
 /// in case the preconditions for UA selection were not fulfilled.

--- a/rama-ua/src/profile/http.rs
+++ b/rama-ua/src/profile/http.rs
@@ -30,6 +30,7 @@ pub static CUSTOM_HEADER_MARKER: HeaderName =
     HeaderName::from_static("x-rama-custom-header-marker");
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ua, http))]
 /// A User Agent (UA) profile for HTTP.
 ///
 /// This profile contains the HTTP profiles for

--- a/rama-ua/src/profile/runtime_hints.rs
+++ b/rama-ua/src/profile/runtime_hints.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::{fmt, ops::Deref, str::FromStr};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Extension)]
+#[extension(tags(ua))]
 #[non_exhaustive]
 /// Runtime hint to request a user agent to be preserved,
 /// useful for systems that modify requests based on the context and request,
@@ -28,6 +29,7 @@ impl PreserveHeaderUserAgent {
 
 /// ClientHints requested for the (http) Request.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default, Extension)]
+#[extension(tags(ua))]
 pub struct RequestClientHints(pub Arc<[ClientHint]>);
 
 impl AsRef<[ClientHint]> for RequestClientHints {
@@ -45,6 +47,7 @@ impl Deref for RequestClientHints {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Extension)]
+#[extension(tags(ua))]
 /// The initiator of the (http) Request.
 ///
 /// It is used to determine the request initiator for the to be emulated http request,

--- a/rama-ua/src/profile/tls.rs
+++ b/rama-ua/src/profile/tls.rs
@@ -13,6 +13,7 @@ use rama_net::{
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ua, tls))]
 /// Profile of the user-agent's TLS (client) configuration.
 ///
 /// It is used to emulate the TLS configuration of the user-agent.

--- a/rama-ua/src/ua/info.rs
+++ b/rama-ua/src/ua/info.rs
@@ -9,6 +9,7 @@ use std::{convert::Infallible, fmt, str::FromStr};
 ///
 /// See [the module level documentation](crate) for more information.
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ua))]
 pub struct UserAgent {
     pub(super) header: ArcStr,
     pub(super) data: UserAgentData,

--- a/rama-ws/src/handshake/matcher/service.rs
+++ b/rama-ws/src/handshake/matcher/service.rs
@@ -35,11 +35,13 @@ pub struct HttpWebSocketRelayServiceRequestMatcher<S = IoForwardService> {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ws))]
 /// Stored in the Ingress extensions
 /// by the [`HttpWebSocketRelayServiceRequestMatcher`] if configured to do so.
 pub struct HttpWebSocketRelayHandshakeRequest(pub Arc<request::Parts>);
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ws))]
 /// Stored in the Egress extensions
 /// by the [`HttpWebSocketRelayServiceResponseMatcher`] if configured to do so.
 pub struct HttpWebSocketRelayHandshakeResponse(pub Arc<response::Parts>);
@@ -202,6 +204,7 @@ pub struct HttpWebSocketRelayServiceResponseMatcher<S> {
 }
 
 #[derive(Debug, Clone, Extension)]
+#[extension(tags(ws))]
 /// A [`WebSocketConfig`] extracted as part of the handshake phase prior to the relay...
 pub struct RelayWebSocketConfig(pub WebSocketConfig);
 


### PR DESCRIPTION
Add traits such as `TlsExtension`, `HttpExtension` that can be implement to "tag" extension. This makes it very easy to find them in rust docs and also allows us to group similar extensions. 

This also extends the derive `Extension` macro to support a syntax like this to make this ergonomic
```rust
#[derive(Debug, Clone, Extension)]
#[extension(tags(tls, net))]
pub struct SecureTransport;
```