### PR TITLE
ffi/apple: tproxy stability fixes + FFI safety hardening

### DIFF
--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -204,6 +204,23 @@ typedef struct {
     size_t app_group_dir_utf8_len;
 } RamaTransparentProxyInitConfig;
 
+/// Outcome of `rama_transparent_proxy_tcp_session_on_client_bytes` /
+/// `rama_transparent_proxy_tcp_session_on_egress_bytes`.
+///
+/// Swift MUST distinguish `Paused` from `Closed`:
+///   * On `Paused`, pause reads and resume only when the matching
+///     `on_*_read_demand` callback fires.
+///   * On `Closed`, terminate the read pump immediately — no demand
+///     callback will ever follow.
+typedef enum {
+    /// Bytes were queued; Swift may continue reading from the kernel.
+    RAMA_TCP_DELIVER_ACCEPTED = 0,
+    /// Per-flow channel is full; pause until on_*_read_demand fires.
+    RAMA_TCP_DELIVER_PAUSED = 1,
+    /// Per-flow channel is closed (session teardown); stop reading.
+    RAMA_TCP_DELIVER_CLOSED = 2,
+} RamaTcpDeliverStatus;
+
 typedef void (*RamaTcpServerBytesFn)(void* context, RamaBytesView bytes);
 typedef void (*RamaTcpServerClosedFn)(void* context);
 typedef void (*RamaTcpClientReadDemandFn)(void* context);
