### PR TITLE
Custom Debug impl for Extensions

### DIFF
--- a/rama-core/src/extensions.rs
+++ b/rama-core/src/extensions.rs
@@ -32,6 +32,7 @@
 //! ```
 
 use std::any::{Any, TypeId};
+use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -39,7 +40,7 @@ use rama_utils::collections::AppendOnlyVec;
 
 pub use rama_macros::Extension;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
 /// A type map of protocol extensions.
 ///
 /// [`Extension`]s are internally stored in a type erased [`Arc`]. Since values are
@@ -228,6 +229,16 @@ impl Extensions {
     /// convert it back to type `T` if it matches the erasaed type stored internally.
     pub fn iter_all(&self) -> impl Iterator<Item = &TypeErasedExtension> {
         self.extensions.iter()
+    }
+}
+
+impl fmt::Debug for Extensions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_list();
+        for ext in self.extensions.iter() {
+            d.entry(&ext.value);
+        }
+        d.finish()
     }
 }
 


### PR DESCRIPTION
Hi
While exploring your interesting project, I noticed that recently, after it's storage was changed to AppendOnlyVec, `Extensions`' automatic `Debug` impl became rather uninformative:
`Extensions { extensions: AppendOnlyVec { count: 5, reserved: 5, data: [0x10263ac80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0] }`
So this PR adds an impl which formats it as an array:
`[Extension1, Extension2, Extension3]`
