### PR TITLE
prevent allocations for static str errors

### DIFF
--- a/examples/http_anti_bot_infinite_resource.rs
+++ b/examples/http_anti_bot_infinite_resource.rs
@@ -30,7 +30,7 @@
 use rama::{
     Layer, Service,
     conversion::FromRef,
-    error::{BoxError, ErrorContext as _, ErrorExt},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::{Extensions, ExtensionsRef},
     http::{
         InfiniteReader,
@@ -220,7 +220,8 @@ where
         let block_list = self.block_list.lock().await;
         if block_list.contains(&ip_addr) {
             return Err(
-                BoxError::from("drop connection for blocked ip").context_field("ip_addr", ip_addr)
+                OpaqueError::from_static_str("drop connection for blocked ip")
+                    .context_field("ip_addr", ip_addr),
             );
         }
         std::mem::drop(block_list);

--- a/examples/http_pooled_client.rs
+++ b/examples/http_pooled_client.rs
@@ -16,7 +16,7 @@
 
 use rama::{
     Layer,
-    error::BoxError,
+    error::{BoxError, ErrorExt, extra::OpaqueError},
     http::{
         BodyExtractExt,
         client::EasyHttpWebClient,
@@ -136,7 +136,9 @@ where
     async fn check(&self, request: Request) -> PolicyResult<Request, Self::Guard, Self::Error> {
         let output = match !self.0.swap(true, Ordering::AcqRel) {
             true => PolicyOutput::Ready(()),
-            false => PolicyOutput::Abort(BoxError::from("only first connection is allowed")),
+            false => PolicyOutput::Abort(
+                OpaqueError::from_static_str("only first connection is allowed").into_box_error(),
+            ),
         };
         PolicyResult {
             input: request,

--- a/examples/http_rama_tower.rs
+++ b/examples/http_rama_tower.rs
@@ -18,7 +18,7 @@
 /// rama provides everything out of the box to build a complete web service.
 use rama::{
     Layer as _,
-    error::{BoxError, ErrorContext as _},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     http::{
         HeaderValue, Request,
         layer::trace::TraceLayer,
@@ -204,7 +204,10 @@ where
         // Now check the sleep
         match this.sleep.poll(cx) {
             std::task::Poll::Pending => std::task::Poll::Pending,
-            std::task::Poll::Ready(_) => std::task::Poll::Ready(Err(BoxError::from("Elapses"))),
+            std::task::Poll::Ready(_) => std::task::Poll::Ready(Err(OpaqueError::from_static_str(
+                "Elapses",
+            )
+            .into_box_error())),
         }
     }
 }

--- a/examples/tls_rustls_dynamic_config.rs
+++ b/examples/tls_rustls_dynamic_config.rs
@@ -51,7 +51,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorContext, ErrorExt},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     graceful::Shutdown,
     http::{Request, Response, server::HttpServer, service::web::response::IntoResponse},
     layer::ConsumeErrLayer,
@@ -120,18 +120,18 @@ impl DynamicConfigProvider for DynamicConfig {
         &self,
         client_hello: rama::tls::rustls::dep::rustls::server::ClientHello<'_>,
     ) -> Result<Arc<rama::tls::rustls::dep::rustls::ServerConfig>, BoxError> {
-        let (cert_chain, key_der) =
-            match client_hello.server_name() {
-                Some(name) => match name {
-                    "example" => load_example_certificate().await,
-                    "second.example" => load_second_example_certificate().await,
-                    name => Err(BoxError::from("server name not recognised")
-                        .context_str_field("name", name)),
-                },
-                _ => Err(BoxError::from(
-                    "server name required for this server to work",
-                )),
-            }?;
+        let (cert_chain, key_der) = match client_hello.server_name() {
+            Some(name) => match name {
+                "example" => load_example_certificate().await,
+                "second.example" => load_second_example_certificate().await,
+                name => Err(OpaqueError::from_static_str("server name not recognised")
+                    .context_str_field("name", name)),
+            },
+            _ => Err(
+                OpaqueError::from_static_str("server name required for this server to work")
+                    .into_box_error(),
+            ),
+        }?;
 
         let config = TlsAcceptorDataBuilder::new(cert_chain, key_der)
             .unwrap()

--- a/examples/tls_sni_router.rs
+++ b/examples/tls_sni_router.rs
@@ -44,7 +44,7 @@
 // rama provides everything out of the box to build a TLS termination proxy
 use rama::{
     Layer, Service,
-    error::BoxError,
+    error::{BoxError, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     graceful::{Shutdown, ShutdownGuard},
     http::{layer::trace::TraceLayer, server::HttpServer, service::web::Router},
@@ -148,7 +148,9 @@ where
                         server.address = %sni,
                         "block connection for unknown destination",
                     );
-                    return Err(BoxError::from("unknown destination"));
+                    return Err(
+                        OpaqueError::from_static_str("unknown destination").into_box_error()
+                    );
                 }
             }
         };

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/certs.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/certs.rs
@@ -139,7 +139,7 @@ fn load_file_secret(service: &str) -> Result<Option<Vec<u8>>, BoxError> {
     match std::fs::read(&path) {
         Ok(raw) => Ok(Some(raw)),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(err) => Err(BoxError::from(err)
+        Err(err) => Err(err
             .context("load filesystem secret")
             .context_str_field("service", service)
             .context_str_field("path", path.display().to_string())),

--- a/rama-cli/src/cmd/probe/tls/mod.rs
+++ b/rama-cli/src/cmd/probe/tls/mod.rs
@@ -2,7 +2,7 @@
 
 use rama::{
     Layer, Service,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     net::{
         Protocol,
@@ -83,9 +83,10 @@ pub async fn run(cfg: CliCommandTls) -> Result<(), BoxError> {
             }
             DataEncoding::DerStack(raw_data_slice) => {
                 if raw_data_slice.is_empty() {
-                    return Err(BoxError::from(
+                    return Err(OpaqueError::from_static_str(
                         "DER-encoded stack byte slice for TLS cert is empty",
-                    ));
+                    )
+                    .into_box_error());
                 } else {
                     vec![
                         X509::from_der(raw_data_slice[0].as_slice())
@@ -107,7 +108,9 @@ pub async fn run(cfg: CliCommandTls) -> Result<(), BoxError> {
             println!();
         }
     } else {
-        return Err(BoxError::from("no peer cert information found"));
+        return Err(
+            OpaqueError::from_static_str("no peer cert information found").into_box_error(),
+        );
     }
 
     Ok(())

--- a/rama-cli/src/cmd/resolve.rs
+++ b/rama-cli/src/cmd/resolve.rs
@@ -25,7 +25,7 @@ use rama::{
             HappyEyeballAddressResolverExt,
         },
     },
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     extensions::Extensions,
     futures::StreamExt,
     net::{
@@ -65,7 +65,10 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(BoxError::from("failed to resolve domain into any A record"));
+                return Err(OpaqueError::from_static_str(
+                    "failed to resolve domain into any A record",
+                )
+                .into_box_error());
             }
         }
         Some(RecordType::AAAA) => {
@@ -82,9 +85,10 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "failed to resolve domain into any AAAA record",
-                ));
+                )
+                .into_box_error());
             }
         }
         Some(RecordType::TXT) => {
@@ -104,13 +108,16 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if records_found == 0 {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "failed to resolve domain into any TXT record",
-                ));
+                )
+                .into_box_error());
             }
         }
         Some(RecordType::Unknown(variant)) => {
-            return Err(BoxError::from("unknown record type").context_field("value", variant));
+            return Err(
+                OpaqueError::from_static_str("unknown record type").context_field("value", variant)
+            );
         }
         None => {
             println!("Resolving IP for domain: {domain}");
@@ -146,9 +153,10 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "failed to resolve domain into any IP address",
-                ));
+                )
+                .into_box_error());
             }
         }
     }
@@ -215,9 +223,9 @@ fn build_dns_config_and_options(
 fn apply_options(
     cfg: &ResolveCommand,
     dns_options: &mut hickory::resolver::config::ResolverOpts,
-) -> Result<(), BoxError> {
+) -> Result<(), OpaqueError> {
     if cfg.ipv4_only && cfg.ipv6_only {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "IPv4-only and IPv6-only transport cannot be requested at the same time",
         ));
     }
@@ -326,7 +334,8 @@ impl FromStr for NameServerArg {
             return Ok(Self { ip, port: None });
         }
 
-        Err(BoxError::from("invalid nameserver address").context_field("value", s.to_owned()))
+        Err(OpaqueError::from_static_str("invalid nameserver address")
+            .context_field("value", s.to_owned()))
     }
 }
 
@@ -399,23 +408,23 @@ pub struct ResolveCommand {
 }
 
 impl ResolveCommand {
-    fn domain(&self) -> Result<Domain, BoxError> {
+    fn domain(&self) -> Result<Domain, OpaqueError> {
         match (&self.domain, &self.query_name) {
             (Some(domain), None) | (None, Some(domain)) => Ok(domain.clone()),
-            (Some(_), Some(_)) => Err(BoxError::from(
+            (Some(_), Some(_)) => Err(OpaqueError::from_static_str(
                 "domain cannot be provided both positionally and via --name",
             )),
-            (None, None) => Err(BoxError::from(
+            (None, None) => Err(OpaqueError::from_static_str(
                 "domain is required either positionally or via --name",
             )),
         }
     }
 
-    fn record_type(&self) -> Result<Option<RecordType>, BoxError> {
+    fn record_type(&self) -> Result<Option<RecordType>, OpaqueError> {
         match (&self.record_type, &self.query_type) {
             (Some(record_type), None) | (None, Some(record_type)) => Ok(Some(record_type.clone())),
             (None, None) => Ok(None),
-            (Some(_), Some(_)) => Err(BoxError::from(
+            (Some(_), Some(_)) => Err(OpaqueError::from_static_str(
                 "record type cannot be provided both positionally and via --type",
             )),
         }

--- a/rama-cli/src/cmd/send/arg.rs
+++ b/rama-cli/src/cmd/send/arg.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use rama::{
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     net::address::Domain,
 };
 use std::{fmt, net::IpAddr, str::FromStr};
@@ -62,10 +62,10 @@ impl FromStr for ResolveArg {
                 .map(|suffix| suffix.chars().all(|c| c.is_alphabetic() || c == '.'))
                 .unwrap_or_default()
             {
-                return Err(
-                    BoxError::from("invalid domain (suffix not found or invalid)")
-                        .context_field("host", host),
-                );
+                return Err(OpaqueError::from_static_str(
+                    "invalid domain (suffix not found or invalid)",
+                )
+                .context_field("host", host));
             }
             arg.host = Some(host);
         }
@@ -81,9 +81,10 @@ impl FromStr for ResolveArg {
         }
 
         if arg.addresses.is_empty() {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "no addresses found while at least one is required",
-            ));
+            )
+            .into_box_error());
         }
 
         Ok(arg)

--- a/rama-cli/src/cmd/send/http/client/mod.rs
+++ b/rama-cli/src/cmd/send/http/client/mod.rs
@@ -144,7 +144,7 @@ fn new_inner_client(
         (false, false, true, false) => Some(SslVersion::TLS1_2),
         (false, false, false, true) => Some(SslVersion::TLS1_3),
         (false, false, false, false) => None,
-        _ => Err(BoxError::from(
+        _ => Err(OpaqueError::from_static_str(
             "--tlsv1.0, --tlsv1.1, --tlsv1.2, --tlsv1.3 are mutually exclusive",
         ))?,
     } {

--- a/rama-cli/src/cmd/send/http/mod.rs
+++ b/rama-cli/src/cmd/send/http/mod.rs
@@ -1,6 +1,6 @@
 use rama::{
     Service,
-    error::{BoxError, ErrorContext as _, ErrorExt},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     utils::collections::NonEmptySmallVec,
 };
 
@@ -59,7 +59,8 @@ pub async fn run_inner(cfg: &SendCommand, is_ws: bool) -> Result<(), BoxError> {
             let code = resp.status();
             if code.is_client_error() || code.is_server_error() {
                 return Err(Box::new(ErrorWithExitCode {
-                    error: BoxError::from("http failure status code").context_field("code", code),
+                    error: OpaqueError::from_static_str("http failure status code")
+                        .context_field("code", code),
                     code: 22,
                 }));
             }

--- a/rama-cli/src/cmd/send/http/request.rs
+++ b/rama-cli/src/cmd/send/http/request.rs
@@ -1,6 +1,6 @@
 use rama::{
     bytes::Bytes,
-    error::{BoxError, ErrorContext as _},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     futures::{StreamExt, stream},
     http::{
@@ -21,7 +21,7 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
 
     let input = build_data_input(cfg).await?;
     if input.is_some() && is_ws {
-        return Err(BoxError::from("input not allowed in WS mode"));
+        return Err(OpaqueError::from_static_str("input not allowed in WS mode").into_box_error());
     }
 
     let uri: Uri = expand_url(&cfg.uri)
@@ -42,7 +42,7 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
         (false, false, false, true, false) => Some(Version::HTTP_2),
         (false, false, false, false, true) => Some(Version::HTTP_3),
         (false, false, false, false, false) => None,
-        _ => Err(BoxError::from(
+        _ => Err(OpaqueError::from_static_str(
             "--http0.9, --http1.0, --http1.1, --http2, --http3 are mutually exclusive",
         ))?,
     } {
@@ -78,7 +78,9 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
     }
 
     match (cfg.ipv4, cfg.ipv6) {
-        (true, true) => Err(BoxError::from("--ipv4, --ipv6 are mutually exclusive"))?,
+        (true, true) => Err(OpaqueError::from_static_str(
+            "--ipv4, --ipv6 are mutually exclusive",
+        ))?,
         (true, false) => {
             request.extensions().insert(DnsResolveIpMode::SingleIpV4);
             request.extensions().insert(ConnectIpMode::Ipv4);
@@ -103,7 +105,9 @@ async fn build_data_input(cfg: &SendCommand) -> Result<Option<(Body, ContentType
         (true, false) => (ContentType::octet_stream(), None),
         (false, true) => (ContentType::json(), Some(NATIVE_NEWLINE)),
         (false, false) => (ContentType::form_url_encoded(), Some("&")),
-        _ => Err(BoxError::from("--binary, --json are mutually exclusive"))?,
+        _ => Err(OpaqueError::from_static_str(
+            "--binary, --json are mutually exclusive",
+        ))?,
     };
 
     let Some(data) = cfg.data.as_deref() else {

--- a/rama-cli/src/cmd/send/http/ws/tui.rs
+++ b/rama-cli/src/cmd/send/http/ws/tui.rs
@@ -236,9 +236,8 @@ impl App {
                     self.history.push_server_message(text);
                 }
                 Ok(Message::Close(close)) => {
-                    return Err(
-                        BoxError::from("recv close msg").context_debug_field("frame", close)
-                    );
+                    return Err(OpaqueError::from_static_str("recv close msg")
+                        .context_debug_field("frame", close));
                 }
                 Ok(message) => {
                     tracing::info!("received non-text message: {message}");

--- a/rama-cli/src/cmd/send/mod.rs
+++ b/rama-cli/src/cmd/send/mod.rs
@@ -1,5 +1,5 @@
 use rama::{
-    error::{BoxError, ErrorExt},
+    error::{BoxError, ErrorExt, extra::OpaqueError},
     net::{address::ProxyAddress, user::Basic},
     utils::str::{NonEmptyStr, starts_with_ignore_ascii_case},
 };
@@ -14,7 +14,7 @@ mod layer;
 
 pub async fn run(cfg: SendCommand) -> Result<(), BoxError> {
     if cfg.uri.is_empty() {
-        return Err(BoxError::from("empty URI is not valid"));
+        return Err(OpaqueError::from_static_str("empty URI is not valid").into_box_error());
     }
 
     let uri_scheme_raw = cfg
@@ -30,7 +30,7 @@ pub async fn run(cfg: SendCommand) -> Result<(), BoxError> {
         let is_ws = starts_with_ignore_ascii_case(uri_scheme_raw.as_bytes(), b"ws");
         http::run(cfg, is_ws).await
     } else {
-        Err(BoxError::from("scheme is not supported")
+        Err(OpaqueError::from_static_str("scheme is not supported")
             .context_str_field("raw_value", uri_scheme_raw))
     }
 }

--- a/rama-cli/src/cmd/serve/echo/mod.rs
+++ b/rama-cli/src/cmd/serve/echo/mod.rs
@@ -6,7 +6,7 @@ use rama::{
     Layer as _,
     cli::{ForwardKind, service::echo::EchoServiceBuilder},
     combinators::Either,
-    error::{BoxError, ErrorContext, ErrorExt as _},
+    error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError},
     graceful::ShutdownGuard,
     layer::{
         ConsumeErrLayer, LimitLayer, TimeoutLayer,
@@ -210,14 +210,16 @@ async fn bind_echo_tcp_service(
 ) -> Result<(), BoxError> {
     let exec = Executor::graceful(graceful);
     if cfg.ws {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "websocket support is only possible in http(s) mode",
-        ));
+        )
+        .into_box_error());
     }
     if cfg.http_version != HttpVersion::Auto {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "http version selection is only possible in http(s) mode",
-        ));
+        )
+        .into_box_error());
     }
 
     let with_ha_proxy = match cfg.forward {
@@ -230,9 +232,10 @@ async fn bind_echo_tcp_service(
             | ForwardKind::CFConnectingIp
             | ForwardKind::TrueClientIp,
         ) => {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "forward http headers are only possible in http(s) mode",
-            ));
+            )
+            .into_box_error());
         }
         Some(ForwardKind::HaProxy) => true,
         None => false,
@@ -297,27 +300,33 @@ async fn bind_echo_udp_service(
     etx: tokio::sync::mpsc::Sender<BoxError>,
 ) -> Result<(), BoxError> {
     if cfg.ws {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "websocket support is only possible in http(s) mode",
-        ));
+        )
+        .into_box_error());
     }
     if cfg.http_version != HttpVersion::Auto {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "http version selection is only possible in http(s) mode",
-        ));
+        )
+        .into_box_error());
     }
     if maybe_tls_config.is_some() {
-        return Err(BoxError::from("TLS is not supported for UDP mode"));
+        return Err(
+            OpaqueError::from_static_str("TLS is not supported for UDP mode").into_box_error(),
+        );
     }
     if cfg.forward.is_some() {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "Forward info capabilities is not supported for UDP mode",
-        ));
+        )
+        .into_box_error());
     }
     if cfg.timeout.is_some() {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "connection timeout is not supported for UDP mode",
-        ));
+        )
+        .into_box_error());
     }
 
     tracing::info!("starting UDP echo service: bind interface = {:?}", cfg.bind);