@@ -444,11 +461,13 @@ void rama_transparent_proxy_tcp_session_free(RamaTransparentProxyTcpSession* ses
 ///
 /// `bytes` is borrowed for duration of the call.
 ///
-/// Returns `true` when Swift may continue calling `flow.readData` and `false`
-/// when Rust's per-flow ingress channel is full or closed. On `false` the
-/// caller MUST stop reading from the kernel and wait for the matching
-/// `on_client_read_demand` callback before resuming.
-bool rama_transparent_proxy_tcp_session_on_client_bytes(
+/// Returns a `RamaTcpDeliverStatus`:
+///   * `RAMA_TCP_DELIVER_ACCEPTED`: Swift may keep reading from the kernel.
+///   * `RAMA_TCP_DELIVER_PAUSED`: per-flow ingress channel is full; pause
+///     `flow.readData` until `on_client_read_demand` fires.
+///   * `RAMA_TCP_DELIVER_CLOSED`: session has been torn down; terminate the
+///     read pump immediately, no demand callback will follow.
+RamaTcpDeliverStatus rama_transparent_proxy_tcp_session_on_client_bytes(
     RamaTransparentProxyTcpSession* session,
     RamaBytesView bytes
 );
@@ -484,10 +503,9 @@ void rama_transparent_proxy_tcp_session_activate(
 /// Called by Swift when NWConnection.receive delivers data from the remote server.
 /// `bytes` is borrowed for the duration of the call.
 ///
-/// Returns `true` when Swift may keep calling `connection.receive(...)` and
-/// `false` when Rust's per-flow egress channel is full or closed. On `false`,
-/// pause receives until the matching `on_egress_read_demand` callback fires.
-bool rama_transparent_proxy_tcp_session_on_egress_bytes(
+/// Same `RamaTcpDeliverStatus` return contract as
+/// `rama_transparent_proxy_tcp_session_on_client_bytes`.
+RamaTcpDeliverStatus rama_transparent_proxy_tcp_session_on_egress_bytes(
     RamaTransparentProxyTcpSession* session,
     RamaBytesView bytes
 );

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -206,6 +206,7 @@ typedef struct {
 
 typedef void (*RamaTcpServerBytesFn)(void* context, RamaBytesView bytes);
 typedef void (*RamaTcpServerClosedFn)(void* context);
+typedef void (*RamaTcpClientReadDemandFn)(void* context);
 
 /// Callbacks Swift provides for Rust TCP session events.
 ///
@@ -229,6 +230,13 @@ typedef struct {
     RamaTcpServerBytesFn on_server_bytes;
     /// Called when Rust closes server-side TCP direction.
     RamaTcpServerClosedFn on_server_closed;
+    /// Called when the Rust ingress channel has space again after
+    /// `rama_transparent_proxy_tcp_session_on_client_bytes` returned `false`.
+    /// Swift MUST keep `flow.readData` paused between the `false` return and
+    /// this callback firing — otherwise bytes pile up in Apple's per-flow NE
+    /// kernel buffer and eventually abort the shared NEAppProxyProvider
+    /// director.
+    RamaTcpClientReadDemandFn on_client_read_demand;
 } RamaTransparentProxyTcpSessionCallbacks;
 
 typedef void (*RamaUdpServerDatagramFn)(void* context, RamaBytesView bytes);
@@ -306,6 +314,7 @@ typedef struct {
 
 typedef void (*RamaTcpEgressWriteFn)(void* context, RamaBytesView bytes);
 typedef void (*RamaTcpEgressCloseFn)(void* context);
+typedef void (*RamaTcpEgressReadDemandFn)(void* context);
 
 /// Callbacks passed to `rama_transparent_proxy_tcp_session_activate`.
 ///
@@ -325,6 +334,11 @@ typedef struct {
     void* context;
     RamaTcpEgressWriteFn on_write_to_egress;
     RamaTcpEgressCloseFn on_close_egress;
+    /// Called when the Rust egress channel has space again after
+    /// `rama_transparent_proxy_tcp_session_on_egress_bytes` returned `false`.
+    /// Swift MUST keep `connection.receive(...)` paused between the `false`
+    /// return and this callback firing.
+    RamaTcpEgressReadDemandFn on_egress_read_demand;
 } RamaTransparentProxyTcpEgressCallbacks;
 
 typedef void (*RamaUdpEgressSendFn)(void* context, RamaBytesView bytes);
@@ -426,10 +440,15 @@ RamaTransparentProxyTcpSessionResult rama_transparent_proxy_engine_new_tcp_sessi
 /// NULL is allowed and ignored.
 void rama_transparent_proxy_tcp_session_free(RamaTransparentProxyTcpSession* session);
 
-/// Deliver client->server TCP bytes into Rust session.
+/// Deliver client->server TCP bytes into the Rust session.
 ///
 /// `bytes` is borrowed for duration of the call.
-void rama_transparent_proxy_tcp_session_on_client_bytes(
+///
+/// Returns `true` when Swift may continue calling `flow.readData` and `false`
+/// when Rust's per-flow ingress channel is full or closed. On `false` the
+/// caller MUST stop reading from the kernel and wait for the matching
+/// `on_client_read_demand` callback before resuming.
+bool rama_transparent_proxy_tcp_session_on_client_bytes(
     RamaTransparentProxyTcpSession* session,
     RamaBytesView bytes
 );
@@ -464,7 +483,11 @@ void rama_transparent_proxy_tcp_session_activate(
 ///
 /// Called by Swift when NWConnection.receive delivers data from the remote server.
 /// `bytes` is borrowed for the duration of the call.
-void rama_transparent_proxy_tcp_session_on_egress_bytes(
+///
+/// Returns `true` when Swift may keep calling `connection.receive(...)` and
+/// `false` when Rust's per-flow egress channel is full or closed. On `false`,
+/// pause receives until the matching `on_egress_read_demand` callback fires.
+bool rama_transparent_proxy_tcp_session_on_egress_bytes(
     RamaTransparentProxyTcpSession* session,
     RamaBytesView bytes
 );

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -212,7 +212,12 @@ typedef struct {
 ///     `on_*_read_demand` callback fires.
 ///   * On `Closed`, terminate the read pump immediately — no demand
 ///     callback will ever follow.
-typedef enum {
+///
+/// The underlying type is fixed at `uint8_t` to match the Rust side's
+/// `#[repr(u8)]` exactly. Without the explicit `: uint8_t` the C standard
+/// leaves the enum width implementation-defined (typically `int`), which
+/// would mismatch the 1-byte Rust return on some ABIs / bindgen configs.
+typedef enum : uint8_t {
     /// Bytes were queued; Swift may continue reading from the kernel.
     RAMA_TCP_DELIVER_ACCEPTED = 0,
     /// Per-flow channel is full; pause until on_*_read_demand fires.

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -38,6 +38,24 @@ enum RamaTransparentProxyTcpSessionDecision {
     case blocked
 }
 
+/// Outcome of a Swift → Rust TCP byte-delivery call.
+///
+/// Mirrors the C-side `RamaTcpDeliverStatus` enum exactly. Swift code must
+/// distinguish `.paused` from `.closed`: `.paused` means wait for the
+/// matching `onClientReadDemand` / `onEgressReadDemand` callback before
+/// resuming; `.closed` is terminal and the read pump must stop immediately.
+enum RamaTcpDeliverStatusBridge: UInt8 {
+    case accepted = 0
+    case paused = 1
+    case closed = 2
+}
+
+private func tcpDeliverStatus(_ raw: RamaTcpDeliverStatus) -> RamaTcpDeliverStatusBridge {
+    // The C enum is `repr(u8)` with the same discriminants; treat any
+    // unknown value as `.closed` rather than silently dropping the signal.
+    RamaTcpDeliverStatusBridge(rawValue: UInt8(raw.rawValue)) ?? .closed
+}
+
 enum RamaTransparentProxyUdpSessionDecision {
     case intercept(RamaUdpSessionHandle)
     case passthrough
@@ -529,25 +547,25 @@ final class RamaTcpSessionHandle {
 
     /// Deliver bytes from the intercepted flow to the Rust session.
     ///
-    /// Returns `true` when the caller may keep reading from the kernel and
-    /// `false` when Rust signaled backpressure (per-flow ingress channel was
-    /// full or closed). On `false` the caller MUST stop calling
-    /// `flow.readData` until the matching `onClientReadDemand` callback
-    /// fires; ignoring this lets bytes accumulate in Apple's per-flow NE
-    /// kernel buffer and eventually aborts the shared director.
+    /// Returns the FFI delivery status. Callers MUST honor the status:
+    ///   * `.accepted` — keep reading from the kernel.
+    ///   * `.paused` — pause `flow.readData` until `onClientReadDemand` fires.
+    ///   * `.closed` — terminate the read pump; no demand will follow.
     @discardableResult
-    func onClientBytes(_ data: Data) -> Bool {
-        guard !data.isEmpty else { return true }
+    func onClientBytes(_ data: Data) -> RamaTcpDeliverStatusBridge {
+        guard !data.isEmpty else { return .accepted }
 
         lock.lock()
         defer { lock.unlock() }
-        guard !cancelled, let s = sessionPtr else { return false }
+        guard !cancelled, let s = sessionPtr else { return .closed }
 
-        return data.withUnsafeBytes { raw -> Bool in
+        return data.withUnsafeBytes { raw -> RamaTcpDeliverStatusBridge in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
-            guard let base else { return false }
+            guard let base else { return .closed }
             let view = RamaBytesView(ptr: base, len: Int(data.count))
-            return rama_transparent_proxy_tcp_session_on_client_bytes(s, view)
+            return tcpDeliverStatus(
+                rama_transparent_proxy_tcp_session_on_client_bytes(s, view)
+            )
         }
     }
 
@@ -617,22 +635,22 @@ final class RamaTcpSessionHandle {
 
     /// Deliver bytes from the egress `NWConnection` to the Rust session.
     ///
-    /// Returns `true` when the caller may keep calling
-    /// `connection.receive(...)` and `false` when Rust signaled backpressure.
-    /// On `false`, pause receives until `onEgressReadDemand` fires.
+    /// Same status contract as [`onClientBytes`] — see there.
     @discardableResult
-    func onEgressBytes(_ data: Data) -> Bool {
-        guard !data.isEmpty else { return true }
+    func onEgressBytes(_ data: Data) -> RamaTcpDeliverStatusBridge {
+        guard !data.isEmpty else { return .accepted }
 
         lock.lock()
         defer { lock.unlock() }
-        guard !cancelled, let s = sessionPtr else { return false }
+        guard !cancelled, let s = sessionPtr else { return .closed }
 
-        return data.withUnsafeBytes { raw -> Bool in
+        return data.withUnsafeBytes { raw -> RamaTcpDeliverStatusBridge in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
-            guard let base else { return false }
+            guard let base else { return .closed }
             let view = RamaBytesView(ptr: base, len: data.count)
-            return rama_transparent_proxy_tcp_session_on_egress_bytes(s, view)
+            return tcpDeliverStatus(
+                rama_transparent_proxy_tcp_session_on_egress_bytes(s, view)
+            )
         }
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -46,13 +46,16 @@ enum RamaTransparentProxyUdpSessionDecision {
 
 final class TcpSessionCallbackBox {
     let onServerBytes: (Data) -> Void
+    let onClientReadDemand: () -> Void
     let onServerClosed: () -> Void
 
     init(
         onServerBytes: @escaping (Data) -> Void,
+        onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) {
         self.onServerBytes = onServerBytes
+        self.onClientReadDemand = onClientReadDemand
         self.onServerClosed = onServerClosed
     }
 }
@@ -79,13 +82,16 @@ final class UdpSessionCallbackBox {
 /// while the egress `NWConnection` is active.
 final class TcpEgressCallbackBox {
     let onWriteToEgress: (Data) -> Void
+    let onEgressReadDemand: () -> Void
     let onCloseEgress: () -> Void
 
     init(
         onWriteToEgress: @escaping (Data) -> Void,
+        onEgressReadDemand: @escaping () -> Void,
         onCloseEgress: @escaping () -> Void
     ) {
         self.onWriteToEgress = onWriteToEgress
+        self.onEgressReadDemand = onEgressReadDemand
         self.onCloseEgress = onCloseEgress
     }
 }
@@ -202,6 +208,13 @@ private let ramaTcpOnServerBytesCallback:
             box.onServerBytes(data)
         }
 
+private let ramaTcpOnClientReadDemandCallback: @convention(c) (UnsafeMutableRawPointer?) -> Void =
+    { context in
+        guard let context else { return }
+        let box = Unmanaged<TcpSessionCallbackBox>.fromOpaque(context).takeUnretainedValue()
+        box.onClientReadDemand()
+    }
+
 private let ramaTcpOnServerClosedCallback: @convention(c) (UnsafeMutableRawPointer?) -> Void = {
     context in
     guard let context else { return }
@@ -251,6 +264,13 @@ private let ramaTcpOnCloseEgressCallback: @convention(c) (UnsafeMutableRawPointe
     let box = Unmanaged<TcpEgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
     box.onCloseEgress()
 }
+
+private let ramaTcpOnEgressReadDemandCallback: @convention(c) (UnsafeMutableRawPointer?) -> Void =
+    { context in
+        guard let context else { return }
+        let box = Unmanaged<TcpEgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
+        box.onEgressReadDemand()
+    }
 
 private let ramaUdpOnSendToEgressCallback:
     @convention(c) (UnsafeMutableRawPointer?, RamaBytesView) -> Void = { context, view in
@@ -386,6 +406,7 @@ final class RamaTransparentProxyEngineHandle {
     func newTcpSession(
         meta: RamaTransparentProxyFlowMetaBridge,
         onServerBytes: @escaping (Data) -> Void,
+        onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) -> RamaTransparentProxyTcpSessionDecision {
         guard let p = enginePtr else { return .passthrough }
@@ -393,12 +414,14 @@ final class RamaTransparentProxyEngineHandle {
         let callbackBox = Unmanaged.passRetained(
             TcpSessionCallbackBox(
                 onServerBytes: onServerBytes,
+                onClientReadDemand: onClientReadDemand,
                 onServerClosed: onServerClosed
             ))
         let callbacks = RamaTransparentProxyTcpSessionCallbacks(
             context: callbackBox.toOpaque(),
             on_server_bytes: ramaTcpOnServerBytesCallback,
-            on_server_closed: ramaTcpOnServerClosedCallback
+            on_server_closed: ramaTcpOnServerClosedCallback,
+            on_client_read_demand: ramaTcpOnClientReadDemandCallback
         )
 
         let result = withFlowMeta(meta) { metaPtr in
@@ -504,18 +527,27 @@ final class RamaTcpSessionHandle {
         egressBox?.release()
     }
 
-    func onClientBytes(_ data: Data) {
-        guard !data.isEmpty else { return }
+    /// Deliver bytes from the intercepted flow to the Rust session.
+    ///
+    /// Returns `true` when the caller may keep reading from the kernel and
+    /// `false` when Rust signaled backpressure (per-flow ingress channel was
+    /// full or closed). On `false` the caller MUST stop calling
+    /// `flow.readData` until the matching `onClientReadDemand` callback
+    /// fires; ignoring this lets bytes accumulate in Apple's per-flow NE
+    /// kernel buffer and eventually aborts the shared director.
+    @discardableResult
+    func onClientBytes(_ data: Data) -> Bool {
+        guard !data.isEmpty else { return true }
 
         lock.lock()
         defer { lock.unlock() }
-        guard !cancelled, let s = sessionPtr else { return }
+        guard !cancelled, let s = sessionPtr else { return false }
 
-        data.withUnsafeBytes { raw in
+        return data.withUnsafeBytes { raw -> Bool in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
-            guard let base else { return }
+            guard let base else { return false }
             let view = RamaBytesView(ptr: base, len: Int(data.count))
-            rama_transparent_proxy_tcp_session_on_client_bytes(s, view)
+            return rama_transparent_proxy_tcp_session_on_client_bytes(s, view)
         }
     }
 
@@ -560,6 +592,7 @@ final class RamaTcpSessionHandle {
     ///   - onCloseEgress: Called by Rust when the egress write direction is done.
     func activate(
         onWriteToEgress: @escaping (Data) -> Void,
+        onEgressReadDemand: @escaping () -> Void,
         onCloseEgress: @escaping () -> Void
     ) {
         lock.lock()
@@ -568,6 +601,7 @@ final class RamaTcpSessionHandle {
         let box = Unmanaged.passRetained(
             TcpEgressCallbackBox(
                 onWriteToEgress: onWriteToEgress,
+                onEgressReadDemand: onEgressReadDemand,
                 onCloseEgress: onCloseEgress
             ))
         egressCallbackBox = box
@@ -575,24 +609,30 @@ final class RamaTcpSessionHandle {
         let callbacks = RamaTransparentProxyTcpEgressCallbacks(
             context: box.toOpaque(),
             on_write_to_egress: ramaTcpOnWriteToEgressCallback,
-            on_close_egress: ramaTcpOnCloseEgressCallback
+            on_close_egress: ramaTcpOnCloseEgressCallback,
+            on_egress_read_demand: ramaTcpOnEgressReadDemandCallback
         )
         rama_transparent_proxy_tcp_session_activate(s, callbacks)
     }
 
     /// Deliver bytes from the egress `NWConnection` to the Rust session.
-    func onEgressBytes(_ data: Data) {
-        guard !data.isEmpty else { return }
+    ///
+    /// Returns `true` when the caller may keep calling
+    /// `connection.receive(...)` and `false` when Rust signaled backpressure.
+    /// On `false`, pause receives until `onEgressReadDemand` fires.
+    @discardableResult
+    func onEgressBytes(_ data: Data) -> Bool {
+        guard !data.isEmpty else { return true }
 
         lock.lock()
         defer { lock.unlock() }
-        guard !cancelled, let s = sessionPtr else { return }
+        guard !cancelled, let s = sessionPtr else { return false }
 
-        data.withUnsafeBytes { raw in
+        return data.withUnsafeBytes { raw -> Bool in
             let base = raw.bindMemory(to: UInt8.self).baseAddress
-            guard let base else { return }
+            guard let base else { return false }
             let view = RamaBytesView(ptr: base, len: data.count)
-            rama_transparent_proxy_tcp_session_on_egress_bytes(s, view)
+            return rama_transparent_proxy_tcp_session_on_egress_bytes(s, view)
         }
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -239,17 +239,23 @@ private final class TcpClientReadPump {
                     self.terminate(with: nil)
                     return
                 }
-                let accepted = session.onClientBytes(data)
-                if !accepted {
-                    // Rust signaled the ingress channel is full or closed —
-                    // hold off reading until `resume()` is called from the
-                    // demand callback. Without this, every `flow.readData`
-                    // we issue would hand bytes to a Rust side that has
-                    // nowhere to put them, defeating the bound.
+                switch session.onClientBytes(data) {
+                case .accepted:
+                    self.requestReadLocked()
+                case .paused:
+                    // Rust signaled the ingress channel is full — hold off
+                    // reading until `resume()` is called from the demand
+                    // callback. Without this, every `flow.readData` we issue
+                    // would hand bytes to a Rust side that has nowhere to
+                    // put them, defeating the bound.
                     self.paused = true
-                    return
+                case .closed:
+                    // Rust signaled the session is gone (teardown or
+                    // bridge-side write failure). No demand callback will
+                    // ever follow, so terminate the pump now instead of
+                    // waiting for an outer cleanup path.
+                    self.terminate(with: nil)
                 }
-                self.requestReadLocked()
             }
         }
     }
@@ -699,12 +705,26 @@ private final class NwTcpConnectionReadPump {
             self.queue.async {
                 self.receiving = false
                 guard !self.closed else { return }
+
                 if let data, !data.isEmpty {
-                    if let session = self.session {
-                        let accepted = session.onEgressBytes(data)
-                        if !accepted {
-                            self.paused = true
-                        }
+                    guard let session = self.session else {
+                        // Session was torn down while a receive was in
+                        // flight — drop the bytes and stop. Re-issuing
+                        // another `connection.receive` here would keep the
+                        // NWConnection's read side draining bytes that have
+                        // nowhere to go.
+                        self.closed = true
+                        return
+                    }
+                    switch session.onEgressBytes(data) {
+                    case .accepted:
+                        break
+                    case .paused:
+                        self.paused = true
+                    case .closed:
+                        // No demand will follow; tear the pump down now.
+                        self.closed = true
+                        return
                     }
                 }
                 if isComplete || error != nil {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -162,12 +162,21 @@ private func tcpUpstreamUnavailableError() -> NSError {
 
 private final class TcpClientReadPump {
     private let flow: NEAppProxyTCPFlow
-    private let session: RamaTcpSessionHandle
+    /// `weak` so the pump doesn't pin the session alive (the session map is
+    /// the single strong owner). Equally important: stops the strong-ref
+    /// cycle ctx → pump → session → callback closures → ctx.
+    private weak var session: RamaTcpSessionHandle?
     private let logger: (FlowLogMessage) -> Void
     private let onTerminal: (Error?) -> Void
     private let queue: DispatchQueue
     private var readPending = false
     private var closed = false
+    /// Set when the Rust ingress channel signaled "full". While paused we
+    /// stop calling `flow.readData` so kernel buffer pressure is propagated
+    /// upstream to the originating app instead of accumulating on our side.
+    /// Cleared by `resume()`, which is wired to the Rust → Swift
+    /// `onClientReadDemand` callback.
+    private var paused = false
 
     init(
         flow: NEAppProxyTCPFlow,
@@ -184,36 +193,63 @@ private final class TcpClientReadPump {
     }
 
     func requestRead() {
+        queue.async { self.requestReadLocked() }
+    }
+
+    /// Resume reading after the Rust side has freed capacity in the per-flow
+    /// ingress channel. Idempotent — calling while not paused is a no-op.
+    func resume() {
         queue.async {
-            guard !self.closed, !self.readPending else { return }
-            self.readPending = true
-            self.flow.readData { data, error in
-                self.queue.async {
-                    guard !self.closed else { return }
-                    self.readPending = false
+            guard !self.closed else { return }
+            self.paused = false
+            self.requestReadLocked()
+        }
+    }
 
-                    if let error {
-                        self.logger(
-                            classifyFlowCallbackError(error, operation: "tcp flow.read")
-                        )
-                        self.terminate(with: error)
-                        return
-                    }
+    private func requestReadLocked() {
+        guard !self.closed, !self.readPending, !self.paused else { return }
+        self.readPending = true
+        self.flow.readData { data, error in
+            self.queue.async {
+                guard !self.closed else { return }
+                self.readPending = false
 
-                    guard let data, !data.isEmpty else {
-                        self.logger(
-                            FlowLogMessage(
-                                level: .trace,
-                                text: "flow.readData eof"
-                            )
-                        )
-                        self.terminate(with: nil)
-                        return
-                    }
-
-                    self.session.onClientBytes(data)
-                    self.requestRead()
+                if let error {
+                    self.logger(
+                        classifyFlowCallbackError(error, operation: "tcp flow.read")
+                    )
+                    self.terminate(with: error)
+                    return
                 }
+
+                guard let data, !data.isEmpty else {
+                    self.logger(
+                        FlowLogMessage(
+                            level: .trace,
+                            text: "flow.readData eof"
+                        )
+                    )
+                    self.terminate(with: nil)
+                    return
+                }
+
+                guard let session = self.session else {
+                    // Session was torn down while a read was in flight — drop
+                    // the bytes and stop reading.
+                    self.terminate(with: nil)
+                    return
+                }
+                let accepted = session.onClientBytes(data)
+                if !accepted {
+                    // Rust signaled the ingress channel is full or closed —
+                    // hold off reading until `resume()` is called from the
+                    // demand callback. Without this, every `flow.readData`
+                    // we issue would hand bytes to a Rust side that has
+                    // nowhere to put them, defeating the bound.
+                    self.paused = true
+                    return
+                }
+                self.requestReadLocked()
             }
         }
     }
@@ -616,11 +652,23 @@ private func nwInterfaceType(_ raw: UInt8) -> NWInterface.InterfaceType {
 ///
 /// Calls `session.onEgressBytes(_:)` for each received chunk and
 /// `session.onEgressEof()` when the connection closes or fails.
+///
+/// Honors backpressure: when `onEgressBytes` returns `false` the Rust side's
+/// per-flow egress channel is full, and we stop scheduling further
+/// `connection.receive` calls until the matching `onEgressReadDemand`
+/// callback flips `paused` back to `false` via `resume()`.
 private final class NwTcpConnectionReadPump {
     private let connection: NWConnection
-    private let session: RamaTcpSessionHandle
+    /// `weak` for the same retain-cycle / ownership reasons as
+    /// [`TcpClientReadPump.session`].
+    private weak var session: RamaTcpSessionHandle?
     private let queue: DispatchQueue
     private var closed = false
+    private var paused = false
+    /// Tracks whether a `connection.receive(...)` call is in flight. Prevents
+    /// `resume()` (or repeated `start()`s) from issuing a second concurrent
+    /// receive, which `Network.framework` does not support.
+    private var receiving = false
 
     init(connection: NWConnection, session: RamaTcpSessionHandle, queue: DispatchQueue) {
         self.connection = connection
@@ -629,24 +677,42 @@ private final class NwTcpConnectionReadPump {
     }
 
     func start() {
-        scheduleRead()
+        queue.async { self.scheduleReadLocked() }
     }
 
-    private func scheduleRead() {
+    /// Resume scheduling receives after the Rust side has freed egress
+    /// capacity. Idempotent.
+    func resume() {
+        queue.async {
+            guard !self.closed else { return }
+            self.paused = false
+            self.scheduleReadLocked()
+        }
+    }
+
+    private func scheduleReadLocked() {
+        guard !self.closed, !self.paused, !self.receiving else { return }
+        self.receiving = true
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) {
             [weak self] data, _, isComplete, error in
             guard let self else { return }
             self.queue.async {
+                self.receiving = false
                 guard !self.closed else { return }
                 if let data, !data.isEmpty {
-                    self.session.onEgressBytes(data)
+                    if let session = self.session {
+                        let accepted = session.onEgressBytes(data)
+                        if !accepted {
+                            self.paused = true
+                        }
+                    }
                 }
                 if isComplete || error != nil {
                     self.closed = true
-                    self.session.onEgressEof()
+                    self.session?.onEgressEof()
                     return
                 }
-                self.scheduleRead()
+                self.scheduleReadLocked()
             }
         }
     }
@@ -787,6 +853,15 @@ private final class TcpFlowContext {
     /// of "undead" flows under sustained traffic until the kernel hands back
     /// `ENOMEM` on every new outbound connection.
     var connection: NWConnection?
+    /// Read pumps reachable from the Rust → Swift demand callbacks set up at
+    /// `newTcpSession` / `activate` time, before the pumps themselves exist.
+    ///
+    /// Strong refs because while paused, a pump has no in-flight
+    /// `flow.readData` / `connection.receive` callback to keep it alive — the
+    /// session map is the only thing that holds it (via this context). Cleared
+    /// on terminal teardown so the pump deallocates with the rest of the flow.
+    var clientReadPump: TcpClientReadPump?
+    var egressReadPump: NwTcpConnectionReadPump?
 }
 
 private final class UdpFlowContext {
@@ -987,6 +1062,16 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                 onServerBytes: { data in
                     writer.enqueue(data)
                 },
+                onClientReadDemand: { [weak ctx] in
+                    // Rust → Swift: the per-flow ingress channel has space
+                    // again, so we may resume `flow.readData`. Hop onto the
+                    // flow's queue before touching `ctx`, since this fires
+                    // from a Rust worker thread. `weak ctx` breaks the cycle
+                    // ctx → clientReadPump → session → callbackBox → here.
+                    flowQueue.async { [weak ctx] in
+                        ctx?.clientReadPump?.resume()
+                    }
+                },
                 onServerClosed: { [weak self] in
                     writer.closeWhenDrained { wasOpened in
                         if wasOpened {
@@ -1082,9 +1167,15 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                         connection: connection, queue: flowQueue)
                     let readPump = NwTcpConnectionReadPump(
                         connection: connection, session: session, queue: flowQueue)
+                    ctx.egressReadPump = readPump
 
                     session.activate(
                         onWriteToEgress: { data in writePump.enqueue(data) },
+                        onEgressReadDemand: { [weak ctx] in
+                            flowQueue.async { [weak ctx] in
+                                ctx?.egressReadPump?.resume()
+                            }
+                        },
                         onCloseEgress: { writePump.closeWhenDrained() }
                     )
 
@@ -1115,6 +1206,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                                     self?.removeTcpFlow(flowId)
                                 }
                             )
+                            ctx.clientReadPump = flowReadPump
                             flowReadPump.requestRead()
                         }
                     }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -778,10 +778,21 @@ private final class NwUdpConnectionReadPump {
 /// runtimes, so no extra locking is required here.
 private final class TcpFlowContext {
     weak var session: RamaTcpSessionHandle?
+    /// Egress NWConnection.
+    ///
+    /// Stored so late callbacks (Rust `onServerClosed`, writer terminal-error)
+    /// that are wired up *before* the connection is created can still call
+    /// `cancel()` on it. Without that explicit cancel the kernel's NECP flow
+    /// slot (Skywalk nexus channel) is never returned, accumulating thousands
+    /// of "undead" flows under sustained traffic until the kernel hands back
+    /// `ENOMEM` on every new outbound connection.
+    var connection: NWConnection?
 }
 
 private final class UdpFlowContext {
     weak var session: RamaUdpSessionHandle?
+    /// See `TcpFlowContext.connection`.
+    var connection: NWConnection?
 }
 
 public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
@@ -964,6 +975,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             onTerminalError: { [weak self] error in
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)
+                ctx.connection?.cancel()
                 ctx.session?.cancel()
                 self?.removeTcpFlow(flowId)
             }
@@ -985,6 +997,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                             flow.closeReadWithError(error)
                             flow.closeWriteWithError(error)
                         }
+                        ctx.connection?.cancel()
                         self?.removeTcpFlow(flowId)
                     }
                 }
@@ -1041,6 +1054,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             removeTcpFlow(flowId)
             return true
         }
+        ctx.connection = connection
 
         // Track whether the egress connection succeeded before flow.open was called.
         var egressReady = false
@@ -1111,11 +1125,22 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     self?.logDebug(
                         "egress NWConnection failed before flow opened: \(String(describing: error))"
                     )
+                    // Explicit cancel() releases the kernel NECP flow slot and
+                    // drives the connection to .cancelled, where we drop the
+                    // stateUpdateHandler reference to break the retain cycle
+                    // (handler captures connection; connection retains handler).
+                    connection.cancel()
                     session.cancel()
                     self?.removeTcpFlow(flowId)
 
                 case .cancelled:
-                    break  // our own cancel() call; nothing extra needed
+                    // Drop the handler so the closure's strong capture of
+                    // `connection` is released, allowing the NWConnection to
+                    // deallocate. Without this, `connection.cancel()` returns
+                    // the kernel slot but the Swift object lingers (which is
+                    // fine in itself — but together with bugs that skip
+                    // cancel() it caused thousands of orphaned flows).
+                    connection.stateUpdateHandler = nil
 
                 default:
                     break
@@ -1143,6 +1168,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                 writer?.close()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)
+                ctx.connection?.cancel()
                 ctx.session?.onClientClose()
                 self?.removeUdpFlow(flowId)
             }
@@ -1265,6 +1291,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             removeUdpFlow(flowId)
             return true
         }
+        ctx.connection = connection
 
         var egressReady = false
 
@@ -1320,11 +1347,14 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     self?.logDebug(
                         "egress NWConnection failed before udp flow opened: \(String(describing: error))"
                     )
+                    // See TCP path: explicit cancel() returns the kernel flow
+                    // slot; .cancelled drops the handler to break the cycle.
+                    connection.cancel()
                     session.onClientClose()
                     self?.removeUdpFlow(flowId)
 
                 case .cancelled:
-                    break
+                    connection.stateUpdateHandler = nil
 
                 default:
                     break

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
@@ -31,6 +31,13 @@ unsafe extern "C" fn on_tcp_server_closed(ctx: *mut c_void) {
     ctx.closed.notify_waiters();
 }
 
+/// Resume signal from Rust. The e2e test reads in a tight loop so it never
+/// has to honor a backpressure pause — but we still log the call to keep the
+/// FFI shape exercised.
+unsafe extern "C" fn on_tcp_client_read_demand(_ctx: *mut c_void) {}
+
+unsafe extern "C" fn on_tcp_egress_read_demand(_ctx: *mut c_void) {}
+
 // ── Egress (service → upstream) callback context ─────────────────────────────
 
 struct TcpEgressCallbackContext {
@@ -215,6 +222,7 @@ async fn serve_one_ingress_connection(
                     context: server_ctx_ptr as *mut c_void,
                     on_server_bytes: Some(on_tcp_server_bytes),
                     on_server_closed: Some(on_tcp_server_closed),
+                    on_client_read_demand: Some(on_tcp_client_read_demand),
                 },
             )
         };
@@ -238,6 +246,7 @@ async fn serve_one_ingress_connection(
                 context: egress_ctx_ptr as *mut c_void,
                 on_write_to_egress: Some(on_tcp_write_to_egress),
                 on_close_egress: Some(on_tcp_close_egress),
+                on_egress_read_demand: Some(on_tcp_egress_read_demand),
             },
         );
     }

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_xpc_server.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_xpc_server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use base64::Engine as _;
 use rama::{
     bytes::Bytes,
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError},
     net::apple::xpc::{
         PeerSecurityRequirement, XpcListener, XpcListenerConfig, XpcMessageRouter, XpcServer,
     },
@@ -148,7 +148,10 @@ pub(crate) fn spawn_xpc_server(
                  config; refusing to bind XPC listener (fail-closed). Set it from the container \
                  app's `Bundle.main.bundleIdentifier`.",
             );
-            "xpc demo server: missing container_signing_identifier (fail-closed)".into()
+            OpaqueError::from_static_str(
+                "xpc demo server: missing container_signing_identifier (fail-closed)",
+            )
+            .into_box_error()
         })?;
 
     tracing::info!(
@@ -157,8 +160,9 @@ pub(crate) fn spawn_xpc_server(
         "xpc demo server: start config+spawn (peer pinned to same-team + signing identifier)",
     );
 
-    let config = XpcListenerConfig::new(service_name.clone())
-        .with_peer_requirement(PeerSecurityRequirement::TeamIdentity(Some(signing_identifier)));
+    let config = XpcListenerConfig::new(service_name.clone()).with_peer_requirement(
+        PeerSecurityRequirement::TeamIdentity(Some(signing_identifier)),
+    );
 
     let router = XpcMessageRouter::new()
         .with_typed_route::<UpdateSettingsRequest, UpdateSettingsReply, _>(

--- a/rama-cli/src/cmd/serve/stunnel/mod.rs
+++ b/rama-cli/src/cmd/serve/stunnel/mod.rs
@@ -27,7 +27,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorContext as _},
+    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
     graceful::ShutdownGuard,
     net::{
         address::{HostWithPort, SocketAddress},
@@ -271,7 +271,10 @@ fn load_server_config(
             })))
         }
         (None, None) => Ok(try_new_server_config(None, exec)?),
-        _ => Err("Both certificate and key must be provided together, or neither".into()),
+        _ => Err(OpaqueError::from_static_str(
+            "Both certificate and key must be provided together, or neither",
+        )
+        .into_box_error()),
     }
 }
 

--- a/rama-net-apple-networkextension/src/ffi/bytes.rs
+++ b/rama-net-apple-networkextension/src/ffi/bytes.rs
@@ -23,6 +23,14 @@ impl BytesOwned {
             return;
         }
 
+        // `Vec::from_raw_parts` requires `len <= cap`. We clamp defensively for
+        // release builds (matches what the original `Vec` would have upheld),
+        // and shout in dev if the caller violated the contract — that means a
+        // bug somewhere upstream in the FFI ownership chain.
+        debug_assert!(
+            len <= cap,
+            "BytesOwned::free: len ({len}) > cap ({cap}) — caller violated Vec invariant"
+        );
         let vec_len = len.min(cap);
         let vec_cap = cap;
         // SAFETY: caller contract guarantees pointer/capacity originate from a `Vec<u8>`.

--- a/rama-net-apple-networkextension/src/ffi/log.rs
+++ b/rama-net-apple-networkextension/src/ffi/log.rs
@@ -17,7 +17,7 @@ impl LogLevel {
             // SAFETY: repr(u32) and valid range 0..=4 maps to a real variant
             unsafe { ::std::mem::transmute::<u32, Self>(x) }
         } else {
-            tracing::debug!("invalid raw u32 value transmuted as u32: {x} (defaulting it to DEBUG");
+            tracing::debug!("invalid raw u32 value for LogLevel: {x} (defaulting to DEBUG)");
             Self::Debug
         }
     }

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -268,6 +268,10 @@ pub struct TransparentProxyTcpSessionCallbacks {
     pub context: *mut c_void,
     pub on_server_bytes: Option<unsafe extern "C" fn(*mut c_void, BytesView)>,
     pub on_server_closed: Option<unsafe extern "C" fn(*mut c_void)>,
+    /// Rust → Swift: signal that the per-flow ingress channel has space again
+    /// after [`crate::tproxy::TransparentProxyTcpSession::on_client_bytes`] returned `false`.
+    /// Swift must keep `flow.readData` paused until this fires.
+    pub on_client_read_demand: Option<unsafe extern "C" fn(*mut c_void)>,
 }
 
 /// Callbacks Swift provides for Rust UDP session events.
@@ -414,6 +418,10 @@ pub struct TransparentProxyTcpEgressCallbacks {
     pub on_write_to_egress: Option<unsafe extern "C" fn(*mut c_void, BytesView)>,
     /// Rust calls this when the service is done writing to the egress NWConnection.
     pub on_close_egress: Option<unsafe extern "C" fn(*mut c_void)>,
+    /// Rust → Swift: signal that the per-flow egress channel has space again
+    /// after [`crate::tproxy::TransparentProxyTcpSession::on_egress_bytes`] returned `false`.
+    /// Swift must keep `connection.receive` paused until this fires.
+    pub on_egress_read_demand: Option<unsafe extern "C" fn(*mut c_void)>,
 }
 
 /// Callbacks passed to `rama_transparent_proxy_udp_session_activate`.

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -77,6 +77,7 @@ impl TransparentProxyFlowMeta {
     /// All pointer + length fields in `self` must be valid for reads during
     /// this call.
     pub unsafe fn as_owned_rust_type(&self) -> tproxy::TransparentProxyFlowMeta {
+        // SAFETY: pointer + length validity is guaranteed by caller contract.
         let source_app_audit_token = unsafe {
             opt_audit_token(
                 self.source_app_audit_token_bytes,
@@ -547,6 +548,8 @@ mod tests {
             source_app_pid_is_set: true,
         };
 
+        // SAFETY: every pointer field is null with matching len 0 above, so
+        // the read-validity contract is trivially satisfied.
         let owned = unsafe { meta.as_owned_rust_type() };
         assert_eq!(owned.source_app_pid, Some(4242));
         assert!(owned.source_app_audit_token.is_none());

--- a/rama-net-apple-networkextension/src/macros.rs
+++ b/rama-net-apple-networkextension/src/macros.rs
@@ -284,6 +284,7 @@ macro_rules! __transparent_proxy_ffi_emit {
 
             let context = callbacks.context as usize;
             let on_server_bytes = callbacks.on_server_bytes;
+            let on_client_read_demand = callbacks.on_client_read_demand;
             let on_server_closed = callbacks.on_server_closed;
 
             let engine = unsafe { &*engine };
@@ -304,6 +305,11 @@ macro_rules! __transparent_proxy_ffi_emit {
                                 len: bytes.len(),
                             },
                         );
+                    }
+                }),
+                ::std::sync::Arc::new(move || {
+                    if let Some(callback) = on_client_read_demand {
+                        unsafe { callback(context as *mut ::std::ffi::c_void) };
                     }
                 }),
                 ::std::sync::Arc::new(move || {
@@ -346,17 +352,25 @@ macro_rules! __transparent_proxy_ffi_emit {
             unsafe { drop(::std::boxed::Box::from_raw(session)) };
         }
 
+        /// Deliver bytes from the intercepted client flow into the Rust TCP
+        /// session.
+        ///
+        /// Returns `true` when Swift may continue reading from the kernel and
+        /// `false` when the per-flow ingress channel is full or the session
+        /// has been torn down. On `false` the caller MUST stop calling
+        /// `flow.readData` until the matching `on_client_read_demand`
+        /// callback fires.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_on_client_bytes(
             session: *mut RamaTransparentProxyTcpSession,
             bytes: $crate::ffi::BytesView,
-        ) {
+        ) -> bool {
             if session.is_null() {
-                return;
+                return false;
             }
 
             let slice = unsafe { bytes.into_slice() };
-            unsafe { (*session).on_client_bytes(slice) };
+            unsafe { (*session).on_client_bytes(slice) }
         }
 
         #[unsafe(no_mangle)]
@@ -546,6 +560,7 @@ macro_rules! __transparent_proxy_ffi_emit {
             let context = callbacks.context as usize;
             let on_write_to_egress = callbacks.on_write_to_egress;
             let on_close_egress = callbacks.on_close_egress;
+            let on_egress_read_demand = callbacks.on_egress_read_demand;
 
             unsafe {
                 (*session).activate(
@@ -567,6 +582,11 @@ macro_rules! __transparent_proxy_ffi_emit {
                         }
                     },
                     move || {
+                        if let Some(callback) = on_egress_read_demand {
+                            unsafe { callback(context as *mut ::std::ffi::c_void) };
+                        }
+                    },
+                    move || {
                         if let Some(callback) = on_close_egress {
                             unsafe { callback(context as *mut ::std::ffi::c_void) };
                         }
@@ -577,18 +597,22 @@ macro_rules! __transparent_proxy_ffi_emit {
 
         /// Deliver bytes from the egress `NWConnection` into the Rust TCP session.
         ///
-        /// Called by Swift when the NWConnection receives data from the remote server.
+        /// Called by Swift when the NWConnection receives data from the remote
+        /// server. Returns `true` when Swift may keep calling
+        /// `connection.receive`, and `false` when the per-flow egress channel
+        /// is full or the session has been torn down — Swift must then pause
+        /// receives until the matching `on_egress_read_demand` callback fires.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_on_egress_bytes(
             session: *mut RamaTransparentProxyTcpSession,
             bytes: $crate::ffi::BytesView,
-        ) {
+        ) -> bool {
             if session.is_null() {
-                return;
+                return false;
             }
 
             let slice = unsafe { bytes.into_slice() };
-            unsafe { (*session).on_egress_bytes(slice) };
+            unsafe { (*session).on_egress_bytes(slice) }
         }
 
         /// Signal EOF on the egress `NWConnection` direction.

--- a/rama-net-apple-networkextension/src/macros.rs
+++ b/rama-net-apple-networkextension/src/macros.rs
@@ -85,6 +85,7 @@ macro_rules! __transparent_proxy_ffi_emit {
         pub type RamaTransparentProxyEngine = $crate::tproxy::BoxedTransparentProxyEngine;
         pub type RamaTransparentProxyTcpSession = $crate::tproxy::TransparentProxyTcpSession;
         pub type RamaTransparentProxyUdpSession = $crate::tproxy::TransparentProxyUdpSession;
+        pub type RamaTcpDeliverStatus = $crate::tproxy::TcpDeliverStatus;
 
         pub type RamaTransparentProxyFlowMeta = $crate::ffi::tproxy::TransparentProxyFlowMeta;
         pub type RamaTransparentProxyFlowAction = $crate::ffi::tproxy::TransparentProxyFlowAction;
@@ -355,18 +356,21 @@ macro_rules! __transparent_proxy_ffi_emit {
         /// Deliver bytes from the intercepted client flow into the Rust TCP
         /// session.
         ///
-        /// Returns `true` when Swift may continue reading from the kernel and
-        /// `false` when the per-flow ingress channel is full or the session
-        /// has been torn down. On `false` the caller MUST stop calling
-        /// `flow.readData` until the matching `on_client_read_demand`
-        /// callback fires.
+        /// Returns a [`RamaTcpDeliverStatus`] code:
+        /// - `0` (`Accepted`): Swift may keep reading from the kernel.
+        /// - `1` (`Paused`): the per-flow ingress channel is full; Swift must
+        ///   pause `flow.readData` until the matching `on_client_read_demand`
+        ///   callback fires.
+        /// - `2` (`Closed`): the session is being torn down; Swift must
+        ///   terminate the read pump immediately — no further demand
+        ///   callback will fire.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_on_client_bytes(
             session: *mut RamaTransparentProxyTcpSession,
             bytes: $crate::ffi::BytesView,
-        ) -> bool {
+        ) -> RamaTcpDeliverStatus {
             if session.is_null() {
-                return false;
+                return RamaTcpDeliverStatus::Closed;
             }
 
             let slice = unsafe { bytes.into_slice() };
@@ -598,17 +602,15 @@ macro_rules! __transparent_proxy_ffi_emit {
         /// Deliver bytes from the egress `NWConnection` into the Rust TCP session.
         ///
         /// Called by Swift when the NWConnection receives data from the remote
-        /// server. Returns `true` when Swift may keep calling
-        /// `connection.receive`, and `false` when the per-flow egress channel
-        /// is full or the session has been torn down — Swift must then pause
-        /// receives until the matching `on_egress_read_demand` callback fires.
+        /// server. Same [`RamaTcpDeliverStatus`] return contract as
+        /// `rama_transparent_proxy_tcp_session_on_client_bytes`.
         #[unsafe(no_mangle)]
         pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_on_egress_bytes(
             session: *mut RamaTransparentProxyTcpSession,
             bytes: $crate::ffi::BytesView,
-        ) -> bool {
+        ) -> RamaTcpDeliverStatus {
             if session.is_null() {
-                return false;
+                return RamaTcpDeliverStatus::Closed;
             }
 
             let slice = unsafe { bytes.into_slice() };

--- a/rama-net-apple-networkextension/src/nw_udp_socket.rs
+++ b/rama-net-apple-networkextension/src/nw_udp_socket.rs
@@ -9,13 +9,13 @@ use tokio::sync::mpsc;
 /// Datagrams arriving from the NWConnection are delivered via [`recv`](Self::recv),
 /// and datagrams to send to the NWConnection are dispatched via [`send`](Self::send).
 pub struct NwUdpSocket {
-    incoming: mpsc::UnboundedReceiver<Bytes>,
+    incoming: mpsc::Receiver<Bytes>,
     outgoing: Arc<dyn Fn(Bytes) + Send + Sync + 'static>,
 }
 
 impl NwUdpSocket {
     pub(crate) fn new(
-        incoming: mpsc::UnboundedReceiver<Bytes>,
+        incoming: mpsc::Receiver<Bytes>,
         outgoing: Arc<dyn Fn(Bytes) + Send + Sync + 'static>,
     ) -> Self {
         Self { incoming, outgoing }

--- a/rama-net-apple-networkextension/src/process.rs
+++ b/rama-net-apple-networkextension/src/process.rs
@@ -221,6 +221,11 @@ pub unsafe fn pid_arguments(pid: i32) -> io::Result<Vec<String>> {
         return Ok(Vec::new());
     }
 
+    // The unsafe read below dereferences via `buf.as_ptr()`, so the relevant
+    // invariant is on `buf.len()` (the allocation size), not `buf_len` (the
+    // bytes the kernel reported). They satisfy `buf.len() >= buf_len`, but
+    // make that explicit so a future change to either side trips this in dev.
+    debug_assert!(buf.len() >= size_of::<i32>());
     // SAFETY: `buf` is at least `size_of::<i32>()` bytes long.
     let argc =
         (unsafe { ptr::read_unaligned(buf.as_ptr().cast::<i32>()) }.max(0) as usize).min(4096);

--- a/rama-net-apple-networkextension/src/process.rs
+++ b/rama-net-apple-networkextension/src/process.rs
@@ -275,6 +275,8 @@ mod tests {
     #[test]
     fn current_process_path_is_available() {
         let current = std::process::id() as i32;
+        // SAFETY: querying our own pid is always safe — `proc_pidpath`
+        // accepts any valid pid and the current process necessarily exists.
         let path = unsafe { pid_path(current) }
             .expect("read process path")
             .expect("current process path");
@@ -288,6 +290,7 @@ mod tests {
     #[test]
     fn current_process_arguments_are_available() {
         let current = std::process::id() as i32;
+        // SAFETY: same as above — querying our own pid is always valid.
         let args = unsafe { pid_arguments(current) }.expect("read process arguments");
         assert!(!args.is_empty(), "current process should expose argv");
         assert!(!args[0].is_empty(), "argv[0] should not be empty");

--- a/rama-net-apple-networkextension/src/system_keychain/ca.rs
+++ b/rama-net-apple-networkextension/src/system_keychain/ca.rs
@@ -154,6 +154,7 @@ pub fn uninstall_system_ca(cert_der: &[u8]) -> Result<(), SystemKeychainError> {
 
         // SAFETY: cf_data is a valid non-null CFDataRef.
         let len = unsafe { sys::CFDataGetLength(cf_data) } as usize;
+        // SAFETY: cf_data is a valid non-null CFDataRef.
         let bytes_ptr = unsafe { sys::CFDataGetBytePtr(cf_data) };
         if bytes_ptr.is_null() || len != cert_der.len() {
             continue;

--- a/rama-net-apple-networkextension/src/system_keychain/mod.rs
+++ b/rama-net-apple-networkextension/src/system_keychain/mod.rs
@@ -142,6 +142,9 @@ pub fn load_secret(service: &str, account: &str) -> Result<Option<Vec<u8>>, Syst
             std::slice::from_raw_parts(password_data.cast::<u8>(), password_length as usize)
         };
         let vec = slice.to_vec();
+        // SAFETY: `password_data` was returned by
+        // `SecKeychainFindGenericPassword` and has not yet been freed; we
+        // copied the bytes into `vec` above so freeing is safe.
         unsafe { sys::SecKeychainItemFreeContent(std::ptr::null_mut(), password_data) };
         vec
     };

--- a/rama-net-apple-networkextension/src/tproxy/engine/boxed.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/boxed.rs
@@ -20,6 +20,7 @@ trait BoxedTransparentProxyEngineInner: Send + Sync + 'static {
         &self,
         meta: TransparentProxyFlowMeta,
         on_server_bytes: BoxedServerBytesSink,
+        on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession>;
     fn new_udp_session(
@@ -51,11 +52,13 @@ where
         &self,
         meta: TransparentProxyFlowMeta,
         on_server_bytes: BoxedServerBytesSink,
+        on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession> {
         self.new_tcp_session(
             meta,
             move |bytes| on_server_bytes(bytes.as_ref()),
+            move || on_client_read_demand(),
             move || on_server_closed(),
         )
     }
@@ -95,10 +98,15 @@ impl BoxedTransparentProxyEngine {
         &self,
         meta: TransparentProxyFlowMeta,
         on_server_bytes: BoxedServerBytesSink,
+        on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession> {
-        self.0
-            .new_tcp_session(meta, on_server_bytes, on_server_closed)
+        self.0.new_tcp_session(
+            meta,
+            on_server_bytes,
+            on_client_read_demand,
+            on_server_closed,
+        )
     }
 
     pub fn new_udp_session(

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -14,6 +14,8 @@ use super::{
 pub struct TransparentProxyEngineBuilder<F, R = DefaultTransparentProxyAsyncRuntimeFactory> {
     handler_factory: F,
     tcp_flow_buffer_size: Option<usize>,
+    tcp_channel_capacity: Option<usize>,
+    udp_channel_capacity: Option<usize>,
     opaque_config: Option<Arc<[u8]>>,
     runtime_factory: R,
 }
@@ -27,6 +29,8 @@ where
         Self {
             handler_factory: factory,
             tcp_flow_buffer_size: None,
+            tcp_channel_capacity: None,
+            udp_channel_capacity: None,
             opaque_config: None,
             runtime_factory: DefaultTransparentProxyAsyncRuntimeFactory::default(),
         }
@@ -39,6 +43,8 @@ where
         TransparentProxyEngineBuilder {
             handler_factory: self.handler_factory,
             tcp_flow_buffer_size: self.tcp_flow_buffer_size,
+            tcp_channel_capacity: self.tcp_channel_capacity,
+            udp_channel_capacity: self.udp_channel_capacity,
             opaque_config: self.opaque_config,
             runtime_factory,
         }
@@ -55,6 +61,31 @@ where
         pub fn tcp_flow_buffer_size(mut self, size: Option<usize>) -> Self
         {
             self.tcp_flow_buffer_size = size;
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Capacity (in chunks) of each per-flow TCP ingress / egress mpsc channel
+        /// between the Swift FFI boundary and the Rust bridge tasks.
+        ///
+        /// Bounds the worst-case memory pinned by a slow service before Swift is
+        /// told to stop reading from the kernel and wait for the matching
+        /// `on_*_read_demand` callback. `None` uses the default.
+        pub fn tcp_channel_capacity(mut self, capacity: Option<usize>) -> Self
+        {
+            self.tcp_channel_capacity = capacity;
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Capacity (in datagrams) of each per-flow UDP ingress / egress mpsc
+        /// channel. UDP datagrams are dropped when the channel is full
+        /// (matching wire-level UDP semantics). `None` uses the default.
+        pub fn udp_channel_capacity(mut self, capacity: Option<usize>) -> Self
+        {
+            self.udp_channel_capacity = capacity;
             self
         }
     }
@@ -82,6 +113,8 @@ where
         let Self {
             handler_factory,
             tcp_flow_buffer_size,
+            tcp_channel_capacity,
+            udp_channel_capacity,
             opaque_config,
             runtime_factory,
         } = self;
@@ -111,6 +144,12 @@ where
             handler,
             tcp_flow_buffer_size: tcp_flow_buffer_size
                 .unwrap_or(super::DEFAULT_TCP_FLOW_BUFFER_SIZE),
+            tcp_channel_capacity: tcp_channel_capacity
+                .filter(|c| *c > 0)
+                .unwrap_or(super::DEFAULT_TCP_CHANNEL_CAPACITY),
+            udp_channel_capacity: udp_channel_capacity
+                .filter(|c| *c > 0)
+                .unwrap_or(super::DEFAULT_UDP_CHANNEL_CAPACITY),
             shutdown: Some(shutdown),
             stop_trigger: Some(stop_tx),
         })

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -119,6 +119,17 @@ where
             runtime_factory,
         } = self;
 
+        // Reject explicit `Some(0)` rather than silently falling back to the
+        // default. `tokio::sync::mpsc::channel(0)` panics, and a misconfigured
+        // capacity is more useful as a build-time error than as a footgun.
+        // `None` continues to mean "use the default".
+        if matches!(tcp_channel_capacity, Some(0)) {
+            return Err("tcp_channel_capacity must be > 0".into());
+        }
+        if matches!(udp_channel_capacity, Some(0)) {
+            return Err("udp_channel_capacity must be > 0".into());
+        }
+
         let rt = runtime_factory
             .create_async_runtime(opaque_config.as_deref())
             .context("TransparentProxyEngineBuilder: create async runtime")?;
@@ -145,10 +156,8 @@ where
             tcp_flow_buffer_size: tcp_flow_buffer_size
                 .unwrap_or(super::DEFAULT_TCP_FLOW_BUFFER_SIZE),
             tcp_channel_capacity: tcp_channel_capacity
-                .filter(|c| *c > 0)
                 .unwrap_or(super::DEFAULT_TCP_CHANNEL_CAPACITY),
             udp_channel_capacity: udp_channel_capacity
-                .filter(|c| *c > 0)
                 .unwrap_or(super::DEFAULT_UDP_CHANNEL_CAPACITY),
             shutdown: Some(shutdown),
             stop_trigger: Some(stop_tx),

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rama_core::{
-    error::{BoxError, ErrorContext},
+    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
     graceful::Shutdown,
     rt::Executor,
 };
@@ -124,10 +124,14 @@ where
         // capacity is more useful as a build-time error than as a footgun.
         // `None` continues to mean "use the default".
         if matches!(tcp_channel_capacity, Some(0)) {
-            return Err("tcp_channel_capacity must be > 0".into());
+            return Err(
+                OpaqueError::from_static_str("tcp_channel_capacity must be > 0").into_box_error(),
+            );
         }
         if matches!(udp_channel_capacity, Some(0)) {
-            return Err("udp_channel_capacity must be > 0".into());
+            return Err(
+                OpaqueError::from_static_str("udp_channel_capacity must be > 0").into_box_error(),
+            );
         }
 
         let rt = runtime_factory

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -1,4 +1,10 @@
-use std::{future::Future, sync::Arc};
+use std::{
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use rama_core::{
     bytes::Bytes,
@@ -11,7 +17,10 @@ use rama_core::{
 use rama_net::{conn::is_connection_error, proxy::ProxyTarget};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    sync::{mpsc, oneshot, watch},
+    sync::{
+        mpsc::{self, error::TrySendError},
+        oneshot, watch,
+    },
 };
 
 use crate::{
@@ -43,6 +52,21 @@ pub use self::runtime::{
 };
 
 const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 64 * 1024; // 64 KiB
+/// Number of `Bytes` chunks each TCP per-flow channel (ingress and egress) will
+/// buffer before we tell Swift to stop reading from the kernel and wait for a
+/// demand callback to resume. Each chunk is whatever Swift hands us in one
+/// `flow.readData` / `connection.receive` callback (typically 4–64 KiB).
+///
+/// 8 chunks is a small multiple of `DEFAULT_TCP_FLOW_BUFFER_SIZE` to keep
+/// per-flow worst-case memory bounded under load: the prior unbounded design
+/// let one slow flow buffer arbitrary amounts of pending bytes, which under
+/// sustained traffic exhausts Apple's per-flow NE kernel buffer and aborts the
+/// shared NEAppProxyProvider director, killing every flow on the extension.
+const DEFAULT_TCP_CHANNEL_CAPACITY: usize = 8;
+/// Bound on the UDP ingress and egress channels. UDP datagrams are inherently
+/// lossy, so on a full channel we drop the datagram rather than block; the
+/// bound is just a memory cap.
+const DEFAULT_UDP_CHANNEL_CAPACITY: usize = 64;
 
 type BytesSink = Arc<dyn Fn(Bytes) + Send + Sync + 'static>;
 type ClosedSink = Arc<dyn Fn() + Send + Sync + 'static>;
@@ -58,6 +82,8 @@ pub struct TransparentProxyEngine<H> {
     rt: tokio::runtime::Runtime,
     handler: H,
     tcp_flow_buffer_size: usize,
+    tcp_channel_capacity: usize,
+    udp_channel_capacity: usize,
     shutdown: Option<Shutdown>,
     stop_trigger: Option<oneshot::Sender<()>>,
 }
@@ -85,14 +111,16 @@ where
         block_on_async_task(&self.rt, handler.handle_app_message(exec, message))
     }
 
-    pub fn new_tcp_session<OnBytes, OnClosed>(
+    pub fn new_tcp_session<OnBytes, OnDemand, OnClosed>(
         &self,
         meta: TransparentProxyFlowMeta,
         on_server_bytes: OnBytes,
+        on_client_read_demand: OnDemand,
         on_server_closed: OnClosed,
     ) -> SessionFlowAction<TransparentProxyTcpSession>
     where
         OnBytes: Fn(Bytes) + Send + Sync + 'static,
+        OnDemand: Fn() + Send + Sync + 'static,
         OnClosed: Fn() + Send + Sync + 'static,
     {
         let Some(guard) = self.shutdown_guard() else {
@@ -104,6 +132,7 @@ where
         };
 
         let tcp_flow_buffer_size = self.tcp_flow_buffer_size;
+        let tcp_channel_capacity = self.tcp_channel_capacity;
         let exec = Executor::graceful(guard.clone());
         let handler = self.handler.clone();
 
@@ -114,7 +143,9 @@ where
                 exec,
                 meta,
                 tcp_flow_buffer_size,
+                tcp_channel_capacity,
                 on_server_bytes,
+                on_client_read_demand,
                 on_server_closed,
                 handler,
             ),
@@ -141,6 +172,7 @@ where
             return SessionFlowAction::Passthrough;
         };
 
+        let udp_channel_capacity = self.udp_channel_capacity;
         let exec = Executor::graceful(guard.clone());
         let handler = self.handler.clone();
 
@@ -150,6 +182,7 @@ where
                 guard,
                 exec,
                 meta,
+                udp_channel_capacity,
                 on_server_datagram,
                 on_client_read_demand,
                 on_server_closed,
@@ -174,7 +207,14 @@ struct TcpSessionPendingData {
     /// Delivers the completed `BridgeIo` to the waiting service task.
     bridge_tx: oneshot::Sender<BridgeIo<TcpFlow, NwTcpStream>>,
     /// Ingress (client→Rust) bytes; handed to the ingress bridge at activate.
-    client_rx: mpsc::UnboundedReceiver<Bytes>,
+    client_rx: mpsc::Receiver<Bytes>,
+    /// Ingress paused flag, shared with `on_client_bytes` and the bridge.
+    /// See [`TransparentProxyTcpSession::client_paused`].
+    client_paused: Arc<AtomicBool>,
+    /// Rust→Swift: signal Swift it can resume reading from the intercepted flow.
+    /// Fired by the ingress bridge after it drained a chunk while
+    /// `client_paused` was set.
+    on_client_read_demand: DemandSink,
     /// Ingress EOF watch; handed to the ingress bridge at activate.
     eof_rx: watch::Receiver<bool>,
     /// Rust→Swift: response bytes back to the intercepted client flow.
@@ -183,6 +223,8 @@ struct TcpSessionPendingData {
     on_server_closed: ClosedSink,
     /// Both ingress and egress duplex buffer size.
     tcp_flow_buffer_size: usize,
+    /// Capacity of the bounded ingress and egress mpsc channels (in chunks).
+    tcp_channel_capacity: usize,
     /// Per-flow metadata inserted into `TcpFlow` extensions at activate.
     meta: TransparentProxyFlowMeta,
     /// Flow-scoped guard; held by bridge tasks to delay shutdown until they finish.
@@ -200,12 +242,20 @@ struct TcpSessionPendingData {
 
 pub struct TransparentProxyTcpSession {
     // ingress data path
-    client_tx: Option<mpsc::UnboundedSender<Bytes>>,
+    client_tx: Option<mpsc::Sender<Bytes>>,
+    /// `true` while Swift has been told to stop calling `on_client_bytes`
+    /// (because the ingress channel was full). Cleared by the ingress bridge
+    /// after it drains a chunk; the bridge then fires
+    /// `on_client_read_demand` to wake Swift.
+    client_paused: Arc<AtomicBool>,
     eof_tx: watch::Sender<bool>,
     saw_client_bytes: bool,
 
     // egress data path (populated by activate)
-    egress_tx: Option<mpsc::UnboundedSender<Bytes>>,
+    egress_tx: Option<mpsc::Sender<Bytes>>,
+    /// Same role as `client_paused` but for the egress (NWConnection→Rust)
+    /// channel; populated at `activate`.
+    egress_paused: Option<Arc<AtomicBool>>,
     egress_eof_tx: Option<watch::Sender<bool>>,
 
     // lifecycle
@@ -223,13 +273,34 @@ pub struct TransparentProxyTcpSession {
 
 impl TransparentProxyTcpSession {
     /// Called by Swift when client bytes arrive on the intercepted flow.
-    pub fn on_client_bytes(&mut self, bytes: &[u8]) {
+    ///
+    /// Returns `true` when the bytes were accepted (Swift may continue reading
+    /// from the kernel) and `false` when the per-flow ingress channel was full
+    /// or has been closed (Swift must stop reading and wait for the
+    /// `on_client_read_demand` callback before resuming).
+    ///
+    /// Never blocks the calling thread: this is invoked synchronously from a
+    /// Swift dispatch queue, so we use `try_send` and surface fullness as a
+    /// pause signal instead of awaiting capacity.
+    #[must_use = "the caller must honor the returned backpressure signal"]
+    pub fn on_client_bytes(&mut self, bytes: &[u8]) -> bool {
         if bytes.is_empty() {
-            return;
+            return true;
         }
         self.saw_client_bytes = true;
-        if let Some(tx) = self.client_tx.as_mut() {
-            let _ = tx.send(Bytes::copy_from_slice(bytes));
+        let Some(tx) = self.client_tx.as_mut() else {
+            // Session is being torn down; tell Swift to pause. The follow-up
+            // `on_server_closed` callback (or a future cancel) will tear down
+            // the flow on the Swift side.
+            return false;
+        };
+        match tx.try_send(Bytes::copy_from_slice(bytes)) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => {
+                self.client_paused.store(true, Ordering::Release);
+                false
+            }
+            Err(TrySendError::Closed(_)) => false,
         }
     }
 
@@ -243,12 +314,25 @@ impl TransparentProxyTcpSession {
     }
 
     /// Called by Swift when bytes arrive from the egress `NWConnection`.
-    pub fn on_egress_bytes(&mut self, bytes: &[u8]) {
+    ///
+    /// See [`Self::on_client_bytes`] for the bool-return contract.
+    #[must_use = "the caller must honor the returned backpressure signal"]
+    pub fn on_egress_bytes(&mut self, bytes: &[u8]) -> bool {
         if bytes.is_empty() {
-            return;
+            return true;
         }
-        if let Some(tx) = self.egress_tx.as_mut() {
-            let _ = tx.send(Bytes::copy_from_slice(bytes));
+        let Some(tx) = self.egress_tx.as_mut() else {
+            return false;
+        };
+        match tx.try_send(Bytes::copy_from_slice(bytes)) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => {
+                if let Some(paused) = self.egress_paused.as_ref() {
+                    paused.store(true, Ordering::Release);
+                }
+                false
+            }
+            Err(TrySendError::Closed(_)) => false,
         }
     }
 
@@ -270,13 +354,17 @@ impl TransparentProxyTcpSession {
     /// intercepted flow has been successfully opened.
     ///
     /// * `on_write_to_egress` — Rust→Swift: service bytes destined for the remote server.
+    /// * `on_egress_read_demand` — Rust→Swift: signal Swift it can resume reading
+    ///   from the egress `NWConnection` after `on_egress_bytes` returned `false`.
     /// * `on_close_egress` — Rust→Swift: egress stream is done writing.
-    pub fn activate<OnEgressWrite, OnEgressClose>(
+    pub fn activate<OnEgressWrite, OnEgressDemand, OnEgressClose>(
         &mut self,
         on_write_to_egress: OnEgressWrite,
+        on_egress_read_demand: OnEgressDemand,
         on_close_egress: OnEgressClose,
     ) where
         OnEgressWrite: Fn(Bytes) + Send + Sync + 'static,
+        OnEgressDemand: Fn() + Send + Sync + 'static,
         OnEgressClose: Fn() + Send + Sync + 'static,
     {
         let Some(pending) = self.pending.take() else {
@@ -289,10 +377,13 @@ impl TransparentProxyTcpSession {
         let TcpSessionPendingData {
             bridge_tx,
             client_rx,
+            client_paused,
+            on_client_read_demand,
             eof_rx,
             on_server_bytes,
             on_server_closed,
             tcp_flow_buffer_size,
+            tcp_channel_capacity,
             meta,
             flow_guard,
             rt_handle,
@@ -313,18 +404,23 @@ impl TransparentProxyTcpSession {
         let (egress_user, egress_internal) = tokio::io::duplex(tcp_flow_buffer_size);
         let egress_stream = NwTcpStream::new(egress_user);
 
-        let (egress_client_tx, egress_client_rx) = mpsc::unbounded_channel::<Bytes>();
+        let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
         let (egress_eof_tx, egress_eof_rx) = watch::channel(false);
+        let egress_paused = Arc::new(AtomicBool::new(false));
         self.egress_tx = Some(egress_client_tx);
+        self.egress_paused = Some(egress_paused.clone());
         self.egress_eof_tx = Some(egress_eof_tx);
 
         // guard egress callbacks
         let egress_bytes_sink: BytesSink = Arc::new(on_write_to_egress);
         let egress_closed_sink: ClosedSink = Arc::new(on_close_egress);
+        let egress_demand_sink: DemandSink = Arc::new(on_egress_read_demand);
         let guarded_egress_bytes =
             guarded_bytes_sink(self.callback_active.clone(), egress_bytes_sink);
         let guarded_egress_closed =
             guarded_closed_sink(self.callback_active.clone(), egress_closed_sink);
+        let guarded_egress_demand =
+            guarded_demand_sink(self.callback_active.clone(), egress_demand_sink);
 
         // Spawn bridge tasks via the stored runtime handle so that `activate` can be
         // called from an external (non-Tokio) thread — e.g. a Swift dispatch queue.
@@ -339,6 +435,8 @@ impl TransparentProxyTcpSession {
                 run_tcp_bridge(
                     ingress_internal,
                     client_rx,
+                    client_paused,
+                    on_client_read_demand,
                     eof_rx,
                     on_server_bytes,
                     on_server_closed,
@@ -354,6 +452,8 @@ impl TransparentProxyTcpSession {
                 run_tcp_bridge(
                     egress_internal,
                     egress_client_rx,
+                    egress_paused,
+                    guarded_egress_demand,
                     egress_eof_rx,
                     guarded_egress_bytes,
                     guarded_egress_closed,
@@ -380,6 +480,7 @@ impl TransparentProxyTcpSession {
         *self.callback_active.lock() = false;
         self.client_tx = None;
         self.egress_tx = None;
+        self.egress_paused = None;
         let _ = self.eof_tx.send(true);
         if let Some(tx) = self.egress_eof_tx.as_mut() {
             let _ = tx.send(true);
@@ -409,17 +510,20 @@ impl Drop for TransparentProxyTcpSession {
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn new_tcp_session_flow_action<OnBytes, OnClosed, H>(
+async fn new_tcp_session_flow_action<OnBytes, OnDemand, OnClosed, H>(
     parent_guard: ShutdownGuard,
     exec: Executor,
     meta: TransparentProxyFlowMeta,
     tcp_flow_buffer_size: usize,
+    tcp_channel_capacity: usize,
     on_server_bytes: OnBytes,
+    on_client_read_demand: OnDemand,
     on_server_closed: OnClosed,
     handler: H,
 ) -> SessionFlowAction<TransparentProxyTcpSession>
 where
     OnBytes: Fn(Bytes) + Send + Sync + 'static,
+    OnDemand: Fn() + Send + Sync + 'static,
     OnClosed: Fn() + Send + Sync + 'static,
     H: TransparentProxyHandler,
 {
@@ -441,7 +545,8 @@ where
     });
     let flow_guard = flow_shutdown.guard();
 
-    let (client_tx, client_rx) = mpsc::unbounded_channel::<Bytes>();
+    let (client_tx, client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
+    let client_paused = Arc::new(AtomicBool::new(false));
     let (eof_tx, eof_rx) = watch::channel(false);
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<TcpFlow, NwTcpStream>>();
 
@@ -450,6 +555,8 @@ where
         guarded_bytes_sink(callback_active.clone(), Arc::new(on_server_bytes));
     let on_server_closed_guarded =
         guarded_closed_sink(callback_active.clone(), Arc::new(on_server_closed));
+    let on_client_read_demand_guarded =
+        guarded_demand_sink(callback_active.clone(), Arc::new(on_client_read_demand));
 
     // Capture the current runtime handle so `activate` can spawn bridge tasks from
     // any thread (including an external Swift thread) via `Handle::spawn`.
@@ -468,10 +575,13 @@ where
     let pending = TcpSessionPendingData {
         bridge_tx,
         client_rx,
+        client_paused: client_paused.clone(),
+        on_client_read_demand: on_client_read_demand_guarded,
         eof_rx,
         on_server_bytes: on_server_bytes_guarded,
         on_server_closed: on_server_closed_guarded,
         tcp_flow_buffer_size,
+        tcp_channel_capacity,
         meta,
         flow_guard,
         rt_handle,
@@ -480,9 +590,11 @@ where
 
     SessionFlowAction::Intercept(TransparentProxyTcpSession {
         client_tx: Some(client_tx),
+        client_paused,
         eof_tx,
         saw_client_bytes: false,
         egress_tx: None,
+        egress_paused: None,
         egress_eof_tx: None,
         callback_active,
         flow_stop_tx: Some(flow_stop_tx),
@@ -500,11 +612,13 @@ struct UdpSessionPendingData {
     /// Delivers the completed `BridgeIo` to the waiting service task.
     bridge_tx: oneshot::Sender<BridgeIo<UdpFlow, NwUdpSocket>>,
     /// Ingress datagrams (client→Rust); handed to `UdpFlow` at activate.
-    client_rx: mpsc::UnboundedReceiver<Bytes>,
+    client_rx: mpsc::Receiver<Bytes>,
     /// Rust→Swift: datagram back to the intercepted client flow.
     on_server_datagram: BytesSink,
     /// Demand sink captured into `UdpFlow` at activate.
     client_read_demand_sink: DemandSink,
+    /// Capacity used for the egress mpsc channel created at activate.
+    udp_channel_capacity: usize,
     /// Per-flow metadata.
     meta: TransparentProxyFlowMeta,
     /// Handler-supplied egress options.
@@ -512,11 +626,11 @@ struct UdpSessionPendingData {
 }
 
 pub struct TransparentProxyUdpSession {
-    client_tx: Option<mpsc::UnboundedSender<Bytes>>,
+    client_tx: Option<mpsc::Sender<Bytes>>,
     on_client_read_demand: DemandSink,
 
     /// Egress datagrams (NWConnection→Rust, populated by activate).
-    egress_tx: Option<mpsc::UnboundedSender<Bytes>>,
+    egress_tx: Option<mpsc::Sender<Bytes>>,
 
     flow_stop_tx: Option<oneshot::Sender<()>>,
     pending: Option<UdpSessionPendingData>,
@@ -529,7 +643,14 @@ impl TransparentProxyUdpSession {
             return;
         }
         if let Some(tx) = self.client_tx.as_mut() {
-            let _ = tx.send(Bytes::copy_from_slice(bytes));
+            // Bounded channel + lossy semantics: when the service can't keep up
+            // we drop the datagram rather than block the FFI thread or grow the
+            // queue without bound. UDP is lossy by design, so this matches what
+            // the wire protocol already tolerates.
+            match tx.try_send(Bytes::copy_from_slice(bytes)) {
+                Ok(()) | Err(TrySendError::Full(_)) => {}
+                Err(TrySendError::Closed(_)) => return,
+            }
             (self.on_client_read_demand)();
         }
     }
@@ -547,12 +668,14 @@ impl TransparentProxyUdpSession {
     }
 
     /// Called by Swift when a datagram arrives from the egress `NWConnection`.
+    ///
+    /// Same drop-on-full semantics as [`Self::on_client_datagram`].
     pub fn on_egress_datagram(&mut self, bytes: &[u8]) {
         if bytes.is_empty() {
             return;
         }
         if let Some(tx) = self.egress_tx.as_mut() {
-            let _ = tx.send(Bytes::copy_from_slice(bytes));
+            let _ = tx.try_send(Bytes::copy_from_slice(bytes));
         }
     }
 
@@ -582,6 +705,7 @@ impl TransparentProxyUdpSession {
             client_rx,
             on_server_datagram,
             client_read_demand_sink,
+            udp_channel_capacity,
             meta,
             egress_connect_options: _,
         } = pending;
@@ -600,7 +724,7 @@ impl TransparentProxyUdpSession {
         }
 
         // egress socket (service ↔ NWConnection)
-        let (egress_client_tx, egress_client_rx) = mpsc::unbounded_channel::<Bytes>();
+        let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(udp_channel_capacity);
         let egress_sink: BytesSink = Arc::new(on_send_to_egress);
         let egress_socket = NwUdpSocket::new(egress_client_rx, egress_sink);
         self.egress_tx = Some(egress_client_tx);
@@ -617,10 +741,12 @@ impl Drop for TransparentProxyUdpSession {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn new_udp_session_flow_action<OnDatagram, OnClosed, OnDemand, H>(
     parent_guard: ShutdownGuard,
     exec: Executor,
     meta: TransparentProxyFlowMeta,
+    udp_channel_capacity: usize,
     on_server_datagram: OnDatagram,
     on_client_read_demand: OnDemand,
     on_server_closed: OnClosed,
@@ -649,7 +775,7 @@ where
     });
     let flow_guard = flow_shutdown.guard();
 
-    let (client_tx, client_rx) = mpsc::unbounded_channel::<Bytes>();
+    let (client_tx, client_rx) = mpsc::channel::<Bytes>(udp_channel_capacity);
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<UdpFlow, NwUdpSocket>>();
 
     let callback_active_demand = Arc::new(parking_lot::Mutex::new(true));
@@ -674,6 +800,7 @@ where
         client_rx,
         on_server_datagram: datagram_sink,
         client_read_demand_sink: client_read_demand_sink.clone(),
+        udp_channel_capacity,
         meta,
         egress_connect_options,
     };
@@ -781,7 +908,9 @@ fn guarded_demand_sink(
 
 async fn run_tcp_bridge(
     internal: tokio::io::DuplexStream,
-    mut client_rx: mpsc::UnboundedReceiver<Bytes>,
+    mut client_rx: mpsc::Receiver<Bytes>,
+    paused: Arc<AtomicBool>,
+    on_read_demand: DemandSink,
     mut eof_rx: watch::Receiver<bool>,
     on_server_bytes: BytesSink,
     on_server_closed: ClosedSink,
@@ -798,21 +927,35 @@ async fn run_tcp_bridge(
         tokio::select! {
             maybe = client_rx.recv(), if !write_done => {
                 if let Some(bytes) = maybe {
-                     if let Err(err) = write_half.write_all(&bytes).await {
-                         if is_connection_error(&err) {
-                             tracing::trace!("tcp bridge write_all conn error: {err}");
-                         } else {
-                             tracing::debug!("tcp bridge write_all failed: {err}");
-                         }
-                         // The service dropped its read side (e.g. it already wrote its
-                         // response and returned).  Stop writing, but keep reading so
-                         // any buffered response bytes still reach the client.
-                         write_done = true;
-                     }
-                 } else {
-                     let _ = write_half.shutdown().await;
-                     write_done = true;
-                 }
+                    // We just freed a slot — if Swift was paused waiting for capacity,
+                    // wake it once. Edge-triggered: only the swap from `true` actually
+                    // fires the callback, so we never spam Swift with redundant demand
+                    // signals while the channel is draining.
+                    if paused.swap(false, Ordering::AcqRel) {
+                        on_read_demand();
+                    }
+                    if let Err(err) = write_half.write_all(&bytes).await {
+                        if is_connection_error(&err) {
+                            tracing::trace!("tcp bridge write_all conn error: {err}");
+                        } else {
+                            tracing::debug!("tcp bridge write_all failed: {err}");
+                        }
+                        // The service dropped its read side (e.g. it already wrote its
+                        // response and returned).  Stop writing, but keep reading so
+                        // any buffered response bytes still reach the client.
+                        //
+                        // Close the receiver: any subsequent `try_send` from the FFI
+                        // side returns `TrySendError::Closed` so Swift stops queueing
+                        // bytes that no one will ever read. Without this the FFI tx
+                        // accumulates Bytes until the task aborts, which under
+                        // sustained load lets a single broken flow keep buffering.
+                        write_done = true;
+                        client_rx.close();
+                    }
+                } else {
+                    let _ = write_half.shutdown().await;
+                    write_done = true;
+                }
             }
             _ = eof_rx.changed(), if !write_done => {
                 if *eof_rx.borrow() {

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -106,6 +106,13 @@ pub enum TcpDeliverStatus {
     Closed = 2,
 }
 
+// Pin the ABI shape: the C header declares `RamaTcpDeliverStatus` as
+// `enum : uint8_t`, and the Swift bridge imports it as a 1-byte rawValue.
+// If anyone ever drops the `#[repr(u8)]` (or changes the discriminant size)
+// without updating the C/Swift side in lockstep, this assertion fails at
+// compile time instead of corrupting return values at runtime.
+const _: () = assert!(std::mem::size_of::<TcpDeliverStatus>() == 1);
+
 pub struct TransparentProxyEngine<H> {
     rt: tokio::runtime::Runtime,
     handler: H,

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -78,6 +78,34 @@ pub enum SessionFlowAction<S> {
     Passthrough,
 }
 
+/// Outcome of a Swift → Rust byte-delivery FFI call
+/// ([`TransparentProxyTcpSession::on_client_bytes`] /
+/// [`TransparentProxyTcpSession::on_egress_bytes`]).
+///
+/// We deliberately use a tri-state rather than a `bool` so Swift can tell
+/// transient backpressure (`Paused` — wait for the matching demand callback
+/// and then resume) apart from terminal "session is gone" (`Closed` — stop
+/// the read pump immediately, no demand callback will ever fire). Collapsing
+/// these into a single "false" left Swift's pumps sitting paused during
+/// teardown, waiting on a demand callback that could only arrive via the
+/// outer `on_server_closed` cleanup path.
+///
+/// `repr(u8)` is C-ABI-compatible: the FFI thunks return this directly, the
+/// matching C header / Swift wrappers see plain `uint8_t` / `UInt8`.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TcpDeliverStatus {
+    /// The chunk was queued. Swift may keep reading from the kernel.
+    Accepted = 0,
+    /// The chunk was rejected because the per-flow channel is full. Swift
+    /// must pause reads until the matching `on_*_read_demand` callback fires.
+    Paused = 1,
+    /// The chunk was rejected because the per-flow channel is closed (session
+    /// teardown or write-side failure on the bridge). Swift must terminate
+    /// the read pump — no further demand callback will fire.
+    Closed = 2,
+}
+
 pub struct TransparentProxyEngine<H> {
     rt: tokio::runtime::Runtime,
     handler: H,
@@ -274,33 +302,26 @@ pub struct TransparentProxyTcpSession {
 impl TransparentProxyTcpSession {
     /// Called by Swift when client bytes arrive on the intercepted flow.
     ///
-    /// Returns `true` when the bytes were accepted (Swift may continue reading
-    /// from the kernel) and `false` when the per-flow ingress channel was full
-    /// or has been closed (Swift must stop reading and wait for the
-    /// `on_client_read_demand` callback before resuming).
-    ///
-    /// Never blocks the calling thread: this is invoked synchronously from a
-    /// Swift dispatch queue, so we use `try_send` and surface fullness as a
-    /// pause signal instead of awaiting capacity.
-    #[must_use = "the caller must honor the returned backpressure signal"]
-    pub fn on_client_bytes(&mut self, bytes: &[u8]) -> bool {
+    /// See [`TcpDeliverStatus`] for the return contract. Never blocks the
+    /// calling thread: this is invoked synchronously from a Swift dispatch
+    /// queue, so we use `try_send` and surface fullness as a pause signal
+    /// instead of awaiting capacity.
+    #[must_use = "the caller must honor the returned backpressure / closed signal"]
+    pub fn on_client_bytes(&mut self, bytes: &[u8]) -> TcpDeliverStatus {
         if bytes.is_empty() {
-            return true;
+            return TcpDeliverStatus::Accepted;
         }
         self.saw_client_bytes = true;
         let Some(tx) = self.client_tx.as_mut() else {
-            // Session is being torn down; tell Swift to pause. The follow-up
-            // `on_server_closed` callback (or a future cancel) will tear down
-            // the flow on the Swift side.
-            return false;
+            return TcpDeliverStatus::Closed;
         };
         match tx.try_send(Bytes::copy_from_slice(bytes)) {
-            Ok(()) => true,
+            Ok(()) => TcpDeliverStatus::Accepted,
             Err(TrySendError::Full(_)) => {
                 self.client_paused.store(true, Ordering::Release);
-                false
+                TcpDeliverStatus::Paused
             }
-            Err(TrySendError::Closed(_)) => false,
+            Err(TrySendError::Closed(_)) => TcpDeliverStatus::Closed,
         }
     }
 
@@ -315,24 +336,24 @@ impl TransparentProxyTcpSession {
 
     /// Called by Swift when bytes arrive from the egress `NWConnection`.
     ///
-    /// See [`Self::on_client_bytes`] for the bool-return contract.
-    #[must_use = "the caller must honor the returned backpressure signal"]
-    pub fn on_egress_bytes(&mut self, bytes: &[u8]) -> bool {
+    /// See [`TcpDeliverStatus`] for the return contract.
+    #[must_use = "the caller must honor the returned backpressure / closed signal"]
+    pub fn on_egress_bytes(&mut self, bytes: &[u8]) -> TcpDeliverStatus {
         if bytes.is_empty() {
-            return true;
+            return TcpDeliverStatus::Accepted;
         }
         let Some(tx) = self.egress_tx.as_mut() else {
-            return false;
+            return TcpDeliverStatus::Closed;
         };
         match tx.try_send(Bytes::copy_from_slice(bytes)) {
-            Ok(()) => true,
+            Ok(()) => TcpDeliverStatus::Accepted,
             Err(TrySendError::Full(_)) => {
                 if let Some(paused) = self.egress_paused.as_ref() {
                     paused.store(true, Ordering::Release);
                 }
-                false
+                TcpDeliverStatus::Paused
             }
-            Err(TrySendError::Closed(_)) => false,
+            Err(TrySendError::Closed(_)) => TcpDeliverStatus::Closed,
         }
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
@@ -475,11 +475,12 @@ fn tcp_cancel_many_idle_sessions_suppresses_callbacks_and_stops_fast() {
 }
 
 #[test]
-fn tcp_on_client_bytes_returns_false_when_ingress_channel_full() {
+fn tcp_on_client_bytes_signals_paused_when_ingress_channel_full() {
     // Without `activate`, the bridge tasks never start, so the channel never
-    // drains: any send beyond `tcp_channel_capacity` must be rejected. This
-    // proves `on_client_bytes` is non-blocking and surfaces fullness as a
-    // pause signal — the load-bearing property the Swift FFI relies on.
+    // drains: any send beyond `tcp_channel_capacity` must come back as
+    // `Paused`. This proves `on_client_bytes` is non-blocking and surfaces
+    // fullness as a pause signal — the load-bearing property the Swift FFI
+    // relies on.
     let handler = TestHandler {
         app_message_handler: Arc::new(|_| None),
         tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
@@ -502,17 +503,17 @@ fn tcp_on_client_bytes_returns_false_when_ingress_channel_full() {
 
     let chunk = vec![0u8; 16];
     let mut accepted = 0usize;
-    let mut rejected = 0usize;
+    let mut paused = 0usize;
     for _ in 0..10 {
-        if session.on_client_bytes(&chunk) {
-            accepted += 1;
-        } else {
-            rejected += 1;
+        match session.on_client_bytes(&chunk) {
+            TcpDeliverStatus::Accepted => accepted += 1,
+            TcpDeliverStatus::Paused => paused += 1,
+            TcpDeliverStatus::Closed => panic!("unexpected Closed before teardown"),
         }
     }
 
     assert_eq!(accepted, 2, "channel capacity is 2");
-    assert_eq!(rejected, 8);
+    assert_eq!(paused, 8);
 
     engine.stop(0);
 }
@@ -570,14 +571,14 @@ fn tcp_demand_callback_fires_after_ingress_channel_drains() {
     // Pump until we hit backpressure. With a slow service and capacity=2 we
     // expect this within a handful of iterations.
     let chunk = vec![0u8; 4096];
-    let mut got_rejected = false;
+    let mut got_paused = false;
     for _ in 0..1000 {
-        if !session.on_client_bytes(&chunk) {
-            got_rejected = true;
+        if matches!(session.on_client_bytes(&chunk), TcpDeliverStatus::Paused) {
+            got_paused = true;
             break;
         }
     }
-    assert!(got_rejected, "expected the bounded channel to fill up");
+    assert!(got_paused, "expected the bounded channel to fill up");
 
     // Give the bridge time to drain at least one chunk and fire demand.
     let _ = notify_rx.recv_timeout(Duration::from_secs(2));
@@ -593,8 +594,9 @@ fn tcp_demand_callback_fires_after_ingress_channel_drains() {
 fn tcp_bridge_write_failure_closes_ingress_channel() {
     // When the service finishes (and drops its half of the duplex) the
     // bridge's `write_all` fails and we close the receiver. From that point
-    // on `on_client_bytes` reports `false` (closed) — Swift treats this as
-    // "stop reading" and waits for the eventual `on_server_closed`.
+    // on `on_client_bytes` MUST report `Closed` (not `Paused`) — Swift uses
+    // that to terminate the read pump immediately rather than waiting on a
+    // demand callback that will never come.
     let (closed_tx, closed_rx) = std::sync::mpsc::channel::<()>();
 
     let handler = TestHandler {
@@ -624,22 +626,89 @@ fn tcp_bridge_write_failure_closes_ingress_channel() {
 
     // The service has nothing to do and exits, dropping ingress; the bridge's
     // first `write_all` will fail and close the receiver. Pump bytes until
-    // we observe the closed signal.
+    // we observe the Closed status.
     let chunk = vec![0u8; 1024];
-    let mut saw_false = false;
+    let mut saw_closed = false;
     for _ in 0..200 {
-        if !session.on_client_bytes(&chunk) {
-            saw_false = true;
+        if matches!(session.on_client_bytes(&chunk), TcpDeliverStatus::Closed) {
+            saw_closed = true;
             break;
         }
         std::thread::sleep(Duration::from_millis(2));
     }
     assert!(
-        saw_false,
-        "on_client_bytes must surface the channel-closed signal after a write failure"
+        saw_closed,
+        "on_client_bytes must report Closed after a bridge write failure"
     );
 
     let _ = closed_rx.recv_timeout(Duration::from_secs(1));
+    engine.stop(0);
+}
+
+#[test]
+fn tcp_on_bytes_signals_closed_after_session_cancel() {
+    // After `cancel()`, the FFI byte-delivery calls MUST surface
+    // `Closed` (not `Paused`) so the Swift pumps terminate immediately.
+    // Regression: the egress read pump previously dropped the chunk on
+    // a nil-session and rescheduled another `connection.receive`, leaving
+    // NWConnection traffic alive after the session was gone.
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(|_: BridgeIo<TcpFlow, NwTcpStream>| async move { Ok(()) }).boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+    let engine = build_engine(handler);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| {},
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+
+    session.activate(|_| {}, || {}, || {});
+    session.cancel();
+
+    let chunk = vec![0u8; 16];
+    assert_eq!(
+        session.on_client_bytes(&chunk),
+        TcpDeliverStatus::Closed,
+        "on_client_bytes must report Closed after cancel"
+    );
+    assert_eq!(
+        session.on_egress_bytes(&chunk),
+        TcpDeliverStatus::Closed,
+        "on_egress_bytes must report Closed after cancel — \
+         this is the contract the Swift egress read pump relies on to \
+         terminate instead of looping on connection.receive forever"
+    );
+
+    engine.stop(0);
+}
+
+#[test]
+fn builder_rejects_zero_channel_capacity() {
+    // `tokio::sync::mpsc::channel(0)` panics; an explicit `Some(0)` is
+    // treated as a misconfiguration rather than silently substituting the
+    // default. `None` continues to mean "use default".
+    let make = |tcp: Option<usize>, udp: Option<usize>| {
+        let mut builder =
+            TransparentProxyEngineBuilder::new(TestHandlerFactory(TestHandler::passthrough()))
+                .with_runtime_factory(TestRuntimeFactory);
+        builder = builder.maybe_with_tcp_channel_capacity(tcp);
+        builder = builder.maybe_with_udp_channel_capacity(udp);
+        builder.build()
+    };
+
+    assert!(make(Some(0), None).is_err(), "Some(0) tcp must error");
+    assert!(make(None, Some(0)).is_err(), "Some(0) udp must error");
+    let engine = make(None, None).expect("None defaults must build");
     engine.stop(0);
 }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
@@ -116,6 +116,17 @@ fn build_engine(handler: TestHandler) -> TransparentProxyEngine<TestHandler> {
         .expect("build engine")
 }
 
+fn build_engine_with_tcp_channel_capacity(
+    handler: TestHandler,
+    capacity: usize,
+) -> TransparentProxyEngine<TestHandler> {
+    TransparentProxyEngineBuilder::new(TestHandlerFactory(handler))
+        .with_runtime_factory(TestRuntimeFactory)
+        .with_tcp_channel_capacity(capacity)
+        .build()
+        .expect("build engine")
+}
+
 #[test]
 fn engine_builds_live_and_stop_is_terminal() {
     let engine = build_engine(TestHandler::passthrough());
@@ -128,6 +139,7 @@ fn tcp_session_passthrough_by_default() {
     let decision = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp),
         |_| {},
+        || {},
         || {},
     );
     assert!(matches!(decision, SessionFlowAction::Passthrough));
@@ -155,6 +167,7 @@ fn tcp_session_can_be_blocked() {
     let decision = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp),
         |_| {},
+        || {},
         || {},
     );
     assert!(matches!(decision, SessionFlowAction::Blocked));
@@ -206,13 +219,14 @@ fn tcp_bridge_delivers_server_bytes() {
             let _ = notify_tx.send(());
         },
         || {},
+        || {},
     ) else {
         panic!("expected intercept session");
     };
 
     // Phase 2: activate egress (no-op callbacks) so the service task starts.
-    session.activate(|_| {}, || {});
-    session.on_client_bytes(b"ping");
+    session.activate(|_| {}, || {}, || {});
+    let _ = session.on_client_bytes(b"ping");
 
     let _ = notify_rx.recv_timeout(Duration::from_secs(1));
     engine.stop(0);
@@ -345,11 +359,12 @@ fn tcp_flow_exposes_meta_extension() {
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp).with_source_app_pid(777),
         |_| {},
         || {},
+        || {},
     ) else {
         panic!("expected intercept session");
     };
     // Phase 2: activate so the service task runs and reads extensions.
-    session.activate(|_| {}, || {});
+    session.activate(|_| {}, || {}, || {});
     let _ = notify_rx.recv_timeout(Duration::from_secs(1));
     engine.stop(0);
 
@@ -436,6 +451,7 @@ fn tcp_cancel_many_idle_sessions_suppresses_callbacks_and_stops_fast() {
             move |_bytes| {
                 bytes_count.fetch_add(1, Ordering::Relaxed);
             },
+            || {},
             move || {
                 closed_count.fetch_add(1, Ordering::Relaxed);
             },
@@ -456,6 +472,175 @@ fn tcp_cancel_many_idle_sessions_suppresses_callbacks_and_stops_fast() {
     let start = Instant::now();
     engine.stop(0);
     assert!(start.elapsed() < Duration::from_secs(1));
+}
+
+#[test]
+fn tcp_on_client_bytes_returns_false_when_ingress_channel_full() {
+    // Without `activate`, the bridge tasks never start, so the channel never
+    // drains: any send beyond `tcp_channel_capacity` must be rejected. This
+    // proves `on_client_bytes` is non-blocking and surfaces fullness as a
+    // pause signal — the load-bearing property the Swift FFI relies on.
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(|_: BridgeIo<TcpFlow, NwTcpStream>| async move { Ok(()) }).boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+    let engine = build_engine_with_tcp_channel_capacity(handler, 2);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| {},
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+
+    let chunk = vec![0u8; 16];
+    let mut accepted = 0usize;
+    let mut rejected = 0usize;
+    for _ in 0..10 {
+        if session.on_client_bytes(&chunk) {
+            accepted += 1;
+        } else {
+            rejected += 1;
+        }
+    }
+
+    assert_eq!(accepted, 2, "channel capacity is 2");
+    assert_eq!(rejected, 8);
+
+    engine.stop(0);
+}
+
+#[test]
+fn tcp_demand_callback_fires_after_ingress_channel_drains() {
+    // The bridge runs and the service drains the duplex, so the bounded
+    // channel transitions from full → empty. After every successful `recv`
+    // the bridge swaps `client_paused` and fires `on_client_read_demand`
+    // exactly once per pause event. We expect at least one demand callback
+    // by the time the service finishes draining.
+    let demand_count = Arc::new(AtomicUsize::new(0));
+    let demand_count_clone = demand_count.clone();
+    let (notify_tx, notify_rx) = std::sync::mpsc::channel::<()>();
+
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(|bridge: BridgeIo<TcpFlow, NwTcpStream>| async move {
+                let BridgeIo(mut ingress, _egress) = bridge;
+                let mut buf = vec![0u8; 4096];
+                // Slow drain: forces the bounded channel + duplex to back up
+                // while the test pumps bytes from another thread.
+                loop {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    match ingress.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(_) => {}
+                    }
+                }
+                Ok(())
+            })
+            .boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+    let engine = build_engine_with_tcp_channel_capacity(handler, 2);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| {},
+        move || {
+            demand_count_clone.fetch_add(1, Ordering::Relaxed);
+            let _ = notify_tx.send(());
+        },
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+
+    session.activate(|_| {}, || {}, || {});
+
+    // Pump until we hit backpressure. With a slow service and capacity=2 we
+    // expect this within a handful of iterations.
+    let chunk = vec![0u8; 4096];
+    let mut got_rejected = false;
+    for _ in 0..1000 {
+        if !session.on_client_bytes(&chunk) {
+            got_rejected = true;
+            break;
+        }
+    }
+    assert!(got_rejected, "expected the bounded channel to fill up");
+
+    // Give the bridge time to drain at least one chunk and fire demand.
+    let _ = notify_rx.recv_timeout(Duration::from_secs(2));
+    assert!(
+        demand_count.load(Ordering::Relaxed) >= 1,
+        "demand callback should fire when the bridge frees a slot"
+    );
+
+    engine.stop(0);
+}
+
+#[test]
+fn tcp_bridge_write_failure_closes_ingress_channel() {
+    // When the service finishes (and drops its half of the duplex) the
+    // bridge's `write_all` fails and we close the receiver. From that point
+    // on `on_client_bytes` reports `false` (closed) — Swift treats this as
+    // "stop reading" and waits for the eventual `on_server_closed`.
+    let (closed_tx, closed_rx) = std::sync::mpsc::channel::<()>();
+
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            // Service exits immediately, dropping its end of the duplex.
+            service: service_fn(|_: BridgeIo<TcpFlow, NwTcpStream>| async move { Ok(()) }).boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+    let engine = build_engine_with_tcp_channel_capacity(handler, 2);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| {},
+        || {},
+        move || {
+            let _ = closed_tx.send(());
+        },
+    ) else {
+        panic!("expected intercept session");
+    };
+
+    session.activate(|_| {}, || {}, || {});
+
+    // The service has nothing to do and exits, dropping ingress; the bridge's
+    // first `write_all` will fail and close the receiver. Pump bytes until
+    // we observe the closed signal.
+    let chunk = vec![0u8; 1024];
+    let mut saw_false = false;
+    for _ in 0..200 {
+        if !session.on_client_bytes(&chunk) {
+            saw_false = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    assert!(
+        saw_false,
+        "on_client_bytes must surface the channel-closed signal after a write failure"
+    );
+
+    let _ = closed_rx.recv_timeout(Duration::from_secs(1));
+    engine.stop(0);
 }
 
 #[test]

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -13,9 +13,10 @@ pub use self::{
     engine::{
         BoxedClosedSink, BoxedDemandSink, BoxedServerBytesSink, BoxedTransparentProxyEngine,
         DefaultTransparentProxyAsyncRuntimeFactory, FlowAction, SessionFlowAction,
-        TransparentProxyAsyncRuntimeFactory, TransparentProxyEngine, TransparentProxyEngineBuilder,
-        TransparentProxyHandler, TransparentProxyHandlerFactory, TransparentProxyServiceContext,
-        TransparentProxyTcpSession, TransparentProxyUdpSession, log_engine_build_error,
+        TcpDeliverStatus, TransparentProxyAsyncRuntimeFactory, TransparentProxyEngine,
+        TransparentProxyEngineBuilder, TransparentProxyHandler, TransparentProxyHandlerFactory,
+        TransparentProxyServiceContext, TransparentProxyTcpSession, TransparentProxyUdpSession,
+        log_engine_build_error,
     },
     types::{
         NwAttribution, NwEgressParameters, NwInterfaceType, NwMultipathServiceType, NwServiceClass,

--- a/rama-net-apple-networkextension/src/udp.rs
+++ b/rama-net-apple-networkextension/src/udp.rs
@@ -8,7 +8,7 @@ use tokio::sync::mpsc;
 
 /// A per-flow UDP datagram socket abstraction for transparent proxy services.
 pub struct UdpFlow {
-    incoming: mpsc::UnboundedReceiver<Bytes>,
+    incoming: mpsc::Receiver<Bytes>,
     outgoing: Arc<dyn Fn(Bytes) + Send + Sync + 'static>,
     extensions: Extensions,
     io_demand_once: Once,
@@ -17,7 +17,7 @@ pub struct UdpFlow {
 
 impl UdpFlow {
     pub(crate) fn new_with_io_demand(
-        incoming: mpsc::UnboundedReceiver<Bytes>,
+        incoming: mpsc::Receiver<Bytes>,
         outgoing: Arc<dyn Fn(Bytes) + Send + Sync + 'static>,
         on_io_demand: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
     ) -> Self {

--- a/rama-net-apple-xpc/src/connection.rs
+++ b/rama-net-apple-xpc/src/connection.rs
@@ -164,7 +164,17 @@ pub struct XpcConnection {
     receiver: UnboundedReceiver<XpcEvent>,
 }
 
+// SAFETY: `XpcConnection` wraps an `OwnedXpcObject` (an `xpc_connection_t`), an
+// `Extensions` map, and an `UnboundedReceiver<XpcEvent>`. Apple documents
+// `xpc_connection_t` as safe to use from any thread. `Extensions` is `Send`.
+// `UnboundedReceiver` is `Send` for `T: Send`.
 unsafe impl Send for XpcConnection {}
+// SAFETY: every `&self` method on `XpcConnection` only touches the
+// xpc_connection_t (Apple-documented thread-safe) and `Extensions`. The
+// `UnboundedReceiver` is exclusively reached via `&mut self` (`recv`), so two
+// threads sharing `&XpcConnection` cannot race on it. The auto `Sync` derive
+// is blocked only because `UnboundedReceiver` is not `Sync`; we re-assert
+// here under that exclusive-access guarantee.
 unsafe impl Sync for XpcConnection {}
 
 impl XpcConnection {
@@ -455,13 +465,19 @@ impl Service<XpcMessage> for XpcConnection {
     }
 }
 
+/// Caller must pass a valid, non-null `xpc_object_t` (we always do — these
+/// helpers are reached only from the connection event-handler block where
+/// libxpc hands us a retained event).
 fn raw_is_type(event: xpc_object_t, ty: *const c_void) -> bool {
+    // SAFETY: see function-level comment — `event` is a valid xpc_object_t.
     let value_type = unsafe { xpc_get_type(event) };
     ptr::eq(value_type.cast::<c_void>(), ty)
 }
 
 fn raw_is_error(event: xpc_object_t) -> bool {
     raw_is_type(event, unsafe {
+        // SAFETY: `_xpc_type_error` is a static XPC type singleton exported by
+        // libxpc and valid for the lifetime of the process.
         &_xpc_type_error as *const _ as *const c_void
     })
 }
@@ -472,6 +488,8 @@ pub(crate) fn map_event(connection: xpc_connection_t, event: OwnedXpcObject) -> 
         return XpcEvent::Error(error);
     }
 
+    // SAFETY: `_xpc_type_connection` is a static XPC type singleton exported
+    // by libxpc and valid for the lifetime of the process.
     if event.is_type(unsafe { &_xpc_type_connection as *const _ as *const std::ffi::c_void }) {
         tracing::debug!("xpc listener received peer connection");
         return match XpcConnection::from_owned_peer(event) {
@@ -501,6 +519,8 @@ pub(crate) fn map_connection_error(
     connection: xpc_connection_t,
     event: &OwnedXpcObject,
 ) -> Option<XpcConnectionError> {
+    // SAFETY: `_xpc_type_error` is a static XPC type singleton exported by
+    // libxpc and valid for the lifetime of the process.
     if !event.is_type(unsafe { &_xpc_type_error as *const _ as *const std::ffi::c_void }) {
         return None;
     }
@@ -559,17 +579,26 @@ fn connection_error_description(
         return Some(value);
     }
 
+    // SAFETY: `_xpc_error_key_description` is a static XPC dictionary key
+    // exported by libxpc; reading it is always sound.
     let key = unsafe { _xpc_error_key_description };
     if key.is_null() {
         return None;
     }
 
+    // SAFETY: `event` is a valid retained xpc_object_t (caller passed it down
+    // from the live OwnedXpcObject). `key` is a valid XPC dictionary key
+    // checked non-null above. `xpc_dictionary_get_string` returns a borrowed
+    // NUL-terminated C string (or NULL if the key is absent / type mismatch),
+    // valid for the lifetime of `event`.
     let value = unsafe { xpc_dictionary_get_string(event, key) };
     if value.is_null() {
         return None;
     }
 
     Some(ArcStr::from(
+        // SAFETY: `value` was just checked non-null and is a NUL-terminated
+        // C string borrowed from `event`; the borrow ends before this scope.
         unsafe { CStr::from_ptr(value) }.to_string_lossy(),
     ))
 }

--- a/rama-net-apple-xpc/src/listener.rs
+++ b/rama-net-apple-xpc/src/listener.rs
@@ -192,19 +192,27 @@ impl Drop for XpcListener {
     }
 }
 
+/// Caller must pass a valid, non-null `xpc_object_t` (we always do — these
+/// helpers are reached only from the listener event-handler block where
+/// libxpc hands us a retained event).
 fn raw_is_type(event: xpc_object_t, ty: *const c_void) -> bool {
+    // SAFETY: see function-level comment — `event` is a valid xpc_object_t.
     let value_type = unsafe { xpc_get_type(event) };
     ptr::eq(value_type.cast::<c_void>(), ty)
 }
 
 fn raw_is_error(event: xpc_object_t) -> bool {
     raw_is_type(event, unsafe {
+        // SAFETY: `_xpc_type_error` is a static XPC type singleton exported
+        // by libxpc and valid for the lifetime of the process.
         &_xpc_type_error as *const _ as *const c_void
     })
 }
 
 fn raw_is_connection(event: xpc_object_t) -> bool {
     raw_is_type(event, unsafe {
+        // SAFETY: `_xpc_type_connection` is a static XPC type singleton
+        // exported by libxpc and valid for the lifetime of the process.
         &_xpc_type_connection as *const _ as *const c_void
     })
 }

--- a/src/http/client/proxy_connector.rs
+++ b/src/http/client/proxy_connector.rs
@@ -94,7 +94,10 @@ where
         match proxy {
             None => {
                 if self.required {
-                    return Err("proxy required but none is defined".into());
+                    return Err(
+                        OpaqueError::from_static_str("proxy required but none is defined")
+                            .into_box_error(),
+                    );
                 }
                 tracing::trace!("no proxy detected in ctx, using inner connector");
                 let EstablishedClientConnection { input, conn } =


### PR DESCRIPTION
Two stability fixes for the Apple NE transparent proxy, both of which
manifest as host-wide outbound networking outages under sustained
load:

- Egress `NWConnection` leak that exhausts the kernel's NECP/Skywalk
  flow slots after ~15h uptime, returning ENOMEM on every new
  outbound flow.
- No backpressure on the TCP intercept path: unbounded per-flow byte
  channels grow until Apple's per-flow NE kernel buffer hits ENOMEM
  on `writeData` and the shared `NEAppProxyProvider` director aborts
  every flow on the extension — including unrelated passthrough
  flows from neighbouring proxies (Zscaler, in the partner case
  that surfaced this).

Both directions of the TCP path are now bounded with a Rust → Swift
demand callback pausing reads on full and resuming on drain (mirroring
the UDP flow that already had this). The byte-delivery FFI returns a
tri-state status so Swift can tell transient backpressure apart from
session teardown and stop reading immediately on the latter. Breaking
FFI change; Swift consumer and e2e harness updated in this PR.

Plus an audit-driven sweep across the two Apple FFI crates: tightened
a handful of SAFETY comments, added missing justifications on
`unsafe impl Send/Sync for XpcConnection` and previously undocumented
unsafe blocks in connection.rs / listener.rs, and made two implicit
invariants explicit with `debug_assert!`s.