### PR TITLE
ffi/apple/ne: ownership cleanup, FFI serialization, fail-closed port, propagate flow metadata

### DIFF
--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -282,6 +282,10 @@ typedef struct {
     uint8_t attribution;
     /// Bitmask: bit0=Cellular bit1=Loopback bit2=Other bit3=Wifi bit4=Wired.
     uint8_t prohibited_interface_types_mask;
+    /// When true, Swift stamps the intercepted flow's NEFlowMetaData onto the
+    /// egress NWParameters via NEAppProxyFlow.setMetadata(_:) before
+    /// constructing the NWConnection. Defaults to true on the Rust side.
+    bool preserve_original_meta_data;
 } RamaNwEgressParameters;
 
 /// Options for the egress NWConnection on TCP flows.

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -541,7 +541,8 @@ final class RamaTcpSessionHandle {
                 has_multipath_service_type: false, multipath_service_type: 0,
                 has_required_interface_type: false, required_interface_type: 0,
                 has_attribution: false, attribution: 0,
-                prohibited_interface_types_mask: 0
+                prohibited_interface_types_mask: 0,
+                preserve_original_meta_data: true
             ),
             has_connect_timeout_ms: false,
             connect_timeout_ms: 0
@@ -671,7 +672,8 @@ final class RamaUdpSessionHandle {
                 has_multipath_service_type: false, multipath_service_type: 0,
                 has_required_interface_type: false, required_interface_type: 0,
                 has_attribution: false, attribution: 0,
-                prohibited_interface_types_mask: 0
+                prohibited_interface_types_mask: 0,
+                preserve_original_meta_data: true
             )
         )
         let hasCustom = rama_transparent_proxy_udp_session_get_egress_connect_options(s, &opts)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -501,11 +501,8 @@ final class RamaTcpSessionHandle {
         guard !data.isEmpty else { return }
 
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
 
         data.withUnsafeBytes { raw in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
@@ -517,11 +514,8 @@ final class RamaTcpSessionHandle {
 
     func onClientEof() {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         rama_transparent_proxy_tcp_session_on_client_eof(s)
     }
 
@@ -531,11 +525,8 @@ final class RamaTcpSessionHandle {
     /// `nil` when Swift should use `NWParameters` defaults.
     func getEgressConnectOptions() -> RamaTcpEgressConnectOptions? {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return nil
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return nil }
 
         var opts = RamaTcpEgressConnectOptions(
             parameters: RamaNwEgressParameters(
@@ -564,17 +555,14 @@ final class RamaTcpSessionHandle {
         onCloseEgress: @escaping () -> Void
     ) {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         let box = Unmanaged.passRetained(
             TcpEgressCallbackBox(
                 onWriteToEgress: onWriteToEgress,
                 onCloseEgress: onCloseEgress
             ))
         egressCallbackBox = box
-        lock.unlock()
 
         let callbacks = RamaTransparentProxyTcpEgressCallbacks(
             context: box.toOpaque(),
@@ -589,11 +577,8 @@ final class RamaTcpSessionHandle {
         guard !data.isEmpty else { return }
 
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
 
         data.withUnsafeBytes { raw in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
@@ -606,22 +591,16 @@ final class RamaTcpSessionHandle {
     /// Signal that the egress `NWConnection` has closed or failed.
     func onEgressEof() {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         rama_transparent_proxy_tcp_session_on_egress_eof(s)
     }
 
     func cancel() {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         cancelled = true
-        lock.unlock()
         rama_transparent_proxy_tcp_session_cancel(s)
     }
 }
@@ -659,11 +638,8 @@ final class RamaUdpSessionHandle {
         guard !data.isEmpty else { return }
 
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
 
         data.withUnsafeBytes { raw in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
@@ -679,11 +655,8 @@ final class RamaUdpSessionHandle {
     /// `nil` when Swift should use `NWParameters` defaults.
     func getEgressConnectOptions() -> RamaUdpEgressConnectOptions? {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return nil
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return nil }
 
         var opts = RamaUdpEgressConnectOptions(
             parameters: RamaNwEgressParameters(
@@ -704,13 +677,10 @@ final class RamaUdpSessionHandle {
     ///   to deliver via the egress NWConnection.
     func activate(onSendToEgress: @escaping (Data) -> Void) {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         let box = Unmanaged.passRetained(UdpEgressCallbackBox(onSendToEgress: onSendToEgress))
         egressCallbackBox = box
-        lock.unlock()
 
         let callbacks = RamaTransparentProxyUdpEgressCallbacks(
             context: box.toOpaque(),
@@ -724,11 +694,8 @@ final class RamaUdpSessionHandle {
         guard !data.isEmpty else { return }
 
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
-        lock.unlock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
 
         data.withUnsafeBytes { raw in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
@@ -740,12 +707,9 @@ final class RamaUdpSessionHandle {
 
     func onClientClose() {
         lock.lock()
-        guard !cancelled, let s = sessionPtr else {
-            lock.unlock()
-            return
-        }
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
         cancelled = true
-        lock.unlock()
         rama_transparent_proxy_udp_session_on_client_close(s)
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -361,6 +361,13 @@ final class RamaTransparentProxyEngineHandle {
         enginePtr = nil
     }
 
+    /// Forward a provider message into Rust and return the reply (or `nil` for
+    /// "no reply").
+    ///
+    /// The Rust shim already maps `None` and `Some(empty)` to the same empty
+    /// payload, so an empty `Data` reaching this point is indistinguishable
+    /// from "no reply" — we surface both as `nil`. Rust handlers that want a
+    /// distinguishable ack must return a non-empty payload.
     func handleAppMessage(_ message: Data) -> Data? {
         guard let p = enginePtr else { return nil }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/NwConnectionFactory.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/NwConnectionFactory.swift
@@ -13,12 +13,12 @@ import Network
 
 /// Create an `NWConnection` to the given host/port using the supplied parameters.
 ///
-/// The port falls back to `80` if `rawValue` produces `nil` (port 0 is invalid for
-/// `NWEndpoint.Port`).
-func makeNwConnection(host: String, port: UInt16, using params: NWParameters) -> NWConnection {
-    NWConnection(
-        host: NWEndpoint.Host(host),
-        port: NWEndpoint.Port(rawValue: port) ?? 80,
-        using: params
-    )
+/// Returns `nil` when the port is invalid (`NWEndpoint.Port(rawValue:)` rejects 0).
+/// Callers must surface that as a connect failure rather than silently substituting
+/// a default port — connecting to the wrong destination is worse than not connecting.
+func makeNwConnection(host: String, port: UInt16, using params: NWParameters) -> NWConnection? {
+    guard let port = NWEndpoint.Port(rawValue: port) else {
+        return nil
+    }
+    return NWConnection(host: NWEndpoint.Host(host), port: port, using: params)
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -165,18 +165,20 @@ private final class TcpClientReadPump {
     private let session: RamaTcpSessionHandle
     private let logger: (FlowLogMessage) -> Void
     private let onTerminal: (Error?) -> Void
-    private let queue = DispatchQueue(label: "rama.tproxy.tcp.read", qos: .utility)
+    private let queue: DispatchQueue
     private var readPending = false
     private var closed = false
 
     init(
         flow: NEAppProxyTCPFlow,
         session: RamaTcpSessionHandle,
+        queue: DispatchQueue,
         logger: @escaping (FlowLogMessage) -> Void,
         onTerminal: @escaping (Error?) -> Void
     ) {
         self.flow = flow
         self.session = session
+        self.queue = queue
         self.logger = logger
         self.onTerminal = onTerminal
     }
@@ -305,7 +307,7 @@ private final class TcpClientWritePump {
     private let flow: NEAppProxyTCPFlow
     private let logger: (FlowLogMessage) -> Void
     private let onTerminalError: (Error) -> Void
-    private let queue = DispatchQueue(label: "rama.tproxy.tcp.write", qos: .utility)
+    private let queue: DispatchQueue
     private var pending: [Data] = []
     private var writing = false
     private var closeRequested = false
@@ -315,10 +317,12 @@ private final class TcpClientWritePump {
 
     init(
         flow: NEAppProxyTCPFlow,
+        queue: DispatchQueue,
         logger: @escaping (FlowLogMessage) -> Void,
         onTerminalError: @escaping (Error) -> Void
     ) {
         self.flow = flow
+        self.queue = queue
         self.logger = logger
         self.onTerminalError = onTerminalError
     }
@@ -411,7 +415,7 @@ private final class UdpClientWritePump {
     private let flow: NEAppProxyUDPFlow
     private let logger: (FlowLogMessage) -> Void
     private let onTerminalError: (Error) -> Void
-    private let queue = DispatchQueue(label: "rama.tproxy.udp.write", qos: .utility)
+    private let queue: DispatchQueue
     private var pending: [Data] = []
     private var writing = false
     private var closed = false
@@ -422,10 +426,12 @@ private final class UdpClientWritePump {
 
     init(
         flow: NEAppProxyUDPFlow,
+        queue: DispatchQueue,
         logger: @escaping (FlowLogMessage) -> Void,
         onTerminalError: @escaping (Error) -> Void
     ) {
         self.flow = flow
+        self.queue = queue
         self.logger = logger
         self.onTerminalError = onTerminalError
     }
@@ -740,11 +746,48 @@ private final class NwUdpConnectionReadPump {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Per-flow late-binding container for the Rust session handle.
+///
+/// `engine.newTcpSession(...)` and `engine.newUdpSession(...)` accept callbacks
+/// that may need to refer back to the session, but the session is only
+/// returned *after* those calls. The context lets early closures capture a
+/// stable reference and read the session once it's set.
+///
+/// `weak` keeps the session map (`tcpSessions`/`udpSessions`) as the single
+/// strong owner: once that map drops the session, late callbacks see `nil`
+/// and become no-ops, avoiding a retain cycle through closures.
+///
+/// Swift weak references are thread-safe for both load and store on modern
+/// runtimes, so no extra locking is required here.
+private final class TcpFlowContext {
+    weak var session: RamaTcpSessionHandle?
+}
+
+private final class UdpFlowContext {
+    weak var session: RamaUdpSessionHandle?
+}
+
 public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
     private var engine: RamaTransparentProxyEngineHandle?
     private let stateQueue = DispatchQueue(label: "rama.tproxy.state")
     private var tcpSessions: [ObjectIdentifier: RamaTcpSessionHandle] = [:]
     private var udpSessions: [ObjectIdentifier: RamaUdpSessionHandle] = [:]
+
+    private func registerTcpFlow(_ flowId: ObjectIdentifier, session: RamaTcpSessionHandle) {
+        stateQueue.async { self.tcpSessions[flowId] = session }
+    }
+
+    private func registerUdpFlow(_ flowId: ObjectIdentifier, session: RamaUdpSessionHandle) {
+        stateQueue.async { self.udpSessions[flowId] = session }
+    }
+
+    private func removeTcpFlow(_ flowId: ObjectIdentifier) {
+        stateQueue.async { self.tcpSessions.removeValue(forKey: flowId) }
+    }
+
+    private func removeUdpFlow(_ flowId: ObjectIdentifier) {
+        stateQueue.async { self.udpSessions.removeValue(forKey: flowId) }
+    }
 
     public override func startProxy(
         options: [String: Any]?, completionHandler: @escaping (Error?) -> Void
@@ -892,21 +935,20 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         -> Bool
     {
         let flowId = ObjectIdentifier(flow)
-        let egressQueue = DispatchQueue(label: "rama.tproxy.tcp.egress", qos: .utility)
+        let flowQueue = DispatchQueue(label: "rama.tproxy.tcp.flow", qos: .utility)
+        let ctx = TcpFlowContext()
 
         let writer = TcpClientWritePump(
             flow: flow,
+            queue: flowQueue,
             logger: { [weak self] message in
                 self?.logFlowMessage(message)
             },
             onTerminalError: { [weak self] error in
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)
-                self?.stateQueue.async {
-                    if let session = self?.tcpSessions.removeValue(forKey: flowId) {
-                        session.cancel()
-                    }
-                }
+                ctx.session?.cancel()
+                self?.removeTcpFlow(flowId)
             }
         )
 
@@ -917,7 +959,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     writer.enqueue(data)
                 },
                 onServerClosed: { [weak self] in
-                    writer.closeWhenDrained { [weak self] wasOpened in
+                    writer.closeWhenDrained { wasOpened in
                         if wasOpened {
                             flow.closeReadWithError(nil)
                             flow.closeWriteWithError(nil)
@@ -926,9 +968,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                             flow.closeReadWithError(error)
                             flow.closeWriteWithError(error)
                         }
-                        self?.stateQueue.async {
-                            self?.tcpSessions.removeValue(forKey: flowId)
-                        }
+                        self?.removeTcpFlow(flowId)
                     }
                 }
             ) ?? .passthrough
@@ -946,10 +986,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             return true
         }
 
+        // Publish the session before any callback that may observe it can fire.
+        // The session map is the single strong owner; ctx holds a weak ref.
+        registerTcpFlow(flowId, session: session)
+        ctx.session = session
+
         // ── Phase 2: pre-connect egress NWConnection before opening the flow ──
         guard let remoteHost = meta.remoteHost, meta.remotePort > 0 else {
             logDebug("handleTcpFlow: missing remote endpoint; cancelling session")
             session.cancel()
+            removeTcpFlow(flowId)
             return true
         }
 
@@ -959,10 +1005,6 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         let nwParams = makeTcpNwParameters(egressOpts)
 
         let connection = makeNwConnection(host: remoteHost, port: meta.remotePort, using: nwParams)
-
-        stateQueue.async {
-            self.tcpSessions[flowId] = session
-        }
 
         // Track whether the egress connection succeeded before flow.open was called.
         var egressReady = false
@@ -974,12 +1016,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             self?.logDebug("egress NWConnection timed out for tcp flow remote=\(remoteHost):\(meta.remotePort)")
             connection.cancel()
             session.cancel()
-            self?.stateQueue.async { self?.tcpSessions.removeValue(forKey: flowId) }
+            self?.removeTcpFlow(flowId)
         }
-        egressQueue.asyncAfter(deadline: .now() + .milliseconds(timeoutMs), execute: timeoutWork)
+        flowQueue.asyncAfter(deadline: .now() + .milliseconds(timeoutMs), execute: timeoutWork)
 
         connection.stateUpdateHandler = { [weak self] (state: NWConnection.State) in
-            egressQueue.async {
+            flowQueue.async {
                 switch state {
                 case .ready:
                     guard !egressReady else { return }
@@ -987,9 +1029,9 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     timeoutWork.cancel()
 
                     let writePump = NwTcpConnectionWritePump(
-                        connection: connection, queue: egressQueue)
+                        connection: connection, queue: flowQueue)
                     let readPump = NwTcpConnectionReadPump(
-                        connection: connection, session: session, queue: egressQueue)
+                        connection: connection, session: session, queue: flowQueue)
 
                     session.activate(
                         onWriteToEgress: { data in writePump.enqueue(data) },
@@ -997,14 +1039,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     )
 
                     flow.open(withLocalEndpoint: nil) { [weak self] error in
-                        egressQueue.async {
+                        flowQueue.async {
                             if let error {
                                 self?.logDebug("flow.open error after egress ready: \(error)")
                                 connection.cancel()
                                 session.cancel()
-                                self?.stateQueue.async {
-                                    self?.tcpSessions.removeValue(forKey: flowId)
-                                }
+                                self?.removeTcpFlow(flowId)
                                 return
                             }
                             self?.logTrace("flow.open ok (tcp, egress pre-connected)")
@@ -1014,16 +1054,15 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                             let flowReadPump = TcpClientReadPump(
                                 flow: flow,
                                 session: session,
+                                queue: flowQueue,
                                 logger: { [weak self] message in self?.logFlowMessage(message) },
                                 onTerminal: { [weak self] readError in
                                     flow.closeReadWithError(readError)
                                     flow.closeWriteWithError(readError)
                                     connection.cancel()
                                     readPump.cancel()
-                                    self?.stateQueue.async {
-                                        self?.tcpSessions.removeValue(forKey: flowId)
-                                    }
                                     session.cancel()
+                                    self?.removeTcpFlow(flowId)
                                 }
                             )
                             flowReadPump.requestRead()
@@ -1037,7 +1076,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                         "egress NWConnection failed before flow opened: \(String(describing: error))"
                     )
                     session.cancel()
-                    self?.stateQueue.async { self?.tcpSessions.removeValue(forKey: flowId) }
+                    self?.removeTcpFlow(flowId)
 
                 case .cancelled:
                     break  // our own cancel() call; nothing extra needed
@@ -1048,14 +1087,14 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             }
         }
 
-        connection.start(queue: egressQueue)
+        connection.start(queue: flowQueue)
         return true
     }
 
     private func handleUdpFlow(_ flow: NEAppProxyUDPFlow) -> Bool {
         let flowId = ObjectIdentifier(flow)
-        let egressQueue = DispatchQueue(label: "rama.tproxy.udp.egress", qos: .utility)
         let flowQueue = DispatchQueue(label: "rama.tproxy.udp.flow", qos: .utility)
+        let ctx = UdpFlowContext()
         var readPending = false
         var demandPending = false
         var closed = false
@@ -1068,16 +1107,14 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                 writer?.close()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)
-                self?.stateQueue.async {
-                    if let session = self?.udpSessions.removeValue(forKey: flowId) {
-                        session.onClientClose()
-                    }
-                }
+                ctx.session?.onClientClose()
+                self?.removeUdpFlow(flowId)
             }
         }
 
         writer = UdpClientWritePump(
             flow: flow,
+            queue: flowQueue,
             logger: { [weak self] message in
                 self?.logFlowMessage(message)
             },
@@ -1121,7 +1158,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                         let endpoint = endpoints?.first
                         writer.setSentByEndpoint(endpoint)
 
-                        guard let session = self?.udpSessions[flowId] else {
+                        guard let session = ctx.session else {
                             self?.logDebug(
                                 "udp flow read received but session no longer active; closing flow"
                             )
@@ -1161,10 +1198,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             return true
         }
 
+        // Publish the session before any callback that may observe it can fire.
+        // The session map is the single strong owner; ctx holds a weak ref.
+        registerUdpFlow(flowId, session: session)
+        ctx.session = session
+
         // ── Phase 2: pre-connect egress NWConnection before opening the flow ──
         guard let remoteHost = bootMeta.remoteHost, bootMeta.remotePort > 0 else {
             logDebug("handleUdpFlow: missing remote endpoint; cancelling session")
             session.onClientClose()
+            removeUdpFlow(flowId)
             return true
         }
 
@@ -1172,10 +1215,6 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         let nwParams = makeUdpNwParameters(egressOpts)
 
         let connection = makeNwConnection(host: remoteHost, port: bootMeta.remotePort, using: nwParams)
-
-        stateQueue.async {
-            self.udpSessions[flowId] = session
-        }
 
         var egressReady = false
 
@@ -1187,12 +1226,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             )
             connection.cancel()
             session.onClientClose()
-            self?.stateQueue.async { self?.udpSessions.removeValue(forKey: flowId) }
+            self?.removeUdpFlow(flowId)
         }
-        egressQueue.asyncAfter(deadline: .now() + 30, execute: timeoutWork)
+        flowQueue.asyncAfter(deadline: .now() + 30, execute: timeoutWork)
 
         connection.stateUpdateHandler = { [weak self] (state: NWConnection.State) in
-            egressQueue.async {
+            flowQueue.async {
                 switch state {
                 case .ready:
                     guard !egressReady else { return }
@@ -1200,7 +1239,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     timeoutWork.cancel()
 
                     let readPump = NwUdpConnectionReadPump(
-                        connection: connection, session: session, queue: egressQueue)
+                        connection: connection, session: session, queue: flowQueue)
 
                     session.activate(onSendToEgress: { data in
                         connection.send(
@@ -1209,15 +1248,13 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     })
 
                     flow.open(withLocalEndpoint: nil) { [weak self] error in
-                        egressQueue.async {
+                        flowQueue.async {
                             if let error {
                                 self?.logDebug("udp flow.open error after egress ready: \(error)")
                                 connection.cancel()
                                 readPump.cancel()
                                 session.onClientClose()
-                                self?.stateQueue.async {
-                                    self?.udpSessions.removeValue(forKey: flowId)
-                                }
+                                self?.removeUdpFlow(flowId)
                                 return
                             }
                             self?.logTrace("flow.open ok (udp, egress pre-connected)")
@@ -1234,7 +1271,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                         "egress NWConnection failed before udp flow opened: \(String(describing: error))"
                     )
                     session.onClientClose()
-                    self?.stateQueue.async { self?.udpSessions.removeValue(forKey: flowId) }
+                    self?.removeUdpFlow(flowId)
 
                 case .cancelled:
                     break
@@ -1245,7 +1282,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             }
         }
 
-        connection.start(queue: egressQueue)
+        connection.start(queue: flowQueue)
         return true
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -539,6 +539,23 @@ private func makeUdpNwParameters(_ opts: RamaUdpEgressConnectOptions?) -> NWPara
     return params
 }
 
+/// Stamp the intercepted flow's `NEFlowMetaData` onto the given egress
+/// `NWParameters` via `NEAppProxyFlow.setMetadata(_:)`.
+///
+/// On macOS 15.0+ we call the typed Swift overlay (`setMetadata(on:)`).
+/// On macOS 12.0–14.x we fall back to the Obj-C selector via
+/// `perform(_:with:)`: the underlying selector `setMetadata:` is available
+/// since macOS 10.15.4, but as of the macOS 26 SDK the Swift overlay only
+/// exposes it under the renamed name gated on macOS 15.0+, even though the
+/// runtime method exists earlier.
+private func applyFlowMetadata(_ flow: NEAppProxyFlow, _ params: NWParameters) {
+    if #available(macOS 15.0, *) {
+        flow.setMetadata(on: params)
+    } else {
+        _ = flow.perform(NSSelectorFromString("setMetadata:"), with: params)
+    }
+}
+
 private func applyNwEgressParameters(_ p: RamaNwEgressParameters, to params: NWParameters) {
     if p.has_service_class, let sc = nwServiceClass(p.service_class) {
         params.serviceClass = sc
@@ -1004,6 +1021,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             ? egressOpts!.connect_timeout_ms : 30_000
         let nwParams = makeTcpNwParameters(egressOpts)
 
+        // Stamp the intercepted flow's NEFlowMetaData (source app identifier,
+        // audit token, …) onto the egress NWParameters when the handler asks
+        // for it (default true). Downstream NEAppProxyProviders that
+        // intercept our egress see the original app rather than this
+        // extension. Must run before the NWConnection is constructed from
+        // these params.
+        if egressOpts?.parameters.preserve_original_meta_data ?? true {
+            applyFlowMetadata(flow, nwParams)
+        }
+
         guard let connection = makeNwConnection(
             host: remoteHost, port: meta.remotePort, using: nwParams)
         else {
@@ -1222,6 +1249,11 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
 
         let egressOpts = session.getEgressConnectOptions()
         let nwParams = makeUdpNwParameters(egressOpts)
+
+        // See TCP path for rationale; same metadata-propagation behavior.
+        if egressOpts?.parameters.preserve_original_meta_data ?? true {
+            applyFlowMetadata(flow, nwParams)
+        }
 
         guard let connection = makeNwConnection(
             host: remoteHost, port: bootMeta.remotePort, using: nwParams)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -1004,7 +1004,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             ? egressOpts!.connect_timeout_ms : 30_000
         let nwParams = makeTcpNwParameters(egressOpts)
 
-        let connection = makeNwConnection(host: remoteHost, port: meta.remotePort, using: nwParams)
+        guard let connection = makeNwConnection(
+            host: remoteHost, port: meta.remotePort, using: nwParams)
+        else {
+            logDebug(
+                "handleTcpFlow: invalid remote port \(meta.remotePort); cancelling session"
+            )
+            session.cancel()
+            removeTcpFlow(flowId)
+            return true
+        }
 
         // Track whether the egress connection succeeded before flow.open was called.
         var egressReady = false
@@ -1214,7 +1223,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         let egressOpts = session.getEgressConnectOptions()
         let nwParams = makeUdpNwParameters(egressOpts)
 
-        let connection = makeNwConnection(host: remoteHost, port: bootMeta.remotePort, using: nwParams)
+        guard let connection = makeNwConnection(
+            host: remoteHost, port: bootMeta.remotePort, using: nwParams)
+        else {
+            logDebug(
+                "handleUdpFlow: invalid remote port \(bootMeta.remotePort); cancelling session"
+            )
+            session.onClientClose()
+            removeUdpFlow(flowId)
+            return true
+        }
 
         var egressReady = false
 

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -312,6 +312,10 @@ pub struct NwEgressParameters {
     /// Bitmask of prohibited interface types (bit0=Cellular bit1=Loopback
     /// bit2=Other bit3=Wifi bit4=Wired).
     pub prohibited_interface_types_mask: u8,
+    /// When `true`, Swift calls `NEAppProxyFlow.setMetadata(_:)` to stamp the
+    /// intercepted flow's `NEFlowMetaData` onto the egress `NWParameters`.
+    /// See `tproxy::types::NwEgressParameters::preserve_original_meta_data`.
+    pub preserve_original_meta_data: bool,
 }
 
 impl NwEgressParameters {
@@ -329,6 +333,7 @@ impl NwEgressParameters {
             has_attribution: p.attribution.is_some(),
             attribution: p.attribution.map(attribution_to_u8).unwrap_or(0),
             prohibited_interface_types_mask: interface_types_to_mask(&p.prohibited_interface_types),
+            preserve_original_meta_data: p.preserve_original_meta_data,
         }
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/handler.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/handler.rs
@@ -53,6 +53,12 @@ pub enum FlowAction<S> {
 pub trait TransparentProxyHandler: Clone + Send + Sync + 'static {
     fn transparent_proxy_config(&self) -> TransparentProxyConfig;
 
+    /// Handle a provider message from the container app.
+    ///
+    /// The FFI bridge collapses `None` and `Some(Bytes::new())` to the same
+    /// "no reply" outcome on the Swift side (see the `BytesOwned` shim in
+    /// `rama_transparent_proxy_engine_handle_app_message`). To send a
+    /// distinguishable acknowledgement, return a non-empty payload.
     fn handle_app_message(
         &self,
         _exec: Executor,

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -68,7 +68,7 @@ pub enum NwAttribution {
 ///
 /// All fields map directly to top-level `NWParameters` properties (not protocol-specific options).
 /// Only parameters meaningful for a `NETransparentProxyProvider` egress connection are included.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct NwEgressParameters {
     /// Maps to `NWParameters.serviceClass`.
     pub service_class: Option<NwServiceClass>,
@@ -81,6 +81,34 @@ pub struct NwEgressParameters {
     /// Maps to `NWParameters.attribution` — attribute outbound traffic to the
     /// originating app rather than the extension process.
     pub attribution: Option<NwAttribution>,
+    /// When `true`, Swift calls `NEAppProxyFlow.setMetadata(_:)` on the egress
+    /// `NWParameters` before constructing the `NWConnection`, propagating the
+    /// intercepted flow's `NEFlowMetaData` (source app identifier / audit
+    /// token) onto the egress connection.
+    ///
+    /// This is good-citizen behavior for stacked-proxy deployments: a
+    /// downstream `NEAppProxyProvider` that intercepts our egress sees the
+    /// **original** app rather than this extension's process.
+    ///
+    /// Defaults to `true`. Note that this propagates *identity*, it does not
+    /// mark the flow as already-proxied — it cannot prevent infinite loops
+    /// between two providers that both claim the same destinations. Disable
+    /// it if you need downstream observers to see this extension as the
+    /// source.
+    pub preserve_original_meta_data: bool,
+}
+
+impl Default for NwEgressParameters {
+    fn default() -> Self {
+        Self {
+            service_class: None,
+            multipath_service_type: None,
+            prohibited_interface_types: Vec::new(),
+            required_interface_type: None,
+            attribution: None,
+            preserve_original_meta_data: true,
+        }
+    }
 }
 
 /// Options for the egress `NWConnection` on TCP flows.


### PR DESCRIPTION
- Replace late `tcpSessions`/`udpSessions` lookups in flow callbacks with a
  per-flow weak-ref `FlowContext`. Map stays as the single strong owner.
  Also fixes an unsynchronized read of `udpSessions` from the UDP read pump.
- Collapse 3 (TCP) / 2 (UDP) per-flow dispatch queues into one per flow.
- Hold the session NSLock across the FFI call in `Rama{Tcp,Udp}SessionHandle`
  to close a cancel/FFI TOCTOU and respect Rust's `&mut self` exclusivity.
- `makeNwConnection` returns `NWConnection?` and fails on invalid port
  instead of substituting 80; callers cancel the session.
- Document that `None` and `Some(empty)` collapse to "no reply" across the
  app-message FFI boundary.
- Plumb `preserve_original_meta_data: bool` through `NwEgressParameters`
  (default true). When set, Swift calls `NEAppProxyFlow.setMetadata(_:)` on
  the egress `NWParameters` so downstream `NEAppProxyProvider`s see the
  original source app rather than this extension. Typed overlay on
  macOS 15+, Obj-C selector fallback on 12–14.