--- a/rama-cli/src/utils/http.rs
+++ b/rama-cli/src/utils/http.rs
@@ -1,5 +1,5 @@
 use rama::{
-    error::{BoxError, ErrorExt as _},
+    error::{BoxError, ErrorExt as _, extra::OpaqueError},
     http,
     utils::str::smol_str::StrExt,
 };
@@ -31,7 +31,7 @@ impl FromStr for HttpVersion {
             "h1" | "http1" | "http/1" | "http/1.0" | "http/1.1" => Self::H1,
             "h2" | "http2" | "http/2" | "http/2.0" => Self::H2,
             version => {
-                return Err(BoxError::from("unsupported http version")
+                return Err(OpaqueError::from_static_str("unsupported http version")
                     .context_str_field("version", version));
             }
         })

--- a/rama-core/src/stream/json/io/read.rs
+++ b/rama-core/src/stream/json/io/read.rs
@@ -91,6 +91,7 @@ mod tests {
 
     use crate::futures::StreamExt;
     use crate::futures::stream;
+    use rama_error::extra::OpaqueError;
     use tokio_test::assert_pending;
     use tokio_test::task;
 
@@ -248,10 +249,10 @@ mod tests {
     #[test]
     fn fallible_stream_operates_correctly_with_interspersed_errors() {
         let data_vec = vec![
-            Err(BoxError::from("test message 1")),
+            Err(OpaqueError::from_static_str("test message 1")),
             Ok("invalid json\n{\"key\":11,\"val"),
             Ok("ue\":22}\n{\"key\":33,\"value\":44}\ninvalid json\n"),
-            Err(BoxError::from("test message 2")),
+            Err(OpaqueError::from_static_str("test message 2")),
             Ok("{\"key\":55,\"value\":66}\n"),
         ];
         let data_stream = stream::iter(data_vec);

--- a/rama-core/src/username/parse.rs
+++ b/rama-core/src/username/parse.rs
@@ -1,6 +1,7 @@
 use super::DEFAULT_USERNAME_LABEL_SEPARATOR;
 use crate::error::BoxError;
 use crate::extensions::{Extension, Extensions};
+use rama_error::extra::OpaqueError;
 use rama_error::{ErrorContext as _, ErrorExt};
 use rama_utils::macros::all_the_tuples_no_last_special_case;
 use std::convert::Infallible;
@@ -36,24 +37,24 @@ where
     let username = match label_it.next() {
         Some(username) => {
             if username.is_empty() {
-                return Err(BoxError::from("empty username"));
+                return Err(OpaqueError::from_static_str("empty username").into_box_error());
             } else {
                 username
             }
         }
-        None => return Err(BoxError::from("missing username")),
+        None => return Err(OpaqueError::from_static_str("missing username").into_box_error()),
     };
 
     for (index, label) in label_it.enumerate() {
         match parser.parse_label(label) {
             UsernameLabelState::Used => (), // optimistic smiley
             UsernameLabelState::Ignored => {
-                return Err(BoxError::from("ignored username label")
+                return Err(OpaqueError::from_static_str("ignored username label")
                     .context_field("index", index)
                     .context_str_field("label", label));
             }
             UsernameLabelState::Abort => {
-                return Err(BoxError::from("invalid username label")
+                return Err(OpaqueError::from_static_str("invalid username label")
                     .context_field("index", index)
                     .context_str_field("label", label));
             }

--- a/rama-crypto/src/jose/jwa.rs
+++ b/rama-crypto/src/jose/jwa.rs
@@ -12,7 +12,7 @@ use aws_lc_rs::{
         RSA_PSS_SHA512, RsaEncoding, VerificationAlgorithm,
     },
 };
-use rama_core::error::BoxError;
+use rama_core::error::{BoxError, extra::OpaqueError};
 use serde::{Deserialize, Serialize};
 
 use crate::jose::JWKEllipticCurves;
@@ -63,37 +63,37 @@ impl From<JWKEllipticCurves> for JWA {
 }
 
 impl TryFrom<JWA> for JWKEllipticCurves {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::ES256 => Ok(Self::P256),
             JWA::ES384 => Ok(Self::P384),
             JWA::ES512 => Ok(Self::P521),
-            JWA::HS256 | JWA::HS384 | JWA::HS512 => {
-                Err(BoxError::from("Hmac cannot be converted to elliptic curve"))
-            }
-            JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => {
-                Err(BoxError::from("RSA cannot be converted to elliptic curve"))
-            }
+            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(OpaqueError::from_static_str(
+                "Hmac cannot be converted to elliptic curve",
+            )),
+            JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => Err(
+                OpaqueError::from_static_str("RSA cannot be converted to elliptic curve"),
+            ),
         }
     }
 }
 
 impl TryFrom<JWA> for &'static EcdsaSigningAlgorithm {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::ES256 => Ok(&ECDSA_P256_SHA256_FIXED_SIGNING),
             JWA::ES384 => Ok(&ECDSA_P384_SHA384_FIXED_SIGNING),
             JWA::ES512 => Ok(&ECDSA_P521_SHA512_FIXED_SIGNING),
-            JWA::HS256 | JWA::HS384 | JWA::HS512 => {
-                Err(BoxError::from("Hmac cannot be converted to elliptic curve"))
-            }
-            JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => {
-                Err(BoxError::from("RSA cannot be converted to elliptic curve"))
-            }
+            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(OpaqueError::from_static_str(
+                "Hmac cannot be converted to elliptic curve",
+            )),
+            JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => Err(
+                OpaqueError::from_static_str("RSA cannot be converted to elliptic curve"),
+            ),
         }
     }
 }
@@ -108,27 +108,27 @@ impl TryFrom<JWA> for &'static EcdsaVerificationAlgorithm {
 }
 
 impl TryFrom<&'static EcdsaSigningAlgorithm> for JWA {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: &'static EcdsaSigningAlgorithm) -> Result<Self, Self::Error> {
         match value {
             alg if *alg == ECDSA_P256_SHA256_FIXED_SIGNING => Ok(Self::ES256),
             alg if *alg == ECDSA_P384_SHA384_FIXED_SIGNING => Ok(Self::ES384),
             alg if *alg == ECDSA_P521_SHA512_FIXED_SIGNING => Ok(Self::ES512),
-            _ => Err(BoxError::from("cannot convert to jwa")),
+            _ => Err(OpaqueError::from_static_str("cannot convert to jwa")),
         }
     }
 }
 
 impl TryFrom<JWA> for &'static hmac::Algorithm {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::HS256 => Ok(&HMAC_SHA256),
             JWA::HS384 => Ok(&HMAC_SHA384),
             JWA::HS512 => Ok(&HMAC_SHA512),
-            _ => Err(BoxError::from(
+            _ => Err(OpaqueError::from_static_str(
                 "Non-Hmac algorithm cannot be converted to hmac types",
             )),
         }
@@ -136,7 +136,7 @@ impl TryFrom<JWA> for &'static hmac::Algorithm {
 }
 
 impl TryFrom<JWA> for &'static dyn RsaEncoding {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
@@ -146,7 +146,7 @@ impl TryFrom<JWA> for &'static dyn RsaEncoding {
             JWA::PS256 => Ok(&RSA_PSS_SHA256),
             JWA::PS384 => Ok(&RSA_PSS_SHA384),
             JWA::PS512 => Ok(&RSA_PSS_SHA512),
-            _ => Err(BoxError::from(
+            _ => Err(OpaqueError::from_static_str(
                 "Non-RSA algorithm cannot be converted to rsa types",
             )),
         }
@@ -154,7 +154,7 @@ impl TryFrom<JWA> for &'static dyn RsaEncoding {
 }
 
 impl TryFrom<JWA> for &'static dyn VerificationAlgorithm {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
@@ -168,7 +168,9 @@ impl TryFrom<JWA> for &'static dyn VerificationAlgorithm {
                 let signing_algo: &'static EcdsaSigningAlgorithm = value.try_into()?;
                 Ok(signing_algo.deref())
             }
-            _ => Err(BoxError::from("Verification algorithm is not supported")),
+            _ => Err(OpaqueError::from_static_str(
+                "Verification algorithm is not supported",
+            )),
         }
     }
 }

--- a/rama-crypto/src/jose/jwk.rs
+++ b/rama-crypto/src/jose/jwk.rs
@@ -10,7 +10,7 @@ use aws_lc_rs::{
     },
 };
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 
 use crate::jose::{JWA, Signer, jwk_utils::create_subject_public_key_info};
@@ -173,9 +173,10 @@ impl JWK {
                     rsa_public_key_sequence,
                 ))
             }
-            JWKType::OCT { .. } => Err(BoxError::from(
+            JWKType::OCT { .. } => Err(OpaqueError::from_static_str(
                 "Symmetric key cannot be converted to public key",
-            )),
+            )
+            .into_box_error()),
             JWKType::EC { crv, x, y } => {
                 let alg: &'static EcdsaVerificationAlgorithm =
                     JWA::from(crv.to_owned()).try_into()?;

--- a/rama-crypto/src/jose/jws.rs
+++ b/rama-crypto/src/jose/jws.rs
@@ -1,5 +1,5 @@
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
 use rama_utils::macros::generate_set_and_with;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -63,7 +63,7 @@ impl Headers {
 
             let mut headers = match headers {
                 Value::Object(map) => map,
-                _ => Err(BoxError::from(
+                _ => Err(OpaqueError::from_static_str(
                     "Can only set multiple headers if input is key value object",
                 ))?,
             };
@@ -104,9 +104,10 @@ impl Headers {
     {
         match &self.0 {
             Some(headers) => Ok(T::deserialize(headers).context("deserialize headers into T")?),
-            None => Err(BoxError::from(
+            None => Err(OpaqueError::from_static_str(
                 "headers are None, deserialize not supported",
-            )),
+            )
+            .into_box_error()),
         }
     }
 }
@@ -211,9 +212,10 @@ impl JWSBuilder {
     /// This only available if there is no unprotected header set
     pub fn build_compact(mut self, signer: &impl Signer) -> Result<JWSCompact, BoxError> {
         if self.unprotected_headers.is_some() {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "Compact jws does not support unprotected headers",
-            ));
+            )
+            .into_box_error());
         }
 
         signer
@@ -581,9 +583,10 @@ impl JWSFlattened {
     /// Create a [`JWSCompact`] from this [`JWSFlattened`]
     pub fn as_compact(&self) -> Result<String, BoxError> {
         if self.signature.unprotected.is_some() {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "JWSCompact does not support unprotected headers",
-            ));
+            )
+            .into_box_error());
         };
 
         Ok(format!(
@@ -799,6 +802,7 @@ pub trait Verifier {
 
 #[cfg(test)]
 mod tests {
+    use rama_core::error::extra::OpaqueError;
     use tokio_test::assert_err;
 
     use super::*;
@@ -837,27 +841,31 @@ mod tests {
     }
 
     impl Verifier for DummyKey {
-        type Error = BoxError;
+        type Error = OpaqueError;
         type Output = ();
 
         fn verify(
             &self,
             _payload: &[u8],
             to_verify_sigs: &[ToVerifySignature],
-        ) -> Result<(), BoxError> {
+        ) -> Result<(), OpaqueError> {
             let to_verify = &to_verify_sigs[0];
             let original = to_verify.signed_data.as_bytes();
 
             let signature = to_verify.decoded_signature.signature();
 
             if original.len() + 1 != signature.len() {
-                Err(BoxError::from(
+                Err(OpaqueError::from_static_str(
                     "signature should add single u8 to original slice",
                 ))
             } else if original[..] != signature[..original.len()] {
-                Err(BoxError::from("original data should be equal"))
+                Err(OpaqueError::from_static_str(
+                    "original data should be equal",
+                ))
             } else if signature[signature.len() - 1] != 33 {
-                Err(BoxError::from("last element in signature should be 33"))
+                Err(OpaqueError::from_static_str(
+                    "last element in signature should be 33",
+                ))
             } else {
                 Ok(())
             }
@@ -1089,9 +1097,10 @@ mod tests {
                 if protected_header.data.as_str() == "very protected" {
                     Ok(())
                 } else {
-                    Err(BoxError::from(
-                        "received unexpected second protected header",
-                    ))
+                    Err(
+                        OpaqueError::from_static_str("received unexpected second protected header")
+                            .into_box_error(),
+                    )
                 }
             }
         }

--- a/rama-dns/src/client/apple.rs
+++ b/rama-dns/src/client/apple.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 
 use parking_lot::Mutex;
 use rama_core::bytes::Bytes;
-use rama_core::error::BoxError;
+use rama_core::error::{BoxError, ErrorExt};
 use rama_core::futures::{Stream, async_stream::stream_fn};
 use rama_core::telemetry::tracing;
 use rama_net::address::Domain;
@@ -279,7 +279,7 @@ where
     P: Fn(&[u8], &mut dyn FnMut(T)) -> Result<(), BoxError> + Send + Sync,
 {
     state.done.store(true, Ordering::SeqCst);
-    state.queue.lock().push_back(Err(BoxError::from(err)));
+    state.queue.lock().push_back(Err(err.into_box_error()));
 }
 
 fn finish_empty<T, P>(

--- a/rama-dns/src/client/resolver/address/happy_eyeball.rs
+++ b/rama-dns/src/client/resolver/address/happy_eyeball.rs
@@ -7,7 +7,7 @@ use std::{
 
 use pin_project_lite::pin_project;
 use rama_core::{
-    error::{BoxError, ErrorExt, extra::OpaqueError},
+    error::{ErrorExt, extra::OpaqueError},
     extensions::Extensions,
     futures::{DelayStream, Stream, stream},
     stream::{StreamExt as _, adapters::Merge},
@@ -87,10 +87,12 @@ impl<'a, R: crate::client::resolver::DnsAddressResolver> HappyEyeballAddressReso
                 return HappyEyeballIpStream::Once {
                     stream: rama_core::stream::once(match (ip, ip_mode) {
                         (IpAddr::V4(_), ConnectIpMode::Ipv6) => {
-                            Err(BoxError::from("IPv4 address is not allowed").into_opaque_error())
+                            Err(OpaqueError::from_static_str("IPv4 address is not allowed")
+                                .into_opaque_error())
                         }
                         (IpAddr::V6(_), ConnectIpMode::Ipv4) => {
-                            Err(BoxError::from("IPv6 address is not allowed").into_opaque_error())
+                            Err(OpaqueError::from_static_str("IPv6 address is not allowed")
+                                .into_opaque_error())
                         }
                         _ => {
                             // if the host is already defined as an allowed IP address

--- a/rama-error/src/ext/context.rs
+++ b/rama-error/src/ext/context.rs
@@ -233,7 +233,7 @@ impl crate::StdError for ErrorWithContext {
 mod tests {
     use super::*;
 
-    use crate::{ErrorExt, StdError};
+    use crate::{ErrorExt, StdError, extra::OpaqueError};
 
     use std::io;
 
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn empty_keys_are_seen_as_simple_values_and_keys_are_trimmed() {
-        let err = BoxError::from("test error")
+        let err = OpaqueError::from_static_str("test error")
             .context_field("foo  ", "bar")
             .context_field("  ", "baz")
             .context_field("", 42);

--- a/rama-error/src/ext/mod.rs
+++ b/rama-error/src/ext/mod.rs
@@ -253,7 +253,7 @@ impl<T> ErrorContext for Option<T> {
     fn into_box_error(self) -> Self::Context {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())),
         }
     }
@@ -269,7 +269,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context(value)),
         }
@@ -281,7 +281,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_hex(value)),
         }
@@ -293,7 +293,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_debug(value)),
         }
@@ -305,7 +305,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_field(key, value)),
         }
@@ -317,7 +317,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_str_field(key, value)),
         }
@@ -329,7 +329,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_hex_field(key, value)),
         }
@@ -341,7 +341,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .context_debug_field(key, value)),
         }
@@ -354,7 +354,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .with_context(cb)),
         }
@@ -367,7 +367,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .with_context_hex(cb)),
         }
@@ -380,7 +380,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .with_context_debug(cb)),
         }
@@ -393,7 +393,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None")
+            None => Err(OpaqueError::from_static_str("Option is None")
                 .context_debug_field("type", std::any::type_name::<Self>())
                 .with_context_field(key, cb)),
         }
@@ -406,7 +406,9 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None").with_context_str_field(key, cb)),
+            None => {
+                Err(OpaqueError::from_static_str("Option is None").with_context_str_field(key, cb))
+            }
         }
     }
 
@@ -417,7 +419,9 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None").with_context_hex_field(key, cb)),
+            None => {
+                Err(OpaqueError::from_static_str("Option is None").with_context_hex_field(key, cb))
+            }
         }
     }
 
@@ -428,7 +432,10 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(BoxError::from("Option is None").with_context_debug_field(key, cb)),
+            None => {
+                Err(OpaqueError::from_static_str("Option is None")
+                    .with_context_debug_field(key, cb))
+            }
         }
     }
 }

