### PR TITLE
Connection extensions

### DIFF
--- a/examples/http_connect_proxy.rs
+++ b/examples/http_connect_proxy.rs
@@ -58,7 +58,7 @@
 
 use rama::{
     Layer, Service,
-    extensions::{Extension, Extensions, ExtensionsRef, InputExtensions},
+    extensions::{Extension, Extensions, ExtensionsRef},
     http::{
         Body, Request, Response, StatusCode,
         client::EasyHttpWebClient,
@@ -75,7 +75,7 @@ use rama::{
     layer::{ConsumeErrLayer, HijackLayer},
     net::{
         proxy::IoForwardService,
-        stream::{ClientSocketInfo, layer::http::BodyLimitLayer},
+        stream::{SocketInfo, layer::http::BodyLimitLayer},
         user::credentials::basic,
     },
     rt::Executor,
@@ -180,10 +180,12 @@ async fn http_plain_proxy(req: Request) -> Result<Response, Infallible> {
     let client = EasyHttpWebClient::default();
     match client.serve(req).await {
         Ok(resp) => {
+            // We can also just directly fetch SocketInfo and it will traverse into egress/ingress chains,
+            // however to be clear and to avoid confusion in a MITM setup we access the egress one directly.
             if let Some(client_socket_info) = resp
                 .extensions()
-                .get_ref()
-                .and_then(|InputExtensions(ext)| ext.get_ref::<ClientSocketInfo>())
+                .egress()
+                .and_then(|e| e.get_ref::<SocketInfo>())
             {
                 tracing::info!(
                     http.response.status_code = %resp.status(),

--- a/examples/http_https_socks5_and_socks5h_connect_proxy.rs
+++ b/examples/http_https_socks5_and_socks5h_connect_proxy.rs
@@ -25,7 +25,7 @@
 
 use rama::{
     Layer, Service,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Body, Request, Response, StatusCode,
         client::EasyHttpWebClient,
@@ -41,7 +41,7 @@ use rama::{
     layer::ConsumeErrLayer,
     net::{
         proxy::IoForwardService,
-        stream::ClientSocketInfo,
+        stream::SocketInfo,
         tls::server::{SelfSignedData, TlsPeekRouter},
         user::credentials::basic,
     },
@@ -161,10 +161,12 @@ async fn http_plain_proxy(req: Request) -> Result<Response, Infallible> {
     let client = EasyHttpWebClient::default();
     match client.serve(req).await {
         Ok(resp) => {
+            // We can also just directly fetch SocketInfo and it will traverse into egress/ingress chains,
+            // however to be clear and to avoid confusion in a MITM setup we access the egress one directly.
             if let Some(client_socket_info) = resp
                 .extensions()
-                .get_ref()
-                .and_then(|InputExtensions(ext)| ext.get_ref::<ClientSocketInfo>())
+                .egress()
+                .and_then(|e| e.get_ref::<SocketInfo>())
             {
                 tracing::info!(
                     http.response.status_code = %resp.status(),

--- a/examples/proxy_connectivity_check.rs
+++ b/examples/proxy_connectivity_check.rs
@@ -34,7 +34,7 @@
 
 use rama::{
     Layer, Service,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Body, Request, Response, StatusCode,
         client::EasyHttpWebClient,
@@ -51,7 +51,7 @@ use rama::{
     layer::{ConsumeErrLayer, HijackLayer},
     net::{
         address::SocketAddress, http::server::HttpPeekRouter, proxy::IoForwardService,
-        stream::ClientSocketInfo, user::credentials::basic,
+        stream::SocketInfo, user::credentials::basic,
     },
     proxy::socks5::{
         Socks5Acceptor,
@@ -193,10 +193,12 @@ async fn http_plain_proxy(req: Request) -> Result<Response, Infallible> {
     let client = EasyHttpWebClient::default();
     match client.serve(req).await {
         Ok(resp) => {
+            // We can also just directly fetch SocketInfo and it will traverse into egress/ingress chains,
+            // however to be clear and to avoid confusion in a MITM setup we access the egress one directly.
             if let Some(client_socket_info) = resp
                 .extensions()
-                .get_ref()
-                .and_then(|InputExtensions(ext)| ext.get_ref::<ClientSocketInfo>())
+                .egress()
+                .and_then(|e| e.get_ref::<SocketInfo>())
             {
                 tracing::info!(
                     http.response.status_code = %resp.status(),

--- a/examples/socks5_and_http_proxy.rs
+++ b/examples/socks5_and_http_proxy.rs
@@ -23,7 +23,7 @@
 
 use rama::{
     Layer, Service,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Body, Request, Response, StatusCode,
         client::EasyHttpWebClient,
@@ -37,7 +37,7 @@ use rama::{
         server::HttpServer,
     },
     layer::ConsumeErrLayer,
-    net::{proxy::IoForwardService, stream::ClientSocketInfo, user::credentials::basic},
+    net::{proxy::IoForwardService, stream::SocketInfo, user::credentials::basic},
     proxy::socks5::{Socks5Acceptor, server::Socks5PeekRouter},
     rt::Executor,
     service::service_fn,
@@ -107,10 +107,12 @@ async fn http_plain_proxy(req: Request) -> Result<Response, Infallible> {
     let client = EasyHttpWebClient::default();
     match client.serve(req).await {
         Ok(resp) => {
+            // We can also just directly fetch SocketInfo and it will traverse into egress/ingress chains,
+            // however to be clear and to avoid confusion in a MITM setup we access the egress one directly.
             if let Some(client_socket_info) = resp
                 .extensions()
-                .get_ref()
-                .and_then(|InputExtensions(ext)| ext.get_ref::<ClientSocketInfo>())
+                .egress()
+                .and_then(|e| e.get_ref::<SocketInfo>())
             {
                 tracing::info!(
                     http.response.status_code = %resp.status(),

--- a/examples/socks5_connect_proxy_over_tls.rs
+++ b/examples/socks5_connect_proxy_over_tls.rs
@@ -22,7 +22,7 @@
 
 use rama::{
     Layer as _, Service,
-    extensions::ExtensionsRef,
+    extensions::{Egress, ExtensionsRef},
     http::{
         Body, BodyExtractExt, Request, client::HttpConnectorLayer, server::HttpServer,
         service::web::Router,
@@ -109,7 +109,8 @@ async fn main() {
         .await
         .expect("establish a proxied connection ready to make http requests");
 
-    req.extensions().extend(http_service.extensions());
+    req.extensions()
+        .insert(Egress(http_service.extensions().clone()));
 
     tracing::info!(
         url.full = %uri,

--- a/rama-core/src/extensions.rs
+++ b/rama-core/src/extensions.rs
@@ -37,35 +37,71 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use rama_utils::collections::AppendOnlyVec;
+use rama_utils::macros::impl_deref;
 
 pub use rama_macros::Extension;
 
 #[derive(Clone, Default)]
 /// A type map of protocol extensions.
 ///
-/// [`Extension`]s are internally stored in a type erased [`Arc`]. Since values are
-/// stored in an [`Arc`] there are extra methods exposed that build on top of this
-/// and leverage characteristics of an [`Arc`] to expose things like cheap cloning of the Arc.
+/// [`Extension`]s are internally stored in a type erased [`Arc`]. Since values
+/// are stored in an [`Arc`] there are extra methods exposed that build on top
+/// of this and leverage characteristics of an [`Arc`] to expose things like
+/// cheap cloning of the Arc.
+///
+/// [`Extensions`] may have an optional [`parent`][Self::parent]: the
+/// [`Extensions`] this one was forked from. Lookups walk the parent chain when
+/// the local [`Extension`]s don't have the requested type. The parent relationship is
+/// best described as "I'm layered on top of that, but I'm not exactly the same":
+/// - Retry attempts fork from the original request (dont leak failed extensions)
+/// - Responses fork the request (response != request)
+/// - H2 streams fork from underlying H2 connection (nested connection with isolated properties)
+///
+/// Connection's who logically map one-to-one we don't fork and we just pass the [`Extensions`]
+/// up, examples are:
+/// - TLS layered on top of TCP
+/// - HTTP layered on top of TLS
+/// - ...
 pub struct Extensions {
     extensions: Arc<AppendOnlyVec<TypeErasedExtension, 12, 3>>,
+    parent: Option<Box<Self>>,
 }
 
 impl Extensions {
-    /// Create an empty [`Extensions`] store.
+    /// Create an empty [`Extensions`] store with no parent.
     #[inline(always)]
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Create a fresh child [`Extensions`] whose parent is this [`Extensions`] store.
+    ///
+    /// The child has its own empty top-level storage. Lookups that miss
+    /// locally walk into the parent (and recursively up the chain). Inserts
+    /// land on this child only, parents are never mutated through the child.
+    #[must_use]
+    pub fn fork(&self) -> Self {
+        Self {
+            extensions: Arc::new(AppendOnlyVec::new()),
+            parent: Some(Box::new(self.clone())),
+        }
+    }
+
+    /// The parent [`Extensions`] this blob was forked from, if any.
+    #[inline(always)]
+    #[must_use]
+    pub fn parent(&self) -> Option<&Self> {
+        self.parent.as_deref()
+    }
+
     /// Insert a type `T` into this [`Extensions`] store.
     ///
-    /// This method returns a refence to the just insert value
+    /// This method returns a reference to the just inserted value.
     ///
     /// If the value you are inserting is an `Arc<T>`, prefer using
-    /// [`Self::insert_arc()`] to prevent the double indirection of storing
-    /// an `Arc<Arc<T>>`. This happens because internally we use a type erased
-    /// Arc to store the actual value.
+    /// [`Self::insert_arc`] to prevent the double indirection of storing
+    /// an `Arc<Arc<T>>`.
     pub fn insert<T: Extension>(&self, val: T) -> &T {
         let extension = TypeErasedExtension::new(val);
         let idx = self.extensions.push(extension);
@@ -104,8 +140,22 @@ impl Extensions {
     }
 
     /// Returns true if the [`Extensions`] store contains the given type.
+    ///
+    /// This function is recursive and will traverse multiple nested [`Extensions`]
+    /// stores to find the correct item. See [`Extensions::get_ref()`] for how this works.
+    ///
+    /// If you don't want any of this special logic and you just want to check this
+    /// [`Extensions`] store, use [`Extensions::raw_contains()`] instead.
     #[must_use]
     pub fn contains<T: Extension>(&self) -> bool {
+        self.get_ref::<T>().is_some()
+    }
+
+    /// Returns true if the [`Extensions`] store contains the given type
+    ///
+    /// This only checks this [`Extensions`] store
+    #[must_use]
+    pub fn raw_contains<T: Extension>(&self) -> bool {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -114,13 +164,60 @@ impl Extensions {
     }
 
     #[must_use]
-    /// Get a reference to the most recently insert item of type `T`, or insert in case no item was found
+    /// Get a reference to `T`. Walks the parent chain and the connection
+    /// wrappers ([`Egress`] / [`Ingress`]) if not found locally.
     ///
-    /// If an owned `Arc<T>` is needed prefer using [`Self::get_arc()`]
+    /// Search rule (single pass, newest insertion wins):
     ///
-    /// [`Self::get_ref`] will return the last added item `T`, in most cases this is exactly what you want, but
-    /// if you need the oldest item `T` use [`Self::first_ref`]
+    /// 1. Iterate local entries newest -> oldest. For each entry:
+    ///    - if its type matches `T`, return it,
+    ///    - if it is an [`Egress<Extensions>`] or [`Ingress<Extensions>`]
+    ///      wrapper, recurse into the wrapped blob with the same rule
+    ///      (its own local first, then its wrappers, then its parent)
+    ///      and return any match found,
+    ///    - otherwise skip.
+    /// 2. If still not found, recurse into the parent (same rule applied).
+    ///
+    /// Wrappers are spliced into the local scan in insertion order, so a
+    /// connection-pointer detour inserted on this blob is treated as part of
+    /// "local" for ordering purposes: a directly-inserted `T` and a wrapper
+    /// containing `T` both compete by insertion time, newest wins. Parent is
+    /// only consulted after the entire local scan (including wrapper
+    /// recursion) finishes empty. The wrappers themselves can still be
+    /// retrieved directly (or via [`Self::egress`] / [`Self::ingress`]).
+    ///
+    /// For a raw flat lookup, use [`Self::raw_get_ref`].
+    ///
+    /// Returns the most recently inserted match, for the oldest, see [`Self::raw_first_ref`].
     pub fn get_ref<T: Extension>(&self) -> Option<&T> {
+        let target = TypeId::of::<T>();
+        let egress_id = TypeId::of::<Egress<Self>>();
+        let ingress_id = TypeId::of::<Ingress<Self>>();
+        for ext in self.extensions.iter().rev() {
+            if ext.type_id == target {
+                if let Some(v) = ext.downcast_ref::<T>() {
+                    return Some(v);
+                }
+            } else if ext.type_id == egress_id
+                && let Some(eg) = ext.downcast_ref::<Egress<Self>>()
+                && let Some(v) = eg.0.get_ref::<T>()
+            {
+                return Some(v);
+            } else if ext.type_id == ingress_id
+                && let Some(ig) = ext.downcast_ref::<Ingress<Self>>()
+                && let Some(v) = ig.0.get_ref::<T>()
+            {
+                return Some(v);
+            }
+        }
+        self.parent().and_then(|p| p.get_ref::<T>())
+    }
+
+    /// Raw flat [`Self::get_ref`]: returns the most recently inserted `T`, for the oldest, see [`Self::raw_first_ref`].
+    ///
+    /// This only checks this [`Extensions`] store
+    #[must_use]
+    pub fn raw_get_ref<T: Extension>(&self) -> Option<&T> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -130,13 +227,41 @@ impl Extensions {
     }
 
     #[must_use]
-    /// Get an owned `Arc<T>` of the most recently insert item of type `T`, or insert in case no item was found
+    /// Get an owned `Arc<T>`. Walks the parent chain and the structural
+    /// connection wrappers if not found locally.
     ///
-    /// If a reference is needed prefer using [`Self::get_ref()`]
+    /// See [`Self::get_ref`] for the search order.
     ///
-    /// [`Self::get_arc`] will return the last added item `T`, in most cases this is exactly what you want, but
-    /// if you need the oldest item `T` use [`Self::first_arc`]
+    /// For a raw flat lookup (top-level only), use [`Self::raw_get_arc`].
     pub fn get_arc<T: Extension>(&self) -> Option<Arc<T>> {
+        let target = TypeId::of::<T>();
+        let egress_id = TypeId::of::<Egress<Self>>();
+        let ingress_id = TypeId::of::<Ingress<Self>>();
+        for ext in self.extensions.iter().rev() {
+            if ext.type_id == target {
+                if let Some(v) = ext.cloned_downcast::<T>() {
+                    return Some(v);
+                }
+            } else if ext.type_id == egress_id
+                && let Some(eg) = ext.downcast_ref::<Egress<Self>>()
+                && let Some(v) = eg.0.get_arc::<T>()
+            {
+                return Some(v);
+            } else if ext.type_id == ingress_id
+                && let Some(ig) = ext.downcast_ref::<Ingress<Self>>()
+                && let Some(v) = ig.0.get_arc::<T>()
+            {
+                return Some(v);
+            }
+        }
+        self.parent().and_then(|p| p.get_arc::<T>())
+    }
+
+    /// Raw flat [`Self::get_arc`]: returns the most recently inserted `T`
+    ///
+    /// This only checks this [`Extensions`] store
+    #[must_use]
+    pub fn raw_get_arc<T: Extension>(&self) -> Option<Arc<T>> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -145,9 +270,15 @@ impl Extensions {
             .and_then(|ext| ext.cloned_downcast())
     }
 
-    /// Get a reference to the most recently insert item of type `T`, or insert in case no item was found
+    /// Recursive find-or-create: return `&T` if one exists anywhere in this
+    /// this [`Extensions`] store (using [`Self::get_ref`] dispatch), otherwise
+    /// insert the value produced by `create_fn` at the top level and return
+    /// a reference to it.
     ///
-    /// If an owned `Arc<T>` is needed or inserting prefer using [`Self::get_arc_or_insert()`]
+    /// Useful when a type conceptually belongs to the scope (e.g. `ConnectionHealth`
+    /// on a connection chain) and you want to reuse an existing instance rather
+    /// than create a duplicate at every layer. For strict "ensure local exists",
+    /// use [`Self::raw_get_ref_or_insert`].
     pub fn get_ref_or_insert<T, F>(&self, create_fn: F) -> &T
     where
         T: Extension,
@@ -156,9 +287,7 @@ impl Extensions {
         self.get_ref().unwrap_or_else(|| self.insert(create_fn()))
     }
 
-    /// Get an owned `Arc<T>` of the most recently insert item of type `T`, or insert in case no item was found
-    ///
-    /// If a reference is needed or the type being inserted in not an `Arc<T>` prefer using [`Self::get_ref_or_insert()`]
+    /// Recursive find-or-create returning an [`Arc<T>`]: see [`Self::get_ref_or_insert`].
     pub fn get_arc_or_insert<T, F>(&self, create_fn: F) -> Arc<T>
     where
         T: Extension,
@@ -168,14 +297,43 @@ impl Extensions {
             .unwrap_or_else(|| self.insert_arc(create_fn()))
     }
 
-    /// Get a shared reference to the oldest inserted item of type `T`
+    /// Raw flat find-or-create: return `&T` if one exists at the top level of
+    /// this [`Extensions`] store, otherwise insert the value produced by
+    /// `create_fn` at the top level and return a reference to it.
     ///
-    /// If an owned `Arc<T>` is needed prefer using [`Self::get_arc()`]
+    /// Does not follow the parent chain. Useful when you want strict "ensure T
+    /// exists on THIS blob" (e.g. materializing a direction wrapper
+    /// like [`Ingress<Connection<Extensions>>`] at the outer blob).
+    pub fn raw_get_ref_or_insert<T, F>(&self, create_fn: F) -> &T
+    where
+        T: Extension,
+        F: FnOnce() -> T,
+    {
+        self.raw_get_ref()
+            .unwrap_or_else(|| self.insert(create_fn()))
+    }
+
+    /// Raw flat find-or-create returning an [`Arc<T>`]: see [`Self::raw_get_ref_or_insert`].
+    pub fn raw_get_arc_or_insert<T, F>(&self, create_fn: F) -> Arc<T>
+    where
+        T: Extension,
+        F: FnOnce() -> Arc<T>,
+    {
+        self.raw_get_arc()
+            .unwrap_or_else(|| self.insert_arc(create_fn()))
+    }
+
+    /// Raw flat reference to the oldest inserted `T` at the top level of this
+    /// [`Extensions`] store, does not walk structural wrappers.
     ///
-    /// [`Self::first_ref`] will return the first added item `T`, in most cases this is not what you want,
-    /// instead use [`Self::get_ref`] to get the most recently inserted item `T`
+    /// In most cases you want [`Self::get_ref`] (newest, scope-aware). Use this
+    /// only when you specifically need insertion order access inside this [`Extensions`]
+    /// store.
+    ///
+    /// Currently we dont provide a recursive variant of this method since we don't have
+    /// a use case for it, and it's not exactly clear what would be considered "first".
     #[must_use]
-    pub fn first_ref<T: Extension>(&self) -> Option<&T> {
+    pub fn raw_first_ref<T: Extension>(&self) -> Option<&T> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -183,14 +341,10 @@ impl Extensions {
             .and_then(|ext| ext.downcast_ref())
     }
 
+    /// Raw flat [`Arc<T>`] to the oldest inserted `T` at the top level, see
+    /// [`Self::raw_first_ref`] for caveats.
     #[must_use]
-    /// Get an owned `Arc<T>` of the oldest inserted item of type `T`
-    ///
-    /// If a reference is needed prefer using [`Self::first_ref()`]
-    ///
-    /// [`Self::first_arc`] will return the first added item `T`, in most cases this is not what you want,
-    /// instead use [`Self::get_arc`] to get the most recently inserted item `T`
-    pub fn first_arc<T: Extension>(&self) -> Option<Arc<T>> {
+    pub fn raw_first_arc<T: Extension>(&self) -> Option<Arc<T>> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -198,47 +352,177 @@ impl Extensions {
             .and_then(|ext| ext.cloned_downcast())
     }
 
-    /// Iterate over all the inserted items of type `T` as shared references.
+    /// Raw flat iteration over all inserted items of type `T` at the top level
+    /// of this [`Extensions`] store, newest to oldest.
     ///
-    /// Items are ordered from oldest to newest.
-    pub fn iter_ref<T: Extension>(&self) -> impl Iterator<Item = &T> {
+    /// The order matches [`Self::raw_get_ref`] (newest-first), so
+    /// `raw_iter_ref::<T>().next() == raw_get_ref::<T>()`.
+    pub fn raw_iter_ref<T: Extension>(&self) -> impl Iterator<Item = &T> {
         let type_id = TypeId::of::<T>();
 
         self.extensions
             .iter()
+            .rev()
             .filter(move |item| item.type_id == type_id)
             .filter_map(TypeErasedExtension::downcast_ref::<T>)
     }
 
-    /// Iterate over all the inserted items of type `T` as cloned [`Arc`] values.
+    /// Raw flat iteration over all inserted items of type `T` at the top level
+    /// as cloned [`Arc`] values, newest to oldest.
     ///
-    /// Items are ordered from oldest to newest.
-    pub fn iter_arc<T: Extension>(&self) -> impl Iterator<Item = Arc<T>> {
+    /// The order matches [`Self::raw_get_arc`] (newest-first), so
+    /// `raw_iter_arc::<T>().next() == raw_get_arc::<T>()`.
+    pub fn raw_iter_arc<T: Extension>(&self) -> impl Iterator<Item = Arc<T>> {
         let type_id = TypeId::of::<T>();
 
         self.extensions
             .iter()
+            .rev()
             .filter(move |item| item.type_id == type_id)
             .filter_map(TypeErasedExtension::cloned_downcast::<T>)
     }
 
-    /// Iter over all the [`TypeErasedExtension`]
+    /// Raw flat iteration over all [`TypeErasedExtension`] entries at the top
+    /// level of this [`Extensions`] store.
     ///
-    /// This can be used to efficiently combine different types of [`Extension`]s in
-    /// only a single iteration. [`TypeErasedExtension`] exposes methods to easily
-    /// convert it back to type `T` if it matches the erasaed type stored internally.
-    pub fn iter_all(&self) -> impl Iterator<Item = &TypeErasedExtension> {
+    /// Use to efficiently combine different types of [`Extension`]s in a single
+    /// iteration. [`TypeErasedExtension`] exposes methods to convert back to
+    /// type `T` when it matches the erased type.
+    pub fn raw_iter_all(&self) -> impl Iterator<Item = &TypeErasedExtension> {
         self.extensions.iter()
+    }
+
+    /// Iterate over all inserted items of type `T`, walking the parent chain
+    /// and the structural [`Egress`] / [`Ingress`] connection wrappers.
+    ///
+    /// Yield order matches [`Self::get_ref`] preference (so
+    /// `iter_ref::<T>().next() == get_ref::<T>()`):
+    ///
+    /// At each level, iterate the local entries newest -> oldest. For each
+    /// entry: yield it if its type matches `T`, if it is an
+    /// [`Egress<Extensions>`] or [`Ingress<Extensions>`] wrapper, recurse into
+    /// the wrapped blob (same rule applied) and yield its results inline. Then
+    /// recurse into the parent.
+    ///
+    /// For a flat top-level-only iteration use [`Self::raw_iter_ref`].
+    ///
+    /// The iterator type is left opaque (`impl Iterator`) so the internal
+    /// representation can change without breaking callers.
+    pub fn iter_ref<T: Extension>(&self) -> impl Iterator<Item = &T> + '_ {
+        self.iter_ref_inner::<T>()
+    }
+
+    /// Iteration yielding cloned [`Arc<T>`] values, see [`Self::iter_ref`].
+    pub fn iter_arc<T: Extension>(&self) -> impl Iterator<Item = Arc<T>> + '_ {
+        self.iter_arc_inner::<T>()
+    }
+
+    // TODO replace this later with a custom Iterator to avoid boxing
+    fn iter_ref_inner<T: Extension>(&self) -> Box<dyn Iterator<Item = &T> + '_> {
+        let target = TypeId::of::<T>();
+        let egress_id = TypeId::of::<Egress<Self>>();
+        let ingress_id = TypeId::of::<Ingress<Self>>();
+        let local = self.extensions.iter().rev().flat_map(
+            move |ext| -> Box<dyn Iterator<Item = &T> + '_> {
+                if ext.type_id == target {
+                    match ext.downcast_ref::<T>() {
+                        Some(v) => Box::new(std::iter::once(v)),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else if ext.type_id == egress_id {
+                    match ext.downcast_ref::<Egress<Self>>() {
+                        Some(e) => e.0.iter_ref_inner::<T>(),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else if ext.type_id == ingress_id {
+                    match ext.downcast_ref::<Ingress<Self>>() {
+                        Some(i) => i.0.iter_ref_inner::<T>(),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else {
+                    Box::new(std::iter::empty())
+                }
+            },
+        );
+        let parent: Box<dyn Iterator<Item = &T>> = match self.parent() {
+            Some(p) => p.iter_ref_inner::<T>(),
+            None => Box::new(std::iter::empty()),
+        };
+        Box::new(local.chain(parent))
+    }
+
+    // TODO replace this later with a custom Iterator to avoid boxing
+    fn iter_arc_inner<T: Extension>(&self) -> Box<dyn Iterator<Item = Arc<T>> + '_> {
+        let target = TypeId::of::<T>();
+        let egress_id = TypeId::of::<Egress<Self>>();
+        let ingress_id = TypeId::of::<Ingress<Self>>();
+        let local = self.extensions.iter().rev().flat_map(
+            move |ext| -> Box<dyn Iterator<Item = Arc<T>> + '_> {
+                if ext.type_id == target {
+                    match ext.cloned_downcast::<T>() {
+                        Some(v) => Box::new(std::iter::once(v)),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else if ext.type_id == egress_id {
+                    match ext.downcast_ref::<Egress<Self>>() {
+                        Some(e) => e.0.iter_arc_inner::<T>(),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else if ext.type_id == ingress_id {
+                    match ext.downcast_ref::<Ingress<Self>>() {
+                        Some(i) => i.0.iter_arc_inner::<T>(),
+                        None => Box::new(std::iter::empty()),
+                    }
+                } else {
+                    Box::new(std::iter::empty())
+                }
+            },
+        );
+        let parent: Box<dyn Iterator<Item = Arc<T>>> = match self.parent() {
+            Some(p) => p.iter_arc_inner::<T>(),
+            None => Box::new(std::iter::empty()),
+        };
+        Box::new(local.chain(parent))
+    }
+
+    /// Get a reference to the [`Ingress<Extensions>`] wrapper if one exists
+    /// on this blob or anywhere reachable through the parent chain.
+    ///
+    /// Returns `None` when no ingress wrapper has been set up. For correctly
+    /// constructed server-side requests this is always `Some`, server
+    /// stacks insert the wrapper at the boundary where the connection becomes
+    /// visible to a request, so a `None` here is almost always a framework
+    /// setup bug rather than a normal state.
+    ///
+    /// This is just a shortcut for `extensions.get_ref::<Ingress<Extensions>>()`
+    #[must_use]
+    pub fn ingress(&self) -> Option<&Ingress<Self>> {
+        self.get_ref::<Ingress<Self>>()
+    }
+
+    /// Get a reference to the [`Egress<Extensions>`] wrapper if one exists
+    /// on this blob or anywhere reachable through the parent chain.
+    /// See [`Self::ingress`] for semantics.
+    ///
+    /// This is just a shortcut for `extensions.get_ref::<Egress<Extensions>>()`
+    #[must_use]
+    pub fn egress(&self) -> Option<&Egress<Self>> {
+        self.get_ref::<Egress<Self>>()
     }
 }
 
 impl fmt::Debug for Extensions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut d = f.debug_list();
-        for ext in self.extensions.iter() {
-            d.entry(&ext.value);
+        let mut s = f.debug_struct("Extensions");
+        if let Some(parent) = self.parent() {
+            s.field("parent", parent);
         }
-        d.finish()
+        s.field(
+            "entries",
+            &self.extensions.iter().map(|e| &e.value).collect::<Vec<_>>(),
+        );
+
+        s.finish()
     }
 }
 
@@ -301,27 +585,17 @@ impl TypeErasedExtension {
     }
 }
 
-// TODO remove this once we start using input<>
-
 #[derive(Debug, Clone, Extension)]
-/// Wrapper type that can be inserted by leaf-like services
-/// when returning an output, to have the input extensions be accessible and preserved.
-pub struct InputExtensions(pub Extensions);
-
-#[derive(Debug, Clone, Extension)]
+/// Ingress connection wrapper use by servers
 pub struct Ingress<T>(pub T);
 
+impl_deref!(Ingress);
+
 #[derive(Debug, Clone, Extension)]
+/// Egress connection wrapper use by client
 pub struct Egress<T>(pub T);
 
-#[derive(Debug, Clone, Extension)]
-pub struct Connection<T>(pub T);
-
-#[derive(Debug, Clone, Extension)]
-pub struct Stream<T>(pub T);
-
-#[derive(Debug, Clone, Extension)]
-pub struct Input<T>(pub T);
+impl_deref!(Egress);
 
 // We use this syntax: [`TlsExtension`] — TLS and secure transport
 // Instead of [`TlsExtension`]: TLS and secure transport
@@ -585,13 +859,13 @@ mod tests {
     #[test]
     fn first_ref_none_when_absent() {
         let ext = Extensions::new();
-        assert_eq!(ext.first_ref::<TraceNote>(), None);
+        assert_eq!(ext.raw_first_ref::<TraceNote>(), None);
     }
 
     #[test]
     fn first_arc_none_when_absent() {
         let ext = Extensions::new();
-        assert!(ext.first_arc::<TraceNote>().is_none());
+        assert!(ext.raw_first_arc::<TraceNote>().is_none());
     }
 
     #[test]
@@ -601,7 +875,7 @@ mod tests {
         ext.insert(TraceNote("second".to_owned()));
 
         assert_eq!(
-            ext.first_ref::<TraceNote>(),
+            ext.raw_first_ref::<TraceNote>(),
             Some(&TraceNote("first".to_owned()))
         );
     }
@@ -656,7 +930,7 @@ mod tests {
         ext.insert_arc(Arc::new(TraceNote(String::from("second"))));
 
         assert_eq!(
-            ext.first_arc::<TraceNote>()
+            ext.raw_first_arc::<TraceNote>()
                 .as_deref()
                 .map(|it| it.0.as_str()),
             Some("first")
@@ -675,14 +949,14 @@ mod tests {
         ext.insert(RetryBudget(5));
 
         let calls = AtomicUsize::new(0);
-        let existing = ext.get_ref_or_insert(|| {
+        let existing = ext.raw_get_ref_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             RetryBudget(6)
         });
         assert_eq!(existing.0, 5u32);
         assert_eq!(calls.load(Ordering::SeqCst), 0);
 
-        let missing = ext.get_ref_or_insert(|| {
+        let missing = ext.raw_get_ref_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             ConnectionTimeoutMs(7)
         });
@@ -696,14 +970,14 @@ mod tests {
         ext.insert_arc(Arc::new(TraceNote(String::from("stored"))));
 
         let calls = AtomicUsize::new(0);
-        let existing = ext.get_arc_or_insert(|| {
+        let existing = ext.raw_get_arc_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             Arc::new(TraceNote(String::from("new")))
         });
         assert_eq!(existing.0.as_str(), "stored");
         assert_eq!(calls.load(Ordering::SeqCst), 0);
 
-        let missing = ext.get_arc_or_insert(|| {
+        let missing = ext.raw_get_arc_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             Arc::new(RetryBudget(11))
         });
@@ -718,7 +992,10 @@ mod tests {
         ext.insert(FeatureToggle(true));
         ext.insert(HealthSignal(2));
 
-        let type_ids: Vec<TypeId> = ext.iter_all().map(TypeErasedExtension::type_id).collect();
+        let type_ids: Vec<TypeId> = ext
+            .raw_iter_all()
+            .map(TypeErasedExtension::type_id)
+            .collect();
         assert_eq!(
             type_ids,
             vec![
@@ -734,36 +1011,36 @@ mod tests {
         let ext = Extensions::new();
         ext.insert(HealthSignal(1));
 
-        assert_eq!(ext.iter_ref::<TraceNote>().count(), 0);
-        assert_eq!(ext.iter_arc::<TraceNote>().count(), 0);
+        assert_eq!(ext.raw_iter_ref::<TraceNote>().count(), 0);
+        assert_eq!(ext.raw_iter_arc::<TraceNote>().count(), 0);
     }
 
     #[test]
-    fn iter_ref_returns_items_for_present_type_in_oldest_to_newest_order() {
+    fn iter_ref_returns_items_for_present_type_in_newest_to_oldest_order() {
         let ext = Extensions::new();
         ext.insert(TraceNote(String::from("first")));
         ext.insert(HealthSignal(9));
         ext.insert(TraceNote(String::from("second")));
 
         let output: Vec<&str> = ext
-            .iter_ref::<TraceNote>()
+            .raw_iter_ref::<TraceNote>()
             .map(|it| it.0.as_str())
             .collect();
-        assert_eq!(output, vec!["first", "second"]);
+        assert_eq!(output, vec!["second", "first"]);
     }
 
     #[test]
-    fn iter_arc_returns_items_for_present_type_in_oldest_to_newest_order() {
+    fn iter_arc_returns_items_for_present_type_in_newest_to_oldest_order() {
         let ext = Extensions::new();
         ext.insert(TraceNote(String::from("first")));
         ext.insert(HealthSignal(9));
         ext.insert(TraceNote(String::from("second")));
 
         let output: Vec<String> = ext
-            .iter_arc::<TraceNote>()
+            .raw_iter_arc::<TraceNote>()
             .map(|arc| arc.0.clone())
             .collect();
-        assert_eq!(output, vec!["first".to_owned(), "second".to_owned()]);
+        assert_eq!(output, vec!["second".to_owned(), "first".to_owned()]);
     }
 
     #[test]
@@ -889,6 +1166,186 @@ mod tests {
         assert_eq!(
             arced.extensions().get_ref::<RetryBudget>(),
             Some(&RetryBudget(7))
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+    struct ConnSocketInfo(&'static str);
+
+    #[derive(Debug, Clone, PartialEq, Eq, Extension)]
+    struct RequestId(u64);
+
+    #[test]
+    fn get_finds_local() {
+        let req = Extensions::new();
+        req.insert(RequestId(42));
+        assert_eq!(req.get_ref::<RequestId>(), Some(&RequestId(42)));
+    }
+
+    #[test]
+    fn get_walks_parent_chain() {
+        let req = Extensions::new();
+        req.insert(RequestId(7));
+
+        let resp = req.fork();
+        assert_eq!(resp.get_ref::<RequestId>(), Some(&RequestId(7)));
+    }
+
+    #[test]
+    fn local_shadows_parent() {
+        let req = Extensions::new();
+        req.insert(RequestId(7));
+
+        let attempt = req.fork();
+        attempt.insert(RequestId(99));
+
+        assert_eq!(attempt.get_ref::<RequestId>(), Some(&RequestId(99)));
+    }
+
+    #[test]
+    fn fork_isolates_writes() {
+        let req = Extensions::new();
+        req.insert(RequestId(1));
+
+        let attempt = req.fork();
+        attempt.insert(RequestId(2));
+
+        assert_eq!(req.get_ref::<RequestId>(), Some(&RequestId(1)));
+    }
+
+    #[test]
+    fn ingress_view_walks_parent() {
+        let conn_ext = Extensions::new();
+        conn_ext.insert(ConnSocketInfo("client-in"));
+
+        let req = Extensions::new();
+        req.insert(Ingress(conn_ext));
+
+        assert_eq!(
+            req.ingress().and_then(|i| i.get_ref::<ConnSocketInfo>()),
+            Some(&ConnSocketInfo("client-in"))
+        );
+    }
+
+    #[test]
+    fn egress_view_walks_parent() {
+        let conn_ext = Extensions::new();
+        conn_ext.insert(ConnSocketInfo("egress-side"));
+
+        let req = Extensions::new();
+        req.insert(Egress(conn_ext));
+
+        assert_eq!(
+            req.egress().and_then(|e| e.get_ref::<ConnSocketInfo>()),
+            Some(&ConnSocketInfo("egress-side"))
+        );
+    }
+
+    #[test]
+    fn ingress_egress_disambiguate_in_mitm() {
+        let in_conn = Extensions::new();
+        in_conn.insert(ConnSocketInfo("in"));
+        let out_conn = Extensions::new();
+        out_conn.insert(ConnSocketInfo("out"));
+
+        let req = Extensions::new();
+        req.insert(Ingress(in_conn));
+        req.insert(Egress(out_conn));
+
+        assert_eq!(
+            req.ingress().and_then(|i| i.get_ref::<ConnSocketInfo>()),
+            Some(&ConnSocketInfo("in"))
+        );
+        assert_eq!(
+            req.egress().and_then(|e| e.get_ref::<ConnSocketInfo>()),
+            Some(&ConnSocketInfo("out"))
+        );
+    }
+
+    #[test]
+    fn egress_view_walks_through_parent_to_find_wrapper() {
+        let conn_ext = Extensions::new();
+        conn_ext.insert(ConnSocketInfo("inside-parent"));
+        let req = Extensions::new();
+        req.insert(Egress(conn_ext));
+
+        let resp = req.fork();
+        assert_eq!(
+            resp.egress().and_then(|e| e.get_ref::<ConnSocketInfo>()),
+            Some(&ConnSocketInfo("inside-parent"))
+        );
+    }
+
+    #[test]
+    fn ingress_egress_return_none_when_absent() {
+        let req = Extensions::new();
+        assert!(req.ingress().is_none());
+        assert!(req.egress().is_none());
+    }
+
+    #[test]
+    fn iter_ref_yields_local_then_parent_newest_to_oldest() {
+        let parent = Extensions::new();
+        parent.insert(RequestId(1));
+        parent.insert(RequestId(2));
+
+        let child = parent.fork();
+        child.insert(RequestId(3));
+        child.insert(RequestId(4));
+
+        let ids: Vec<_> = child.iter_ref::<RequestId>().map(|r| r.0).collect();
+        assert_eq!(ids, vec![4, 3, 2, 1]);
+    }
+
+    #[test]
+    fn iter_ref_walks_egress_and_ingress_wrappers_inline() {
+        let conn_in = Extensions::new();
+        conn_in.insert(RequestId(10));
+        conn_in.insert(RequestId(11));
+        let conn_out = Extensions::new();
+        conn_out.insert(RequestId(20));
+
+        let req = Extensions::new();
+        req.insert(RequestId(1));
+        req.insert(Ingress(conn_in));
+        req.insert(Egress(conn_out));
+
+        let ids: Vec<_> = req.iter_ref::<RequestId>().map(|r| r.0).collect();
+        assert_eq!(ids, vec![20, 11, 10, 1]);
+    }
+
+    #[test]
+    fn local_direct_after_wrapper_shadows_wrapper() {
+        let conn = Extensions::new();
+        conn.insert(RequestId(99));
+        let req = Extensions::new();
+        req.insert(Ingress(conn));
+        req.insert(RequestId(1));
+
+        assert_eq!(req.get_ref::<RequestId>(), Some(&RequestId(1)));
+    }
+
+    #[test]
+    fn wrapper_after_local_direct_shadows_direct() {
+        let conn = Extensions::new();
+        conn.insert(RequestId(99));
+        let req = Extensions::new();
+        req.insert(RequestId(1));
+        req.insert(Ingress(conn));
+
+        assert_eq!(req.get_ref::<RequestId>(), Some(&RequestId(99)));
+    }
+
+    #[test]
+    fn iter_ref_first_matches_get_ref() {
+        let parent = Extensions::new();
+        parent.insert(RequestId(1));
+        let child = parent.fork();
+        child.insert(RequestId(2));
+
+        assert_eq!(
+            child.iter_ref::<RequestId>().next(),
+            child.get_ref::<RequestId>()
         );
     }
 }

--- a/rama-core/src/extensions.rs
+++ b/rama-core/src/extensions.rs
@@ -145,17 +145,17 @@ impl Extensions {
     /// stores to find the correct item. See [`Extensions::get_ref()`] for how this works.
     ///
     /// If you don't want any of this special logic and you just want to check this
-    /// [`Extensions`] store, use [`Extensions::raw_contains()`] instead.
+    /// [`Extensions`] store, use [`Extensions::self_contains()`] instead.
     #[must_use]
     pub fn contains<T: Extension>(&self) -> bool {
         self.get_ref::<T>().is_some()
     }
 
-    /// Returns true if the [`Extensions`] store contains the given type
+    /// Returns true if this [`Extensions`] store contains the given type
     ///
     /// This only checks this [`Extensions`] store
     #[must_use]
-    pub fn raw_contains<T: Extension>(&self) -> bool {
+    pub fn self_contains<T: Extension>(&self) -> bool {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -186,9 +186,9 @@ impl Extensions {
     /// recursion) finishes empty. The wrappers themselves can still be
     /// retrieved directly (or via [`Self::egress`] / [`Self::ingress`]).
     ///
-    /// For a raw flat lookup, use [`Self::raw_get_ref`].
+    /// For a raw flat lookup, use [`Self::self_get_ref`].
     ///
-    /// Returns the most recently inserted match, for the oldest, see [`Self::raw_first_ref`].
+    /// Returns the most recently inserted match, for the oldest, see [`Self::self_first_ref`].
     pub fn get_ref<T: Extension>(&self) -> Option<&T> {
         let target = TypeId::of::<T>();
         let egress_id = TypeId::of::<Egress<Self>>();
@@ -213,11 +213,11 @@ impl Extensions {
         self.parent().and_then(|p| p.get_ref::<T>())
     }
 
-    /// Raw flat [`Self::get_ref`]: returns the most recently inserted `T`, for the oldest, see [`Self::raw_first_ref`].
+    /// Raw flat [`Self::get_ref`]: returns the most recently inserted `T`, for the oldest, see [`Self::self_first_ref`].
     ///
     /// This only checks this [`Extensions`] store
     #[must_use]
-    pub fn raw_get_ref<T: Extension>(&self) -> Option<&T> {
+    pub fn self_get_ref<T: Extension>(&self) -> Option<&T> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -232,7 +232,7 @@ impl Extensions {
     ///
     /// See [`Self::get_ref`] for the search order.
     ///
-    /// For a raw flat lookup (top-level only), use [`Self::raw_get_arc`].
+    /// For a raw flat lookup (top-level only), use [`Self::self_get_arc`].
     pub fn get_arc<T: Extension>(&self) -> Option<Arc<T>> {
         let target = TypeId::of::<T>();
         let egress_id = TypeId::of::<Egress<Self>>();
@@ -261,7 +261,7 @@ impl Extensions {
     ///
     /// This only checks this [`Extensions`] store
     #[must_use]
-    pub fn raw_get_arc<T: Extension>(&self) -> Option<Arc<T>> {
+    pub fn self_get_arc<T: Extension>(&self) -> Option<Arc<T>> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -278,7 +278,7 @@ impl Extensions {
     /// Useful when a type conceptually belongs to the scope (e.g. `ConnectionHealth`
     /// on a connection chain) and you want to reuse an existing instance rather
     /// than create a duplicate at every layer. For strict "ensure local exists",
-    /// use [`Self::raw_get_ref_or_insert`].
+    /// use [`Self::self_get_ref_or_insert`].
     pub fn get_ref_or_insert<T, F>(&self, create_fn: F) -> &T
     where
         T: Extension,
@@ -304,22 +304,22 @@ impl Extensions {
     /// Does not follow the parent chain. Useful when you want strict "ensure T
     /// exists on THIS blob" (e.g. materializing a direction wrapper
     /// like [`Ingress<Connection<Extensions>>`] at the outer blob).
-    pub fn raw_get_ref_or_insert<T, F>(&self, create_fn: F) -> &T
+    pub fn self_get_ref_or_insert<T, F>(&self, create_fn: F) -> &T
     where
         T: Extension,
         F: FnOnce() -> T,
     {
-        self.raw_get_ref()
+        self.self_get_ref()
             .unwrap_or_else(|| self.insert(create_fn()))
     }
 
-    /// Raw flat find-or-create returning an [`Arc<T>`]: see [`Self::raw_get_ref_or_insert`].
-    pub fn raw_get_arc_or_insert<T, F>(&self, create_fn: F) -> Arc<T>
+    /// Raw flat find-or-create returning an [`Arc<T>`]: see [`Self::self_get_ref_or_insert`].
+    pub fn self_get_arc_or_insert<T, F>(&self, create_fn: F) -> Arc<T>
     where
         T: Extension,
         F: FnOnce() -> Arc<T>,
     {
-        self.raw_get_arc()
+        self.self_get_arc()
             .unwrap_or_else(|| self.insert_arc(create_fn()))
     }
 
@@ -333,7 +333,7 @@ impl Extensions {
     /// Currently we dont provide a recursive variant of this method since we don't have
     /// a use case for it, and it's not exactly clear what would be considered "first".
     #[must_use]
-    pub fn raw_first_ref<T: Extension>(&self) -> Option<&T> {
+    pub fn self_first_ref<T: Extension>(&self) -> Option<&T> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -342,9 +342,9 @@ impl Extensions {
     }
 
     /// Raw flat [`Arc<T>`] to the oldest inserted `T` at the top level, see
-    /// [`Self::raw_first_ref`] for caveats.
+    /// [`Self::self_first_ref`] for caveats.
     #[must_use]
-    pub fn raw_first_arc<T: Extension>(&self) -> Option<Arc<T>> {
+    pub fn self_first_arc<T: Extension>(&self) -> Option<Arc<T>> {
         let type_id = TypeId::of::<T>();
         self.extensions
             .iter()
@@ -355,9 +355,9 @@ impl Extensions {
     /// Raw flat iteration over all inserted items of type `T` at the top level
     /// of this [`Extensions`] store, newest to oldest.
     ///
-    /// The order matches [`Self::raw_get_ref`] (newest-first), so
-    /// `raw_iter_ref::<T>().next() == raw_get_ref::<T>()`.
-    pub fn raw_iter_ref<T: Extension>(&self) -> impl Iterator<Item = &T> {
+    /// The order matches [`Self::self_get_ref`] (newest-first), so
+    /// `self_iter_ref::<T>().next() == self_get_ref::<T>()`.
+    pub fn self_iter_ref<T: Extension>(&self) -> impl Iterator<Item = &T> {
         let type_id = TypeId::of::<T>();
 
         self.extensions
@@ -370,9 +370,9 @@ impl Extensions {
     /// Raw flat iteration over all inserted items of type `T` at the top level
     /// as cloned [`Arc`] values, newest to oldest.
     ///
-    /// The order matches [`Self::raw_get_arc`] (newest-first), so
-    /// `raw_iter_arc::<T>().next() == raw_get_arc::<T>()`.
-    pub fn raw_iter_arc<T: Extension>(&self) -> impl Iterator<Item = Arc<T>> {
+    /// The order matches [`Self::self_get_arc`] (newest-first), so
+    /// `self_iter_arc::<T>().next() == self_get_arc::<T>()`.
+    pub fn self_iter_arc<T: Extension>(&self) -> impl Iterator<Item = Arc<T>> {
         let type_id = TypeId::of::<T>();
 
         self.extensions
@@ -388,7 +388,7 @@ impl Extensions {
     /// Use to efficiently combine different types of [`Extension`]s in a single
     /// iteration. [`TypeErasedExtension`] exposes methods to convert back to
     /// type `T` when it matches the erased type.
-    pub fn raw_iter_all(&self) -> impl Iterator<Item = &TypeErasedExtension> {
+    pub fn self_iter_all(&self) -> impl Iterator<Item = &TypeErasedExtension> {
         self.extensions.iter()
     }
 
@@ -404,7 +404,7 @@ impl Extensions {
     /// the wrapped blob (same rule applied) and yield its results inline. Then
     /// recurse into the parent.
     ///
-    /// For a flat top-level-only iteration use [`Self::raw_iter_ref`].
+    /// For a flat top-level-only iteration use [`Self::self_iter_ref`].
     ///
     /// The iterator type is left opaque (`impl Iterator`) so the internal
     /// representation can change without breaking callers.
@@ -859,13 +859,13 @@ mod tests {
     #[test]
     fn first_ref_none_when_absent() {
         let ext = Extensions::new();
-        assert_eq!(ext.raw_first_ref::<TraceNote>(), None);
+        assert_eq!(ext.self_first_ref::<TraceNote>(), None);
     }
 
     #[test]
     fn first_arc_none_when_absent() {
         let ext = Extensions::new();
-        assert!(ext.raw_first_arc::<TraceNote>().is_none());
+        assert!(ext.self_first_arc::<TraceNote>().is_none());
     }
 
     #[test]
@@ -875,7 +875,7 @@ mod tests {
         ext.insert(TraceNote("second".to_owned()));
 
         assert_eq!(
-            ext.raw_first_ref::<TraceNote>(),
+            ext.self_first_ref::<TraceNote>(),
             Some(&TraceNote("first".to_owned()))
         );
     }
@@ -930,7 +930,7 @@ mod tests {
         ext.insert_arc(Arc::new(TraceNote(String::from("second"))));
 
         assert_eq!(
-            ext.raw_first_arc::<TraceNote>()
+            ext.self_first_arc::<TraceNote>()
                 .as_deref()
                 .map(|it| it.0.as_str()),
             Some("first")
@@ -949,14 +949,14 @@ mod tests {
         ext.insert(RetryBudget(5));
 
         let calls = AtomicUsize::new(0);
-        let existing = ext.raw_get_ref_or_insert(|| {
+        let existing = ext.self_get_ref_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             RetryBudget(6)
         });
         assert_eq!(existing.0, 5u32);
         assert_eq!(calls.load(Ordering::SeqCst), 0);
 
-        let missing = ext.raw_get_ref_or_insert(|| {
+        let missing = ext.self_get_ref_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             ConnectionTimeoutMs(7)
         });
@@ -970,14 +970,14 @@ mod tests {
         ext.insert_arc(Arc::new(TraceNote(String::from("stored"))));
 
         let calls = AtomicUsize::new(0);
-        let existing = ext.raw_get_arc_or_insert(|| {
+        let existing = ext.self_get_arc_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             Arc::new(TraceNote(String::from("new")))
         });
         assert_eq!(existing.0.as_str(), "stored");
         assert_eq!(calls.load(Ordering::SeqCst), 0);
 
-        let missing = ext.raw_get_arc_or_insert(|| {
+        let missing = ext.self_get_arc_or_insert(|| {
             calls.fetch_add(1, Ordering::SeqCst);
             Arc::new(RetryBudget(11))
         });
@@ -993,7 +993,7 @@ mod tests {
         ext.insert(HealthSignal(2));
 
         let type_ids: Vec<TypeId> = ext
-            .raw_iter_all()
+            .self_iter_all()
             .map(TypeErasedExtension::type_id)
             .collect();
         assert_eq!(
@@ -1011,8 +1011,8 @@ mod tests {
         let ext = Extensions::new();
         ext.insert(HealthSignal(1));
 
-        assert_eq!(ext.raw_iter_ref::<TraceNote>().count(), 0);
-        assert_eq!(ext.raw_iter_arc::<TraceNote>().count(), 0);
+        assert_eq!(ext.self_iter_ref::<TraceNote>().count(), 0);
+        assert_eq!(ext.self_iter_arc::<TraceNote>().count(), 0);
     }
 
     #[test]
@@ -1023,7 +1023,7 @@ mod tests {
         ext.insert(TraceNote(String::from("second")));
 
         let output: Vec<&str> = ext
-            .raw_iter_ref::<TraceNote>()
+            .self_iter_ref::<TraceNote>()
             .map(|it| it.0.as_str())
             .collect();
         assert_eq!(output, vec!["second", "first"]);
@@ -1037,7 +1037,7 @@ mod tests {
         ext.insert(TraceNote(String::from("second")));
 
         let output: Vec<String> = ext
-            .raw_iter_arc::<TraceNote>()
+            .self_iter_arc::<TraceNote>()
             .map(|arc| arc.0.clone())
             .collect();
         assert_eq!(output, vec!["second".to_owned(), "first".to_owned()]);

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -1,7 +1,7 @@
 use rama_core::{
     Service,
     error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
-    extensions::{Extensions, ExtensionsRef, InputExtensions},
+    extensions::{Extensions, ExtensionsRef},
     telemetry::tracing,
 };
 use rama_http::{StreamingBody, header::SEC_WEBSOCKET_KEY};
@@ -68,8 +68,6 @@ where
         // directly instead of here...
         let req = sanitize_client_req_header(req)?;
 
-        let req_extensions = req.extensions().clone();
-
         let resp = match &self.sender {
             SendRequest::Http1(sender) => {
                 let mut sender = sender.lock().await;
@@ -112,8 +110,6 @@ where
                 }
             }
         };
-
-        resp.extensions().insert(InputExtensions(req_extensions));
 
         Ok(resp.map(rama_http_types::Body::new))
     }

--- a/rama-http-backend/src/server/layer/upgrade/mitm/svc.rs
+++ b/rama-http-backend/src/server/layer/upgrade/mitm/svc.rs
@@ -3,7 +3,6 @@ use std::convert::Infallible;
 use rama_core::{
     Service, bytes,
     error::BoxError,
-    extensions::ExtensionsRef as _,
     io::BridgeIo,
     matcher::service::{ServiceMatch, ServiceMatcher},
     rt::Executor,
@@ -74,7 +73,6 @@ where
             tracing::debug!("HttpUpgradeMitmRelay: upgrade MITM relay req match made...");
 
             let on_upgrade_ingress = rama_http::io::upgrade::handle_upgrade(&req);
-            let req_extensions = req.extensions().clone();
 
             let relay_upgrade_span = tracing::trace_root_span!(
                 "upgrade::mitm_relay::serve",
@@ -112,8 +110,6 @@ where
                 );
 
                 let on_upgrade_egress = rama_http::io::upgrade::handle_upgrade(&res);
-                let res_extensions = res.extensions().clone();
-
                 tracing::trace!("HttpUpgradeMitmRelay: spawn relay svc on its own task");
 
                 self.exec.spawn_task(async move {
@@ -129,8 +125,6 @@ where
                         }
                     };
 
-                    ingress_stream.extensions().extend(&req_extensions);
-                    egress_stream.extensions().extend(&res_extensions);
 
                     tracing::trace!(
                         "HttpUpgradeMitmRelay: relay task: bidirectional upgrade complete: continue serving via upgrade relay svc"

--- a/rama-http-backend/src/server/layer/upgrade/service.rs
+++ b/rama-http-backend/src/server/layer/upgrade/service.rs
@@ -121,7 +121,6 @@ where
                         async move {
                             match rama_http::io::upgrade::handle_upgrade(&req).await {
                                 Ok(upgraded) => {
-                                    upgraded.extensions().extend(req.extensions());
                                     let _ = handler.serve(upgraded).await;
                                 }
                                 Err(e) => {

--- a/rama-http-core/src/h2/proto/streams/recv.rs
+++ b/rama-http-core/src/h2/proto/streams/recv.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::h2::codec::UserError;
 use crate::h2::proto;
+use rama_core::extensions::{Egress, Extensions, Ingress};
 use rama_core::telemetry::tracing::{self, warn};
 use rama_http_types::proto::h1::headers::original::OriginalHttp1Headers;
 use rama_http_types::proto::h2::frame::{
@@ -263,7 +264,24 @@ impl Recv {
         }
 
         if !pseudo.is_informational() {
-            let extensions = stream.extensions.clone();
+            let extensions = if counts.peer().is_server() {
+                // Server receiving a request
+                let ext = Extensions::new();
+                ext.insert(Ingress(stream.extensions.clone()));
+                ext
+            } else {
+                // Client receiving a response
+                stream
+                    .req_extensions
+                    .as_ref()
+                    .map(|req_ext| req_ext.fork())
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            "req_extensions should always be set in recv_headers but it was missing; falling back to default; report bug in rama"
+                        );
+                        Extensions::new()
+                    })
+            };
             let message = counts.peer().convert_poll_message(
                 pseudo,
                 fields,
@@ -287,9 +305,17 @@ impl Recv {
                 self.pending_accept.push(stream);
             }
         } else {
-            // This is an informational response (1xx status code)
-            // Convert to response and store it for polling
-            let extensions = stream.extensions.clone();
+            // Client receiving an informational response
+            let extensions =  stream
+                .req_extensions
+                .as_ref()
+                .map(|req_ext| req_ext.fork())
+                .unwrap_or_else(|| {
+                    tracing::warn!(
+                        "req_extensions should always be set in recv_headers but it was missing; falling back to default; report bug in rama"
+                    );
+                    Extensions::new()
+                });
             let message = counts.peer().convert_poll_message(
                 pseudo,
                 fields,
@@ -865,14 +891,18 @@ impl Recv {
         let promised_id = frame.promised_id();
         let header_size = frame.calculate_header_list_size();
         let (pseudo, fields, field_order) = frame.into_parts();
-        // TODO we can probably mem::take them here, but will need to be tested for side-effects
+
+        let push_ext = Extensions::new();
+        push_ext.insert(Egress(stream.extensions.clone()));
+        stream.req_extensions = Some(push_ext.clone());
+
         let req = crate::h2::server::Peer::convert_poll_message(
             pseudo,
             fields,
             field_order,
             header_size,
             promised_id,
-            stream.extensions.clone(),
+            push_ext,
         )?;
 
         if let Err(e) = frame::PushPromise::validate_request(&req) {

--- a/rama-http-core/src/h2/proto/streams/stream.rs
+++ b/rama-http-core/src/h2/proto/streams/stream.rs
@@ -75,8 +75,14 @@ pub(super) struct Stream {
     /// Set to true when a push is pending for this stream
     pub is_pending_push: bool,
 
-    /// The extensions of this stream
+    /// The stream's own extensions
+    ///
+    /// An h2 stream is a sub-connection layered on the multiplexer/TCP.
     pub extensions: Extensions,
+
+    /// Captured at `send_request` time and carried so the response builder can fork
+    /// it to create the response extensions
+    pub req_extensions: Option<Extensions>,
 
     // ===== Fields related to receiving =====
     /// Next node in the accept linked list
@@ -203,7 +209,7 @@ impl Stream {
         id: StreamId,
         init_send_window: WindowSize,
         init_recv_window: WindowSize,
-        extensions: Extensions,
+        connection_extensions: &Extensions,
     ) -> Result<Self, Reason> {
         let mut send_flow = FlowControl::new();
         let mut recv_flow = FlowControl::new();
@@ -229,10 +235,14 @@ impl Stream {
             return Err(reason);
         }
 
+        // Create extensions for this specific stream
+        let extensions = connection_extensions.fork();
+
         Ok(Self {
             id,
             state: State::default(),
             extensions,
+            req_extensions: None,
             ref_count: 0,
             is_counted: false,
 

--- a/rama-http-core/src/h2/proto/streams/streams.rs
+++ b/rama-http-core/src/h2/proto/streams/streams.rs
@@ -7,7 +7,7 @@ use crate::h2::{client, proto, server};
 
 use parking_lot::Mutex;
 use rama_core::bytes::{Buf, Bytes};
-use rama_core::extensions::{Extensions, ExtensionsRef};
+use rama_core::extensions::{Egress, Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing;
 use rama_http::proto::RequestHeaders;
 use rama_http::proto::h1::Http1HeaderMap;
@@ -352,7 +352,7 @@ where
 
         // Convert the message
         let is_content_length_head = *request.method() == Method::HEAD;
-        let (headers, extensions) = client::Peer::convert_send_message(
+        let (headers, req_ext) = client::Peer::convert_send_message(
             stream_id,
             request,
             protocol,
@@ -365,11 +365,15 @@ where
             stream_id,
             me.actions.send.init_window_sz(),
             me.actions.recv.init_window_sz(),
-            extensions,
+            &me.extensions,
         ).map_err(|err| {
             tracing::warn!("failed to create stream for id {stream_id:?} in send_request: {err}; library GO AWAY");
             Error::library_go_away(err)
         })?;
+
+        // Update the request so it points at this stream as its egress connection
+        req_ext.insert(Egress(stream.extensions.clone()));
+        stream.req_extensions = Some(req_ext);
 
         if is_content_length_head {
             stream.content_length = ContentLength::Head;
@@ -586,7 +590,7 @@ impl Inner {
                             stream_id,
                             self.actions.send.init_window_sz(),
                             self.actions.recv.init_window_sz(),
-                            self.extensions.clone(),
+                            &self.extensions,
                         )
                         .map_err(|err| {
                             tracing::warn!("failed to create recv stream for id {stream_id:?}: {err}; library GO AWAY");
@@ -940,7 +944,7 @@ impl Inner {
                     promised_id,
                     self.actions.send.init_window_sz(),
                     self.actions.recv.init_window_sz(),
-                    self.extensions.clone(),
+                    &self.extensions,
                 ).map_err(|err| {
                     tracing::warn!("failed to create pushed stream for promised id {promised_id:?}: {err}; library GO AWAY");
                     Error::library_go_away(err)
@@ -1077,7 +1081,7 @@ impl Inner {
                     self.actions.recv.maybe_reset_next_stream_id(id);
                 }
 
-                match Stream::try_new(id, 0, 0, self.extensions.clone()) {
+                match Stream::try_new(id, 0, 0, &self.extensions) {
                     Ok(stream) => e.insert(stream),
                     Err(reason) => {
                         tracing::debug!(
@@ -1383,7 +1387,7 @@ impl<B> StreamRef<B> {
                     promised_id,
                     actions.send.init_window_sz(),
                     actions.recv.init_window_sz(),
-                    me.extensions.clone(),
+                    &me.extensions,
                 ).map_err(|err| {
                     tracing::warn!("failed to create stream for promised id {promised_id:?} in send_push_promise: {err}; library GO AWAY");
                     Error::library_go_away(err)

--- a/rama-http-core/src/proto/h1/conn.rs
+++ b/rama-http-core/src/proto/h1/conn.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use httparse::ParserConfig;
 use rama_core::bytes::{Buf, Bytes};
-use rama_core::extensions::ExtensionsRef;
+use rama_core::extensions::{Extensions, ExtensionsRef, Ingress};
+use rama_core::telemetry::tracing;
 use rama_core::telemetry::tracing::{debug, error, trace};
 use rama_http::io::upgrade;
 use rama_http_types::body::Frame;
@@ -199,16 +200,25 @@ where
             }
         }
 
-        let extensions = if T::is_client() {
-            if self.state.encoded_request_extensions.is_none() {
-                panic!(
-                    "encoded_request_extensions should never be none when receiving response headers"
-                )
-            }
-            &mut self.state.encoded_request_extensions
+        let prepared = if T::is_client() {
+            // Client receiving a response
+            // Client receiving a response
+            self.state.encoded_request_extensions
+                    .as_ref()
+                    .map(|req_ext| req_ext.fork())
+                    .unwrap_or_else(|| {
+                        tracing::warn!(
+                            "encoded_request_extensions should always be set in poll_read_head but it was missing; falling back to default; report bug in rama"
+                        );
+                        Extensions::new()
+                    })
         } else {
-            &mut Some(self.io.extensions().clone())
+            // Server receiving a request
+            let ext = Extensions::new();
+            ext.insert(Ingress(self.io.extensions().clone()));
+            ext
         };
+        let mut prepared_extensions = Some(prepared);
 
         let msg = match self.io.parse::<T>(
             cx,
@@ -218,7 +228,7 @@ where
                 h1_max_headers: self.state.h1_max_headers,
                 h09_responses: self.state.h09_responses,
                 on_informational: &mut self.state.on_informational,
-                extensions,
+                prepared_extensions: &mut prepared_extensions,
             },
         ) {
             Poll::Ready(Ok(msg)) => msg,

--- a/rama-http-core/src/proto/h1/dispatch.rs
+++ b/rama-http-core/src/proto/h1/dispatch.rs
@@ -557,7 +557,7 @@ where
         *req.uri_mut() = msg.subject.1;
         *req.headers_mut() = msg.headers;
         *req.version_mut() = msg.version;
-        req.extensions().extend(&msg.extensions);
+        *req.extensions_mut() = msg.extensions;
         let fut = {
             let svc = self.service.clone();
             async move { svc.serve(req).await }

--- a/rama-http-core/src/proto/h1/dispatch.rs
+++ b/rama-http-core/src/proto/h1/dispatch.rs
@@ -557,7 +557,7 @@ where
         *req.uri_mut() = msg.subject.1;
         *req.headers_mut() = msg.headers;
         *req.version_mut() = msg.version;
-        *req.extensions_mut() = msg.extensions;
+        req.set_extensions_mut(msg.extensions);
         let fut = {
             let svc = self.service.clone();
             async move { svc.serve(req).await }

--- a/rama-http-core/src/proto/h1/io.rs
+++ b/rama-http-core/src/proto/h1/io.rs
@@ -187,7 +187,7 @@ where
                     h1_max_headers: parse_ctx.h1_max_headers,
                     h09_responses: parse_ctx.h09_responses,
                     on_informational: parse_ctx.on_informational,
-                    extensions: parse_ctx.extensions,
+                    prepared_extensions: parse_ctx.prepared_extensions,
                 },
             )? {
                 debug!("parsed {} headers", msg.head.headers.len());
@@ -701,7 +701,7 @@ mod tests {
                 h1_max_headers: None,
                 h09_responses: false,
                 on_informational: &mut None,
-                extensions: &mut Some(Extensions::default()),
+                prepared_extensions: &mut Some(Extensions::default()),
             };
             assert!(
                 buffered

--- a/rama-http-core/src/proto/h1/mod.rs
+++ b/rama-http-core/src/proto/h1/mod.rs
@@ -70,8 +70,10 @@ pub(crate) struct ParseContext<'a> {
     h1_max_headers: Option<usize>,
     h09_responses: bool,
     on_informational: &'a mut Option<OnInformational>,
-    /// This can be consumed but we pass this as mut ref to prevent cloning in parse loops
-    extensions: &'a mut Option<Extensions>,
+    /// This can be consumed but we pass this as mut ref to prevent cloning in parse loops.
+    /// These extensions have been prepared with the correct scope and they should be consumed
+    /// and used as it without any extra wrapping
+    prepared_extensions: &'a mut Option<Extensions>,
 }
 
 struct EncodeHead<'a, S> {

--- a/rama-http-core/src/proto/h1/role.rs
+++ b/rama-http-core/src/proto/h1/role.rs
@@ -8,7 +8,8 @@ use rama_core::extensions::Extensions;
 use rama_core::telemetry::tracing::{debug, error, trace, trace_span, warn};
 use rama_http::HeaderName;
 use rama_http::proto::h1::ext::ReasonPhrase;
-use rama_http::proto::{HeaderByteLength, RequestExtensions, RequestHeaders};
+use rama_http::proto::{HeaderByteLength, RequestHeaders};
+
 use rama_http_types::header::Entry;
 use rama_http_types::header::{self, HeaderMap, HeaderValue};
 use rama_http_types::proto::h1::{Http1HeaderMap, Http1HeaderName};
@@ -282,9 +283,9 @@ impl Http1Transaction for Server {
             return Err(Parse::transfer_encoding_invalid());
         }
 
-        let extensions = ctx.extensions.take().unwrap_or_else(|| {
+        let extensions = ctx.prepared_extensions.take().unwrap_or_else(|| {
             warn!(
-                "extensions should always be set in ParseContext: was None: use default instead..."
+                "prepared_extensions should always be set in ParseContext: was None: use default instead..."
             );
             Default::default()
         });
@@ -942,20 +943,13 @@ impl Http1Transaction for Client {
                 headers.append(name, value);
             }
 
-            // TODO we can do this without cloning in a lot of cases, but we need
-            // to be careful with things like http 100
-            let extensions = ctx
-                .extensions
-                .as_ref()
-                .cloned()
-                .unwrap_or_else(|| {
-                    warn!("extensions should always be set in ParseContext but it was missing; falling back to default; report bug in rama");
-                    Default::default()
-                });
-
-            // TODO remove but maybe needed for backwards comp for now...
-            let req_ext = RequestExtensions::from(extensions.clone());
-            extensions.insert(req_ext);
+            // Extensions are ready for use and dont need to do any special wrapping here
+            let extensions = ctx.prepared_extensions.take().unwrap_or_else(|| {
+                warn!(
+                    "prepared_extensions should always be set in ParseContext but it was missing; falling back to default; report bug in rama"
+                );
+                Default::default()
+            });
 
             let headers = headers.consume(&extensions);
 
@@ -1483,7 +1477,7 @@ mod tests {
                 h1_max_headers: None,
                 h09_responses: false,
                 on_informational: &mut None,
-                extensions: &mut Some(Extensions::default()),
+                prepared_extensions: &mut Some(Extensions::default()),
             },
         )
         .unwrap()
@@ -1506,7 +1500,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw.len(), 0);
@@ -1525,7 +1519,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         Server::parse(&mut raw, ctx).unwrap_err();
     }
@@ -1541,7 +1535,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: true,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw, H09_RESPONSE);
@@ -1559,7 +1553,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         Client::parse(&mut raw, ctx).unwrap_err();
         assert_eq!(raw, H09_RESPONSE);
@@ -1581,7 +1575,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         let msg = Client::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw.len(), 0);
@@ -1600,7 +1594,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         Client::parse(&mut raw, ctx).unwrap_err();
     }
@@ -1620,7 +1614,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         let msg = Server::parse(&mut raw, ctx).unwrap().unwrap();
         assert_eq!(raw.len(), 0);
@@ -1641,7 +1635,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         Server::parse(&mut raw, ctx).unwrap_err();
     }
@@ -1656,7 +1650,7 @@ mod tests {
             h1_max_headers: None,
             h09_responses: false,
             on_informational: &mut None,
-            extensions: &mut Some(Extensions::default()),
+            prepared_extensions: &mut Some(Extensions::default()),
         };
         let parsed_message = Server::parse(&mut raw, ctx).unwrap().unwrap();
         let mut orig_headers = parsed_message
@@ -1682,7 +1676,7 @@ mod tests {
                     h1_max_headers: None,
                     h09_responses: false,
                     on_informational: &mut None,
-                    extensions: &mut Some(Extensions::default()),
+                    prepared_extensions: &mut Some(Extensions::default()),
                 },
             )
             .expect("parse ok")
@@ -1699,7 +1693,7 @@ mod tests {
                     h1_max_headers: None,
                     h09_responses: false,
                     on_informational: &mut None,
-                    extensions: &mut Some(Extensions::default()),
+                    prepared_extensions: &mut Some(Extensions::default()),
                 },
             )
             .expect_err(comment)
@@ -1912,8 +1906,9 @@ mod tests {
     #[test]
     fn test_decoder_response_request_extensions() {
         let request_exts = Extensions::new();
-
         request_exts.insert(UpstreamRequestId(42));
+
+        let prepared = request_exts.fork();
 
         let mut bytes = BytesMut::from(
             "\
@@ -1929,7 +1924,7 @@ mod tests {
                 h1_max_headers: None,
                 h09_responses: false,
                 on_informational: &mut None,
-                extensions: &mut Some(request_exts),
+                prepared_extensions: &mut Some(prepared),
             },
         )
         .expect("parse ok")
@@ -1939,8 +1934,6 @@ mod tests {
             42u64,
             msg.head
                 .extensions
-                .get_ref::<RequestExtensions>()
-                .unwrap()
                 .get_ref::<UpstreamRequestId>()
                 .map(|request_id| request_id.0)
                 .unwrap()
@@ -1967,7 +1960,7 @@ mod tests {
                         h1_max_headers: None,
                         h09_responses: false,
                         on_informational: &mut None,
-                        extensions: &mut Some(Extensions::default()),
+                        prepared_extensions: &mut Some(Extensions::default()),
                     }
                 )
                 .expect("parse ok")
@@ -1985,7 +1978,7 @@ mod tests {
                     h1_max_headers: None,
                     h09_responses: false,
                     on_informational: &mut None,
-                    extensions: &mut Some(Extensions::default()),
+                    prepared_extensions: &mut Some(Extensions::default()),
                 },
             )
             .expect("parse ok")
@@ -2002,7 +1995,7 @@ mod tests {
                     h1_max_headers: None,
                     h09_responses: false,
                     on_informational: &mut None,
-                    extensions: &mut Some(Extensions::default()),
+                    prepared_extensions: &mut Some(Extensions::default()),
                 },
             )
             .expect_err("parse should err")
@@ -2596,7 +2589,7 @@ mod tests {
                 h1_max_headers: None,
                 h09_responses: false,
                 on_informational: &mut None,
-                extensions: &mut Some(Extensions::default()),
+                prepared_extensions: &mut Some(Extensions::default()),
             },
         )
         .expect("parse ok")
@@ -2635,7 +2628,7 @@ mod tests {
                         h1_max_headers: max_headers,
                         h09_responses: false,
                         on_informational: &mut None,
-                        extensions: &mut Some(Extensions::default()),
+                        prepared_extensions: &mut Some(Extensions::default()),
                     },
                 );
                 if should_success {
@@ -2655,7 +2648,7 @@ mod tests {
                         h1_max_headers: max_headers,
                         h09_responses: false,
                         on_informational: &mut None,
-                        extensions: &mut Some(Extensions::default()),
+                        prepared_extensions: &mut Some(Extensions::default()),
                     },
                 );
                 if should_success {

--- a/rama-http-core/src/proto/mod.rs
+++ b/rama-http-core/src/proto/mod.rs
@@ -56,7 +56,7 @@ impl MessageHead<StatusCode> {
         *res.status_mut() = self.subject;
         *res.headers_mut() = self.headers;
         *res.version_mut() = self.version;
-        *res.extensions_mut() = self.extensions;
+        res.set_extensions(self.extensions);
         res
     }
 }

--- a/rama-http-core/src/proto/mod.rs
+++ b/rama-http-core/src/proto/mod.rs
@@ -1,7 +1,6 @@
 //! Pieces pertaining to the HTTP message protocol.
 
 use rama_core::extensions::Extensions;
-use rama_core::extensions::ExtensionsRef;
 use rama_http::io::upgrade;
 use rama_http_types::{HeaderMap, Method, Response, StatusCode, Uri, Version};
 
@@ -57,7 +56,7 @@ impl MessageHead<StatusCode> {
         *res.status_mut() = self.subject;
         *res.headers_mut() = self.headers;
         *res.version_mut() = self.version;
-        res.extensions().extend(&self.extensions);
+        *res.extensions_mut() = self.extensions;
         res
     }
 }

--- a/rama-http-types/src/proto/mod.rs
+++ b/rama-http-types/src/proto/mod.rs
@@ -5,7 +5,7 @@
 
 use std::{ops::Deref, sync::Arc};
 
-use rama_core::extensions::{Extension, Extensions};
+use rama_core::extensions::Extension;
 
 pub mod h1;
 pub mod h2;
@@ -30,32 +30,6 @@ impl From<h1::Http1HeaderMap> for RequestHeaders {
 
 impl Deref for RequestHeaders {
     type Target = h1::Http1HeaderMap;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
-    }
-}
-
-#[derive(Debug, Clone, Extension)]
-#[extension(tags(http))]
-/// Read-only copy of the parent request extensions.
-///
-/// This extension can be made available as part of a response.
-pub struct RequestExtensions(Arc<Extensions>);
-
-impl From<Extensions> for RequestExtensions {
-    fn from(value: Extensions) -> Self {
-        Self(Arc::new(value))
-    }
-}
-
-// TODO: once we have a more advanced req/resp extension system,
-// as replacement of current rama Context, this could also perhaps
-// act as some kind of automated parent extensions that are fallen back to if
-// not available in response extensions?
-
-impl Deref for RequestExtensions {
-    type Target = Extensions;
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -5,6 +5,7 @@ use crate::dep::hyperium::http::Extensions as HttpExtensions;
 use crate::dep::hyperium::http::request::{Parts as HyperiumParts, Request as HyperiumRequest};
 use crate::{HeaderMap, HeaderName, HeaderValue, Method, Uri, Version, body::Body};
 use rama_core::extensions::{Extension, Extensions, ExtensionsRef};
+use rama_utils::macros::generate_set_and_with;
 
 #[derive(Clone, Debug, Extension)]
 struct HyperExtensions(HttpExtensions);
@@ -668,10 +669,11 @@ impl<T> Request<T> {
         }
     }
 
-    /// Mutable reference to this request's extensions
-    #[inline]
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
-        &mut self.head.extensions
+    generate_set_and_with! {
+        pub fn extensions_mut(mut self, extensions: Extensions) -> Self {
+            self.head.extensions = extensions;
+            self
+        }
     }
 }
 

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -667,6 +667,12 @@ impl<T> Request<T> {
             head: self.head,
         }
     }
+
+    /// Mutable reference to this request's extensions
+    #[inline]
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.head.extensions
+    }
 }
 
 impl<T: Default> Default for Request<T> {

--- a/rama-http-types/src/response.rs
+++ b/rama-http-types/src/response.rs
@@ -540,6 +540,12 @@ impl<T> Response<T> {
             head: self.head,
         }
     }
+
+    /// Mutable reference to this request's extensions
+    #[inline]
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.head.extensions
+    }
 }
 
 impl<T: Default> Default for Response<T> {

--- a/rama-http-types/src/response.rs
+++ b/rama-http-types/src/response.rs
@@ -10,6 +10,7 @@ use crate::status::StatusCode;
 use crate::version::Version;
 use crate::{Body, Result};
 use rama_core::extensions::{Extension, Extensions, ExtensionsRef};
+use rama_utils::macros::generate_set_and_with;
 
 #[derive(Clone, Debug, Extension)]
 struct HyperExtensions(HttpExtensions);
@@ -541,10 +542,11 @@ impl<T> Response<T> {
         }
     }
 
-    /// Mutable reference to this request's extensions
-    #[inline]
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
-        &mut self.head.extensions
+    generate_set_and_with! {
+        pub fn extensions(mut self, extensions: Extensions) -> Self {
+            self.head.extensions = extensions;
+            self
+        }
     }
 }
 

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -53,6 +53,7 @@ use rama_core::extensions::ExtensionsRef;
 use rama_core::io::Io;
 use rama_core::io::rewind::Rewind;
 use rama_core::telemetry::tracing::trace;
+use rama_utils::macros::generate_set_and_with;
 
 /// An upgraded HTTP connection.
 ///
@@ -134,12 +135,11 @@ pub fn handle_upgrade<T: ExtensionsRef>(
     };
 
     async move {
-        let mut upgraded = match on_upgrade {
+        let upgraded = match on_upgrade {
             Ok(on_upgrade) => on_upgrade.await?,
             Err(err) => return Err(err),
         };
-        *upgraded.extensions_mut() = msg_ext.fork();
-        Ok(upgraded)
+        Ok(upgraded.with_extensions(msg_ext.fork()))
     }
 }
 
@@ -181,8 +181,11 @@ impl Upgraded {
         }
     }
 
-    pub fn extensions_mut(&mut self) -> &mut Extensions {
-        &mut self.extensions
+    generate_set_and_with! {
+        pub fn extensions(mut self, extensions: Extensions) -> Self {
+            self.extensions = extensions;
+            self
+        }
     }
 
     /// Tries to downcast the internal trait object to the type passed.

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -107,10 +107,18 @@ pub struct Parts<T> {
 /// - `http::Response<B>`
 /// - `&rama_http::Request<B>`
 /// - `&rama_http::Response<B>`
+///
+/// When the upgrade completes, the returned [`Upgraded`]s [`Extensions`] are reparented to the
+/// message that triggered it: `upgraded.parent = msg.fork()`. That gives the
+/// upgraded a fresh top-level storage of its own while keeping everything
+/// the message could see: both HTTP-level state on the message itself and
+/// connection-level state reachable through the message's `Ingress` / `Egress`
+/// wrappers
 pub fn handle_upgrade<T: ExtensionsRef>(
     msg: T,
 ) -> impl Future<Output = Result<Upgraded, BoxError>> + 'static {
-    let on_upgrade = match msg.extensions().get_ref::<OnUpgrade>().cloned() {
+    let msg_ext = msg.extensions().clone();
+    let on_upgrade = match msg_ext.get_ref::<OnUpgrade>().cloned() {
         Some(on_upgrade) => {
             trace!("upgrading this: {:?}", on_upgrade);
             if on_upgrade.has_handled_upgrade() {
@@ -125,11 +133,13 @@ pub fn handle_upgrade<T: ExtensionsRef>(
         None => Err(OpaqueError::from_static_str("no pending update found").into_box_error()),
     };
 
-    async {
-        match on_upgrade {
-            Ok(on_upgrade) => on_upgrade.await,
-            Err(err) => Err(err),
-        }
+    async move {
+        let mut upgraded = match on_upgrade {
+            Ok(on_upgrade) => on_upgrade.await?,
+            Err(err) => return Err(err),
+        };
+        *upgraded.extensions_mut() = msg_ext.fork();
+        Ok(upgraded)
     }
 }
 
@@ -155,6 +165,12 @@ pub fn pending() -> (Pending, OnUpgrade) {
 
 impl Upgraded {
     /// Create a new [`Upgraded`] from an IO stream and existing buffer.
+    ///
+    /// The [`Upgraded`] starts with the io [`Extensions`]s. When
+    /// driven through [`handle_upgrade`] the parent is set to the message
+    /// that triggered the upgrade (which already encodes the underlying
+    /// connection through its `Ingress` / `Egress` wrapper), so the upgraded
+    /// blob inherits everything reachable from that message.
     pub fn new<T>(io: T, read_buf: Bytes) -> Self
     where
         T: Io + Unpin + ExtensionsRef,
@@ -163,6 +179,10 @@ impl Upgraded {
             extensions: io.extensions().clone(),
             io: Rewind::new_buffered(Box::new(io), read_buf),
         }
+    }
+
+    pub fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
     }
 
     /// Tries to downcast the internal trait object to the type passed.

--- a/rama-http/src/layer/forwarded/set_forwarded_multi.rs
+++ b/rama-http/src/layer/forwarded/set_forwarded_multi.rs
@@ -147,7 +147,13 @@ macro_rules! set_forwarded_service_for_tuple {
 
                 let mut forwarded_element = ForwardedElement::new_forwarded_by(self.by_node.clone());
 
-                if let Some(peer_addr) = req.extensions().get_ref::<SocketInfo>().map(|socket| socket.peer_addr()) {
+                if let Some(peer_addr) = req
+                    .extensions()
+                    .ingress()
+                    .and_then(|ext|ext.get_ref::<SocketInfo>())
+                    .map(|socket| socket.peer_addr())
+                {
+
                     forwarded_element.set_forwarded_for(peer_addr);
                 }
 

--- a/rama-http/src/layer/retry/mod.rs
+++ b/rama-http/src/layer/retry/mod.rs
@@ -3,6 +3,7 @@
 use crate::{Request, StreamingBody, body::util::BodyExt};
 use rama_core::Service;
 use rama_core::error::BoxError;
+use rama_core::extensions::ExtensionsRef;
 use rama_utils::macros::define_inner_service_accessors;
 
 mod layer;
@@ -102,7 +103,11 @@ where
 
         let mut cloned = self.policy.clone_input(&request);
 
+        let parent_ext = request.extensions().clone();
         loop {
+            // Fork extensions so we dont leak extensions from failed attempts
+            *request.extensions_mut() = parent_ext.fork();
+
             let resp = self.inner.serve(request).await;
             match cloned.take() {
                 Some(cloned_req) => {

--- a/rama-http/src/layer/retry/mod.rs
+++ b/rama-http/src/layer/retry/mod.rs
@@ -106,7 +106,7 @@ where
         let parent_ext = request.extensions().clone();
         loop {
             // Fork extensions so we dont leak extensions from failed attempts
-            *request.extensions_mut() = parent_ext.fork();
+            request.set_extensions_mut(parent_ext.fork());
 
             let resp = self.inner.serve(request).await;
             match cloned.take() {

--- a/rama-net/src/stream/mod.rs
+++ b/rama-net/src/stream/mod.rs
@@ -9,7 +9,7 @@ pub mod service;
 
 mod socket;
 #[doc(inline)]
-pub use socket::{ClientSocketInfo, Socket, SocketInfo};
+pub use socket::{Socket, SocketInfo};
 
 pub mod dep {
     //! Dependencies for rama stream modules.

--- a/rama-net/src/stream/socket.rs
+++ b/rama-net/src/stream/socket.rs
@@ -1,5 +1,4 @@
 use std::io::Result;
-use std::ops::{Deref, DerefMut};
 
 use rama_core::ServiceInput;
 use rama_core::extensions::Extension;
@@ -75,36 +74,6 @@ impl<T: Socket> Socket for ServiceInput<T> {
     #[inline]
     fn peer_addr(&self) -> std::io::Result<SocketAddress> {
         self.input.peer_addr()
-    }
-}
-
-#[derive(Debug, Clone, Extension)]
-#[extension(tags(net))]
-/// Information about the socket on the egress end.
-pub struct ClientSocketInfo(pub SocketInfo);
-
-impl AsRef<SocketInfo> for ClientSocketInfo {
-    fn as_ref(&self) -> &SocketInfo {
-        &self.0
-    }
-}
-
-impl AsMut<SocketInfo> for ClientSocketInfo {
-    fn as_mut(&mut self) -> &mut SocketInfo {
-        &mut self.0
-    }
-}
-
-impl Deref for ClientSocketInfo {
-    type Target = SocketInfo;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for ClientSocketInfo {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/rama-tcp/src/client/service/connector.rs
+++ b/rama-tcp/src/client/service/connector.rs
@@ -9,7 +9,7 @@ use rama_dns::client::{GlobalDnsResolver, resolver::DnsAddressResolver};
 use rama_net::{
     address::ProxyAddress,
     client::{ConnectorTarget, EstablishedClientConnection},
-    stream::{ClientSocketInfo, Socket, SocketInfo},
+    stream::{Socket, SocketInfo},
     transport::{TransportProtocol, TryRefIntoTransportContext},
 };
 
@@ -118,7 +118,7 @@ where
             .await
             .context("tcp connector: conncept to proxy")?;
 
-            let socket_info= ClientSocketInfo(SocketInfo::new(
+            let socket_info = SocketInfo::new(
                 conn.local_addr()
                     .inspect_err(|err| {
                         tracing::debug!(
@@ -127,7 +127,7 @@ where
                     })
                     .ok(),
                 addr.into(),
-            ));
+            );
             conn.extensions().insert(socket_info);
 
             return Ok(EstablishedClientConnection { input, conn });
@@ -146,7 +146,7 @@ where
             .await
             .context("tcp connector: conncept to connector target (overwrite?)")?;
 
-            let socket_info= ClientSocketInfo(SocketInfo::new(
+            let socket_info = SocketInfo::new(
                 conn.local_addr()
                     .inspect_err(|err| {
                         tracing::debug!(
@@ -155,7 +155,7 @@ where
                     })
                     .ok(),
                 addr.into(),
-            ));
+            );
             conn.extensions().insert(socket_info);
 
             return Ok(EstablishedClientConnection { input, conn });
@@ -189,7 +189,7 @@ where
         .await
         .context("tcp connector: connect to server")?;
 
-        let socket_info = ClientSocketInfo(SocketInfo::new(
+        let socket_info = SocketInfo::new(
             conn.local_addr()
                 .inspect_err(|err| {
                     tracing::debug!(
@@ -198,7 +198,7 @@ where
                 })
                 .ok(),
             addr.into(),
-        ));
+        );
         conn.extensions().insert(socket_info);
 
         Ok(EstablishedClientConnection { input, conn })

--- a/rama-unix/src/client/connector.rs
+++ b/rama-unix/src/client/connector.rs
@@ -8,7 +8,7 @@ use rama_core::{
 };
 use rama_net::client::EstablishedClientConnection;
 
-use crate::{ClientUnixSocketInfo, TokioUnixStream, UnixSocketInfo, UnixStream};
+use crate::{TokioUnixStream, UnixSocketInfo, UnixStream};
 use std::{convert::Infallible, path::PathBuf, sync::Arc};
 
 /// A connector which can be used to establish a Unix connection to a server.
@@ -82,7 +82,7 @@ where
             .await
             .into_box_error()?;
 
-        let info = ClientUnixSocketInfo(UnixSocketInfo::new(
+        let info = UnixSocketInfo::new(
             conn.stream
                 .local_addr()
                 .inspect_err(|err| {
@@ -94,7 +94,7 @@ where
             conn.stream
                 .peer_addr()
                 .context("failed to retrieve peer address of established connection")?,
-        ));
+        );
         conn.extensions().insert(info);
 
         Ok(EstablishedClientConnection { input, conn })

--- a/rama-unix/src/lib.rs
+++ b/rama-unix/src/lib.rs
@@ -23,7 +23,6 @@
 )]
 
 use rama_core::extensions::Extension;
-use std::ops::{Deref, DerefMut};
 
 mod address;
 pub use address::UnixSocketAddress;
@@ -42,35 +41,6 @@ pub use frame::UnixDatagramFramed;
 
 pub use tokio::net::unix::SocketAddr as TokioSocketAddress;
 pub use tokio::net::{UnixDatagram, UnixSocket};
-
-#[derive(Debug, Clone, Extension)]
-/// Information about the socket on the egress end.
-pub struct ClientUnixSocketInfo(pub UnixSocketInfo);
-
-impl AsRef<UnixSocketInfo> for ClientUnixSocketInfo {
-    fn as_ref(&self) -> &UnixSocketInfo {
-        &self.0
-    }
-}
-
-impl AsMut<UnixSocketInfo> for ClientUnixSocketInfo {
-    fn as_mut(&mut self) -> &mut UnixSocketInfo {
-        &mut self.0
-    }
-}
-
-impl Deref for ClientUnixSocketInfo {
-    type Target = UnixSocketInfo;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl DerefMut for ClientUnixSocketInfo {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 #[derive(Debug, Clone, Extension)]
 /// Connected unix socket information.

--- a/src/http/client/mod.rs
+++ b/src/http/client/mod.rs
@@ -20,6 +20,7 @@ use crate::{
 pub use ::rama_http_backend::client::*;
 use rama_core::{
     error::{ErrorContext, ErrorExt as _, extra::OpaqueError},
+    extensions::Egress,
     layer::MapErr,
 };
 
@@ -210,7 +211,8 @@ where
             conn: http_connection,
         } = self.connector.serve(req).await.into_opaque_error()?;
 
-        req.extensions().extend(http_connection.extensions());
+        req.extensions()
+            .insert(Egress(http_connection.extensions().clone()));
 
         let http_connection = self.jit_layers.layer(http_connection);
 

--- a/tests/integration/examples/example_tests/haproxy_client_ip.rs
+++ b/tests/integration/examples/example_tests/haproxy_client_ip.rs
@@ -4,7 +4,7 @@ use super::utils;
 
 use rama::{
     Layer as _, Service,
-    extensions::ExtensionsRef,
+    extensions::{Egress, ExtensionsRef},
     http::{
         Body, BodyExtractExt, Request, client::HttpConnectorLayer,
         layer::required_header::AddRequiredRequestHeaders,
@@ -67,7 +67,8 @@ async fn test_server_with_haproxy_v1() {
         .await
         .expect("establish a connection to the http server using haproxy v1");
 
-    req.extensions().extend(http_service.extensions());
+    req.extensions()
+        .insert(Egress(http_service.extensions().clone()));
 
     let resp = AddRequiredRequestHeaders::new(http_service)
         .serve(req)
@@ -106,7 +107,8 @@ async fn test_server_with_haproxy_v2() {
         .await
         .expect("establish a connection to the http server using haproxy v2");
 
-    req.extensions().extend(http_service.extensions());
+    req.extensions()
+        .insert(Egress(http_service.extensions().clone()));
 
     let resp = AddRequiredRequestHeaders::new(http_service)
         .serve(req)

--- a/tests/integration/examples/example_tests/tls_boring_dynamic_certs.rs
+++ b/tests/integration/examples/example_tests/tls_boring_dynamic_certs.rs
@@ -2,7 +2,7 @@ use super::utils::{self, ClientService};
 use rama::{
     Layer, Service,
     error::BoxError,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Response, StreamingBody,
         client::EasyHttpWebClient,
@@ -70,8 +70,7 @@ async fn test_tls_boring_dynamic_certs() {
 
         let certificates = response
             .extensions()
-            .get_ref()
-            .and_then(|InputExtensions(ext)| ext.get_ref::<NegotiatedTlsParameters>())
+            .get_ref::<NegotiatedTlsParameters>()
             .unwrap()
             .peer_certificate_chain
             .clone()

--- a/tests/integration/examples/example_tests/tls_rustls_dynamic_certs.rs
+++ b/tests/integration/examples/example_tests/tls_rustls_dynamic_certs.rs
@@ -2,7 +2,7 @@ use super::utils::{self, ClientService};
 use rama::{
     Layer, Service,
     error::BoxError,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Response, StreamingBody,
         client::EasyHttpWebClient,
@@ -73,8 +73,7 @@ async fn test_tls_rustls_dynamic_certs() {
 
         let certificates = response
             .extensions()
-            .get_ref()
-            .and_then(|InputExtensions(ext)| ext.get_ref::<NegotiatedTlsParameters>())
+            .get_ref::<NegotiatedTlsParameters>()
             .unwrap()
             .peer_certificate_chain
             .clone()

--- a/tests/integration/examples/example_tests/tls_rustls_dynamic_config.rs
+++ b/tests/integration/examples/example_tests/tls_rustls_dynamic_config.rs
@@ -2,7 +2,7 @@ use super::utils::{self, ClientService};
 use rama::{
     Layer, Service,
     error::BoxError,
-    extensions::{ExtensionsRef, InputExtensions},
+    extensions::ExtensionsRef,
     http::{
         Response, StreamingBody,
         client::EasyHttpWebClient,
@@ -71,8 +71,7 @@ async fn test_tls_rustls_dynamic_config() {
 
         let certificates = response
             .extensions()
-            .get_ref()
-            .and_then(|InputExtensions(ext)| ext.get_ref::<NegotiatedTlsParameters>())
+            .get_ref::<NegotiatedTlsParameters>()
             .unwrap()
             .peer_certificate_chain
             .clone()

--- a/tests/integration/ua_emulation.rs
+++ b/tests/integration/ua_emulation.rs
@@ -1,4 +1,4 @@
-use rama::extensions::{Extension, Extensions, ExtensionsRef};
+use rama::extensions::{Egress, Extension, Extensions, ExtensionsRef};
 use rama::http::Request;
 use rama::http::client::HttpConnectorLayer;
 use rama::http::proto::h1::Http1HeaderMap;
@@ -321,7 +321,7 @@ async fn test_ua_emulation() {
                 let EstablishedClientConnection { input: req, conn } =
                     connector.serve(req).await.expect(description);
 
-                req.extensions().extend(conn.extensions());
+                req.extensions().insert(Egress(conn.extensions().clone()));
 
                 let svc = (UserAgentEmulateHttpRequestModifierLayer::default()).layer(conn);
                 Ok::<_, Infallible>(svc.serve(req).await.expect(description))
@@ -402,7 +402,7 @@ async fn test_ua_embedded_profiles_are_all_resulting_in_correct_traffic_flow() {
                     let EstablishedClientConnection { input: req, conn } =
                         connector.serve(req).await.expect(&expect_msg);
 
-                    req.extensions().extend(conn.extensions());
+                    req.extensions().insert(Egress(conn.extensions().clone()));
                     let svc = (UserAgentEmulateHttpRequestModifierLayer::default()).layer(conn);
                     Ok::<_, Infallible>(svc.serve(req).await.expect(&expect_msg))
                 }));

--- a/tests/turmoil/types.rs
+++ b/tests/turmoil/types.rs
@@ -3,8 +3,7 @@ use rama::{Service, error::BoxError, extensions::ExtensionsRef, telemetry::traci
 use rama::{
     error::ErrorContext as _,
     net::{
-        client::EstablishedClientConnection,
-        stream::{ClientSocketInfo, SocketInfo},
+        client::EstablishedClientConnection, stream::SocketInfo,
         transport::TryRefIntoTransportContext,
     },
 };
@@ -35,7 +34,7 @@ where
             .map_err(BoxError::from)?;
 
         let addr = conn.local_addr()?;
-        let info = ClientSocketInfo(SocketInfo::new(
+        let info = SocketInfo::new(
             conn.local_addr()
                 .inspect_err(|err| {
                     tracing::debug!(
@@ -45,7 +44,7 @@ where
                 .ok()
                 .map(Into::into),
             addr.into(),
-        ));
+        );
 
         let conn = TcpStream::new(conn);
         conn.extensions().insert(info);


### PR DESCRIPTION
What this adds:
- Shared connection extensions: a connection can update extensions and req/resp can see the updated content
- Extensions can be forked/have a live parent. We explored this idea before, but now with this shared AppendOnlyVec this has become possible
- Extensions are smart and will traverse ingress/egress/parents to find what is needed in a way that feels natural (hopefully)

Ok, so how does all of this work? Lets have a look at a common use cases: retry_layer -> http_client (with internal connection_pool):

Start two requests at exactly the same time (so pool needs to create two connections)

First request:
1. Retry layers forks the extensions, so retry requests start with the same extensions
1. The first request goes through the connector stack: TCP creates new Extensions and stores it on the connection
1. We go up the connector stack, each connector reads from Request extensions and transfers what it uses to the connection Extensions or adds extra info/state in there
1. We pass the connection pool, so connection will be stored here after use
1. HttpClient stores the connection Extensions as Egress<Extensions> on the request, so further layers down the stack can see this
1. We do the actual request, h2 machinery create a stream. Stream forks the connection extensions, so it has access to them but it doesn't edit them (but it can through internal mutability tricks if needed). It also stores this on the request so layers layers can see this
1. We get a response, extensions are request.extensions().fork(). So all request (and connections) are reachable
1. Connection goes back 

Second request:
1. Retry layers forks the extensions, so retry requests start with the same extensions
1. We do the exact same connection logic as first request
1. HttpClient stores the connection Extensions as Egress<Extensions> on the request, so further layers down the stack can see this
1. Something fails
1. Retry layer makes a retry request, because it forked the extensions nothing we did above "leaked" into this request
1. We go through connector setup, but now pool has the connection from the first request. So we use that
1. HttpClient stores the connection Extensions as Egress<Extensions> on the request, so further layers down the stack can see this
1. We get a response, extensions are request.extensions().fork(). So all request (and connections) are reachable
1. Connection goes back, but importantly we can still read these extensions from the response. So we can do things like `resp.extensions().get_ref::<ConnectionHealth>().mark_broken()`, if this has been stored on the connection we will be able to live modify it, and this will be readable by the pool

But how does this work? The rules for finding extensions are pretty simple
- Search the AppendOnlyVec starting from the end. If you find `T`, return Some(T)
- If you find Egress/Ingress extensions, recurse into these extensions and follow the same rules
- If all extensions are checked without a match, search extensions.parents() with the same rules

The rules kind of map to this:
- If you stored something recent: this should get priority
- If you store a connection ingress/egress, you should search in that entire chain, since connection specific info should always have priority over initial config/extensions
- If not found yet, search the initial extensions since nothing "more important" has recently set it

So how does this work when we do `resp.extensions().get_ref::<ConnectionHealth>()` in a h2 response:
- Search response -> no match and no ingress/egress chain
- Search parent = request_extensions -> at some point we find egress chain
- Search egress_chain = h2 stream -> no match
- Search parent = actual_connection that h2 stream is multiplexed over(tcp/tls/...) -> we find ConnectionHealth

So how does this work when we do `resp.extensions().get_ref::<State>()` in a h2 response:
- Search response -> no match and no ingress/egress chain
- Search parent = request_extensions -> at some point we find egress chain
- Search egress_chain = h2 stream -> no match
- Search parent = actual_connection that h2 stream is multiplexed over(tcp/tls/...) -> no match
- Parent chains are depleted, so we continue in requests_extensions -> find State

Many many many different approaches have been tried and they all failed in one of these things (if you are curious ask me about it):
- Doesn't scale to a mitm situation
- Breaks around upgrades, upgrades are weird they are kind of a connection, but a request/response at the same time
- Should be easy to use. Ingress/egress should be unimportant detail in most stacks, but explicit in mitm setup

I think this works for all of them? But curious what you think

Future work / what this unblocks:
- ConnectionHealth can now be inserted in a much nicer way, it just has to be in connection extensions, order is waaay less tricky
- Custom iterator for Extensions iter -> we dont really rely on this and the boxing approach only has minor overhead, if do use this more, we should make this (will probably do this soon just as future proofing)
- We can use Extension trait (+ derive) to build on this system. Some ideas might be: give a search hint to traverse it in a different way (eg for State: search from the start), add replace-like behaviour...
- Extensions can now be used to talk between connections and the external system. Eg connectionHealth, but a lot more is possible, explore this without going overboard
- Start using this for things like TLS and see what extra utilities might be needed