--- a/rama-error/src/ext/opaque.rs
+++ b/rama-error/src/ext/opaque.rs
@@ -15,6 +15,16 @@ impl OpaqueError {
     pub(super) fn from_box_error(e: impl Into<BoxError>) -> Self {
         Self(e.into())
     }
+
+    #[inline(always)]
+    /// Create an opaque error from a static str.
+    ///
+    /// Use this instead of `"msg".context()` or
+    /// some other method that turns it into a BoxError...
+    /// Because the std rust library turns this into a `String` otherwise...
+    pub fn from_static_str(e: &'static str) -> Self {
+        Self(Box::new(StaticStrError(e)))
+    }
 }
 
 impl fmt::Debug for OpaqueError {
@@ -42,3 +52,22 @@ impl From<Infallible> for OpaqueError {
         unreachable!()
     }
 }
+
+#[derive(Clone, Copy)]
+struct StaticStrError(&'static str);
+
+impl fmt::Debug for StaticStrError {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for StaticStrError {
+    #[inline(always)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for StaticStrError {}

--- a/rama-haproxy/src/client/layer.rs
+++ b/rama-haproxy/src/client/layer.rs
@@ -4,7 +4,7 @@ use crate::protocol::{v1, v2};
 use rama_core::{
     Layer, Service,
     bytes::Bytes,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::{ChainableExtensions, ExtensionsRef},
     io::Io,
 };
@@ -226,7 +226,9 @@ where
                         .get_ref::<SocketInfo>()
                         .map(|info| info.peer_addr())
                 })
-                .ok_or_else(|| BoxError::from("PROXY client (v1): missing src socket address"))?
+                .ok_or_else(|| {
+                    OpaqueError::from_static_str("PROXY client (v1): missing src socket address")
+                })?
         };
 
         let peer_addr = conn.peer_addr()?;
@@ -238,9 +240,10 @@ where
                 v1::Addresses::new_tcp6(src_ip, dst_ip, src.port, peer_addr.port)
             }
             (_, _) => {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "PROXY client (v1): IP version mismatch between src and dest",
-                ));
+                )
+                .into_box_error());
             }
         };
 
@@ -275,7 +278,9 @@ where
                         .get_ref::<SocketInfo>()
                         .map(|info| info.peer_addr())
                 })
-                .ok_or_else(|| BoxError::from("PROXY client (v2): missing src socket address"))?
+                .ok_or_else(|| {
+                    OpaqueError::from_static_str("PROXY client (v2): missing src socket address")
+                })?
         };
 
         let peer_addr = conn.peer_addr()?;
@@ -291,9 +296,10 @@ where
                 v2::IPv6::new(src_ip, dst_ip, src.port, peer_addr.port),
             ),
             (_, _) => {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "PROXY client (v2): IP version mismatch between src and dest",
-                ));
+                )
+                .into_box_error());
             }
         };
 

--- a/rama-haproxy/src/server/layer.rs
+++ b/rama-haproxy/src/server/layer.rs
@@ -1,7 +1,7 @@
 use crate::protocol::{HeaderResult, PartialResult, v1, v2};
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::{HeapReader, Io, PrefixedIo},
     telemetry::tracing,
@@ -131,7 +131,10 @@ where
 
         let header = loop {
             if read >= buffer.len() {
-                return Err(BoxError::from("Buffer exhausted before parsing completed"));
+                return Err(OpaqueError::from_static_str(
+                    "Buffer exhausted before parsing completed",
+                )
+                .into_box_error());
             }
 
             let n = stream.read(&mut buffer[read..]).await?;

--- a/rama-http-backend/src/client/conn.rs
+++ b/rama-http-backend/src/client/conn.rs
@@ -217,7 +217,7 @@ where
                 conn: svc,
             })
         }
-        version => Err(BoxError::from("unsupported Http version")
+        version => Err(OpaqueError::from_static_str("unsupported Http version")
             .context_debug_field("version", version)
             .into_opaque_error()),
     }

--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
@@ -4,7 +4,7 @@ use super::InnerHttpProxyConnector;
 use pin_project_lite::pin_project;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext as _, ErrorExt},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::{Extension, Extensions, ExtensionsRef},
     io::Io,
     telemetry::tracing,
@@ -120,9 +120,10 @@ where
             .map(|p| p.is_http())
             .unwrap_or(true)
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "http proxy connector can only serve http protocol",
-            ));
+            )
+            .into_box_error());
         }
 
         let transport_ctx = input

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -1,6 +1,6 @@
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, ErrorExt},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::{Extensions, ExtensionsRef, InputExtensions},
     telemetry::tracing,
 };
@@ -48,11 +48,11 @@ where
         match (&self.sender, req.version()) {
             (SendRequest::Http1(_), Version::HTTP_10 | Version::HTTP_11)
             | (SendRequest::Http2(_), Version::HTTP_2) => (),
-            (SendRequest::Http1(_), version) => Err(BoxError::from(
+            (SendRequest::Http1(_), version) => Err(OpaqueError::from_static_str(
                 "Http1 connector cannot send request with version",
             )
             .context_debug_field("version", version))?,
-            (SendRequest::Http2(_), version) => Err(BoxError::from(
+            (SendRequest::Http2(_), version) => Err(OpaqueError::from_static_str(
                 "Http2 connector cannot send request with version",
             )
             .context_debug_field("version", version))?,
@@ -128,7 +128,9 @@ impl<B> ExtensionsRef for HttpClientService<B> {
 fn sanitize_client_req_header<B>(req: Request<B>) -> Result<Request<B>, BoxError> {
     // logic specific to this method
     if req.method() == Method::CONNECT && req.uri().host().is_none() {
-        return Err(BoxError::from("missing host in CONNECT request"));
+        return Err(
+            OpaqueError::from_static_str("missing host in CONNECT request").into_box_error(),
+        );
     }
 
     let uses_http_proxy = req

--- a/rama-http-backend/src/proxy/mitm.rs
+++ b/rama-http-backend/src/proxy/mitm.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     io::{BridgeIo, GracefulIo, Io},
@@ -253,8 +253,10 @@ impl TryFrom<Version> for RelayMode {
         match version {
             Version::HTTP_2 => Ok(Self::Http2),
             Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11 => Ok(Self::Http1),
-            version => Err(BoxError::from("unsupported request version for MITM relay")
-                .context_debug_field("version", version)),
+            version => Err(OpaqueError::from_static_str(
+                "unsupported request version for MITM relay",
+            )
+            .context_debug_field("version", version)),
         }
     }
 }

--- a/rama-http-core/src/client/conn/http1.rs
+++ b/rama-http-core/src/client/conn/http1.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, ready};
 
 use httparse::ParserConfig;
 use rama_core::bytes::Bytes;
-use rama_core::error::BoxError;
+use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
 use rama_core::extensions::ExtensionsRef;
 use rama_core::telemetry::tracing::{debug, trace};
 use rama_http::StreamingBody;
@@ -488,9 +488,9 @@ impl Builder {
         /// The minimum value allowed is 8192. This method errors if the passed `max` is less than the minimum.
         pub fn max_buf_size(mut self, max: usize) -> Result<Self, BoxError> {
             if max < proto::h1::MINIMUM_MAX_BUFFER_SIZE {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "the max_buf_size cannot be smaller than the minimum that h1 specifies."
-                ));
+                ).into_box_error());
             }
 
             self.h1_max_buf_size = Some(max);

--- a/rama-http-core/src/error.rs
+++ b/rama-http-core/src/error.rs
@@ -4,7 +4,7 @@ use std::error::Error as StdError;
 use std::fmt;
 
 use crate::h2;
-use rama_core::error::{BoxError, ErrorExt as _};
+use rama_core::error::{BoxError, ErrorExt as _, extra::OpaqueError};
 use rama_http_types as http;
 
 /// Result type often returned from methods that can have hyper `Error`s.
@@ -226,7 +226,7 @@ impl Error {
         mut self,
         msg: impl std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
     ) -> Self {
-        self.inner.cause = Some(BoxError::from("http error cause").context(msg));
+        self.inner.cause = Some(OpaqueError::from_static_str("http error cause").context(msg));
         self
     }
 

--- a/rama-http-core/src/h2/client.rs
+++ b/rama-http-core/src/h2/client.rs
@@ -142,7 +142,7 @@ use crate::h2::proto::{self, Error};
 use crate::h2::{FlowControl, PingPong, RecvStream, SendStream};
 
 use rama_core::bytes::{Buf, Bytes};
-use rama_core::error::BoxError;
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing::{self, Instrument, debug, warn};
 use rama_http::proto::HeaderByteLength;
@@ -1280,10 +1280,10 @@ impl Builder {
 
     rama_utils::macros::generate_set_and_with! {
         /// Sets the first stream ID to something other than 1.
-        pub fn initial_stream_id(mut self, stream_id: u32) -> Result<Self, BoxError> {
+        pub fn initial_stream_id(mut self, stream_id: u32) -> Result<Self, OpaqueError> {
             self.stream_id = stream_id.into();
             if !self.stream_id.is_client_initiated() {
-                return Err(BoxError::from("stream id must be odd"));
+                return Err(OpaqueError::from_static_str("stream id must be odd"));
             }
             Ok(self)
         }

--- a/rama-http-core/src/server/conn/auto.rs
+++ b/rama-http-core/src/server/conn/auto.rs
@@ -10,6 +10,7 @@ use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use rama_core::Service;
+use rama_core::error::{ErrorExt as _, extra::OpaqueError};
 use rama_core::extensions::ExtensionsRef;
 use rama_http::{Request, Response};
 use tokio::io::AsyncRead;
@@ -223,7 +224,7 @@ where
         // We start as H2 and switch to H1 as soon as we don't have the preface.
         while buf.filled().len() < H2_PREFACE.len() {
             let Some(io) = this.io.as_mut() else {
-                return Poll::Ready(Err(std::io::Error::other(BoxError::from(
+                return Poll::Ready(Err(std::io::Error::other(OpaqueError::from_static_str(
                     "unexpected error: ReadVersion(..., >IO<) already taken in earlier Poll::ready, cannot read from it, report bug in rama repo",
                 ))));
             };
@@ -242,7 +243,7 @@ where
         }
 
         let Some(io) = this.io.take() else {
-            return Poll::Ready(Err(std::io::Error::other(BoxError::from(
+            return Poll::Ready(Err(std::io::Error::other(OpaqueError::from_static_str(
                 "unexpected error: ReadVersion(..., >IO<) already taken in earlier Poll::ready, cannot take it again, report bug in rama repo",
             ))));
         };
@@ -377,9 +378,9 @@ where
                 } => {
                     let (version, io) = ready!(read_version.poll(cx))?;
                     let Some(service) = service.take() else {
-                        return Poll::Ready(Err(BoxError::from(
+                        return Poll::Ready(Err(OpaqueError::from_static_str(
                             "unexpected error: auto http svc in connection already taken, report bug in rama repo",
-                        )));
+                        ).into_box_error()));
                     };
                     match version {
                         Version::H1 => {
@@ -507,9 +508,9 @@ where
                 } => {
                     let (version, io) = ready!(read_version.poll(cx))?;
                     let Some(service) = service.take() else {
-                        return Poll::Ready(Err(BoxError::from(
+                        return Poll::Ready(Err(OpaqueError::from_static_str(
                             "unexpected error: auto http svc in upgradeable connection already taken, report bug in rama repo",
-                        )));
+                        ).into_box_error()));
                     };
                     match version {
                         Version::H1 => {

--- a/rama-http-core/src/server/conn/http1.rs
+++ b/rama-http-core/src/server/conn/http1.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use httparse::ParserConfig;
 use rama_core::Service;
 use rama_core::bytes::Bytes;
-use rama_core::error::BoxError;
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::ExtensionsRef;
 use rama_http::io::upgrade::Upgraded;
 use rama_http::{Body, Request, Response};
@@ -375,9 +375,9 @@ impl Builder {
         /// # Error
         ///
         /// The minimum value allowed is 8192. This method errors if the passed `max` is less than the minimum.
-        pub fn max_buf_size(mut self, max: Option<usize>) -> Result<Self, BoxError> {
+        pub fn max_buf_size(mut self, max: Option<usize>) -> Result<Self, OpaqueError> {
             if max.map(|max| max < proto::h1::MINIMUM_MAX_BUFFER_SIZE).unwrap_or_default() {
-                return Err(BoxError::from("the max_buf_size cannot be smaller than the minimum that h1 specifies"));
+                return Err(OpaqueError::from_static_str("the max_buf_size cannot be smaller than the minimum that h1 specifies"));
             }
             self.max_buf_size = max;
             Ok(self)

--- a/rama-http-headers/src/common/sec_websocket_extensions.rs
+++ b/rama-http-headers/src/common/sec_websocket_extensions.rs
@@ -5,6 +5,7 @@
 
 use std::{fmt, str::FromStr};
 
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension as ExtensionTrait;
 use rama_core::telemetry::tracing;
@@ -225,27 +226,31 @@ impl FromStr for Extension {
             for part in parts {
                 if part.eq_ignore_ascii_case("server_no_context_takeover") {
                     if std::mem::replace(&mut config.server_no_context_takeover, true) {
-                        return Err(BoxError::from(
+                        return Err(OpaqueError::from_static_str(
                             "duplicate extension param: server_no_context_takeover",
-                        ));
+                        )
+                        .into_box_error());
                     }
                 } else if part.eq_ignore_ascii_case("client_no_context_takeover") {
                     if std::mem::replace(&mut config.client_no_context_takeover, true) {
-                        return Err(BoxError::from(
+                        return Err(OpaqueError::from_static_str(
                             "duplicate extension param: client_no_context_takeover",
-                        ));
+                        )
+                        .into_box_error());
                     }
                 } else if part.eq_ignore_ascii_case("server_max_window_bits") {
                     if config.server_max_window_bits.replace(0).is_some() {
-                        return Err(BoxError::from(
+                        return Err(OpaqueError::from_static_str(
                             "duplicate extension param: server_max_window_bits",
-                        ));
+                        )
+                        .into_box_error());
                     }
                 } else if part.eq_ignore_ascii_case("client_max_window_bits") {
                     if config.client_max_window_bits.replace(0).is_some() {
-                        return Err(BoxError::from(
+                        return Err(OpaqueError::from_static_str(
                             "duplicate extension param: client_max_window_bits",
-                        ));
+                        )
+                        .into_box_error());
                     }
                 } else if let Some((k, v)) = part.split_once('=') {
                     let k = k.trim();
@@ -265,15 +270,16 @@ impl FromStr for Extension {
                                     tracing::debug!(
                                         "fail per-message-deflate config value for server max windows bits: {v} not in [8,15] range"
                                     );
-                                    return Err(BoxError::from(
+                                    return Err(OpaqueError::from_static_str(
                                         "invalid server max windows bits (OOB)",
                                     )
                                     .context_field("value", v));
                                 }
                                 if config.server_max_window_bits.replace(v).is_some() {
-                                    return Err(BoxError::from(
+                                    return Err(OpaqueError::from_static_str(
                                         "duplicate extension param: server_max_window_bits",
-                                    ));
+                                    )
+                                    .into_box_error());
                                 }
                             }
                             Err(err) => {
@@ -290,15 +296,16 @@ impl FromStr for Extension {
                                     tracing::debug!(
                                         "fail per-message-deflate config value for client max windows bits: {v} not in [8,15] range"
                                     );
-                                    return Err(BoxError::from(
+                                    return Err(OpaqueError::from_static_str(
                                         "invalid client max windows bits (OOB)",
                                     )
                                     .context_field("value", v));
                                 }
                                 if config.client_max_window_bits.replace(v).is_some() {
-                                    return Err(BoxError::from(
+                                    return Err(OpaqueError::from_static_str(
                                         "duplicate extension param: client_max_window_bits",
-                                    ));
+                                    )
+                                    .into_box_error());
                                 }
                             }
                             Err(err) => {
@@ -312,18 +319,20 @@ impl FromStr for Extension {
                         tracing::debug!(
                             "fail per-message-deflate config with unknown permessage-deflate config parameter: {k} = {v}"
                         );
-                        return Err(BoxError::from("value not expected for given key")
-                            .context_str_field("key", k)
-                            .context_str_field("value", v));
+                        return Err(OpaqueError::from_static_str(
+                            "value not expected for given key",
+                        )
+                        .context_str_field("key", k)
+                        .context_str_field("value", v));
                     }
                 } else {
                     tracing::debug!(
                         "received unknown permessage-deflate config parameter part: {part}"
                     );
-                    return Err(
-                        BoxError::from("key not expected for permessage-deflate config")
-                            .context_str_field("key", part),
-                    );
+                    return Err(OpaqueError::from_static_str(
+                        "key not expected for permessage-deflate config",
+                    )
+                    .context_str_field("key", part));
                 }
             }
             Ok(Self::PerMessageDeflate(config))

--- a/rama-http-headers/src/forwarded/exotic_forward_ip.rs
+++ b/rama-http-headers/src/forwarded/exotic_forward_ip.rs
@@ -1,4 +1,5 @@
 use rama_core::error::ErrorExt;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_http_types::header::{
     CF_CONNECTING_IP, CLIENT_IP, TRUE_CLIENT_IP, X_CLIENT_IP, X_REAL_IP,
@@ -41,11 +42,11 @@ impl std::str::FromStr for ClientAddr {
         let ip = try_to_parse_str_to_ip(s).context("parse forwarded ip")?;
 
         match ip {
-            IpAddr::V6(_) if port.is_some() && !s.starts_with('[') => Err(BoxError::from(
-                "missing brackets for IPv6 address with port",
-            )
-            .context_field("ip", ip)
-            .context_debug_field("port", port)),
+            IpAddr::V6(_) if port.is_some() && !s.starts_with('[') => Err(
+                OpaqueError::from_static_str("missing brackets for IPv6 address with port")
+                    .context_field("ip", ip)
+                    .context_debug_field("port", port),
+            ),
             _ => Ok(Self { ip, port }),
         }
     }

--- a/rama-http-headers/src/forwarded/via.rs
+++ b/rama-http-headers/src/forwarded/via.rs
@@ -1,6 +1,6 @@
 use crate::{HeaderDecode, HeaderEncode, TypedHeader, util};
 use rama_core::{
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     telemetry::tracing,
 };
 use rama_http_types::{HeaderName, HeaderValue, header};
@@ -163,7 +163,9 @@ impl std::str::FromStr for ViaElement {
                         .context("parse via utf-8 protocol as protocol")?;
                     bytes = &bytes[index + 1..];
                     let index = bytes.iter().position(|b| *b == b' ').ok_or_else(|| {
-                        BoxError::from("via str: missing space after protocol separator")
+                        OpaqueError::from_static_str(
+                            "via str: missing space after protocol separator",
+                        )
                     })?;
                     let version =
                         ForwardedVersion::try_from(&bytes[..index]).context("parse via version")?;
@@ -179,7 +181,9 @@ impl std::str::FromStr for ViaElement {
                 _ => unreachable!(),
             },
             None => {
-                return Err(BoxError::from("via str: missing version"));
+                return Err(
+                    OpaqueError::from_static_str("via str: missing version").into_box_error()
+                );
             }
         };
 

--- a/rama-http-headers/src/x_robots_tag/components/date_time.rs
+++ b/rama-http-headers/src/x_robots_tag/components/date_time.rs
@@ -4,7 +4,7 @@ use jiff::{
     fmt::{StdFmtWrite, rfc2822, temporal::DateTimePrinter},
     tz::{Offset, TimeZone},
 };
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
 use rama_core::telemetry::tracing;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -119,7 +119,7 @@ impl AsRef<Timestamp> for DirectiveDateTime {
 }
 
 impl FromStr for DirectiveDateTime {
-    type Err = BoxError;
+    type Err = OpaqueError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(dt) = datetime_from_rfc3339(s) {
@@ -141,7 +141,7 @@ impl FromStr for DirectiveDateTime {
             });
         }
         tracing::debug!("failed to parse datetime value: {s}");
-        Err(BoxError::from("invalid datetime value"))
+        Err(OpaqueError::from_static_str("invalid datetime value"))
     }
 }
 
@@ -201,7 +201,7 @@ fn parse_rfc3339_timestamp(s: &str) -> Result<Timestamp, BoxError> {
 
 fn parse_iso8601_date_only(s: &str) -> Result<Timestamp, BoxError> {
     if s.contains('T') || s.contains(' ') {
-        return Err(BoxError::from("invalid ISO 8601 date"));
+        return Err(OpaqueError::from_static_str("invalid ISO 8601 date").into_box_error());
     }
     let date = s
         .parse::<civil::Date>()
@@ -234,11 +234,13 @@ fn validate_rfc3339_offset(s: &str) -> Result<(), BoxError> {
             if hour < 24 && minute < 60 {
                 Ok(())
             } else {
-                Err(BoxError::from("invalid RFC 3339 offset"))
+                Err(OpaqueError::from_static_str("invalid RFC 3339 offset").into_box_error())
             }
         }
-        _ if s.contains('T') => Err(BoxError::from("invalid RFC 3339 offset")),
-        _ => Err(BoxError::from("invalid RFC 3339 datetime")),
+        _ if s.contains('T') => {
+            Err(OpaqueError::from_static_str("invalid RFC 3339 offset").into_box_error())
+        }
+        _ => Err(OpaqueError::from_static_str("invalid RFC 3339 datetime").into_box_error()),
     }
 }
 
@@ -259,8 +261,14 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
     let sign = match bytes.first().copied() {
         Some(b'+') => 1,
         Some(b'-') => -1,
-        Some(_) => return Err(BoxError::from("invalid timezone offset sign")),
-        None => return Err(BoxError::from("missing timezone offset")),
+        Some(_) => {
+            return Err(
+                OpaqueError::from_static_str("invalid timezone offset sign").into_box_error()
+            );
+        }
+        None => {
+            return Err(OpaqueError::from_static_str("missing timezone offset").into_box_error());
+        }
     };
 
     let digits = bytes
@@ -277,7 +285,9 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
             let hours = i32::from((h1 - b'0') * 10 + (h2 - b'0'));
             let minutes = i32::from((m1 - b'0') * 10 + (m2 - b'0'));
             if hours >= 24 || minutes >= 60 {
-                return Err(BoxError::from("invalid timezone offset"));
+                return Err(
+                    OpaqueError::from_static_str("invalid timezone offset").into_box_error()
+                );
             }
 
             let seconds = sign * (hours * 60 * 60 + minutes * 60);
@@ -285,7 +295,7 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
                 .context("timezone offset outside supported range")
                 .context_str_field("offset", offset)
         }
-        _ => Err(BoxError::from("invalid timezone offset digits")),
+        _ => Err(OpaqueError::from_static_str("invalid timezone offset digits").into_box_error()),
     }
 }
 

--- a/rama-http-headers/src/x_robots_tag/tag.rs
+++ b/rama-http-headers/src/x_robots_tag/tag.rs
@@ -1,5 +1,6 @@
 use crate::util::HeaderValueString;
 use crate::x_robots_tag::{CustomRule, DirectiveDateTime, MaxImagePreviewSetting};
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::telemetry::tracing;
 use rama_utils::macros::generate_set_and_with;
@@ -668,9 +669,9 @@ impl Iterator for Parser<'_> {
 
                         if tag.bot_name.is_some() {
                             self.buffer = &self.buffer[self.buffer.len()..];
-                            return Some(Err(BoxError::from(
+                            return Some(Err(OpaqueError::from_static_str(
                                 "unexpected bot name: one is already defined without any directives",
-                            )));
+                            ).into_box_error()));
                         } else {
                             let s = match std::str::from_utf8(key_buffer) {
                                 Ok(value) => value,
@@ -739,7 +740,7 @@ impl Iterator for Parser<'_> {
                 if directive_count == 0 {
                     if let Some(bot_name) = tag.bot_name {
                         self.buffer = &self.buffer[self.buffer.len()..];
-                        return Some(Err(BoxError::from(
+                        return Some(Err(OpaqueError::from_static_str(
                             "tag with only a bot name is not allowed",
                         )
                         .context_field("bot_name", bot_name)));
@@ -752,7 +753,10 @@ impl Iterator for Parser<'_> {
         }
 
         self.buffer = &self.buffer[self.buffer.len()..];
-        Some(Err(BoxError::from("delimiter search overflow")))
+        Some(Err(OpaqueError::from_static_str(
+            "delimiter search overflow",
+        )
+        .into_box_error()))
     }
 }
 

--- a/rama-http-types/src/body/sse/datastar/patch_elements.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_elements.rs
@@ -3,7 +3,8 @@ use crate::sse::{
     Event, EventBuildError, EventDataLineReader, EventDataRead, EventDataWrite,
     datastar::EventType, parser::is_lf,
 };
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::telemetry::tracing;
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
 
@@ -238,9 +239,10 @@ impl EventDataLineReader for PatchElementsReader {
             })
             .unwrap_or_default()
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "PatchElementsReader: unexpected event type: expected: datastar-patch-elements",
-            ));
+            )
+            .into_box_error());
         }
 
         Ok(Some(PatchElements {

--- a/rama-http-types/src/body/sse/datastar/patch_signals.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_signals.rs
@@ -1,7 +1,8 @@
 use crate::sse::{
     Event, EventBuildError, EventDataLineReader, EventDataRead, EventDataWrite, datastar::EventType,
 };
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::telemetry::tracing;
 
 /// [`PatchSignals`] patches signals into the signal store
@@ -170,9 +171,10 @@ impl<R: EventDataLineReader> EventDataLineReader for PatchSignalsReader<R> {
             })
             .unwrap_or_default()
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "PatchSignalsReader: unexpected event type: expected: datastar-patch-signals",
-            ));
+            )
+            .into_box_error());
         }
 
         let only_if_missing = std::mem::take(&mut self.only_if_missing);

--- a/rama-http-types/src/body/sse/event_stream.rs
+++ b/rama-http-types/src/body/sse/event_stream.rs
@@ -5,6 +5,7 @@ use super::utf8_stream::Utf8Stream;
 use super::{Event, EventBuildError, EventDataRead};
 
 use pin_project_lite::pin_project;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::futures::stream::Stream;
 use rama_core::futures::task::{Context, Poll};
@@ -213,7 +214,7 @@ fn parse_event<T: EventDataRead>(
                 return Ok(None);
             }
             Err(nom::Err::Error(err) | nom::Err::Failure(err)) => {
-                return Err(BoxError::from("SSE parse error")
+                return Err(OpaqueError::from_static_str("SSE parse error")
                     .context_debug_field("code", err.code)
                     .context_str_field("input", err.input));
             }

--- a/rama-http-types/src/uri.rs
+++ b/rama-http-types/src/uri.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
 use rama_utils::str::{smol_str::format_smolstr, starts_with_ignore_ascii_case};
 
 pub use crate::dep::hyperium::http::uri::*;
@@ -11,7 +11,9 @@ pub fn try_to_strip_path_prefix_from_uri(
     let og_path = uri.path().trim_start_matches('/');
 
     if !starts_with_ignore_ascii_case(og_path, prefix) {
-        return Err(BoxError::from("URI's path does NOT contain prefix"));
+        return Err(
+            OpaqueError::from_static_str("URI's path does NOT contain prefix").into_box_error(),
+        );
     }
 
     // SAFETY: above 'starts_with_ignore_ascii_case'

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -40,6 +40,8 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use parking_lot::Mutex;
+use rama_core::error::ErrorExt as _;
+use rama_core::error::extra::OpaqueError;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::oneshot;
 
@@ -112,12 +114,15 @@ pub fn handle_upgrade<T: ExtensionsRef>(
         Some(on_upgrade) => {
             trace!("upgrading this: {:?}", on_upgrade);
             if on_upgrade.has_handled_upgrade() {
-                Err(BoxError::from("upgraded has already been handled"))
+                Err(
+                    OpaqueError::from_static_str("upgraded has already been handled")
+                        .into_box_error(),
+                )
             } else {
                 Ok(on_upgrade)
             }
         }
-        None => Err(BoxError::from("no pending update found")),
+        None => Err(OpaqueError::from_static_str("no pending update found").into_box_error()),
     };
 
     async {
@@ -286,9 +291,10 @@ impl Future for OnUpgrade {
             .map(|res| match res {
                 Ok(Ok(upgraded)) => Ok(upgraded),
                 Ok(Err(err)) => Err(err),
-                Err(_oneshot_canceled) => Err(BoxError::from(
+                Err(_oneshot_canceled) => Err(OpaqueError::from_static_str(
                     "OnUpgrade: cancelled while expecting upgrade",
-                )),
+                )
+                .into_box_error()),
             })
     }
 }
@@ -312,9 +318,10 @@ impl Pending {
     /// upgrades are handled manually.
     pub fn manual(self) {
         trace!("pending upgrade handled manually");
-        let _ = self
-            .tx
-            .send(Err(BoxError::from("OnUpgrade: manual upgrade failed")));
+        let _ = self.tx.send(Err(OpaqueError::from_static_str(
+            "OnUpgrade: manual upgrade failed",
+        )
+        .into_box_error()));
     }
 }
 

--- a/rama-http/src/layer/cors/mod.rs
+++ b/rama-http/src/layer/cors/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     HeaderMap, HeaderValue, Method, Request, Response,
     header::{self},
 };
-use rama_core::error::BoxError;
+use rama_core::error::{BoxError, ErrorExt as _, extra::OpaqueError};
 use rama_core::{Layer, Service};
 use rama_http_headers::{
     AccessControlAllowHeaders, AccessControlAllowMethods, AccessControlExposeHeaders,
@@ -125,7 +125,7 @@ impl CorsLayer {
                 || self.allow_methods.as_ref().map(|v| v.is_any()).unwrap_or_default()
                 || self.allow_origin.as_ref().map(|v| v.is_any()).unwrap_or_default()
                 || self.expose_headers.as_ref().map(|v| v.is_any()).unwrap_or_default() {
-                return Err(BoxError::from("CORS combo error: allow credentials is not allowed if some of the wildcard-abled headers are set to use the wildcard value"));
+                return Err(OpaqueError::from_static_str("CORS combo error: allow credentials is not allowed if some of the wildcard-abled headers are set to use the wildcard value").into_box_error());
             }
             self.allow_credentials = Some(AllowCredentials::Const);
             Ok(self)
@@ -156,7 +156,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
         pub fn allow_headers(mut self, headers: AccessControlAllowHeaders) -> Result<Self, BoxError> {
             if headers.is_any() && self.is_allow_credentials_any() {
-                return Err(BoxError::from("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`"))
+                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`").into_box_error())
             }
             self.allow_headers = Some(AllowHeaders::Const(headers));
             Ok(self)
@@ -210,7 +210,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
         pub fn allow_methods(mut self, methods: AccessControlAllowMethods) -> Result<Self, BoxError> {
             if methods.is_any() && self.is_allow_credentials_any() {
-                return Err(BoxError::from("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`"))
+                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`").into_box_error())
             }
             self.allow_methods = Some(AllowMethods::Const(methods));
             Ok(self)
@@ -227,7 +227,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
         pub fn allow_origin_any(mut self) -> Result<Self, BoxError> {
             if self.is_allow_credentials_any() {
-                return Err(BoxError::from("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`"))
+                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`").into_box_error())
             }
             self.allow_origin = Some(AllowOrigin::Any);
             Ok(self)
@@ -277,7 +277,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
         pub fn expose_headers(mut self, headers: AccessControlExposeHeaders) -> Result<Self, BoxError> {
             if headers.is_any() && self.is_allow_credentials_any() {
-                return Err(BoxError::from("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Expose-Headers: *`"))
+                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Expose-Headers: *`").into_box_error())
             }
             self.expose_headers = Some(headers);
             Ok(self)

--- a/rama-http/src/layer/dns/dns_resolve/mod.rs
+++ b/rama-http/src/layer/dns/dns_resolve/mod.rs
@@ -6,7 +6,8 @@
 //! by IP address instead of domain name.
 
 use crate::HeaderValue;
-use rama_core::error::{BoxError, ErrorExt};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_core::username::{ComposeError, Composer, UsernameLabelWriter};
 use rama_utils::macros::match_ignore_ascii_case_str;
@@ -73,22 +74,23 @@ impl DnsResolveMode {
 }
 
 impl std::str::FromStr for DnsResolveMode {
-    type Err = BoxError;
+    type Err = OpaqueError;
 
+    #[inline(always)]
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Self::try_from(value)
     }
 }
 
 impl TryFrom<&str> for DnsResolveMode {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match_ignore_ascii_case_str! {
             match (value) {
                 "eager" => Ok(Self::eager()),
                 "lazy" => Ok(Self::lazy()),
-                _ => Err(BoxError::from("Invalid DNS resolve mode: unknown str")),
+                _ => Err(OpaqueError::from_static_str("Invalid DNS resolve mode: unknown str")),
             }
         }
     }
@@ -99,7 +101,7 @@ impl TryFrom<&HeaderValue> for DnsResolveMode {
 
     fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
         match value.to_str() {
-            Ok(value) => Self::try_from(value),
+            Ok(value) => Self::try_from(value).into_box_error(),
             Err(err) => Err(err.context("Invalid DNS resolve mode")),
         }
     }

--- a/rama-http/src/layer/dns/dns_resolve/username_parser.rs
+++ b/rama-http/src/layer/dns/dns_resolve/username_parser.rs
@@ -1,4 +1,6 @@
 use super::DnsResolveMode;
+use rama_core::error::ErrorExt;
+use rama_core::error::extra::OpaqueError;
 use rama_core::username::{UsernameLabelParser, UsernameLabelState};
 use rama_core::{
     error::{BoxError, ErrorContext},
@@ -53,7 +55,10 @@ impl UsernameLabelParser for DnsResolveModeUsernameParser {
 
     fn build(self, ext: &Extensions) -> Result<(), Self::Error> {
         if self.key_found {
-            return Err(BoxError::from("unused dns resolve mode username key: dns"));
+            return Err(
+                OpaqueError::from_static_str("unused dns resolve mode username key: dns")
+                    .into_box_error(),
+            );
         }
         ext.insert(self.mode);
         Ok(())

--- a/rama-http/src/layer/header_option_value.rs
+++ b/rama-http/src/layer/header_option_value.rs
@@ -6,7 +6,7 @@
 use crate::{HeaderName, Request, utils::HeaderValueGetter};
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::{Extension, ExtensionsRef},
     telemetry::tracing,
 };
@@ -99,7 +99,7 @@ where
                 if str_value == "1" || str_value.eq_ignore_ascii_case("true") {
                     request.extensions().insert(T::default());
                 } else if str_value != "0" && !str_value.eq_ignore_ascii_case("false") {
-                    return Err(BoxError::from("invalid header option")
+                    return Err(OpaqueError::from_static_str("invalid header option")
                         .context_field("header_name", self.header_name.clone())
                         .context_str_field("header_value", str_value));
                 }

--- a/rama-http/src/layer/retry/mod.rs
+++ b/rama-http/src/layer/retry/mod.rs
@@ -139,7 +139,9 @@ mod test {
         service::web::response::IntoResponse,
     };
     use rama_core::{
-        Layer, extensions::Extension, extensions::Extensions, extensions::ExtensionsRef,
+        Layer,
+        error::extra::OpaqueError,
+        extensions::{Extension, Extensions, ExtensionsRef},
         service::service_fn,
     };
     use rama_utils::{backoff::ExponentialBackoff, rng::HasherRng};
@@ -196,7 +198,7 @@ mod test {
                 let txt = req.try_into_string().await.unwrap();
                 match txt.as_str() {
                     "internal" => Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-                    "error" => Err(rama_core::error::BoxError::from("custom error")),
+                    "error" => Err(OpaqueError::from_static_str("custom error")),
                     _ => Ok(txt.into_response()),
                 }
             },

--- a/rama-http/src/layer/retry/tests.rs
+++ b/rama-http/src/layer/retry/tests.rs
@@ -3,7 +3,8 @@ use crate::BodyExtractExt;
 use crate::service::web::response::IntoResponse;
 use crate::{Request, Response};
 use parking_lot::Mutex;
-use rama_core::error::BoxError;
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorExt};
 use rama_core::{Layer, Service};
 use std::sync::{
     Arc,
@@ -29,7 +30,7 @@ async fn retry_errors() {
                 Ok("world".into_response())
             } else {
                 self.error_counter.fetch_add(1, Ordering::AcqRel);
-                Err(BoxError::from("retry me"))
+                Err(OpaqueError::from_static_str("retry me").into_box_error())
             }
         }
     }
@@ -62,7 +63,7 @@ async fn retry_limit() {
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
             self.error_counter.fetch_add(1, Ordering::AcqRel);
-            Err(BoxError::from("error forever"))
+            Err(OpaqueError::from_static_str("error forever").into_box_error())
         }
     }
 
@@ -90,9 +91,9 @@ async fn retry_error_inspection() {
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
             if self.errored.swap(true, Ordering::AcqRel) {
-                Err(BoxError::from("reject"))
+                Err(OpaqueError::from_static_str("reject").into_box_error())
             } else {
-                Err(BoxError::from("retry me"))
+                Err(OpaqueError::from_static_str("retry me").into_box_error())
             }
         }
     }
@@ -115,7 +116,7 @@ async fn retry_cannot_clone_request() {
 
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
-            Err(BoxError::from("failed"))
+            Err(OpaqueError::from_static_str("failed").into_box_error())
         }
     }
 
@@ -297,13 +298,14 @@ where
 {
     async fn retry(
         &self,
-
         _req: Request<RetryBody>,
         _result: Result<Response, Error>,
     ) -> PolicyResult<Response, Error> {
         let mut remaining = self.remaining.lock();
         if *remaining == 0 {
-            PolicyResult::Abort(Err(BoxError::from("out of retries")))
+            PolicyResult::Abort(Err(
+                OpaqueError::from_static_str("out of retries").into_box_error()
+            ))
         } else {
             *remaining -= 1;
             PolicyResult::Retry {

--- a/rama-http/src/service/client/ext.rs
+++ b/rama-http/src/service/client/ext.rs
@@ -233,6 +233,7 @@ impl IntoHeaderValue for &String {}
 impl IntoHeaderValue for &[u8] {}
 
 mod private {
+    use rama_core::error::extra::OpaqueError;
     use rama_http_types::HeaderName;
     use rama_net::Protocol;
 
@@ -250,11 +251,11 @@ mod private {
                     if protocol.is_http() || protocol.is_ws() {
                         Ok(self)
                     } else {
-                        Err(BoxError::from("unsupported protocol")
+                        Err(OpaqueError::from_static_str("unsupported protocol")
                             .context_field("protocol", protocol))
                     }
                 }
-                None => Err(BoxError::from("Missing scheme in URI")),
+                None => Err(OpaqueError::from_static_str("Missing scheme in URI").into_box_error()),
             }
         }
     }
@@ -263,7 +264,10 @@ mod private {
         fn into_url(self) -> Result<Uri, BoxError> {
             match self.parse::<Uri>() {
                 Ok(uri) => uri.into_url(),
-                Err(_) => Err(BoxError::from("invalid url").context_str_field("raw_str", self)),
+                Err(_) => {
+                    Err(OpaqueError::from_static_str("invalid url")
+                        .context_str_field("raw_str", self))
+                }
             }
         }
     }
@@ -296,7 +300,9 @@ mod private {
         fn into_header_name(self) -> Result<crate::HeaderName, BoxError> {
             match self {
                 Some(name) => Ok(name),
-                None => Err(BoxError::from("Header name is required")),
+                None => {
+                    Err(OpaqueError::from_static_str("Header name is required").into_box_error())
+                }
             }
         }
     }

--- a/rama-http/src/service/fs/serve_dir/mod.rs
+++ b/rama-http/src/service/fs/serve_dir/mod.rs
@@ -6,6 +6,7 @@ use crate::{Body, Method, Request, Response, StatusCode, StreamingBody, header};
 use rama_core::Service;
 use rama_core::bytes::Bytes;
 use rama_core::error::BoxError;
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::ExtensionsRef;
 use rama_core::telemetry::tracing;
 use rama_net::uri::util::percent_encoding::percent_decode;
@@ -376,7 +377,7 @@ impl fmt::Display for DirectoryServeMode {
 }
 
 impl FromStr for DirectoryServeMode {
-    type Err = BoxError;
+    type Err = OpaqueError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         rama_utils::macros::match_ignore_ascii_case_str! {
@@ -384,14 +385,14 @@ impl FromStr for DirectoryServeMode {
                 "append-index" | "append_index" => Ok(Self::AppendIndexHtml),
                 "not-found" | "not_found" => Ok(Self::NotFound),
                 "html-file-list" | "html_file_list" => Ok(Self::HtmlFileList),
-                _ => Err(BoxError::from("invalid DirectoryServeMode str")),
+                _ => Err(OpaqueError::from_static_str("invalid DirectoryServeMode str")),
             }
         }
     }
 }
 
 impl TryFrom<&str> for DirectoryServeMode {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -2,7 +2,8 @@ use crate::address::{HostWithOptPort, HostWithPort};
 use crate::user::Basic;
 
 use super::{Domain, DomainAddress, Host, SocketAddress};
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -469,7 +470,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
     let mut s = maybe_borrowed.as_ref();
 
     if s.is_empty() {
-        return Err(BoxError::from("empty string is invalid authority"));
+        return Err(
+            OpaqueError::from_static_str("empty string is invalid authority").into_box_error(),
+        );
     }
 
     let mut user_info = None;

--- a/rama-net/src/address/domain.rs
+++ b/rama-net/src/address/domain.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
 use rama_utils::str::smol_str::{SmolStr, format_smolstr};
 use std::{cmp::Ordering, fmt, iter::repeat};
 
@@ -151,7 +151,7 @@ impl Domain {
     pub fn try_as_sub(&self, sub: impl AsDomainRef) -> Result<Self, BoxError> {
         let sub = format_smolstr!("{}.{}", sub.domain_as_str(), self.0);
         if !is_valid_name(sub.as_bytes()) {
-            return Err(BoxError::from("invalid subdomain"));
+            return Err(OpaqueError::from_static_str("invalid subdomain").into_box_error());
         }
         Ok(Self(sub))
     }
@@ -164,7 +164,7 @@ impl Domain {
     pub fn try_as_wildcard(&self) -> Result<Self, BoxError> {
         let sub = format_smolstr!("*.{}", self.0);
         if !is_valid_name(sub.as_bytes()) {
-            return Err(BoxError::from("invalid subdomain"));
+            return Err(OpaqueError::from_static_str("invalid subdomain").into_box_error());
         }
         Ok(Self(sub))
     }
@@ -304,7 +304,7 @@ impl TryFrom<String> for Domain {
         if is_valid_name(name.as_bytes()) {
             Ok(Self(SmolStr::new(name)))
         } else {
-            Err(BoxError::from("invalid domain"))
+            Err(OpaqueError::from_static_str("invalid domain").into_box_error())
         }
     }
 }
@@ -318,7 +318,7 @@ impl<'a> TryFrom<&'a [u8]> for Domain {
                 std::str::from_utf8(name).context("convert domain bytes to utf-8 string")?,
             )))
         } else {
-            Err(BoxError::from("invalid domain"))
+            Err(OpaqueError::from_static_str("invalid domain").into_box_error())
         }
     }
 }
@@ -332,7 +332,7 @@ impl TryFrom<Vec<u8>> for Domain {
                 String::from_utf8(name).context("convert domain bytes to utf-8 string")?,
             )))
         } else {
-            Err(BoxError::from("invalid domain"))
+            Err(OpaqueError::from_static_str("invalid domain").into_box_error())
         }
     }
 }

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -2,7 +2,8 @@ use crate::Protocol;
 use crate::address::HostWithPort;
 
 use super::{Domain, DomainAddress, Host, SocketAddress};
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -449,9 +450,10 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<HostWithO
     let s = maybe_borrowed.as_ref();
 
     if s.is_empty() {
-        return Err(BoxError::from(
-            "empty string is invalid host (with opt port)",
-        ));
+        return Err(
+            OpaqueError::from_static_str("empty string is invalid host (with opt port)")
+                .into_box_error(),
+        );
     }
 
     let host;

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -1,7 +1,8 @@
 use crate::Protocol;
 
 use super::{Domain, DomainAddress, Host, SocketAddress, parse_utils};
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::generate_set_and_with;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{
@@ -323,9 +324,12 @@ impl TryFrom<&str> for HostWithPort {
         let (host, port) = parse_utils::split_port_from_str(s)?;
         let host = Host::try_from(host).context("parse host from host-with-port")?;
         match host {
-            Host::Address(IpAddr::V6(_)) if !s.starts_with('[') => Err(BoxError::from(
-                "missing brackets for IPv6 address with port (in host-with-port)",
-            )),
+            Host::Address(IpAddr::V6(_)) if !s.starts_with('[') => {
+                Err(OpaqueError::from_static_str(
+                    "missing brackets for IPv6 address with port (in host-with-port)",
+                )
+                .into_box_error())
+            }
             _ => Ok(Self { host, port }),
         }
     }

--- a/rama-net/src/address/parse_utils.rs
+++ b/rama-net/src/address/parse_utils.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorExt};
+use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
 use std::net::{IpAddr, Ipv6Addr};
 
 pub(crate) fn split_port_from_str(s: &str) -> Result<(&str, u16), BoxError> {
@@ -8,7 +8,7 @@ pub(crate) fn split_port_from_str(s: &str) -> Result<(&str, u16), BoxError> {
             Err(err) => Err(err.context("parse port as u16")),
         }
     } else {
-        Err(BoxError::from("missing port"))
+        Err(OpaqueError::from_static_str("missing port").into_box_error())
     }
 }
 

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -2,7 +2,8 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::str::FromStr;
 
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::generate_set_and_with;
 
 use crate::address::ip::{
@@ -333,9 +334,10 @@ impl TryFrom<&str> for SocketAddress {
         let ip_addr =
             try_to_parse_str_to_ip(ip_addr).context("parse ip address from socket address")?;
         match ip_addr {
-            IpAddr::V6(_) if !s.starts_with('[') => Err(BoxError::from(
+            IpAddr::V6(_) if !s.starts_with('[') => Err(OpaqueError::from_static_str(
                 "missing brackets for IPv6 address with port",
-            )),
+            )
+            .into_box_error()),
             _ => Ok(Self { ip_addr, port }),
         }
     }

--- a/rama-net/src/client/pool/mod.rs
+++ b/rama-net/src/client/pool/mod.rs
@@ -3,6 +3,7 @@ use crate::address::SocketAddress;
 use crate::conn::{ConnectionHealth, ConnectionHealthStatus};
 use crate::stream::Socket;
 use parking_lot::Mutex;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::extensions::{Extension, Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing::trace;
@@ -222,18 +223,18 @@ impl<C, ID> Clone for LruDropPool<C, ID> {
 impl<C, ID> LruDropPool<C, ID> {
     pub fn try_new(max_active: usize, max_total: usize) -> Result<Self, BoxError> {
         if max_active == 0 || max_total == 0 {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "max_active or max_total of 0 will make this pool unusable",
             )
             .context_field("max_active", max_active)
             .context_field("max_total", max_total));
         }
         if max_active > max_total {
-            return Err(
-                BoxError::from("max_active should be smaller or equal to max_total")
-                    .context_field("max_active", max_active)
-                    .context_field("max_total", max_total),
-            );
+            return Err(OpaqueError::from_static_str(
+                "max_active should be smaller or equal to max_total",
+            )
+            .context_field("max_active", max_active)
+            .context_field("max_total", max_total));
         }
         let storage = Arc::new(Mutex::new(VecDeque::with_capacity(max_total)));
         let weak_storage = Arc::downgrade(&storage);
@@ -1072,7 +1073,7 @@ mod tests {
 
     impl Service<bool> for InnerService {
         type Output = ();
-        type Error = BoxError;
+        type Error = OpaqueError;
 
         async fn serve(&self, should_error: bool) -> Result<Self::Output, Self::Error> {
             // Once this service is broken it will stay in this state, similar to a closed tcp connection
@@ -1085,7 +1086,7 @@ mod tests {
             }
 
             if self.should_error.load(Ordering::Relaxed) {
-                Err(BoxError::from("service is in broken state"))
+                Err(OpaqueError::from_static_str("service is in broken state"))
             } else {
                 Ok(())
             }

--- a/rama-net/src/forwarded/element/parser.rs
+++ b/rama-net/src/forwarded/element/parser.rs
@@ -1,24 +1,27 @@
 use super::ExtensionValue;
 use super::{ForwardedElement, NodeId};
 use crate::forwarded::ForwardedProtocol;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::match_ignore_ascii_case_str;
 
 pub(crate) fn parse_single_forwarded_element(bytes: &[u8]) -> Result<ForwardedElement, BoxError> {
     if bytes.len() > 512 {
         // custom max length, to keep things sane here...
-        return Err(BoxError::from("forwarded element bytes length is too big")
-            .context_field("length", bytes.len()));
+        return Err(
+            OpaqueError::from_static_str("forwarded element bytes length is too big")
+                .context_field("length", bytes.len()),
+        );
     }
 
     let (element, bytes) = parse_next_forwarded_element(bytes)?;
     if bytes.is_empty() {
         Ok(element)
     } else {
-        Err(
-            BoxError::from("trailing characters found following the forwarded element")
-                .context_field("count", bytes.len()),
+        Err(OpaqueError::from_static_str(
+            "trailing characters found following the forwarded element",
         )
+        .context_field("count", bytes.len()))
     }
 }
 
@@ -27,10 +30,10 @@ pub(crate) fn parse_one_plus_forwarded_elements(
 ) -> Result<(ForwardedElement, Vec<ForwardedElement>), BoxError> {
     if bytes.len() > 8096 {
         // custom max length, to keep things sane here...
-        return Err(
-            BoxError::from("forwarded elements list bytes length is too big")
-                .context_field("length", bytes.len()),
-        );
+        return Err(OpaqueError::from_static_str(
+            "forwarded elements list bytes length is too big",
+        )
+        .context_field("length", bytes.len()));
     }
 
     let mut others = Vec::new();
@@ -44,10 +47,10 @@ pub(crate) fn parse_one_plus_forwarded_elements(
     loop {
         // skip comma first
         if bytes[0] != b',' {
-            return Err(
-                BoxError::from("unexpected char in forward element list: expected comma")
-                    .context_field("char", bytes[0]),
-            );
+            return Err(OpaqueError::from_static_str(
+                "unexpected char in forward element list: expected comma",
+            )
+            .context_field("char", bytes[0]));
         }
         bytes = &bytes[1..];
 
@@ -65,7 +68,10 @@ pub(crate) fn parse_one_plus_forwarded_elements(
 
 fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &[u8]), BoxError> {
     if bytes.is_empty() {
-        return Err(BoxError::from("empty str is not a valid Forwarded Element"));
+        return Err(
+            OpaqueError::from_static_str("empty str is not a valid Forwarded Element")
+                .into_box_error(),
+        );
     }
 
     let mut el = ForwardedElement {
@@ -94,14 +100,14 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
             match bytes[index] {
                 b'"' => {
                     if index != 0 {
-                        return Err(BoxError::from("dangling quote string quote")
+                        return Err(OpaqueError::from_static_str("dangling quote string quote")
                             .context_field("quote_pos", index));
                     } else {
                         bytes = &bytes[1..];
-                        let trailer_quote_index = bytes
-                            .iter()
-                            .position(|b| *b == b'"')
-                            .ok_or_else(|| BoxError::from("quote string missing trailer quote"))?;
+                        let trailer_quote_index =
+                            bytes.iter().position(|b| *b == b'"').ok_or_else(|| {
+                                OpaqueError::from_static_str("quote string missing trailer quote")
+                            })?;
                         let value = &bytes[..trailer_quote_index];
                         bytes = &bytes[trailer_quote_index + 1..];
                         (value, true)
@@ -133,7 +139,7 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
         // >
         // > remark: we do not apply any validation here
         if !quoted && value.contains(['[', ']', ':']) {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "Forwarded Element pair's value was expected to be a quoted string due to the chars it contains"
             ).context_str_field("value", value));
         }
@@ -141,22 +147,22 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
         match_ignore_ascii_case_str! {
             match(key) {
                 "for" => if el.for_node.is_some() {
-                    return Err(BoxError::from("Forwarded Element can only contain one 'for' property"));
+                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'for' property").into_box_error());
                 } else {
                     el.for_node = Some(NodeId::try_from(value).context("parse Forwarded Element 'for' node")?);
                 },
                 "host" => if el.authority.is_some() {
-                    return Err(BoxError::from("Forwarded Element can only contain one 'host' property"));
+                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'host' property").into_box_error());
                 } else {
                     el.authority = Some(value.parse().context("parse Forwarded Element 'host' authority")?);
                 },
                 "by" => if el.by_node.is_some() {
-                    return Err(BoxError::from("Forwarded Element can only contain one 'by' property"));
+                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'by' property").into_box_error());
                 } else {
                     el.by_node = Some(NodeId::try_from(value).context("parse Forwarded Element 'by' node")?);
                 },
                 "proto" => if el.proto.is_some() {
-                    return Err(BoxError::from("Forwarded Element can only contain one 'proto' property"));
+                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'proto' property").into_box_error());
                 } else {
                     el.proto = Some(ForwardedProtocol::try_from(value).context("parse Forwarded Element 'proto' protocol")?);
                 },
@@ -183,9 +189,10 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
 
     if el.for_node.is_none() && el.by_node.is_none() && el.authority.is_none() && el.proto.is_none()
     {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "invalid forwarded element: none of required properties are set",
-        ));
+        )
+        .into_box_error());
     }
 
     bytes = trim_left(bytes);
@@ -218,7 +225,9 @@ fn trim(b: &[u8]) -> &[u8] {
 
 fn parse_value(slice: &[u8]) -> Result<&str, BoxError> {
     if slice.iter().any(|b| !(32..127).contains(b) || *b == b'"') {
-        return Err(BoxError::from("value contains invalid characters"));
+        return Err(
+            OpaqueError::from_static_str("value contains invalid characters").into_box_error(),
+        );
     }
     std::str::from_utf8(slice).context("parse value as utf-8")
 }

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -1,6 +1,6 @@
 use super::{ObfNode, ObfPort};
 use crate::address::{Domain, Host, HostWithOptPort, HostWithPort, SocketAddress};
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
 use std::{
     fmt,
     net::{IpAddr, Ipv6Addr, SocketAddr},
@@ -321,7 +321,8 @@ impl TryFrom<&str> for NodeId {
 
         match name {
             NodeName::Ip(IpAddr::V6(_)) if port.is_some() && !s.starts_with('[') => Err(
-                BoxError::from("missing brackets for node IPv6 address with port"),
+                OpaqueError::from_static_str("missing brackets for node IPv6 address with port")
+                    .into_box_error(),
             ),
             _ => Ok(Self { name, port }),
         }

--- a/rama-net/src/forwarded/obfuscated.rs
+++ b/rama-net/src/forwarded/obfuscated.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
 use rama_utils::str::smol_str::SmolStr;
 use std::fmt;
 
@@ -98,7 +98,7 @@ macro_rules! create_obf_type {
                 if $val_fn(s.as_bytes()) {
                     Ok(Self(SmolStr::new(s)))
                 } else {
-                    Err(BoxError::from(concat!("invalid ", stringify!($name))))
+                    Err(OpaqueError::from_static_str(concat!("invalid ", stringify!($name))).into_box_error())
                 }
             }
         }
@@ -112,7 +112,7 @@ macro_rules! create_obf_type {
                         String::from_utf8(s).context(concat!("convert ", stringify!($name), "bytes to utf-8 string"))?,
                     )))
                 } else {
-                    Err(BoxError::from(concat!("invalid ", stringify!($name))))
+                    Err(OpaqueError::from_static_str(concat!("invalid ", stringify!($name))).into_box_error())
                 }
             }
         }

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -7,6 +7,7 @@ use crate::{
     address::{Domain, Host},
 };
 use rama_core::error::BoxError;
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::{Extension, Extensions};
 use rama_core::telemetry::tracing;
 use rama_http_types::request::Parts;
@@ -145,7 +146,7 @@ pub fn try_request_ctx_from_http_parts(
                 })
         })
         .ok_or_else(|| {
-            BoxError::from("RequestContext: no authourity found in http::Request")
+            OpaqueError::from_static_str("RequestContext: no authourity found in http::Request")
         })?;
 
     tracing::trace!(url.full = %uri, "request context: detected authority: {authority}");

--- a/rama-net/src/http/uri/match_replace/fmt.rs
+++ b/rama-net/src/http/uri/match_replace/fmt.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt};
 
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
 use rama_http_types::Uri;
 
 #[derive(Clone)]
@@ -77,7 +77,7 @@ impl UriFormatter {
                         offset = index + 1;
                     } else if byte == b'?' {
                         if include_query {
-                            return Err(BoxError::from(
+                            return Err(OpaqueError::from_static_str(
                                 "uri can only contain a single '?': multiple found",
                             )
                             .context_field("index", index));
@@ -114,9 +114,10 @@ impl UriFormatter {
         let literal_len =
             template.len() - captures.iter().map(|capture| capture.length).sum::<usize>();
         if literal_len + captures.len() >= MAX_URI_LEN {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "Uri Formatter potential length exceeds max URI length",
-            ));
+            )
+            .into_box_error());
         }
 
         Ok(Self {
@@ -154,10 +155,12 @@ fn try_rule_capture_from_byte_range(
     bytes: &[u8],
     offset: usize,
     index: usize,
-) -> Result<RuleCapture, BoxError> {
+) -> Result<RuleCapture, OpaqueError> {
     let length = index.saturating_sub(offset);
     if length == 0 || length > 2 {
-        return Err(BoxError::from("invalid capture raw byte length (OOR)"));
+        return Err(OpaqueError::from_static_str(
+            "invalid capture raw byte length (OOR)",
+        ));
     }
 
     let capture_index: usize = bytes[offset..offset + length]
@@ -170,7 +173,7 @@ fn try_rule_capture_from_byte_range(
         .sum();
 
     if capture_index == 0 || capture_index > 16 {
-        return Err(BoxError::from(
+        return Err(OpaqueError::from_static_str(
             "uri formatter is invalid: capture index has to be within inclusive range [1, 16]",
         ));
     }

--- a/rama-net/src/https.rs
+++ b/rama-net/src/https.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorExt};
+use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
 use rama_http_types::Version;
 
 use crate::tls::ApplicationProtocol;
@@ -13,7 +13,9 @@ impl TryFrom<Version> for ApplicationProtocol {
             Version::HTTP_11 => Self::HTTP_11,
             Version::HTTP_2 => Self::HTTP_2,
             Version::HTTP_3 => Self::HTTP_3,
-            _ => Err(BoxError::from("received unexpected http version"))?,
+            _ => Err(OpaqueError::from_static_str(
+                "received unexpected http version",
+            ))?,
         };
         Ok(version)
     }
@@ -37,10 +39,10 @@ impl TryFrom<&ApplicationProtocol> for Version {
             ApplicationProtocol::HTTP_11 => Self::HTTP_11,
             ApplicationProtocol::HTTP_2 => Self::HTTP_2,
             ApplicationProtocol::HTTP_3 => Self::HTTP_3,
-            alpn => Err(
-                BoxError::from("cannot convert given alpn {alpn} to http version")
-                    .context_field("alpn", alpn.clone()),
-            )?,
+            alpn => Err(OpaqueError::from_static_str(
+                "cannot convert given alpn {alpn} to http version",
+            )
+            .context_field("alpn", alpn.clone()))?,
         };
         Ok(version)
     }

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -1,7 +1,8 @@
 use std::cmp::min;
 use std::str::FromStr;
 
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::macros::str::eq_ignore_ascii_case;
 use rama_utils::str::smol_str::SmolStr;
@@ -356,7 +357,7 @@ pub(crate) fn try_to_extract_protocol_from_uri_scheme(
     s: &[u8],
 ) -> Result<(Option<Protocol>, usize), BoxError> {
     if s.is_empty() {
-        return Err(BoxError::from("empty uri contains no scheme"));
+        return Err(OpaqueError::from_static_str("empty uri contains no scheme").into_box_error());
     }
 
     for i in 0..min(s.len(), 512) {

--- a/rama-net/src/socket/device_name.rs
+++ b/rama-net/src/socket/device_name.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str::FromStr};
 
-use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
 use rama_utils::str::smol_str::SmolStr;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rama-net/src/socket/device_name.rs
+++ b/rama-net/src/socket/device_name.rs
@@ -73,7 +73,10 @@ impl TryFrom<&str> for DeviceName {
             return Ok(Self(SmolStr::from(s)));
         }
 
-        Err(BoxError::from("invalid (interface) device name").context_str_field("str", s))
+        Err(
+            OpaqueError::from_static_str("invalid (interface) device name")
+                .context_str_field("str", s),
+        )
     }
 }
 

--- a/rama-net/src/tls/client/parser.rs
+++ b/rama-net/src/tls/client/parser.rs
@@ -17,6 +17,7 @@ use nom::{
     multi::{length_data, many0},
     number::streaming::{be_u8, be_u16},
 };
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorExt as _};
 use rama_core::telemetry::tracing;
 use std::str;
@@ -27,8 +28,10 @@ use std::str;
 /// TLS ClientHello message or if there is unexpected trailing data.
 pub fn parse_client_hello(i: &[u8]) -> Result<ClientHello, BoxError> {
     match parse_client_hello_inner(i) {
-        Err(err) => Err(BoxError::from("parse client hello handshake message")
-            .context_debug_field("err", err.to_owned())),
+        Err(err) => Err(
+            OpaqueError::from_static_str("parse client hello handshake message")
+                .context_debug_field("err", err.to_owned()),
+        ),
         Ok((i, hello)) => {
             if !i.is_empty() {
                 tracing::debug!(
@@ -46,8 +49,10 @@ pub fn parse_client_hello(i: &[u8]) -> Result<ClientHello, BoxError> {
 /// instead of just the record
 pub fn parse_client_hello_handshake(i: &[u8]) -> Result<ClientHello, BoxError> {
     match parse_client_hello_handshake_inner(i) {
-        Err(err) => Err(BoxError::from("parse client hello handshake message")
-            .context_debug_field("err", err.to_owned())),
+        Err(err) => Err(
+            OpaqueError::from_static_str("parse client hello handshake message")
+                .context_debug_field("err", err.to_owned()),
+        ),
         Ok((i, hello)) => {
             if !i.is_empty() {
                 tracing::debug!(
@@ -84,7 +89,7 @@ pub fn extract_sni_from_client_hello_handshake(i: &[u8]) -> Result<Option<Domain
     parse_client_hello_handshake_sni_inner(i)
         .map(|(_, domain)| domain)
         .map_err(|err| {
-            BoxError::from("parse client hello handshake message to find SNI")
+            OpaqueError::from_static_str("parse client hello handshake message to find SNI")
                 .context_debug_field("err", err.to_owned())
         })
 }
@@ -102,7 +107,7 @@ pub fn extract_sni_from_client_hello_record(i: &[u8]) -> Result<Option<Domain>, 
     parse_client_hello_record_sni_inner(i)
         .map(|(_, domain)| domain)
         .map_err(|err| {
-            BoxError::from("parse client hello record message to find SNI")
+            OpaqueError::from_static_str("parse client hello record message to find SNI")
                 .context_debug_field("err", err.to_owned())
         })
 }

--- a/rama-net/src/tls/enums.rs
+++ b/rama-net/src/tls/enums.rs
@@ -3,7 +3,7 @@
 
 use rama_core::{
     bytes::{BufMut, Bytes, BytesMut},
-    error::BoxError,
+    error::extra::OpaqueError,
 };
 use rama_utils::macros::enums::enum_builder;
 
@@ -810,7 +810,7 @@ impl ApplicationProtocol {
         if b.len() > 255 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                BoxError::from("application protocol is too large"),
+                OpaqueError::from_static_str("application protocol is too large"),
             ));
         }
 

--- a/rama-net/src/tls/server/sni.rs
+++ b/rama-net/src/tls/server/sni.rs
@@ -8,7 +8,7 @@ use std::{
 use pin_project_lite::pin_project;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::{HeapReader, PrefixedIo, StackReader},
     service::RejectService,
@@ -111,7 +111,10 @@ where
                 read_size,
                 "unexpected read size for client hello handshake data"
             );
-            return Err(BoxError::from("missing client hello tls handshake data"));
+            return Err(
+                OpaqueError::from_static_str("missing client hello tls handshake data")
+                    .into_box_error(),
+            );
         }
         let sni = extract_sni_from_client_hello_handshake(&v)
             .context("parse client hello handshake bytes and extract SNI")?;

--- a/rama-net/src/user/credentials/basic.rs
+++ b/rama-net/src/user/credentials/basic.rs
@@ -1,6 +1,7 @@
 use std::{fmt, str::FromStr};
 
-use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::str::NonEmptyStr;
 
@@ -140,7 +141,10 @@ impl TryFrom<&str> for Basic {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value.find(':') {
-            Some(0) => Err(BoxError::from("missing username in basic credential")),
+            Some(0) => Err(
+                OpaqueError::from_static_str("missing username in basic credential")
+                    .into_box_error(),
+            ),
             Some(n) => Ok(Self {
                 username: NonEmptyStr::try_from(&value[..n])
                     .context("create username for secure basic credentials")?,

--- a/rama-net/src/user/credentials/bearer.rs
+++ b/rama-net/src/user/credentials/bearer.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
 use std::{fmt, str::FromStr};
 
@@ -66,9 +66,10 @@ impl Bearer {
     /// Returns an error in case the token contains non-visible ASCII chars.
     pub fn try_new(s: NonEmptyStr) -> Result<Self, BoxError> {
         if s.as_bytes().iter().any(|b| *b < 32 || *b >= 127) {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "string contains non visible ASCII characters",
-            ));
+            )
+            .into_box_error());
         }
 
         Ok(Self(s))

--- a/rama-proxy/src/proxydb/layer.rs
+++ b/rama-proxy/src/proxydb/layer.rs
@@ -1,7 +1,7 @@
 use super::{Proxy, ProxyContext, ProxyDB, ProxyFilter, ProxyQueryPredicate};
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::{Extensions, ExtensionsRef},
 };
 use rama_net::{
@@ -236,9 +236,9 @@ where
                         } else if proxy.socks5h {
                             Some(Protocol::SOCKS5H)
                         } else {
-                            return Err(BoxError::from(
+                            return Err(OpaqueError::from_static_str(
                                 "selected udp proxy does not have a valid protocol available (db bug?!)",
-                            ));
+                            ).into_box_error());
                         }
                     }
                     TransportProtocol::Tcp => match proxy_address.address.port {
@@ -257,9 +257,9 @@ where
                             } else if proxy.https {
                                 Some(Protocol::HTTPS)
                             } else {
-                                return Err(BoxError::from(
+                                return Err(OpaqueError::from_static_str(
                                     "selected tcp proxy does not have a valid protocol available (db bug?!)",
-                                ));
+                                ).into_box_error());
                             }
                         }
                     },

--- a/rama-proxy/src/proxydb/mod.rs
+++ b/rama-proxy/src/proxydb/mod.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_net::asn::Asn;
 use rama_utils::str::NonEmptyStr;
@@ -154,7 +155,7 @@ pub trait ProxyDB: Send + Sync + 'static {
 }
 
 impl ProxyDB for () {
-    type Error = BoxError;
+    type Error = OpaqueError;
 
     #[inline]
     async fn get_proxy_if(
@@ -163,7 +164,9 @@ impl ProxyDB for () {
         _filter: ProxyFilter,
         _predicate: impl ProxyQueryPredicate,
     ) -> Result<Proxy, Self::Error> {
-        Err(BoxError::from("()::get_proxy_if: no ProxyDB defined"))
+        Err(OpaqueError::from_static_str(
+            "()::get_proxy_if: no ProxyDB defined",
+        ))
     }
 
     #[inline]
@@ -172,7 +175,9 @@ impl ProxyDB for () {
         _ctx: ProxyContext,
         _filter: ProxyFilter,
     ) -> Result<Proxy, Self::Error> {
-        Err(BoxError::from("()::get_proxy: no ProxyDB defined"))
+        Err(OpaqueError::from_static_str(
+            "()::get_proxy: no ProxyDB defined",
+        ))
     }
 }
 
@@ -194,7 +199,10 @@ where
                 .get_proxy_if(ctx, filter, predicate)
                 .await
                 .context("Some::get_proxy_if"),
-            None => Err(BoxError::from("None::get_proxy_if: no ProxyDB defined")),
+            None => Err(
+                OpaqueError::from_static_str("None::get_proxy_if: no ProxyDB defined")
+                    .into_box_error(),
+            ),
         }
     }
 
@@ -206,7 +214,10 @@ where
     ) -> Result<Proxy, Self::Error> {
         match self {
             Some(db) => db.get_proxy(ctx, filter).await.context("Some::get_proxy"),
-            None => Err(BoxError::from("None::get_proxy: no ProxyDB defined")),
+            None => Err(
+                OpaqueError::from_static_str("None::get_proxy: no ProxyDB defined")
+                    .into_box_error(),
+            ),
         }
     }
 }

--- a/rama-proxy/src/proxydb/update.rs
+++ b/rama-proxy/src/proxydb/update.rs
@@ -1,6 +1,6 @@
 use super::ProxyDB;
 use arc_swap::ArcSwap;
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
 use std::{fmt, ops::Deref, sync::Arc};
 
 /// Create a new [`ProxyDB`] updater which allows you to have a (typically in-memory) [`ProxyDB`]
@@ -70,9 +70,10 @@ where
                 .get_proxy_if(ctx, filter, predicate)
                 .await
                 .into_box_error(),
-            None => Err(BoxError::from(
+            None => Err(OpaqueError::from_static_str(
                 "live proxy db: proxy db is None: get_proxy_if unable to proceed",
-            )),
+            )
+            .into_box_error()),
         }
     }
 
@@ -83,9 +84,10 @@ where
     ) -> Result<super::Proxy, Self::Error> {
         match self.0.load().deref().deref() {
             Some(db) => db.get_proxy(ctx, filter).await.into_box_error(),
-            None => Err(BoxError::from(
+            None => Err(OpaqueError::from_static_str(
                 "live proxy db: proxy db is None: get_proxy unable to proceed",
-            )),
+            )
+            .into_box_error()),
         }
     }
 }

--- a/rama-proxy/src/username.rs
+++ b/rama-proxy/src/username.rs
@@ -1,6 +1,6 @@
 use super::ProxyFilter;
 use rama_core::{
-    error::{BoxError, ErrorExt},
+    error::{BoxError, ErrorExt, extra::OpaqueError},
     extensions::Extensions,
     telemetry::tracing,
     username::{UsernameLabelParser, UsernameLabelState, UsernameLabelWriter},
@@ -165,7 +165,8 @@ impl UsernameLabelParser for ProxyFilterUsernameParser {
     fn build(self, ext: &Extensions) -> Result<(), Self::Error> {
         if let Some(key) = self.key {
             return Err(
-                BoxError::from("unused proxy filter username key").context_debug_field("key", key)
+                OpaqueError::from_static_str("unused proxy filter username key")
+                    .context_debug_field("key", key),
             );
         }
         if self.proxy_filter != ProxyFilter::default() {

--- a/rama-socks5/src/client/proxy_connector.rs
+++ b/rama-socks5/src/client/proxy_connector.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::Io,
     telemetry::tracing,
@@ -340,9 +340,10 @@ where
             .map(|p| p.is_socks5())
             .unwrap_or(true)
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "socks5 proxy connector can only serve socks5 protocol",
-            ));
+            )
+            .into_box_error());
         }
 
         let address = match address {
@@ -414,9 +415,10 @@ where
                 client.set_auth(basic.clone());
             }
             Some(ProxyCredential::Bearer(_)) => {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "socks5proxy does not support auth with bearer credential",
-                ));
+                )
+                .into_box_error());
             }
             None => {
                 tracing::trace!(
@@ -431,7 +433,9 @@ where
 
         let Some(connect_authority) = transport_ctx.host_with_port() else {
             return Err(Box::new(Socks5ProxyError::Handshake(
-                HandshakeError::other(BoxError::from("failed to get port from transport context")),
+                HandshakeError::other(OpaqueError::from_static_str(
+                    "failed to get port from transport context",
+                )),
             )));
         };
 

--- a/rama-socks5/src/client/udp.rs
+++ b/rama-socks5/src/client/udp.rs
@@ -1,4 +1,5 @@
 use rama_core::bytes::{BufMut, BytesMut};
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::futures::Sink;
 use rama_core::futures::Stream;
@@ -244,10 +245,10 @@ impl<S: rama_core::io::Io + Unpin> UdpSocketRelay<S> {
 
 fn validate_udp_header(header: UdpHeader) -> Result<(usize, SocketAddress), BoxError> {
     if header.fragment_number != 0 {
-        return Err(
-            BoxError::from("UdpSocketRelay: fragment number != 0 is not supported")
-                .context_field("fragment_number", header.fragment_number),
-        );
+        return Err(OpaqueError::from_static_str(
+            "UdpSocketRelay: fragment number != 0 is not supported",
+        )
+        .context_field("fragment_number", header.fragment_number));
     }
 
     let header_offset = header.serialized_len() - 1;
@@ -255,7 +256,7 @@ fn validate_udp_header(header: UdpHeader) -> Result<(usize, SocketAddress), BoxE
     let HostWithPort { host, port } = header.destination;
     let from: SocketAddress = match host {
         rama_net::address::Host::Name(domain) => {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "server responded with named address: incompatible for udp bind",
             )
             .context_field("domain", domain));

--- a/rama-tcp/src/client/connect.rs
+++ b/rama-tcp/src/client/connect.rs
@@ -1,5 +1,6 @@
 use rama_core::combinators::Either;
 use rama_core::error::ErrorExt as _;
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::Extensions;
 use rama_core::stream::StreamExt;
 use rama_core::stream::wrappers::ReceiverStream;
@@ -313,17 +314,17 @@ where
 
     if resolved_count > 0 {
         Err(
-            BoxError::from("failed to (tcp) connect to any resolved IP address")
+            OpaqueError::from_static_str("failed to (tcp) connect to any resolved IP address")
                 .context_field("host", host)
                 .context_field("port", port)
                 .context_field("resolved_addr_count", resolved_count),
         )
     } else {
-        Err(
-            BoxError::from("failed to resolve into any IP address (as part of tcp connect)")
-                .context_field("host", host)
-                .context_field("port", port),
+        Err(OpaqueError::from_static_str(
+            "failed to resolve into any IP address (as part of tcp connect)",
         )
+        .context_field("host", host)
+        .context_field("port", port))
     }
 }
 

--- a/rama-tcp/src/client/service/connector.rs
+++ b/rama-tcp/src/client/service/connector.rs
@@ -1,6 +1,6 @@
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     rt::Executor,
     telemetry::tracing,
@@ -169,9 +169,10 @@ where
             TransportProtocol::Tcp => (), // a-ok :)
             TransportProtocol::Udp => {
                 // sanity check, shouldn't happen, but in case someone makes a weird stack, it can
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "Tcp Connector Service cannot establish a UDP transport",
-                ));
+                )
+                .into_box_error());
             }
         }
 

--- a/rama-tcp/src/pool/mod.rs
+++ b/rama-tcp/src/pool/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use rama_core::error::BoxError;
+use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
 use rand::Rng as _;
 
 use crate::{TcpStream, client::TcpStreamConnector};
@@ -73,7 +73,8 @@ where
 
     async fn connect(&self, addr: std::net::SocketAddr) -> Result<TcpStream, Self::Error> {
         let connector = self.selector.next(&self.connectors).ok_or_else(|| {
-            BoxError::from("TcpStreamConnectorPool has empty connectors collection")
+            OpaqueError::from_static_str("TcpStreamConnectorPool has empty connectors collection")
+                .into_box_error()
         })?;
         connector.connect(addr).await
     }

--- a/rama-tcp/src/proxy/io_to_bridge_io.rs
+++ b/rama-tcp/src/proxy/io_to_bridge_io.rs
@@ -1,6 +1,6 @@
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::{BridgeIo, Io},
     rt::Executor,
@@ -192,9 +192,9 @@ where
                 if let Some(ProxyTarget(host_with_port)) = ingress.extensions().get_ref().cloned() {
                     host_with_port
                 } else {
-                    return Err(BoxError::from(
+                    return Err(OpaqueError::from_static_str(
                         "missing ProxyTarget in IoToProxyBridgeIo: proxy target assumed to exist in ingress extensions",
-                    ));
+                    ).into_box_error());
                 }
             }
         };

--- a/rama-tls-acme/src/client.rs
+++ b/rama-tls-acme/src/client.rs
@@ -180,7 +180,7 @@ impl AcmeClient {
                 .context("create account request")?;
 
             if mode == CreateAccountMode::Create && response.status() == 200 {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "Tried creating new account, but account already exists",
                 )
                 .into());
@@ -561,7 +561,9 @@ impl<'a> Order<'a> {
                 server::ChallengeStatus::Pending | server::ChallengeStatus::Processing => (),
                 server::ChallengeStatus::Valid => return Ok(()),
                 server::ChallengeStatus::Invalid => {
-                    return Err(BoxError::from("challenge is detected as invalid").into());
+                    return Err(
+                        OpaqueError::from_static_str("challenge is detected as invalid").into(),
+                    );
                 }
             }
 
@@ -677,7 +679,7 @@ impl<'a> Order<'a> {
                 return Ok::<_, ClientError>(&self.inner);
             }
             if self.inner.status == server::OrderStatus::Invalid {
-                return Err(BoxError::from("Order is invalid state").into());
+                return Err(OpaqueError::from_static_str("Order is invalid state").into());
             }
 
             sleep(retry_wait.unwrap_or(self.account.client.default_retry_duration)).await;
@@ -757,7 +759,7 @@ async fn bytes_into_error(response_parts: Parts, bytes: Bytes) -> ClientError {
         problem.into()
     } else {
         match bytes.try_into_string().await {
-            Ok(body_str) => BoxError::from("unexpected problem response")
+            Ok(body_str) => OpaqueError::from_static_str("unexpected problem response")
                 .context_field("status", response_parts.status)
                 .context_str_field("body", body_str),
             Err(err) => err
@@ -831,6 +833,12 @@ impl std::error::Error for ClientError {
 impl From<BoxError> for ClientError {
     fn from(value: BoxError) -> Self {
         Self::Other(value)
+    }
+}
+
+impl From<OpaqueError> for ClientError {
+    fn from(value: OpaqueError) -> Self {
+        Self::Other(value.into_box_error())
     }
 }
 

--- a/rama-tls-boring/src/client/connector.rs
+++ b/rama-tls-boring/src/client/connector.rs
@@ -1,5 +1,6 @@
 use rama_boring_tokio::{HandshakeError, SslStream};
 use rama_core::conversion::RamaTryInto;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::io::Io;
@@ -345,7 +346,7 @@ fn set_target_http_version(
         if let Some(target_version) = request_extensions.get_ref::<TargetHttpVersion>()
             && target_version.0 != neg_version
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "target http version not compatible with negotiated tls alpn version",
             )
             .context_debug_field("target_version", *target_version)
@@ -493,9 +494,11 @@ where
                             .context_debug_field("sni", server_name)
                             .context_debug_field("code", maybe_ssl_code)
                     } else {
-                        BoxError::from("boring ssl connector (connect): without error info")
-                            .context_debug_field("sni", server_name)
-                            .context_debug_field("code", maybe_ssl_code)
+                        OpaqueError::from_static_str(
+                            "boring ssl connector (connect): without error info",
+                        )
+                        .context_debug_field("sni", server_name)
+                        .context_debug_field("code", maybe_ssl_code)
                     }
                 }
             })?;
@@ -506,7 +509,7 @@ where
                 .protocol_version()
                 .rama_try_into()
                 .map_err(|v| {
-                    BoxError::from("boring ssl connector: cast min proto version")
+                    OpaqueError::from_static_str("boring ssl connector: cast min proto version")
                         .context_field("protocol_version", v)
                 })?;
             let application_layer_protocol = stream
@@ -532,9 +535,10 @@ where
             }
         }
         None => {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "boring ssl connector: failed to establish session...",
-            ));
+            )
+            .into_box_error());
         }
     };
 

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -12,12 +12,15 @@ use rama_boring::{
         store::X509Store,
     },
 };
-use rama_core::telemetry::tracing::{debug, trace};
 use rama_core::{
     bytes::Bytes,
     conversion::RamaTryInto,
     error::{BoxError, ErrorContext, ErrorExt},
     extensions::Extension,
+};
+use rama_core::{
+    error::extra::OpaqueError,
+    telemetry::tracing::{debug, trace},
 };
 use rama_net::tls::{
     ApplicationProtocol, CertificateCompressionAlgorithm, ExtensionId, KeyLogIntent,
@@ -594,9 +597,10 @@ impl TlsConnectorDataBuilder {
                         );
 
                         if total_added_cert_count == 0 {
-                            return Err(BoxError::from(
+                            return Err(OpaqueError::from_static_str(
                                 "failed to add windows certs from system (user/machine x Root/CA)",
-                            ));
+                            )
+                            .into_box_error());
                         }
 
                         Ok(builder.build())
@@ -732,9 +736,10 @@ impl TlsConnectorDataBuilder {
                 .set_private_key(auth.private_key.as_ref())
                 .context("build (boring) ssl connector: set private key")?;
             if auth.cert_chain.is_empty() {
-                return Err(BoxError::from(
+                return Err(OpaqueError::from_static_str(
                     "build (boring) ssl connector: cert chain is empty",
-                ));
+                )
+                .into_box_error());
             }
             trace!("boring connector: client mTls: set cert chain root");
             cfg_builder
@@ -994,8 +999,10 @@ impl TlsConnectorDataBuilder {
                                 min_ver
                             );
                             min_ssl_version = Some((*min_ver).rama_try_into().map_err(|v| {
-                                BoxError::from("build boring ssl connector: cast min proto version")
-                                    .context_field("protocol_version", v)
+                                OpaqueError::from_static_str(
+                                    "build boring ssl connector: cast min proto version",
+                                )
+                                .context_field("protocol_version", v)
                             })?);
                         }
 
@@ -1016,8 +1023,10 @@ impl TlsConnectorDataBuilder {
                                 max_ver
                             );
                             max_ssl_version = Some((*max_ver).rama_try_into().map_err(|v| {
-                                BoxError::from("build boring ssl connector: cast max proto version")
-                                    .context_field("protocol_version", v)
+                                OpaqueError::from_static_str(
+                                    "build boring ssl connector: cast max proto version",
+                                )
+                                .context_field("protocol_version", v)
                             })?);
                         }
                     }
@@ -1237,7 +1246,7 @@ impl TryFrom<ClientHello> for TlsConnectorDataBuilder {
         if !has_supported_versions_extension {
             let max_ssl_version =
                 legacy_protocol_version.rama_try_into().map_err(|v| {
-                    BoxError::from(
+                    OpaqueError::from_static_str(
                         "build boring ssl connector: cast max proto version from legacy ClientHello version",
                     )
                     .context_field("protocol_version", v)

--- a/rama-tls-boring/src/proxy/mitm/mod.rs
+++ b/rama-tls-boring/src/proxy/mitm/mod.rs
@@ -7,7 +7,7 @@ use rama_boring_tokio::SslErrorStack;
 use rama_core::{
     Layer,
     conversion::RamaTryInto as _,
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     extensions::{self, ExtensionsRef as _},
     io::{BridgeIo, Io},
     telemetry::tracing,
@@ -374,9 +374,11 @@ where
                     } else {
                         TlsMitmRelayError::handshake(
                             TlsMitmRelayErrorDirection::Egress,
-                            BoxError::from("tls mitm relay: egress tls accept failed")
-                                .context_debug_field("code", maybe_ssl_code)
-                                .context_debug_field("sni", server_name),
+                            OpaqueError::from_static_str(
+                                "tls mitm relay: egress tls accept failed",
+                            )
+                            .context_debug_field("code", maybe_ssl_code)
+                            .context_debug_field("sni", server_name),
                             maybe_ssl_code,
                         )
                     }
@@ -386,7 +388,9 @@ where
         let egress_ssl_ref = egress_tls_stream.ssl_ref();
         let source_cert = egress_ssl_ref
             .peer_certificate()
-            .ok_or_else(|| BoxError::from("tls mitm relay: egress tls stream has no peer cert"))
+            .ok_or_else(|| {
+                OpaqueError::from_static_str("tls mitm relay: egress tls stream has no peer cert")
+            })
             .map_err(TlsMitmRelayError::config)?;
 
         let (mirrored_leaf_cert_chain, mirrored_leaf_key) = self
@@ -443,7 +447,7 @@ where
             let protocol_version = protocol_version
                 .rama_try_into()
                 .map_err(|v| {
-                    BoxError::from("boring ssl connector: cast min proto version")
+                    OpaqueError::from_static_str("boring ssl connector: cast min proto version")
                         .context_field("protocol_version", v)
                 })
                 .map_err(TlsMitmRelayError::config)?;
@@ -546,7 +550,7 @@ where
                 } else {
                     TlsMitmRelayError::handshake(
                         TlsMitmRelayErrorDirection::Ingress,
-                        BoxError::from("tls mitm relay: ingress tls accept failed")
+                        OpaqueError::from_static_str("tls mitm relay: ingress tls accept failed")
                             .context_debug_field("code", maybe_ssl_code),
                         maybe_ssl_code,
                     )

--- a/rama-tls-boring/src/server/service.rs
+++ b/rama-tls-boring/src/server/service.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use rama_core::{
     Service,
     conversion::RamaTryInto,
-    error::{BoxError, ErrorContext, ErrorExt},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::Io,
     telemetry::tracing::{debug, trace},
@@ -97,8 +97,10 @@ where
         if let Some(min_ver) = tls_config.protocol_versions.iter().flatten().min() {
             acceptor_builder
                 .set_min_proto_version(Some((*min_ver).rama_try_into().map_err(|v| {
-                    BoxError::from("build boring ssl acceptor: cast min proto version")
-                        .context_field("protocol_version", v)
+                    OpaqueError::from_static_str(
+                        "build boring ssl acceptor: cast min proto version",
+                    )
+                    .context_field("protocol_version", v)
                 })?))
                 .context("build boring ssl acceptor: set min proto version")?;
         }
@@ -106,8 +108,10 @@ where
         if let Some(max_ver) = tls_config.protocol_versions.iter().flatten().max() {
             acceptor_builder
                 .set_max_proto_version(Some((*max_ver).rama_try_into().map_err(|v| {
-                    BoxError::from("build boring ssl acceptor: cast max proto version")
-                        .context_field("protocol_version", v)
+                    OpaqueError::from_static_str(
+                        "build boring ssl acceptor: cast max proto version",
+                    )
+                    .context_field("protocol_version", v)
                 })?))
                 .context("build boring ssl acceptor: set max proto version")?;
         }
@@ -176,7 +180,7 @@ where
                         .context_debug_field("domain", server_domain)
                         .context_debug_field("code", maybe_ssl_code)
                 } else {
-                    BoxError::from("boring ssl acceptor (accept): without error info")
+                    OpaqueError::from_static_str("boring ssl acceptor (accept): without error info")
                         .context_debug_field("domain", server_domain)
                         .context_debug_field("code", maybe_ssl_code)
                 }
@@ -189,8 +193,10 @@ where
                         .protocol_version()
                         .rama_try_into()
                         .map_err(|v| {
-                            BoxError::from("boring ssl acceptor: cast min proto version")
-                                .context_field("protocol_version", v)
+                            OpaqueError::from_static_str(
+                                "boring ssl acceptor: cast min proto version",
+                            )
+                            .context_field("protocol_version", v)
                         })?;
                 let application_layer_protocol = stream
                     .ssl()
@@ -229,9 +235,10 @@ where
                 }
             }
             None => {
-                return Err(BoxError::from(
-                    "boring ssl acceptor: failed to establish session...",
-                ));
+                return Err(OpaqueError::from_static_str(
+                    "boring ssl acceptor: failed to establish session",
+                )
+                .into_box_error());
             }
         };
 

--- a/rama-tls-rustls/src/client/connector.rs
+++ b/rama-tls-rustls/src/client/connector.rs
@@ -2,6 +2,8 @@ use super::{AutoTlsStream, RustlsTlsStream, TlsConnectorData, TlsStream};
 use crate::dep::tokio_rustls::TlsConnector as RustlsConnector;
 use crate::types::TlsTunnel;
 use rama_core::conversion::{RamaInto, RamaTryFrom};
+#[cfg(feature = "http")]
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::extensions::ExtensionsRef;
 use rama_core::io::Io;
@@ -422,7 +424,7 @@ fn set_target_http_version(
         if let Some(target_version) = request_extensions.get_ref::<TargetHttpVersion>()
             && target_version.0 != neg_version
         {
-            return Err(BoxError::from(
+            return Err(OpaqueError::from_static_str(
                 "TargetHTTPVersion incompatible with tls ALPN negotiated version",
             )
             .context_debug_field("target_version", *target_version)

--- a/rama-tls-rustls/src/client/connector_data.rs
+++ b/rama-tls-rustls/src/client/connector_data.rs
@@ -282,9 +282,12 @@ pub fn client_root_certs() -> Arc<RootCertStore> {
 #[cfg(not(any(feature = "aws-lc", feature = "ring")))]
 pub fn self_signed_client_auth()
 -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), BoxError> {
-    Err(BoxError::from(
+    use rama_core::error::{ErrorExt, extra::OpaqueError};
+
+    Err(OpaqueError::from_static_str(
         "enable aws-lc or ring feature to use fn self_signed_client_auth",
-    ))
+    )
+    .into_box_error())
 }
 
 #[cfg(any(feature = "aws-lc", feature = "ring"))]

--- a/rama-tls-rustls/src/server/acceptor_data.rs
+++ b/rama-tls-rustls/src/server/acceptor_data.rs
@@ -205,9 +205,12 @@ impl TlsAcceptorDataBuilder {
 pub fn self_signed_server_auth(
     _: SelfSignedData,
 ) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), BoxError> {
-    Err(BoxError::from(
+    use rama_core::error::{ErrorExt, extra::OpaqueError};
+
+    Err(OpaqueError::from_static_str(
         "enable aws-lc or ring feature to use fn self_signed_server_auth",
-    ))
+    )
+    .into_box_error())
 }
 
 #[cfg(any(feature = "aws-lc", feature = "ring"))]

--- a/rama-tls-rustls/src/type_conversion.rs
+++ b/rama-tls-rustls/src/type_conversion.rs
@@ -1,5 +1,6 @@
 use crate::RamaTlsRustlsCrateMarker;
 use rama_core::conversion::{RamaFrom, RamaTryFrom};
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_net::{
     address::{Domain, Host},
@@ -54,8 +55,10 @@ impl<'a> RamaTryFrom<rustls::pki_types::ServerName<'a>, RamaTlsRustlsCrateMarker
                 Ok(Domain::try_from(name.as_ref().to_owned())?.into())
             }
             rustls::pki_types::ServerName::IpAddress(ip) => Ok(Self::from(IpAddr::from(ip))),
-            _ => Err(BoxError::from("unrecognised rustls (PKI) server name")
-                .with_context_debug_field("server_name", || value.to_owned())),
+            _ => Err(
+                OpaqueError::from_static_str("unrecognised rustls (PKI) server name")
+                    .with_context_debug_field("server_name", || value.to_owned()),
+            ),
         }
     }
 }
@@ -82,8 +85,10 @@ impl<'a> RamaTryFrom<&rustls::pki_types::ServerName<'a>, RamaTlsRustlsCrateMarke
                 Ok(Domain::try_from(name.as_ref().to_owned())?.into())
             }
             rustls::pki_types::ServerName::IpAddress(ip) => Ok(Self::from(IpAddr::from(*ip))),
-            _ => Err(BoxError::from("urecognised rustls (PKI) server name")
-                .with_context_debug_field("value", || value.to_owned())),
+            _ => Err(
+                OpaqueError::from_static_str("urecognised rustls (PKI) server name")
+                    .with_context_debug_field("value", || value.to_owned()),
+            ),
         }
     }
 }

--- a/rama-ua/src/layer/emulate/service.rs
+++ b/rama-ua/src/layer/emulate/service.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::{ChainableExtensions, ExtensionsRef},
     telemetry::tracing,
 };
@@ -163,9 +163,10 @@ where
             return if self.optional {
                 Ok(self.inner.serve(req).await.into_box_error()?)
             } else {
-                Err(BoxError::from(
+                Err(OpaqueError::from_static_str(
                     "requirement not fulfilled: user agent profile could not be selected",
-                ))
+                )
+                .into_box_error())
             };
         };
 

--- a/rama-ua/src/profile/runtime_hints.rs
+++ b/rama-ua/src/profile/runtime_hints.rs
@@ -1,3 +1,4 @@
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorExt as _};
 use rama_core::extensions::Extension;
 use rama_http::headers::ClientHint;
@@ -127,7 +128,7 @@ impl FromStr for RequestInitiator {
                 "form" => Ok(Self::Form),
                 "xhr" => Ok(Self::Xhr),
                 "fetch" => Ok(Self::Fetch),
-                _ => Err(BoxError::from("invalid request initiator").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid request initiator").context_str_field("str", s)),
             }
         }
     }

--- a/rama-ua/src/ua/info.rs
+++ b/rama-ua/src/ua/info.rs
@@ -1,4 +1,5 @@
 use super::parse_http_user_agent_header;
+use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::{macros::match_ignore_ascii_case_str, str::arcstr::ArcStr};
@@ -241,7 +242,7 @@ impl FromStr for UserAgentKind {
                 "chromium" => Ok(Self::Chromium),
                 "firefox" => Ok(Self::Firefox),
                 "safari" => Ok(Self::Safari),
-                _ => Err(BoxError::from("invalid user agent kind").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid user agent kind").context_str_field("str", s)),
             }
         }
     }
@@ -293,7 +294,7 @@ impl FromStr for DeviceKind {
             match (s) {
                 "desktop" => Ok(Self::Desktop),
                 "mobile" => Ok(Self::Mobile),
-                _ => Err(BoxError::from("invalid device").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid device").context_str_field("str", s)),
             }
         }
     }
@@ -371,7 +372,7 @@ impl FromStr for PlatformKind {
                 "linux" => Ok(Self::Linux),
                 "android" => Ok(Self::Android),
                 "ios" => Ok(Self::IOS),
-                _ => Err(BoxError::from("invalid platform").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid platform").context_str_field("str", s)),
             }
         }
     }
@@ -465,7 +466,7 @@ impl FromStr for HttpAgent {
                 "Firefox" => Ok(Self::Firefox),
                 "Safari" => Ok(Self::Safari),
                 "preserve" => Ok(Self::Preserve),
-                _ => Err(BoxError::from("invalid http agent").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid http agent").context_str_field("str", s)),
             }
         }
     }
@@ -536,7 +537,7 @@ impl FromStr for TlsAgent {
                 "boring" | "boringssl" => Ok(Self::Boringssl),
                 "nss" => Ok(Self::Nss),
                 "preserve" => Ok(Self::Preserve),
-                _ => Err(BoxError::from("invalid tls agent").context_str_field("str", s)),
+                _ => Err(OpaqueError::from_static_str("invalid tls agent").context_str_field("str", s)),
             }
         }
     }

--- a/rama-udp/src/socket.rs
+++ b/rama-udp/src/socket.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use rama_core::{
-    error::{BoxError, ErrorContext as _, ErrorExt as _},
+    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
     extensions::Extensions,
     futures::StreamExt,
     telemetry::tracing,
@@ -152,17 +152,17 @@ where
 
     if resolved_count > 0 {
         Err(
-            BoxError::from("failed to (udp) connect to any resolved IP address")
+            OpaqueError::from_static_str("failed to (udp) connect to any resolved IP address")
                 .context_field("host", host)
                 .context_field("port", port)
                 .context_field("resolved_addr_count", resolved_count),
         )
     } else {
-        Err(
-            BoxError::from("failed to resolve into any IP address (as part of udp connect)")
-                .context_field("host", host)
-                .context_field("port", port),
+        Err(OpaqueError::from_static_str(
+            "failed to resolve into any IP address (as part of udp connect)",
         )
+        .context_field("host", host)
+        .context_field("port", port))
     }
 }
 

--- a/rama-ws/src/handshake/server.rs
+++ b/rama-ws/src/handshake/server.rs
@@ -826,9 +826,11 @@ impl Service<upgrade::Upgraded> for WebSocketEchoService {
         #[cfg(not(feature = "compression"))]
         let maybe_ws_config = {
             if let Some(Extension::PerMessageDeflate(_)) = io.extensions().get_ref() {
-                return Err(BoxError::from(
+                use rama_core::error::{ErrorExt, extra::OpaqueError};
+
+                return Err(OpaqueError::from_static_str(
                     "per-message-deflate is used but compression feature is disabled. Enable it if you wish to use this extension.",
-                ));
+                ).into_box_error());
             }
             None
         };

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -1,11 +1,9 @@
 //! Generic WebSocket message stream.
 
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing;
-use rama_core::{
-    error::BoxError,
-    telemetry::tracing::{debug, trace},
-};
+use rama_core::telemetry::tracing::{debug, trace};
 use std::{
     fmt,
     io::{self, Read, Write},
@@ -682,7 +680,7 @@ impl WebSocketContext {
                 self.state = WebSocketState::Terminated;
                 return Err(ProtocolError::Io(io::Error::new(
                     io::ErrorKind::ConnectionAborted,
-                    BoxError::from("Connection closed normally by me-the-server"),
+                    OpaqueError::from_static_str("Connection closed normally by me-the-server"),
                 )));
             }
 
@@ -842,7 +840,7 @@ impl WebSocketContext {
             self.state = WebSocketState::Terminated;
             Err(ProtocolError::Io(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                BoxError::from("Connection closed normally by me-the-server (EOF)"),
+                OpaqueError::from_static_str("Connection closed normally by me-the-server (EOF)"),
             )))
         } else {
             Ok(should_flush)
@@ -887,7 +885,7 @@ impl WebSocketContext {
                 WebSocketState::ClosedByPeer | WebSocketState::CloseAcknowledged => {
                     Err(ProtocolError::Io(io::Error::new(
                         io::ErrorKind::ConnectionAborted,
-                        BoxError::from("Connection closed normally by peer"),
+                        OpaqueError::from_static_str("Connection closed normally by peer"),
                     )))
                 }
                 WebSocketState::Active
@@ -1231,7 +1229,7 @@ impl WebSocketState {
         match self {
             Self::Terminated => Err(ProtocolError::Io(io::Error::new(
                 io::ErrorKind::NotConnected,
-                BoxError::from("Trying to work with closed connection"),
+                OpaqueError::from_static_str("Trying to work with closed connection"),
             ))),
             Self::Active | Self::CloseAcknowledged | Self::ClosedByPeer | Self::ClosedByUs => {
                 Ok(())

--- a/rama-ws/src/runtime/stream.rs
+++ b/rama-ws/src/runtime/stream.rs
@@ -4,9 +4,8 @@ use std::{
     task::{Context, Poll, ready},
 };
 
-use rama_core::io::Io;
+use rama_core::{error::extra::OpaqueError, io::Io};
 use rama_core::{
-    error::BoxError,
     extensions::{Extensions, ExtensionsRef},
     futures::{self, SinkExt, StreamExt},
     telemetry::tracing::{debug, trace},
@@ -148,7 +147,9 @@ impl<S: Io + Unpin> AsyncWebSocket<S> {
         self.next().await.ok_or_else(|| {
             ProtocolError::Io(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                BoxError::from("Connection closed: no messages to be received any longer"),
+                OpaqueError::from_static_str(
+                    "Connection closed: no messages to be received any longer",
+                ),
             ))
         })?
     }

--- a/src/cli/forward.rs
+++ b/src/cli/forward.rs
@@ -1,5 +1,5 @@
 use crate::error::BoxError;
-use rama_core::error::ErrorExt as _;
+use rama_core::error::{ErrorExt as _, extra::OpaqueError};
 use rama_utils::macros::match_ignore_ascii_case_str;
 use std::str::FromStr;
 
@@ -55,7 +55,7 @@ impl<'a> TryFrom<&'a str> for ForwardKind {
                 "cf-connecting-ip" => Ok(Self::CFConnectingIp),
                 "true-client-ip" => Ok(Self::TrueClientIp),
                 "haproxy" => Ok(Self::HaProxy),
-                _ => Err(BoxError::from("unknown forward kind").context_str_field("str", value)),
+                _ => Err(OpaqueError::from_static_str("unknown forward kind").context_str_field("str", value)),
             }
         }
     }

--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -46,7 +46,7 @@ use crate::{
     ua::{UserAgent, layer::classifier::UserAgentClassifierLayer, profile::UserAgentDatabase},
 };
 
-use rama_core::error::ErrorExt as _;
+use rama_core::error::{ErrorExt as _, extra::OpaqueError};
 use serde::Serialize;
 use serde_json::json;
 use std::{convert::Infallible, sync::Arc, time::Duration};
@@ -292,7 +292,7 @@ where
                 Either3::B(HttpServer::new_http1(exec).service(http_service))
             }
             Some(version) => {
-                return Err(BoxError::from("unsupported http version")
+                return Err(OpaqueError::from_static_str("unsupported http version")
                     .context_debug_field("version", version));
             }
             None => Either3::C({

--- a/src/cli/service/fs.rs
+++ b/src/cli/service/fs.rs
@@ -1,6 +1,6 @@
 //! [`Service`] that serves a file or directory using [`ServeFile`] or [`ServeDir`], or a placeholder page.
 
-use rama_core::error::ErrorExt as _;
+use rama_core::error::{ErrorExt as _, extra::OpaqueError};
 
 use crate::{
     Layer, Service,
@@ -276,7 +276,7 @@ where
                 Either3::B(HttpServer::new_http1(executor).service(http_service))
             }
             Some(version) => {
-                return Err(BoxError::from("unsupported http version")
+                return Err(OpaqueError::from_static_str("unsupported http version")
                     .context_debug_field("version", version));
             }
             None => Either3::C(HttpServer::auto(executor).service(http_service)),
@@ -322,8 +322,10 @@ where
                 Either3::C(ServeDir::new(path).with_directory_serve_mode(self.dir_serve_mode))
             }
             Some(path) => {
-                return Err(BoxError::from("invalid path: no such file or directory")
-                    .with_context_debug_field("path", || path.clone()));
+                return Err(OpaqueError::from_static_str(
+                    "invalid path: no such file or directory",
+                )
+                .with_context_debug_field("path", || path.clone()));
             }
         };
 

--- a/src/cli/service/ip.rs
+++ b/src/cli/service/ip.rs
@@ -51,7 +51,7 @@ type TlsConfig = ServerConfig;
 #[cfg(all(feature = "rustls", not(feature = "boring")))]
 type TlsConfig = TlsAcceptorData;
 
-use rama_core::error::ErrorExt as _;
+use rama_core::error::{ErrorExt as _, extra::OpaqueError};
 use std::{convert::Infallible, marker::PhantomData, net::IpAddr, time::Duration};
 use tokio::io::AsyncWriteExt;
 
@@ -332,8 +332,10 @@ impl<M> IpServiceBuilder<M> {
             None => None,
             Some(ForwardKind::HaProxy) => Some(HaProxyLayer::default()),
             Some(other) => {
-                return Err(BoxError::from("invalid forward kind for Transport mode")
-                    .with_context_debug_field("kind", || other.clone()));
+                return Err(OpaqueError::from_static_str(
+                    "invalid forward kind for Transport mode",
+                )
+                .with_context_debug_field("kind", || other.clone()));
             }
         };
 

--- a/src/http/client/proxy_connector.rs
+++ b/src/http/client/proxy_connector.rs
@@ -16,7 +16,7 @@ use crate::{
     telemetry::tracing,
 };
 use pin_project_lite::pin_project;
-use rama_core::error::{ErrorContext as _, ErrorExt as _};
+use rama_core::error::{ErrorContext as _, ErrorExt as _, extra::OpaqueError};
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -127,8 +127,10 @@ where
                     let conn = MaybeProxiedConnection::http(conn);
                     Ok(EstablishedClientConnection { input, conn })
                 } else {
-                    Err(BoxError::from("received unsupport proxy protocol")
-                        .with_context_debug_field("protocol", || protocol.clone()))
+                    Err(
+                        OpaqueError::from_static_str("received unsupport proxy protocol")
+                            .with_context_debug_field("protocol", || protocol.clone()),
+                    )
                 }
             }
         }

--- a/src/http/tls.rs
+++ b/src/http/tls.rs
@@ -204,8 +204,10 @@ impl CertIssuerHttpClient {
 
         let status = response.status();
         if status != StatusCode::OK {
-            return Err(BoxError::from("unexpected dinocert order response")
-                .context_field("status", status));
+            return Err(
+                OpaqueError::from_static_str("unexpected dinocert order response")
+                    .context_field("status", status),
+            );
         }
 
         let CertOrderOutput {
@@ -249,8 +251,10 @@ impl DynamicCertIssuer for CertIssuerHttpClient {
                 if let Some(ref allow_list) = self.allow_list {
                     match allow_list.match_parent(domain) {
                         None => {
-                            return Err(BoxError::from("sni found: unexpected unknown domain")
-                                .with_context_field("domain", || domain.clone()));
+                            return Err(OpaqueError::from_static_str(
+                                "sni found: unexpected unknown domain",
+                            )
+                            .with_context_field("domain", || domain.clone()));
                         }
                         Some(DomainParentMatch {
                             value: &DomainAllowMode::Exact,
@@ -260,8 +264,10 @@ impl DynamicCertIssuer for CertIssuerHttpClient {
                             if is_exact {
                                 domain.clone()
                             } else {
-                                return Err(BoxError::from("sni found: unexpected child domain")
-                                    .with_context_field("domain", || domain.clone()));
+                                return Err(OpaqueError::from_static_str(
+                                    "sni found: unexpected child domain",
+                                )
+                                .with_context_field("domain", || domain.clone()));
                             }
                         }
                         Some(DomainParentMatch {
@@ -274,7 +280,7 @@ impl DynamicCertIssuer for CertIssuerHttpClient {
                 }
             }
             None => {
-                return Err(BoxError::from("no SNI found"));
+                return Err(OpaqueError::from_static_str("no SNI found").into_box_error());
             }
         };
 


### PR DESCRIPTION
BoxError::from("msg") makes a String internally... new OpaqueError::from_static_str utility allows you to get around that...

ofc where possible do feel free to use a typed error instead