### PR TITLE
ffi/apple: tproxy stability fixes + safety hardening

### DIFF
--- a/docs/target-picker.html
+++ b/docs/target-picker.html
@@ -6,8 +6,12 @@
   per-target customisation — pure JS, no build-time substitution.
 -->
 <style>
+    body {
+        top: 20px;
+    }
+
     .rama-target-picker {
-        position: sticky;
+        position: fixed;
         top: 0;
         left: 0;
         width: 100%;

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -226,7 +226,12 @@ typedef enum : uint8_t {
     RAMA_TCP_DELIVER_CLOSED = 2,
 } RamaTcpDeliverStatus;
 
-typedef void (*RamaTcpServerBytesFn)(void* context, RamaBytesView bytes);
+/// Returns a `RamaTcpDeliverStatus` so the Rust bridge can pause when Swift's
+/// `TcpClientWritePump` is full. Swift MUST call
+/// `rama_transparent_proxy_tcp_session_signal_server_drain` after its writer
+/// drains capacity following a `Paused` return — without that the bridge
+/// stays parked forever.
+typedef RamaTcpDeliverStatus (*RamaTcpServerBytesFn)(void* context, RamaBytesView bytes);
 typedef void (*RamaTcpServerClosedFn)(void* context);
 typedef void (*RamaTcpClientReadDemandFn)(void* context);
 
@@ -334,7 +339,11 @@ typedef struct {
     RamaNwEgressParameters parameters;
 } RamaUdpEgressConnectOptions;
 
-typedef void (*RamaTcpEgressWriteFn)(void* context, RamaBytesView bytes);
+/// Returns a `RamaTcpDeliverStatus` so the Rust bridge can pause when Swift's
+/// `NwTcpConnectionWritePump` is full. Swift MUST call
+/// `rama_transparent_proxy_tcp_session_signal_egress_drain` after its writer
+/// drains capacity following a `Paused` return.
+typedef RamaTcpDeliverStatus (*RamaTcpEgressWriteFn)(void* context, RamaBytesView bytes);
 typedef void (*RamaTcpEgressCloseFn)(void* context);
 typedef void (*RamaTcpEgressReadDemandFn)(void* context);
 
@@ -519,6 +528,22 @@ RamaTcpDeliverStatus rama_transparent_proxy_tcp_session_on_egress_bytes(
 ///
 /// Called by Swift when the NWConnection closes or enters a failed state.
 void rama_transparent_proxy_tcp_session_on_egress_eof(
+    RamaTransparentProxyTcpSession* session
+);
+
+/// Swift → Rust: signal that the response writer pump (`TcpClientWritePump`)
+/// has drained capacity after `on_server_bytes` returned `RAMA_TCP_DELIVER_PAUSED`.
+///
+/// Wakes the Rust bridge so it resumes pulling response bytes through the
+/// duplex. Idempotent — collapses redundant calls into a single permit.
+void rama_transparent_proxy_tcp_session_signal_server_drain(
+    RamaTransparentProxyTcpSession* session
+);
+
+/// Swift → Rust: signal that the egress writer pump
+/// (`NwTcpConnectionWritePump`) has drained capacity after
+/// `on_write_to_egress` returned `RAMA_TCP_DELIVER_PAUSED`.
+void rama_transparent_proxy_tcp_session_signal_egress_drain(
     RamaTransparentProxyTcpSession* session
 );
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -56,6 +56,17 @@ private func tcpDeliverStatus(_ raw: RamaTcpDeliverStatus) -> RamaTcpDeliverStat
     RamaTcpDeliverStatusBridge(rawValue: UInt8(raw.rawValue)) ?? .closed
 }
 
+/// Inverse of [`tcpDeliverStatus`] — used when Swift returns a status to
+/// Rust through the byte-delivery callbacks (`on_server_bytes`,
+/// `on_write_to_egress`).
+private func cTcpDeliverStatus(_ status: RamaTcpDeliverStatusBridge) -> RamaTcpDeliverStatus {
+    switch status {
+    case .accepted: return RAMA_TCP_DELIVER_ACCEPTED
+    case .paused: return RAMA_TCP_DELIVER_PAUSED
+    case .closed: return RAMA_TCP_DELIVER_CLOSED
+    }
+}
+
 enum RamaTransparentProxyUdpSessionDecision {
     case intercept(RamaUdpSessionHandle)
     case passthrough
@@ -63,12 +74,16 @@ enum RamaTransparentProxyUdpSessionDecision {
 }
 
 final class TcpSessionCallbackBox {
-    let onServerBytes: (Data) -> Void
+    /// Returns a [`RamaTcpDeliverStatusBridge`] so the Rust bridge can pause
+    /// when the writer pump is full. `onServerBytes` MUST honor the
+    /// contract: `.paused` requires Swift to call `signalServerDrain` once
+    /// the writer drains; `.closed` is terminal.
+    let onServerBytes: (Data) -> RamaTcpDeliverStatusBridge
     let onClientReadDemand: () -> Void
     let onServerClosed: () -> Void
 
     init(
-        onServerBytes: @escaping (Data) -> Void,
+        onServerBytes: @escaping (Data) -> RamaTcpDeliverStatusBridge,
         onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) {
@@ -99,12 +114,15 @@ final class UdpSessionCallbackBox {
 /// Retained for the lifetime of the session; Rust may call these at any time
 /// while the egress `NWConnection` is active.
 final class TcpEgressCallbackBox {
-    let onWriteToEgress: (Data) -> Void
+    /// See `TcpSessionCallbackBox.onServerBytes` — same status contract for
+    /// the egress (NWConnection-write) direction. `.paused` requires Swift
+    /// to call `signalEgressDrain` once the writer drains.
+    let onWriteToEgress: (Data) -> RamaTcpDeliverStatusBridge
     let onEgressReadDemand: () -> Void
     let onCloseEgress: () -> Void
 
     init(
-        onWriteToEgress: @escaping (Data) -> Void,
+        onWriteToEgress: @escaping (Data) -> RamaTcpDeliverStatusBridge,
         onEgressReadDemand: @escaping () -> Void,
         onCloseEgress: @escaping () -> Void
     ) {
@@ -217,14 +235,14 @@ private func withFlowMeta<T>(
 }
 
 private let ramaTcpOnServerBytesCallback:
-    @convention(c) (UnsafeMutableRawPointer?, RamaBytesView)
-        -> Void = { context, view in
-            guard let context else { return }
-            let box = Unmanaged<TcpSessionCallbackBox>.fromOpaque(context).takeUnretainedValue()
-            let data = dataFromView(view)
-            if data.isEmpty { return }
-            box.onServerBytes(data)
-        }
+    @convention(c) (UnsafeMutableRawPointer?, RamaBytesView) -> RamaTcpDeliverStatus = {
+        context, view in
+        guard let context else { return RAMA_TCP_DELIVER_CLOSED }
+        let box = Unmanaged<TcpSessionCallbackBox>.fromOpaque(context).takeUnretainedValue()
+        let data = dataFromView(view)
+        if data.isEmpty { return RAMA_TCP_DELIVER_ACCEPTED }
+        return cTcpDeliverStatus(box.onServerBytes(data))
+    }
 
 private let ramaTcpOnClientReadDemandCallback: @convention(c) (UnsafeMutableRawPointer?) -> Void =
     { context in
@@ -268,12 +286,13 @@ private let ramaUdpOnClientReadDemandCallback: @convention(c) (UnsafeMutableRawP
 // ── Egress C callbacks ────────────────────────────────────────────────────────
 
 private let ramaTcpOnWriteToEgressCallback:
-    @convention(c) (UnsafeMutableRawPointer?, RamaBytesView) -> Void = { context, view in
-        guard let context else { return }
+    @convention(c) (UnsafeMutableRawPointer?, RamaBytesView) -> RamaTcpDeliverStatus = {
+        context, view in
+        guard let context else { return RAMA_TCP_DELIVER_CLOSED }
         let box = Unmanaged<TcpEgressCallbackBox>.fromOpaque(context).takeUnretainedValue()
         let data = dataFromView(view)
-        if data.isEmpty { return }
-        box.onWriteToEgress(data)
+        if data.isEmpty { return RAMA_TCP_DELIVER_ACCEPTED }
+        return cTcpDeliverStatus(box.onWriteToEgress(data))
     }
 
 private let ramaTcpOnCloseEgressCallback: @convention(c) (UnsafeMutableRawPointer?) -> Void = {
@@ -423,7 +442,7 @@ final class RamaTransparentProxyEngineHandle {
 
     func newTcpSession(
         meta: RamaTransparentProxyFlowMetaBridge,
-        onServerBytes: @escaping (Data) -> Void,
+        onServerBytes: @escaping (Data) -> RamaTcpDeliverStatusBridge,
         onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) -> RamaTransparentProxyTcpSessionDecision {
@@ -609,7 +628,7 @@ final class RamaTcpSessionHandle {
     ///     egress NWConnection.
     ///   - onCloseEgress: Called by Rust when the egress write direction is done.
     func activate(
-        onWriteToEgress: @escaping (Data) -> Void,
+        onWriteToEgress: @escaping (Data) -> RamaTcpDeliverStatusBridge,
         onEgressReadDemand: @escaping () -> Void,
         onCloseEgress: @escaping () -> Void
     ) {
@@ -660,6 +679,25 @@ final class RamaTcpSessionHandle {
         defer { lock.unlock() }
         guard !cancelled, let s = sessionPtr else { return }
         rama_transparent_proxy_tcp_session_on_egress_eof(s)
+    }
+
+    /// Wake the Rust bridge after our `TcpClientWritePump` drains capacity
+    /// following a `.paused` return from `onServerBytes`. Idempotent —
+    /// redundant calls collapse to a single permit on the Rust side.
+    func signalServerDrain() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
+        rama_transparent_proxy_tcp_session_signal_server_drain(s)
+    }
+
+    /// Same as [`signalServerDrain`] but for the egress (NWConnection-write)
+    /// direction.
+    func signalEgressDrain() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !cancelled, let s = sessionPtr else { return }
+        rama_transparent_proxy_tcp_session_signal_egress_drain(s)
     }
 
     func cancel() {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -136,6 +136,50 @@ private let expectedDisconnectPosixCodes: Set<Int32> = [
     EPIPE,
 ]
 
+/// POSIX errors we treat as **transient backpressure** when a write into
+/// `NEAppProxyFlow.writeData` (or the egress `NWConnection.send`) fails.
+///
+/// Hitting these does NOT mean the flow is dead — Apple's per-flow NE kernel
+/// buffer is temporarily full because the destination app drains slower than
+/// upstream produces. The correct response is to back off briefly and retry
+/// the same chunk, not to tear the flow down. Tearing down on the first
+/// `ENOBUFS` is what surfaces large-h2-response downloads (`go mod download`,
+/// large github / golang artifacts) as "random unrelated errors" mid-transfer.
+private let transientWriteBackpressurePosixCodes: Set<Int32> = [
+    ENOBUFS,
+    EAGAIN,
+    // EWOULDBLOCK aliases EAGAIN on macOS.
+]
+
+/// Returns true when `error` should make a writer pump retry the same chunk
+/// after a short backoff instead of tearing the flow down.
+private func isTransientWriteBackpressure(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    if nsError.domain == NSPOSIXErrorDomain,
+        transientWriteBackpressurePosixCodes.contains(Int32(nsError.code))
+    {
+        return true
+    }
+    // `NWError` from `NWConnection.send` bridges to `NSError` with a `.posix`
+    // domain only when the underlying cause is a POSIX errno; the bridged
+    // domain in that case is also `NSPOSIXErrorDomain`, so the check above
+    // covers both `NEAppProxyFlow` and `NWConnection` write paths.
+    return false
+}
+
+/// Initial / capped backoff delays (ms) for transient-error retry. Capped so
+/// we keep retrying but at a bounded rate; the caller's natural drain cycle
+/// is sub-second on a working flow, so 200 ms is plenty.
+private let writeRetryInitialDelayMs: Int = 5
+private let writeRetryMaxDelayMs: Int = 200
+
+/// Maximum number of in-flight chunks each writer pump (TCP response and
+/// TCP egress) keeps queued before it tells the Rust bridge to pause. Small
+/// enough to bound memory but large enough to absorb h2 multiplexing where
+/// many concurrent streams interleave their data through one TCP flow.
+/// Mirrors the rough scale of `DEFAULT_TCP_CHANNEL_CAPACITY` on the Rust side.
+private let writePumpMaxPending: Int = 256
+
 private func blockedFlowError() -> NSError {
     NSError(
         domain: "NEAppProxyFlowErrorDomain",
@@ -349,6 +393,11 @@ private final class TcpClientWritePump {
     private let flow: NEAppProxyTCPFlow
     private let logger: (FlowLogMessage) -> Void
     private let onTerminalError: (Error) -> Void
+    /// Fired when `pending` drops back below `writePumpMaxPending` after a
+    /// previous `enqueue` returned `.paused`. Wired to
+    /// `RamaTcpSessionHandle.signalServerDrain` so the Rust bridge resumes
+    /// pulling response bytes through the duplex.
+    private let onDrained: () -> Void
     private let queue: DispatchQueue
     private var pending: [Data] = []
     private var writing = false
@@ -356,17 +405,27 @@ private final class TcpClientWritePump {
     private var closed = false
     private var opened = false
     private var onDrainedClose: ((Bool) -> Void)?
+    /// Set when an `enqueue` was rejected with `.paused`. We fire `onDrained`
+    /// on the first removal that drops `pending.count` below the cap, then
+    /// clear this flag — edge-triggered so we never spam Rust with redundant
+    /// drain signals while the queue churns at-cap.
+    private var pausedSignaled: Bool = false
+    /// Current exponential backoff for transient write errors (ms). Reset to
+    /// `writeRetryInitialDelayMs` on every successful write.
+    private var retryDelayMs: Int = writeRetryInitialDelayMs
 
     init(
         flow: NEAppProxyTCPFlow,
         queue: DispatchQueue,
         logger: @escaping (FlowLogMessage) -> Void,
-        onTerminalError: @escaping (Error) -> Void
+        onTerminalError: @escaping (Error) -> Void,
+        onDrained: @escaping () -> Void
     ) {
         self.flow = flow
         self.queue = queue
         self.logger = logger
         self.onTerminalError = onTerminalError
+        self.onDrained = onDrained
     }
 
     func markOpened() {
@@ -388,13 +447,40 @@ private final class TcpClientWritePump {
         }
     }
 
-    func enqueue(_ data: Data) {
-        guard !data.isEmpty else { return }
-        queue.async {
-            if self.closed || self.closeRequested { return }
+    /// Enqueue a chunk for delivery via `flow.writeData`.
+    ///
+    /// Synchronous so the caller (the Rust bridge, via the FFI thunk) gets a
+    /// `RamaTcpDeliverStatusBridge` back in the same call:
+    ///   - `.accepted` — chunk queued; Rust may keep producing.
+    ///   - `.paused` — `pending` is at `writePumpMaxPending`. Rust must wait
+    ///     for `signalServerDrain` (wired to `onDrained` below) before
+    ///     producing more.
+    ///   - `.closed` — pump is being torn down; no further drain will fire.
+    @discardableResult
+    func enqueue(_ data: Data) -> RamaTcpDeliverStatusBridge {
+        guard !data.isEmpty else { return .accepted }
+        var status: RamaTcpDeliverStatusBridge = .accepted
+        // queue.sync runs the closure on `flowQueue` and blocks the FFI
+        // thread (a Tokio worker) until it completes. Each per-flow queue is
+        // serial and the items it processes never await, so the wait is
+        // bounded; using `.async` here would force us to maintain a parallel
+        // atomic counter to give the FFI a synchronous bound check, which is
+        // what we used to (asymmetrically) avoid by leaving `pending`
+        // unbounded — exactly the bug we're fixing.
+        queue.sync {
+            if self.closed || self.closeRequested {
+                status = .closed
+                return
+            }
+            if self.pending.count >= writePumpMaxPending {
+                self.pausedSignaled = true
+                status = .paused
+                return
+            }
             self.pending.append(data)
             self.flushLocked()
         }
+        return status
     }
 
     func closeWhenDrained(_ onDrainedClose: @escaping (_ wasOpened: Bool) -> Void) {
@@ -418,10 +504,33 @@ private final class TcpClientWritePump {
 
         writing = true
         let chunk = pending.removeFirst()
+        // Edge-triggered drain signal: if Rust was paused and we just dropped
+        // `pending` below the cap, wake it once. Honouring this from the
+        // pre-write site (rather than the completion handler) lets Rust
+        // start producing the next chunk in parallel with the current write.
+        if pausedSignaled && pending.count < writePumpMaxPending {
+            pausedSignaled = false
+            onDrained()
+        }
         self.flow.write(chunk) { error in
             self.queue.async {
                 self.writing = false
                 if let error {
+                    if isTransientWriteBackpressure(error) {
+                        // Apple's per-flow NE kernel buffer is full. Re-queue
+                        // the chunk at the head of `pending` (preserves order)
+                        // and back off briefly. Tearing the flow down here
+                        // would surface as a "random" mid-stream connection
+                        // drop to the originating app — exactly what was
+                        // breaking large h2 downloads.
+                        self.pending.insert(chunk, at: 0)
+                        let delay = self.retryDelayMs
+                        self.retryDelayMs = min(self.retryDelayMs * 2, writeRetryMaxDelayMs)
+                        self.queue.asyncAfter(deadline: .now() + .milliseconds(delay)) {
+                            self.flushLocked()
+                        }
+                        return
+                    }
                     self.logger(
                         classifyFlowCallbackError(
                             error,
@@ -437,6 +546,9 @@ private final class TcpClientWritePump {
                     return
                 }
 
+                // Reset backoff after any clean write — keeps subsequent
+                // transient hiccups from inheriting an old long delay.
+                self.retryDelayMs = writeRetryInitialDelayMs
                 self.flushLocked()
             }
         }
@@ -749,24 +861,42 @@ private final class NwTcpConnectionReadPump {
 /// signal half-close to the remote.
 private final class NwTcpConnectionWritePump {
     private let connection: NWConnection
+    /// See `TcpClientWritePump.onDrained`. Wired to
+    /// `RamaTcpSessionHandle.signalEgressDrain`.
+    private let onDrained: () -> Void
     private let queue: DispatchQueue
     private var pending: [Data] = []
     private var writing = false
     private var closeRequested = false
     private var closed = false
+    private var pausedSignaled = false
+    private var retryDelayMs: Int = writeRetryInitialDelayMs
 
-    init(connection: NWConnection, queue: DispatchQueue) {
+    init(connection: NWConnection, queue: DispatchQueue, onDrained: @escaping () -> Void) {
         self.connection = connection
         self.queue = queue
+        self.onDrained = onDrained
     }
 
-    func enqueue(_ data: Data) {
-        guard !data.isEmpty else { return }
-        queue.async {
-            guard !self.closed, !self.closeRequested else { return }
+    /// Same status contract as [`TcpClientWritePump.enqueue`].
+    @discardableResult
+    func enqueue(_ data: Data) -> RamaTcpDeliverStatusBridge {
+        guard !data.isEmpty else { return .accepted }
+        var status: RamaTcpDeliverStatusBridge = .accepted
+        queue.sync {
+            if self.closed || self.closeRequested {
+                status = .closed
+                return
+            }
+            if self.pending.count >= writePumpMaxPending {
+                self.pausedSignaled = true
+                status = .paused
+                return
+            }
             self.pending.append(data)
             self.flush()
         }
+        return status
     }
 
     func closeWhenDrained() {
@@ -781,16 +911,33 @@ private final class NwTcpConnectionWritePump {
         guard !writing, !pending.isEmpty, !closed else { return }
         writing = true
         let chunk = pending.removeFirst()
+        if pausedSignaled && pending.count < writePumpMaxPending {
+            pausedSignaled = false
+            onDrained()
+        }
         connection.send(content: chunk, completion: .contentProcessed({ [weak self] error in
             guard let self else { return }
             self.queue.async {
                 self.writing = false
-                if error != nil {
+                if let error {
+                    if isTransientWriteBackpressure(error) {
+                        // Same retry logic as `TcpClientWritePump`: kernel
+                        // socket buffer is temporarily full, back off rather
+                        // than tearing down the connection.
+                        self.pending.insert(chunk, at: 0)
+                        let delay = self.retryDelayMs
+                        self.retryDelayMs = min(self.retryDelayMs * 2, writeRetryMaxDelayMs)
+                        self.queue.asyncAfter(deadline: .now() + .milliseconds(delay)) {
+                            self.flush()
+                        }
+                        return
+                    }
                     self.closed = true
                     self.closeRequested = true
                     self.pending.removeAll(keepingCapacity: false)
                     return
                 }
+                self.retryDelayMs = writeRetryInitialDelayMs
                 self.flush()
                 self.finishCloseIfDrained()
             }
@@ -1073,6 +1220,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                 ctx.connection?.cancel()
                 ctx.session?.cancel()
                 self?.removeTcpFlow(flowId)
+            },
+            onDrained: { [weak ctx] in
+                // Wired below to RamaTcpSessionHandle.signalServerDrain via
+                // the weak ctx → session ref so we don't pin the session
+                // alive past its natural teardown.
+                ctx?.session?.signalServerDrain()
             }
         )
 
@@ -1184,7 +1337,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
                     timeoutWork.cancel()
 
                     let writePump = NwTcpConnectionWritePump(
-                        connection: connection, queue: flowQueue)
+                        connection: connection,
+                        queue: flowQueue,
+                        onDrained: { [weak ctx] in
+                            ctx?.session?.signalEgressDrain()
+                        }
+                    )
                     let readPump = NwTcpConnectionReadPump(
                         connection: connection, session: session, queue: flowQueue)
                     ctx.egressReadPump = readPump

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -173,12 +173,19 @@ private func isTransientWriteBackpressure(_ error: Error) -> Bool {
 private let writeRetryInitialDelayMs: Int = 5
 private let writeRetryMaxDelayMs: Int = 200
 
-/// Maximum number of in-flight chunks each writer pump (TCP response and
-/// TCP egress) keeps queued before it tells the Rust bridge to pause. Small
-/// enough to bound memory but large enough to absorb h2 multiplexing where
-/// many concurrent streams interleave their data through one TCP flow.
-/// Mirrors the rough scale of `DEFAULT_TCP_CHANNEL_CAPACITY` on the Rust side.
-private let writePumpMaxPending: Int = 256
+/// Memory budget (in bytes) each writer pump (TCP response and TCP egress)
+/// keeps queued before it tells the Rust bridge to pause.
+///
+/// Byte-based rather than chunk-count based: a chunk-count cap of N bounds
+/// worst-case memory at `N * max_chunk_size`, which with our 16–64 KiB
+/// chunks blows up fast under h2 multiplexing (many concurrent flows each
+/// holding the full chunk-count budget). A byte budget is constant
+/// regardless of chunk size.
+///
+/// 4 MiB sits comfortably above a typical h2 stream window (1–2 MiB) so
+/// the writer can absorb a full window's worth of frames without pausing
+/// per-stream-worth of bytes, while keeping per-flow memory bounded.
+private let writePumpMaxPendingBytes: Int = 4 * 1024 * 1024
 
 private func blockedFlowError() -> NSError {
     NSError(
@@ -428,13 +435,16 @@ private final class TcpClientWritePump {
     private let onDrained: () -> Void
     private let queue: DispatchQueue
     private var pending: [Data] = []
+    /// Sum of `pending[i].count` — the byte budget we use for backpressure.
+    /// Tracked separately so the FFI bound check stays O(1).
+    private var pendingBytes: Int = 0
     private var writing = false
     private var closeRequested = false
     private var closed = false
     private var opened = false
     private var onDrainedClose: ((Bool) -> Void)?
     /// Set when an `enqueue` was rejected with `.paused`. We fire `onDrained`
-    /// on the first removal that drops `pending.count` below the cap, then
+    /// on the first removal that drops `pendingBytes` below the cap, then
     /// clear this flag — edge-triggered so we never spam Rust with redundant
     /// drain signals while the queue churns at-cap.
     private var pausedSignaled: Bool = false
@@ -470,6 +480,7 @@ private final class TcpClientWritePump {
             self.closed = true
             self.closeRequested = true
             self.pending.removeAll(keepingCapacity: false)
+            self.pendingBytes = 0
             self.onDrainedClose = nil
             self.onTerminalError(error)
         }
@@ -480,9 +491,9 @@ private final class TcpClientWritePump {
     /// Synchronous so the caller (the Rust bridge, via the FFI thunk) gets a
     /// `RamaTcpDeliverStatusBridge` back in the same call:
     ///   - `.accepted` — chunk queued; Rust may keep producing.
-    ///   - `.paused` — `pending` is at `writePumpMaxPending`. Rust must wait
-    ///     for `signalServerDrain` (wired to `onDrained` below) before
-    ///     producing more.
+    ///   - `.paused` — `pendingBytes` reached `writePumpMaxPendingBytes`.
+    ///     Rust must wait for `signalServerDrain` (wired to `onDrained`
+    ///     below) before producing more.
     ///   - `.closed` — pump is being torn down; no further drain will fire.
     @discardableResult
     func enqueue(_ data: Data) -> RamaTcpDeliverStatusBridge {
@@ -500,11 +511,18 @@ private final class TcpClientWritePump {
                 status = .closed
                 return
             }
-            if self.pending.count >= writePumpMaxPending {
+            // Allow the first chunk through unconditionally so a single
+            // oversized chunk (larger than the cap) can never deadlock us;
+            // pause only when there's already queued bytes that need to be
+            // drained first.
+            if !self.pending.isEmpty
+                && self.pendingBytes + data.count > writePumpMaxPendingBytes
+            {
                 self.pausedSignaled = true
                 status = .paused
                 return
             }
+            self.pendingBytes += data.count
             self.pending.append(data)
             self.flushLocked()
         }
@@ -532,11 +550,12 @@ private final class TcpClientWritePump {
 
         writing = true
         let chunk = pending.removeFirst()
+        pendingBytes -= chunk.count
         // Edge-triggered drain signal: if Rust was paused and we just dropped
-        // `pending` below the cap, wake it once. Honouring this from the
-        // pre-write site (rather than the completion handler) lets Rust
+        // `pendingBytes` below the cap, wake it once. Honouring this from
+        // the pre-write site (rather than the completion handler) lets Rust
         // start producing the next chunk in parallel with the current write.
-        if pausedSignaled && pending.count < writePumpMaxPending {
+        if pausedSignaled && pendingBytes < writePumpMaxPendingBytes {
             pausedSignaled = false
             onDrained()
         }
@@ -552,6 +571,7 @@ private final class TcpClientWritePump {
                         // drop to the originating app — exactly what was
                         // breaking large h2 downloads.
                         self.pending.insert(chunk, at: 0)
+                        self.pendingBytes += chunk.count
                         let delay = self.retryDelayMs
                         self.retryDelayMs = min(self.retryDelayMs * 2, writeRetryMaxDelayMs)
                         self.queue.asyncAfter(deadline: .now() + .milliseconds(delay)) {
@@ -569,6 +589,7 @@ private final class TcpClientWritePump {
                     self.closed = true
                     self.closeRequested = true
                     self.pending.removeAll(keepingCapacity: false)
+                    self.pendingBytes = 0
                     self.onDrainedClose = nil
                     self.onTerminalError(error)
                     return
@@ -926,6 +947,8 @@ private final class NwTcpConnectionWritePump {
     private let onDrained: () -> Void
     private let queue: DispatchQueue
     private var pending: [Data] = []
+    /// See [`TcpClientWritePump.pendingBytes`].
+    private var pendingBytes: Int = 0
     private var writing = false
     private var closeRequested = false
     private var closed = false
@@ -948,11 +971,14 @@ private final class NwTcpConnectionWritePump {
                 status = .closed
                 return
             }
-            if self.pending.count >= writePumpMaxPending {
+            if !self.pending.isEmpty
+                && self.pendingBytes + data.count > writePumpMaxPendingBytes
+            {
                 self.pausedSignaled = true
                 status = .paused
                 return
             }
+            self.pendingBytes += data.count
             self.pending.append(data)
             self.flush()
         }
@@ -971,7 +997,8 @@ private final class NwTcpConnectionWritePump {
         guard !writing, !pending.isEmpty, !closed else { return }
         writing = true
         let chunk = pending.removeFirst()
-        if pausedSignaled && pending.count < writePumpMaxPending {
+        pendingBytes -= chunk.count
+        if pausedSignaled && pendingBytes < writePumpMaxPendingBytes {
             pausedSignaled = false
             onDrained()
         }
@@ -985,6 +1012,7 @@ private final class NwTcpConnectionWritePump {
                         // socket buffer is temporarily full, back off rather
                         // than tearing down the connection.
                         self.pending.insert(chunk, at: 0)
+                        self.pendingBytes += chunk.count
                         let delay = self.retryDelayMs
                         self.retryDelayMs = min(self.retryDelayMs * 2, writeRetryMaxDelayMs)
                         self.queue.asyncAfter(deadline: .now() + .milliseconds(delay)) {
@@ -995,6 +1023,7 @@ private final class NwTcpConnectionWritePump {
                     self.closed = true
                     self.closeRequested = true
                     self.pending.removeAll(keepingCapacity: false)
+                    self.pendingBytes = 0
                     return
                 }
                 self.retryDelayMs = writeRetryInitialDelayMs

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -221,6 +221,12 @@ private final class TcpClientReadPump {
     /// Cleared by `resume()`, which is wired to the Rust → Swift
     /// `onClientReadDemand` callback.
     private var paused = false
+    /// Bytes Rust rejected with `.paused` on a previous `onClientBytes`. We
+    /// MUST replay them before issuing the next `flow.readData` — Rust does
+    /// not take ownership on a `.paused` return, so dropping `data` here
+    /// would punch a hole in the byte stream and the downstream TLS layer
+    /// would surface "bad record MAC" once the gap reaches the decryptor.
+    private var pendingData: Data?
 
     init(
         flow: NEAppProxyTCPFlow,
@@ -252,6 +258,30 @@ private final class TcpClientReadPump {
 
     private func requestReadLocked() {
         guard !self.closed, !self.readPending, !self.paused else { return }
+
+        // Replay any chunk Rust rejected with `.paused` last time before we
+        // ask the kernel for new bytes. If this still gets `.paused` we hold
+        // the chunk and wait for the next `resume()`.
+        if let pending = self.pendingData {
+            guard let session = self.session else {
+                self.pendingData = nil
+                self.terminate(with: nil)
+                return
+            }
+            switch session.onClientBytes(pending) {
+            case .accepted:
+                self.pendingData = nil
+                // fall through to issue a fresh readData
+            case .paused:
+                self.paused = true
+                return
+            case .closed:
+                self.pendingData = nil
+                self.terminate(with: nil)
+                return
+            }
+        }
+
         self.readPending = true
         self.flow.readData { data, error in
             self.queue.async {
@@ -287,11 +317,9 @@ private final class TcpClientReadPump {
                 case .accepted:
                     self.requestReadLocked()
                 case .paused:
-                    // Rust signaled the ingress channel is full — hold off
-                    // reading until `resume()` is called from the demand
-                    // callback. Without this, every `flow.readData` we issue
-                    // would hand bytes to a Rust side that has nowhere to
-                    // put them, defeating the bound.
+                    // Rust did NOT take these bytes. Save them for replay on
+                    // the next `resume()` and stop reading.
+                    self.pendingData = data
                     self.paused = true
                 case .closed:
                     // Rust signaled the session is gone (teardown or
@@ -787,6 +815,10 @@ private final class NwTcpConnectionReadPump {
     /// `resume()` (or repeated `start()`s) from issuing a second concurrent
     /// receive, which `Network.framework` does not support.
     private var receiving = false
+    /// See [`TcpClientReadPump.pendingData`] — same contract for the egress
+    /// (NWConnection-receive) direction. Dropping rejected bytes here is what
+    /// the wails-zip / golang-module repro showed as TLS "bad record MAC".
+    private var pendingData: Data?
 
     init(connection: NWConnection, session: RamaTcpSessionHandle, queue: DispatchQueue) {
         self.connection = connection
@@ -810,6 +842,29 @@ private final class NwTcpConnectionReadPump {
 
     private func scheduleReadLocked() {
         guard !self.closed, !self.paused, !self.receiving else { return }
+
+        // Replay any chunk Rust rejected with `.paused` last time before
+        // issuing a new receive.
+        if let pending = self.pendingData {
+            guard let session = self.session else {
+                self.pendingData = nil
+                self.closed = true
+                return
+            }
+            switch session.onEgressBytes(pending) {
+            case .accepted:
+                self.pendingData = nil
+                // fall through to schedule the next receive
+            case .paused:
+                self.paused = true
+                return
+            case .closed:
+                self.pendingData = nil
+                self.closed = true
+                return
+            }
+        }
+
         self.receiving = true
         connection.receive(minimumIncompleteLength: 1, maximumLength: 65_536) {
             [weak self] data, _, isComplete, error in
@@ -832,7 +887,12 @@ private final class NwTcpConnectionReadPump {
                     case .accepted:
                         break
                     case .paused:
+                        // Rust did NOT take these bytes. Save them for
+                        // replay; do NOT issue another receive until
+                        // `resume()`.
+                        self.pendingData = data
                         self.paused = true
+                        return
                     case .closed:
                         // No demand will follow; tear the pump down now.
                         self.closed = true

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/http_h2.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/http_h2.rs
@@ -5,10 +5,12 @@
 //! - proxy: `direct`, `http`, `socks5`
 
 use rama::{
+    bytes::Bytes,
     futures::future::join_all,
-    http::{BodyExtractExt as _, Version},
+    http::{BodyExtractExt as _, Version, body::util::BodyExt as _},
 };
 use serial_test::serial;
+use std::time::Duration;
 
 use crate::shared::{
     clients::{build_http_client, fetch_response, fetch_text},
@@ -34,6 +36,26 @@ macro_rules! h2_multi_stream_test {
         #[serial]
         async fn $name() {
             run_h2_multi_stream_case($target, $proxy).await;
+        }
+    };
+}
+
+macro_rules! h2_large_body_test {
+    ($name:ident, $target:expr, $proxy:expr, $size_kb:expr) => {
+        #[tokio::test]
+        #[serial]
+        async fn $name() {
+            run_h2_large_body_case($target, $proxy, $size_kb).await;
+        }
+    };
+}
+
+macro_rules! h2_concurrent_large_test {
+    ($name:ident, $target:expr, $proxy:expr, $stream_count:expr, $size_kb:expr) => {
+        #[tokio::test]
+        #[serial]
+        async fn $name() {
+            run_h2_concurrent_large_case($target, $proxy, $stream_count, $size_kb).await;
         }
     };
 }
@@ -100,6 +122,42 @@ h2_multi_stream_test!(
     ProxyKind::Socks5
 );
 
+// ── Large-body + many-concurrent-stream coverage ──────────────────────────────
+//
+// These exist specifically to pin the symmetric-backpressure fix for the
+// Rust → Swift response direction: before the writer pumps were bounded
+// (with `signal_*_drain` wired up) and `flow.write` ENOBUFS treated as
+// transient, large h2 responses (e.g. `go mod download` of a multi-MB module
+// zip) intermittently surfaced as "random" mid-stream errors as the per-flow
+// NE kernel buffer overflowed. Plain/TLS × direct only — proxied variants
+// are functionally equivalent for what we're verifying here.
+h2_large_body_test!(
+    ffi_contract_http_h2_plain_direct_large_response_body,
+    HttpTargetKind::Plain,
+    ProxyKind::None,
+    8 * 1024
+);
+h2_large_body_test!(
+    ffi_contract_http_h2_tls_direct_large_response_body,
+    HttpTargetKind::Tls,
+    ProxyKind::None,
+    8 * 1024
+);
+h2_concurrent_large_test!(
+    ffi_contract_http_h2_plain_direct_concurrent_large_streams,
+    HttpTargetKind::Plain,
+    ProxyKind::None,
+    16,
+    1024
+);
+h2_concurrent_large_test!(
+    ffi_contract_http_h2_tls_direct_concurrent_large_streams,
+    HttpTargetKind::Tls,
+    ProxyKind::None,
+    16,
+    1024
+);
+
 async fn run_h2_html_smoke(target: HttpTargetKind, proxy: ProxyKind) {
     let env = setup_env().await;
     let remote_port = match target {
@@ -147,6 +205,136 @@ async fn run_h2_html_smoke(target: HttpTargetKind, proxy: ProxyKind) {
     let html_observation = html_observation.expect("server observed html request");
     assert!(html_observation.observed_header.is_some());
     drop(observed);
+    ingress.shutdown().await;
+}
+
+async fn run_h2_large_body_case(target: HttpTargetKind, proxy: ProxyKind, size_kb: usize) {
+    let env = setup_env().await;
+    let remote_port = match target {
+        HttpTargetKind::Plain => env.ports.http,
+        HttpTargetKind::Tls => env.ports.https,
+    };
+    let scheme = match target {
+        HttpTargetKind::Plain => "http",
+        HttpTargetKind::Tls => "https",
+    };
+    let ingress = spawn_ingress_listener(env.engine.clone(), localhost(remote_port)).await;
+    let ingress_addr = ingress.local_addr();
+    let client = build_http_client(match target {
+        HttpTargetKind::Plain => None,
+        HttpTargetKind::Tls => Some(load_mitm_ca_store()),
+    });
+
+    let url = format!(
+        "{scheme}://127.0.0.1:{}/large?kb={size_kb}",
+        ingress_addr.port()
+    );
+
+    // The wails-zip case took ~2 s end-to-end on a real network; locally we
+    // expect well under that, but allow a generous budget so a CI hiccup
+    // doesn't false-fail.
+    let response = tokio::time::timeout(
+        Duration::from_secs(30),
+        fetch_response(
+            &client,
+            &url,
+            Version::HTTP_2,
+            proxy,
+            localhost(env.ports.proxy),
+        ),
+    )
+    .await
+    .expect("fetch should not time out for large h2 body");
+
+    assert!(
+        response.status().is_success(),
+        "status = {}",
+        response.status()
+    );
+
+    let body: Bytes = tokio::time::timeout(
+        Duration::from_secs(30),
+        response.into_body().collect(),
+    )
+    .await
+    .expect("body collect should not time out")
+    .expect("body bytes")
+    .to_bytes();
+    let expected_bytes = size_kb * 1024;
+    assert_eq!(
+        body.len(),
+        expected_bytes,
+        "expected {expected_bytes} bytes, got {}",
+        body.len()
+    );
+
+    ingress.shutdown().await;
+}
+
+async fn run_h2_concurrent_large_case(
+    target: HttpTargetKind,
+    proxy: ProxyKind,
+    stream_count: usize,
+    size_kb: usize,
+) {
+    let env = setup_env().await;
+    let remote_port = match target {
+        HttpTargetKind::Plain => env.ports.http,
+        HttpTargetKind::Tls => env.ports.https,
+    };
+    let scheme = match target {
+        HttpTargetKind::Plain => "http",
+        HttpTargetKind::Tls => "https",
+    };
+    let ingress = spawn_ingress_listener(env.engine.clone(), localhost(remote_port)).await;
+    let ingress_addr = ingress.local_addr();
+    let client = build_http_client(match target {
+        HttpTargetKind::Plain => None,
+        HttpTargetKind::Tls => Some(load_mitm_ca_store()),
+    });
+    let proxy_addr = localhost(env.ports.proxy);
+    let base = format!("{scheme}://127.0.0.1:{}", ingress_addr.port());
+    let expected_bytes = size_kb * 1024;
+
+    // `stream_count` simultaneous large bodies through the same TCP flow —
+    // exercises h2 multiplexing through the bounded per-flow channel +
+    // bounded writer-pump pending. Pre-fix this would either stall (one
+    // slow stream backpressures every other stream) or fail with ENOBUFS.
+    let results = tokio::time::timeout(
+        Duration::from_secs(60),
+        join_all((0..stream_count).map(|idx| {
+            let client = &client;
+            let url = format!("{base}/large?kb={size_kb}&stream={idx}");
+            async move {
+                let response = fetch_response(
+                    client,
+                    &url,
+                    Version::HTTP_2,
+                    proxy,
+                    proxy_addr,
+                )
+                .await;
+                response
+                    .into_body()
+                    .collect()
+                    .await
+                    .expect("body bytes")
+                    .to_bytes()
+            }
+        })),
+    )
+    .await
+    .expect("concurrent large streams should not time out");
+
+    for (idx, body) in results.iter().enumerate() {
+        assert_eq!(
+            body.len(),
+            expected_bytes,
+            "stream {idx}: expected {expected_bytes} bytes, got {}",
+            body.len()
+        );
+    }
+
     ingress.shutdown().await;
 }
 

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
@@ -16,7 +16,10 @@ struct TcpServerCallbackContext {
     closed: Arc<Notify>,
 }
 
-unsafe extern "C" fn on_tcp_server_bytes(ctx: *mut c_void, bytes: bindings::RamaBytesView) {
+unsafe extern "C" fn on_tcp_server_bytes(
+    ctx: *mut c_void,
+    bytes: bindings::RamaBytesView,
+) -> bindings::RamaTcpDeliverStatus {
     let ctx = unsafe { &*(ctx as *const TcpServerCallbackContext) };
     let payload = if bytes.ptr.is_null() || bytes.len == 0 {
         Vec::new()
@@ -24,6 +27,9 @@ unsafe extern "C" fn on_tcp_server_bytes(ctx: *mut c_void, bytes: bindings::Rama
         unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len).to_vec() }
     };
     let _ = ctx.sender.send(payload);
+    // The e2e harness uses an unbounded mpsc + tight-loop writer, so there's
+    // no Swift-side backpressure to surface here.
+    bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED
 }
 
 unsafe extern "C" fn on_tcp_server_closed(ctx: *mut c_void) {
@@ -45,7 +51,10 @@ struct TcpEgressCallbackContext {
     closed: Arc<Notify>,
 }
 
-unsafe extern "C" fn on_tcp_write_to_egress(ctx: *mut c_void, bytes: bindings::RamaBytesView) {
+unsafe extern "C" fn on_tcp_write_to_egress(
+    ctx: *mut c_void,
+    bytes: bindings::RamaBytesView,
+) -> bindings::RamaTcpDeliverStatus {
     let ctx = unsafe { &*(ctx as *const TcpEgressCallbackContext) };
     let payload = if bytes.ptr.is_null() || bytes.len == 0 {
         Vec::new()
@@ -53,6 +62,7 @@ unsafe extern "C" fn on_tcp_write_to_egress(ctx: *mut c_void, bytes: bindings::R
         unsafe { std::slice::from_raw_parts(bytes.ptr, bytes.len).to_vec() }
     };
     let _ = ctx.sender.send(payload);
+    bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED
 }
 
 unsafe extern "C" fn on_tcp_close_egress(ctx: *mut c_void) {

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
@@ -14,6 +14,12 @@ use super::{bindings, ffi::EngineHandle};
 struct TcpServerCallbackContext {
     sender: mpsc::UnboundedSender<Vec<u8>>,
     closed: Arc<Notify>,
+    /// Fired by the FFI when the per-flow ingress channel transitions from
+    /// full to has-space after `on_client_bytes` returned `Paused`. The
+    /// ingress reader awaits on this before retrying a rejected chunk.
+    /// Without this we'd drop the chunk and corrupt the byte stream — same
+    /// bug that surfaced as `tls: bad record MAC` for large h2 transfers.
+    client_read_demand: Arc<Notify>,
 }
 
 unsafe extern "C" fn on_tcp_server_bytes(
@@ -37,18 +43,27 @@ unsafe extern "C" fn on_tcp_server_closed(ctx: *mut c_void) {
     ctx.closed.notify_waiters();
 }
 
-/// Resume signal from Rust. The e2e test reads in a tight loop so it never
-/// has to honor a backpressure pause — but we still log the call to keep the
-/// FFI shape exercised.
-unsafe extern "C" fn on_tcp_client_read_demand(_ctx: *mut c_void) {}
+/// Resume signal from Rust: the per-flow ingress channel has space again.
+/// Wakes the harness's ingress reader, which is parked waiting to retry a
+/// chunk Rust rejected with `Paused`.
+unsafe extern "C" fn on_tcp_client_read_demand(ctx: *mut c_void) {
+    let ctx = unsafe { &*(ctx as *const TcpServerCallbackContext) };
+    ctx.client_read_demand.notify_one();
+}
 
-unsafe extern "C" fn on_tcp_egress_read_demand(_ctx: *mut c_void) {}
+unsafe extern "C" fn on_tcp_egress_read_demand(ctx: *mut c_void) {
+    let ctx = unsafe { &*(ctx as *const TcpEgressCallbackContext) };
+    ctx.egress_read_demand.notify_one();
+}
 
 // ── Egress (service → upstream) callback context ─────────────────────────────
 
 struct TcpEgressCallbackContext {
     sender: mpsc::UnboundedSender<Vec<u8>>,
     closed: Arc<Notify>,
+    /// See `TcpServerCallbackContext.client_read_demand` — same role for
+    /// the egress (NWConnection-receive) direction.
+    egress_read_demand: Arc<Notify>,
 }
 
 unsafe extern "C" fn on_tcp_write_to_egress(
@@ -186,18 +201,22 @@ async fn serve_one_ingress_connection(
     // service back to the client connection.
     let (server_bytes_tx, mut server_bytes_rx) = mpsc::unbounded_channel::<Vec<u8>>();
     let server_closed = Arc::new(Notify::new());
+    let client_read_demand = Arc::new(Notify::new());
     let server_ctx_ptr = Box::into_raw(Box::new(TcpServerCallbackContext {
         sender: server_bytes_tx,
         closed: server_closed.clone(),
+        client_read_demand: client_read_demand.clone(),
     })) as usize;
 
     // Egress side: callbacks deliver bytes from the Rust service to the
     // upstream socket.
     let (egress_bytes_tx, mut egress_bytes_rx) = mpsc::unbounded_channel::<Vec<u8>>();
     let egress_closed = Arc::new(Notify::new());
+    let egress_read_demand = Arc::new(Notify::new());
     let egress_ctx_ptr = Box::into_raw(Box::new(TcpEgressCallbackContext {
         sender: egress_bytes_tx,
         closed: egress_closed.clone(),
+        egress_read_demand: egress_read_demand.clone(),
     })) as usize;
 
     let session = {
@@ -293,11 +312,39 @@ async fn serve_one_ingress_connection(
     });
 
     // Egress reader: upstream socket → on_egress_bytes / on_egress_eof.
+    //
+    // Honours backpressure: on `Paused` we retain the rejected chunk and
+    // wait for the matching `egress_read_demand` notify before retrying.
+    // Without this we'd silently drop the chunk and corrupt the byte
+    // stream (see `tcp_byte_stream_preserved_under_egress_backpressure`).
     let egress_session = session;
+    let egress_read_demand_for_reader = egress_read_demand.clone();
     let egress_reader = tokio::spawn(async move {
         let mut reader = egress_read;
         let mut buf = [0_u8; 16 * 1024];
-        loop {
+        let mut pending: Option<Vec<u8>> = None;
+        'outer: loop {
+            // Replay any pending rejected chunk before reading new data.
+            while let Some(chunk) = pending.take() {
+                let status = unsafe {
+                    bindings::rama_transparent_proxy_tcp_session_on_egress_bytes(
+                        egress_session as *mut bindings::RamaTransparentProxyTcpSession,
+                        bindings::RamaBytesView {
+                            ptr: chunk.as_ptr(),
+                            len: chunk.len(),
+                        },
+                    )
+                };
+                match status {
+                    bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED => {}
+                    bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_PAUSED => {
+                        pending = Some(chunk);
+                        egress_read_demand_for_reader.notified().await;
+                    }
+                    _ => break 'outer, // closed
+                }
+            }
+
             match reader.read(&mut buf).await {
                 Ok(0) | Err(_) => {
                     unsafe {
@@ -307,23 +354,69 @@ async fn serve_one_ingress_connection(
                     }
                     break;
                 }
-                Ok(n) => unsafe {
-                    bindings::rama_transparent_proxy_tcp_session_on_egress_bytes(
-                        egress_session as *mut bindings::RamaTransparentProxyTcpSession,
-                        bindings::RamaBytesView {
-                            ptr: buf.as_ptr(),
-                            len: n,
-                        },
-                    );
-                },
+                Ok(n) => {
+                    let status = unsafe {
+                        bindings::rama_transparent_proxy_tcp_session_on_egress_bytes(
+                            egress_session as *mut bindings::RamaTransparentProxyTcpSession,
+                            bindings::RamaBytesView {
+                                ptr: buf.as_ptr(),
+                                len: n,
+                            },
+                        )
+                    };
+                    match status {
+                        bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED => {}
+                        bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_PAUSED => {
+                            // Save the rejected chunk for replay.
+                            pending = Some(buf[..n].to_vec());
+                            egress_read_demand_for_reader.notified().await;
+                        }
+                        _ => break, // closed
+                    }
+                }
             }
         }
     });
 
     // Ingress reader: client socket → on_client_bytes / on_client_eof.
+    //
+    // Same backpressure-honouring shape as the egress reader above.
     let mut reader = client_read;
     let mut buf = [0_u8; 16 * 1024];
-    loop {
+    let mut pending: Option<Vec<u8>> = None;
+    'ingress: loop {
+        // Replay before reading new data.
+        while let Some(chunk) = pending.take() {
+            let status = unsafe {
+                bindings::rama_transparent_proxy_tcp_session_on_client_bytes(
+                    session as *mut bindings::RamaTransparentProxyTcpSession,
+                    bindings::RamaBytesView {
+                        ptr: chunk.as_ptr(),
+                        len: chunk.len(),
+                    },
+                )
+            };
+            match status {
+                bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED => {}
+                bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_PAUSED => {
+                    pending = Some(chunk);
+                    tokio::select! {
+                        _ = client_read_demand.notified() => {}
+                        _ = shutdown.notified() => {
+                            unsafe {
+                                bindings::rama_transparent_proxy_tcp_session_on_client_eof(
+                                    session as *mut bindings::RamaTransparentProxyTcpSession,
+                                );
+                            }
+                            break 'ingress;
+                        }
+                        _ = server_closed.notified() => break 'ingress,
+                    }
+                }
+                _ => break 'ingress, // closed
+            }
+        }
+
         tokio::select! {
             result = reader.read(&mut buf) => {
                 match result {
@@ -335,15 +428,24 @@ async fn serve_one_ingress_connection(
                         }
                         break;
                     }
-                    Ok(n) => unsafe {
-                        bindings::rama_transparent_proxy_tcp_session_on_client_bytes(
-                            session as *mut bindings::RamaTransparentProxyTcpSession,
-                            bindings::RamaBytesView {
-                                ptr: buf.as_ptr(),
-                                len: n,
-                            },
-                        );
-                    },
+                    Ok(n) => {
+                        let status = unsafe {
+                            bindings::rama_transparent_proxy_tcp_session_on_client_bytes(
+                                session as *mut bindings::RamaTransparentProxyTcpSession,
+                                bindings::RamaBytesView {
+                                    ptr: buf.as_ptr(),
+                                    len: n,
+                                },
+                            )
+                        };
+                        match status {
+                            bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_ACCEPTED => {}
+                            bindings::RamaTcpDeliverStatus_RAMA_TCP_DELIVER_PAUSED => {
+                                pending = Some(buf[..n].to_vec());
+                            }
+                            _ => break, // closed
+                        }
+                    }
                 }
             }
             _ = shutdown.notified() => {

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
@@ -120,6 +120,46 @@ fn http_app(
                     }
                 }
             })
+            .with_get("/large", {
+                let observations = Arc::clone(observations);
+                move |req: Request| {
+                    let observations = Arc::clone(&observations);
+                    async move {
+                        record_http_observation(observations, &req).await;
+                        // Pseudo-random body sized via `?kb=N` (default 4096 = 4 MiB).
+                        // Used to exercise the symmetric-backpressure path that fired
+                        // ENOBUFS for large h2 responses (`go mod download` etc.) before
+                        // the writer pumps were bounded with drain signaling.
+                        let size_kb = req
+                            .uri()
+                            .query()
+                            .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("kb=")))
+                            .and_then(|v| v.parse::<usize>().ok())
+                            .unwrap_or(4096)
+                            .min(64 * 1024); // cap at 64 MiB to keep test runtime sane
+                        let total = size_kb * 1024;
+                        let body = Body::from_stream(stream_fn(move |mut yielder| async move {
+                            // 16 KiB chunks — same shape as the bridge's read buffer.
+                            let chunk_size: usize = 16 * 1024;
+                            let mut sent: usize = 0;
+                            let mut counter: u8 = 0;
+                            while sent < total {
+                                let remaining = total - sent;
+                                let n = remaining.min(chunk_size);
+                                let chunk: Vec<u8> = (0..n)
+                                    .map(|i| counter.wrapping_add(i as u8))
+                                    .collect();
+                                counter = counter.wrapping_add(n as u8);
+                                sent += n;
+                                yielder
+                                    .yield_item(Ok::<_, io::Error>(RamaBytes::from(chunk)))
+                                    .await;
+                            }
+                        }));
+                        (Headers::single(ContentType::octet_stream()), body).into_response()
+                    }
+                }
+            })
             .with_get("/sse", {
                 let observations = Arc::clone(observations);
                 move |req: Request| {

--- a/rama-dns/src/lib.rs
+++ b/rama-dns/src/lib.rs
@@ -1,32 +1,44 @@
 //! DNS support for Rama.
 //!
-//! # Hickory Dns
+//! # Resolvers
 //!
-//! Hickory Dns is a Rust based DNS client, server, and resolver, built to be safe and secure from the ground up.
-//! It is the default (and only) dns provider for Rama.
+//! Rama ships with several [`client::resolver::DnsResolver`] implementations.
+//! The most commonly used ones are re-exported from [`client`]:
 //!
-//! By implementing the [`client::resolver::DnsResolver`] and optionally also
-//! using [`client::try_init_global_dns_resolver`]
-//! you can set however any kind of [`client::resolver::DnsResolver`] you wish.
+//! - [`client::NativeDnsResolver`] — alias for the platform-native resolver:
+//!   `AppleDnsResolver` on Apple platforms, `WindowsDnsResolver` on
+//!   Windows, `LinuxDnsResolver` on Linux, and [`client::TokioDnsResolver`]
+//!   (host-backed via tokio) elsewhere. Each is exposed under
+//!   [`client`] when the corresponding target is active.
+//! - [`client::TokioDnsResolver`] — host-backed resolver that uses the
+//!   blocking system getaddrinfo via tokio's threadpool.
+//! - `client::HickoryDnsResolver` — pure-Rust resolver from the
+//!   Hickory DNS project (<https://github.com/hickory-dns/hickory-dns>);
+//!   gated behind the `hickory` feature.
+//! - [`client::DenyAllDnsResolver`] — fails every lookup with
+//!   [`client::DnsDeniedError`]; useful when DNS must be disabled.
+//! - [`client::EmptyDnsResolver`] — returns no addresses for every lookup.
 //!
-//! More info about hickory dns can be found at <https://github.com/hickory-dns/hickory-dns>.
+//! Implement [`client::resolver::DnsResolver`] yourself to plug in any
+//! other resolver, and combine resolvers with the chain / tuple / variant
+//! adapters under [`client`].
 //!
 //! ## Global DNS resolver
 //!
-//! Rama uses by default a global and shared dns resolver.
-//! The default one for this is the [`Default`] [`client::HickoryDnsResolver`] value,
-//! which on unix and windows platforms is pulled from the system if possible,
-//! and as a fallback or on all other platforms the default cloudflare config is used.
+//! Rama uses a process-wide shared DNS resolver by default. If nothing is
+//! installed explicitly, it lazily initialises to [`client::NativeDnsResolver`]
+//! on first use — i.e. the best native resolver for the current platform.
 //!
-//! Thank you cloudflare.
+//! Use [`client::try_init_global_dns_resolver`] or
+//! [`client::init_global_dns_resolver`] to install a different resolver
+//! (e.g. `client::HickoryDnsResolver` under the `hickory` feature, or
+//! your own implementation). This
+//! has to happen before the first lookup; both initialisers fail / panic
+//! if the global resolver has already been initialised.
 //!
-//! Use [`client::try_init_global_dns_resolver`] or [`client::init_global_dns_resolver`] to
-//! set the global [`client::resolver::DnsResolver`] as early as possible (e.g. at the top of your _main_ function).
-//!
-//! The global dns resolver can be lazily fetched by making use of [`client::GlobalDnsResolver`]
-//! which allows you to create it _only_ when actually using it. Great in case
-//! you need to have a [`client::resolver::DnsResolver`] value that you do not wish to do _any_ work for,
-//! until you "really" need it.
+//! [`client::GlobalDnsResolver`] is a thin handle that defers fetching the
+//! global resolver until it's actually used — handy when you want to pass
+//! a resolver around without forcing it to be constructed yet.
 //!
 //! ## Rama
 //!

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -267,10 +267,15 @@ impl TransparentProxyConfig {
 #[repr(C)]
 pub struct TransparentProxyTcpSessionCallbacks {
     pub context: *mut c_void,
-    pub on_server_bytes: Option<unsafe extern "C" fn(*mut c_void, BytesView)>,
+    /// Rust → Swift: deliver response bytes to the intercepted client flow.
+    /// Returns a [`crate::tproxy::TcpDeliverStatus`] so the Rust bridge can
+    /// pause when Swift's writer pump (`TcpClientWritePump`) is full and
+    /// resume only after the matching `signal_server_drain` call from Swift.
+    pub on_server_bytes:
+        Option<unsafe extern "C" fn(*mut c_void, BytesView) -> crate::tproxy::TcpDeliverStatus>,
     pub on_server_closed: Option<unsafe extern "C" fn(*mut c_void)>,
     /// Rust → Swift: signal that the per-flow ingress channel has space again
-    /// after [`crate::tproxy::TransparentProxyTcpSession::on_client_bytes`] returned `false`.
+    /// after [`crate::tproxy::TransparentProxyTcpSession::on_client_bytes`] returned `Paused`.
     /// Swift must keep `flow.readData` paused until this fires.
     pub on_client_read_demand: Option<unsafe extern "C" fn(*mut c_void)>,
 }
@@ -416,11 +421,15 @@ pub struct UdpEgressConnectOptions {
 pub struct TransparentProxyTcpEgressCallbacks {
     pub context: *mut c_void,
     /// Rust calls this to send bytes from the service to the egress NWConnection.
-    pub on_write_to_egress: Option<unsafe extern "C" fn(*mut c_void, BytesView)>,
+    /// Returns a [`crate::tproxy::TcpDeliverStatus`] so the Rust bridge can
+    /// pause when Swift's `NwTcpConnectionWritePump` is full and resume only
+    /// after the matching `signal_egress_drain` call from Swift.
+    pub on_write_to_egress:
+        Option<unsafe extern "C" fn(*mut c_void, BytesView) -> crate::tproxy::TcpDeliverStatus>,
     /// Rust calls this when the service is done writing to the egress NWConnection.
     pub on_close_egress: Option<unsafe extern "C" fn(*mut c_void)>,
     /// Rust → Swift: signal that the per-flow egress channel has space again
-    /// after [`crate::tproxy::TransparentProxyTcpSession::on_egress_bytes`] returned `false`.
+    /// after [`crate::tproxy::TransparentProxyTcpSession::on_egress_bytes`] returned `Paused`.
     /// Swift must keep `connection.receive` paused until this fires.
     pub on_egress_read_demand: Option<unsafe extern "C" fn(*mut c_void)>,
 }

--- a/rama-net-apple-networkextension/src/macros.rs
+++ b/rama-net-apple-networkextension/src/macros.rs
@@ -291,12 +291,15 @@ macro_rules! __transparent_proxy_ffi_emit {
             let engine = unsafe { &*engine };
             let result = engine.new_tcp_session(
                 typed_meta,
-                ::std::sync::Arc::new(move |bytes: &[u8]| {
+                ::std::sync::Arc::new(move |bytes: &[u8]| -> RamaTcpDeliverStatus {
                     let Some(callback) = on_server_bytes else {
-                        return;
+                        // No Swift writer registered → behave as accepted
+                        // so the bridge keeps draining the duplex; bytes
+                        // simply go nowhere.
+                        return RamaTcpDeliverStatus::Accepted;
                     };
                     if bytes.is_empty() {
-                        return;
+                        return RamaTcpDeliverStatus::Accepted;
                     }
                     unsafe {
                         callback(
@@ -305,7 +308,7 @@ macro_rules! __transparent_proxy_ffi_emit {
                                 ptr: bytes.as_ptr(),
                                 len: bytes.len(),
                             },
-                        );
+                        )
                     }
                 }),
                 ::std::sync::Arc::new(move || {
@@ -568,12 +571,15 @@ macro_rules! __transparent_proxy_ffi_emit {
 
             unsafe {
                 (*session).activate(
-                    move |bytes: $crate::__RamaBytes| {
+                    move |bytes: $crate::__RamaBytes| -> RamaTcpDeliverStatus {
                         let Some(callback) = on_write_to_egress else {
-                            return;
+                            // No Swift writer registered: behave as accepted
+                            // so the bridge keeps pulling bytes; they go
+                            // nowhere but at least the session doesn't stall.
+                            return RamaTcpDeliverStatus::Accepted;
                         };
                         if bytes.is_empty() {
-                            return;
+                            return RamaTcpDeliverStatus::Accepted;
                         }
                         unsafe {
                             callback(
@@ -582,7 +588,7 @@ macro_rules! __transparent_proxy_ffi_emit {
                                     ptr: bytes.as_ptr(),
                                     len: bytes.len(),
                                 },
-                            );
+                            )
                         }
                     },
                     move || {
@@ -597,6 +603,33 @@ macro_rules! __transparent_proxy_ffi_emit {
                     },
                 )
             };
+        }
+
+        /// Swift → Rust: signal that the `TcpClientWritePump` has drained
+        /// capacity after `on_server_bytes` returned `Paused`.
+        ///
+        /// Wakes the Rust bridge so it resumes forwarding response bytes.
+        /// Idempotent — collapses redundant calls into a single permit.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_signal_server_drain(
+            session: *mut RamaTransparentProxyTcpSession,
+        ) {
+            if session.is_null() {
+                return;
+            }
+            unsafe { (*session).signal_server_drain() };
+        }
+
+        /// Swift → Rust: signal that the `NwTcpConnectionWritePump` has
+        /// drained capacity after `on_write_to_egress` returned `Paused`.
+        #[unsafe(no_mangle)]
+        pub unsafe extern "C" fn rama_transparent_proxy_tcp_session_signal_egress_drain(
+            session: *mut RamaTransparentProxyTcpSession,
+        ) {
+            if session.is_null() {
+                return;
+            }
+            unsafe { (*session).signal_egress_drain() };
         }
 
         /// Deliver bytes from the egress `NWConnection` into the Rust TCP session.

--- a/rama-net-apple-networkextension/src/tproxy/engine/boxed.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/boxed.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
-use crate::tproxy::{SessionFlowAction, TransparentProxyConfig, TransparentProxyFlowMeta};
+use crate::tproxy::{
+    SessionFlowAction, TcpDeliverStatus, TransparentProxyConfig, TransparentProxyFlowMeta,
+};
 use rama_core::bytes::Bytes;
 
 use super::{
@@ -9,6 +11,11 @@ use super::{
 };
 
 pub type BoxedServerBytesSink = Arc<dyn Fn(&[u8]) + Send + Sync + 'static>;
+/// Variant of [`BoxedServerBytesSink`] for the TCP response direction. Returns
+/// a [`TcpDeliverStatus`] so the bridge can pause when Swift's writer pump is
+/// full.
+pub(crate) type BoxedServerBytesStatusSink =
+    Arc<dyn Fn(&[u8]) -> TcpDeliverStatus + Send + Sync + 'static>;
 pub type BoxedClosedSink = Arc<dyn Fn() + Send + Sync + 'static>;
 pub type BoxedDemandSink = Arc<dyn Fn() + Send + Sync + 'static>;
 
@@ -19,7 +26,7 @@ trait BoxedTransparentProxyEngineInner: Send + Sync + 'static {
     fn new_tcp_session(
         &self,
         meta: TransparentProxyFlowMeta,
-        on_server_bytes: BoxedServerBytesSink,
+        on_server_bytes: BoxedServerBytesStatusSink,
         on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession>;
@@ -51,13 +58,13 @@ where
     fn new_tcp_session(
         &self,
         meta: TransparentProxyFlowMeta,
-        on_server_bytes: BoxedServerBytesSink,
+        on_server_bytes: BoxedServerBytesStatusSink,
         on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession> {
         self.new_tcp_session(
             meta,
-            move |bytes| on_server_bytes(bytes.as_ref()),
+            move |bytes: Bytes| -> TcpDeliverStatus { on_server_bytes(bytes.as_ref()) },
             move || on_client_read_demand(),
             move || on_server_closed(),
         )
@@ -97,7 +104,7 @@ impl BoxedTransparentProxyEngine {
     pub fn new_tcp_session(
         &self,
         meta: TransparentProxyFlowMeta,
-        on_server_bytes: BoxedServerBytesSink,
+        on_server_bytes: BoxedServerBytesStatusSink,
         on_client_read_demand: BoxedDemandSink,
         on_server_closed: BoxedClosedSink,
     ) -> SessionFlowAction<TransparentProxyTcpSession> {

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -1038,11 +1038,36 @@ async fn run_tcp_bridge(
     // Set to true once `on_server_bytes` reports the session is gone; we then
     // exit the loop and fire `on_server_closed` once.
     let mut server_closed = false;
+    // Bytes that `on_server_bytes` rejected with `Paused`. Swift does NOT
+    // take ownership on a `Paused` return, so we MUST replay this chunk
+    // after `server_write_notify` fires before reading any more from the
+    // duplex — otherwise we punch a hole in the byte stream and the
+    // downstream TLS layer surfaces "bad record MAC" once the gap reaches
+    // the decryptor. Symmetric to the Swift-side `pendingData` retain
+    // pattern for the Swift → Rust direction.
+    let mut pending_to_server: Option<Bytes> = None;
 
     loop {
         if server_closed {
             break;
         }
+
+        // Drain any pending replay before reading more from the duplex.
+        if let Some(bytes) = pending_to_server.take() {
+            match on_server_bytes(bytes.clone()) {
+                TcpDeliverStatus::Accepted => {}
+                TcpDeliverStatus::Paused => {
+                    pending_to_server = Some(bytes);
+                    server_write_notify.notified().await;
+                    continue;
+                }
+                TcpDeliverStatus::Closed => {
+                    server_closed = true;
+                    continue;
+                }
+            }
+        }
+
         tokio::select! {
             maybe = client_rx.recv(), if !write_done => {
                 if let Some(bytes) = maybe {
@@ -1098,11 +1123,14 @@ async fn run_tcp_bridge(
                         // full. We must not just hand it more bytes — that's
                         // what leads to unbounded `pending` growth and
                         // eventually `ENOBUFS` on `flow.write` /
-                        // `connection.send`. On `Paused`, suspend the bridge
-                        // until Swift signals via `signal_*_drain`.
-                        match on_server_bytes(Bytes::copy_from_slice(&buf[..n])) {
+                        // `connection.send`. On `Paused`, hold the chunk
+                        // (Swift did NOT take it) and suspend the bridge
+                        // until `signal_*_drain` fires.
+                        let bytes = Bytes::copy_from_slice(&buf[..n]);
+                        match on_server_bytes(bytes.clone()) {
                             TcpDeliverStatus::Accepted => {}
                             TcpDeliverStatus::Paused => {
+                                pending_to_server = Some(bytes);
                                 server_write_notify.notified().await;
                             }
                             TcpDeliverStatus::Closed => {

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -1069,6 +1069,14 @@ async fn run_tcp_bridge(
         }
 
         tokio::select! {
+            // `biased`: when both `client_rx` has a pending chunk AND
+            // `eof_rx.changed()` is ready (the caller signalled EOF
+            // immediately after the last `on_*_bytes`), drain the channel
+            // first. Without this the unbiased random pick can shut down
+            // the write half before the last chunk reaches the service —
+            // observable as a 4-byte hole at end-of-stream.
+            biased;
+
             maybe = client_rx.recv(), if !write_done => {
                 if let Some(bytes) = maybe {
                     // We just freed a slot — if Swift was paused waiting for capacity,

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -340,8 +340,14 @@ impl TransparentProxyTcpSession {
     ///
     /// See [`TcpDeliverStatus`] for the return contract. Never blocks the
     /// calling thread: this is invoked synchronously from a Swift dispatch
-    /// queue, so we use `try_send` and surface fullness as a pause signal
+    /// queue, so we use `try_reserve` and surface fullness as a pause signal
     /// instead of awaiting capacity.
+    ///
+    /// Important: when this returns `Paused` the bytes are NOT taken — we
+    /// reserve the channel slot only on the success path, so no allocation
+    /// happens on overflow. Swift MUST retain the rejected `Data` and replay
+    /// it before issuing the next `flow.readData`, otherwise the byte stream
+    /// gets a hole and the downstream TLS layer surfaces "bad record MAC".
     #[must_use = "the caller must honor the returned backpressure / closed signal"]
     pub fn on_client_bytes(&mut self, bytes: &[u8]) -> TcpDeliverStatus {
         if bytes.is_empty() {
@@ -351,13 +357,16 @@ impl TransparentProxyTcpSession {
         let Some(tx) = self.client_tx.as_mut() else {
             return TcpDeliverStatus::Closed;
         };
-        match tx.try_send(Bytes::copy_from_slice(bytes)) {
-            Ok(()) => TcpDeliverStatus::Accepted,
-            Err(TrySendError::Full(_)) => {
+        match tx.try_reserve() {
+            Ok(permit) => {
+                permit.send(Bytes::copy_from_slice(bytes));
+                TcpDeliverStatus::Accepted
+            }
+            Err(TrySendError::Full(())) => {
                 self.client_paused.store(true, Ordering::Release);
                 TcpDeliverStatus::Paused
             }
-            Err(TrySendError::Closed(_)) => TcpDeliverStatus::Closed,
+            Err(TrySendError::Closed(())) => TcpDeliverStatus::Closed,
         }
     }
 
@@ -372,7 +381,9 @@ impl TransparentProxyTcpSession {
 
     /// Called by Swift when bytes arrive from the egress `NWConnection`.
     ///
-    /// See [`TcpDeliverStatus`] for the return contract.
+    /// See [`Self::on_client_bytes`] for the return contract — same shape and
+    /// the same "Swift MUST replay rejected bytes before its next receive"
+    /// requirement.
     #[must_use = "the caller must honor the returned backpressure / closed signal"]
     pub fn on_egress_bytes(&mut self, bytes: &[u8]) -> TcpDeliverStatus {
         if bytes.is_empty() {
@@ -381,15 +392,18 @@ impl TransparentProxyTcpSession {
         let Some(tx) = self.egress_tx.as_mut() else {
             return TcpDeliverStatus::Closed;
         };
-        match tx.try_send(Bytes::copy_from_slice(bytes)) {
-            Ok(()) => TcpDeliverStatus::Accepted,
-            Err(TrySendError::Full(_)) => {
+        match tx.try_reserve() {
+            Ok(permit) => {
+                permit.send(Bytes::copy_from_slice(bytes));
+                TcpDeliverStatus::Accepted
+            }
+            Err(TrySendError::Full(())) => {
                 if let Some(paused) = self.egress_paused.as_ref() {
                     paused.store(true, Ordering::Release);
                 }
                 TcpDeliverStatus::Paused
             }
-            Err(TrySendError::Closed(_)) => TcpDeliverStatus::Closed,
+            Err(TrySendError::Closed(())) => TcpDeliverStatus::Closed,
         }
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -20,7 +20,7 @@ use tokio::{
     sync::{
         Notify,
         mpsc::{self, error::TrySendError},
-        oneshot, watch,
+        oneshot,
     },
 };
 
@@ -263,8 +263,6 @@ struct TcpSessionPendingData {
     /// Fired by the ingress bridge after it drained a chunk while
     /// `client_paused` was set.
     on_client_read_demand: DemandSink,
-    /// Ingress EOF watch; handed to the ingress bridge at activate.
-    eof_rx: watch::Receiver<bool>,
     /// Rust→Swift: response bytes back to the intercepted client flow.
     /// Returns a [`TcpDeliverStatus`] so the bridge can pause when Swift's
     /// writer pump is full and wait for the matching `signal_server_drain`.
@@ -303,7 +301,6 @@ pub struct TransparentProxyTcpSession {
     /// after it drains a chunk; the bridge then fires
     /// `on_client_read_demand` to wake Swift.
     client_paused: Arc<AtomicBool>,
-    eof_tx: watch::Sender<bool>,
     saw_client_bytes: bool,
     /// Symmetric counterpart of `client_paused` for the response direction
     /// (Rust → Swift writer pump). Notified by Swift via
@@ -316,7 +313,6 @@ pub struct TransparentProxyTcpSession {
     /// Same role as `client_paused` but for the egress (NWConnection→Rust)
     /// channel; populated at `activate`.
     egress_paused: Option<Arc<AtomicBool>>,
-    egress_eof_tx: Option<watch::Sender<bool>>,
     /// Symmetric counterpart for the egress request direction (Rust →
     /// Swift NWConnection writer pump); populated at `activate`. Notified by
     /// Swift via [`Self::signal_egress_drain`].
@@ -371,12 +367,19 @@ impl TransparentProxyTcpSession {
     }
 
     /// Called by Swift when the intercepted flow signals read-EOF.
+    ///
+    /// We drop the per-flow ingress sender so the bridge's `recv()` drains
+    /// any buffered chunks and then returns `None`, which is its natural
+    /// EOF signal. Using a side-channel (e.g. a `watch::Sender<bool>`)
+    /// would create a select-fairness race against `read_half.read()`
+    /// that can either drop the last chunk (too-eager EOF) or starve the
+    /// response direction (over-prioritised EOF).
     pub fn on_client_eof(&mut self) {
         if !self.saw_client_bytes {
             self.cancel();
             return;
         }
-        let _ = self.eof_tx.send(true);
+        self.client_tx = None;
     }
 
     /// Called by Swift when bytes arrive from the egress `NWConnection`.
@@ -427,10 +430,10 @@ impl TransparentProxyTcpSession {
     }
 
     /// Called by Swift when the egress `NWConnection` closes or fails.
+    ///
+    /// Same channel-close pattern as [`Self::on_client_eof`].
     pub fn on_egress_eof(&mut self) {
-        if let Some(tx) = self.egress_eof_tx.as_mut() {
-            let _ = tx.send(true);
-        }
+        self.egress_tx = None;
     }
 
     /// Return the handler-supplied egress connect options, if any.
@@ -471,7 +474,6 @@ impl TransparentProxyTcpSession {
             client_rx,
             client_paused,
             on_client_read_demand,
-            eof_rx,
             on_server_bytes,
             server_write_notify,
             on_server_closed,
@@ -498,12 +500,10 @@ impl TransparentProxyTcpSession {
         let egress_stream = NwTcpStream::new(egress_user);
 
         let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
-        let (egress_eof_tx, egress_eof_rx) = watch::channel(false);
         let egress_paused = Arc::new(AtomicBool::new(false));
         let egress_write_notify = Arc::new(Notify::new());
         self.egress_tx = Some(egress_client_tx);
         self.egress_paused = Some(egress_paused.clone());
-        self.egress_eof_tx = Some(egress_eof_tx);
         self.egress_write_notify = Some(egress_write_notify.clone());
 
         // guard egress callbacks
@@ -532,7 +532,6 @@ impl TransparentProxyTcpSession {
                     client_rx,
                     client_paused,
                     on_client_read_demand,
-                    eof_rx,
                     on_server_bytes,
                     server_write_notify,
                     on_server_closed,
@@ -550,7 +549,6 @@ impl TransparentProxyTcpSession {
                     egress_client_rx,
                     egress_paused,
                     guarded_egress_demand,
-                    egress_eof_rx,
                     guarded_egress_bytes,
                     egress_write_notify,
                     guarded_egress_closed,
@@ -575,6 +573,9 @@ impl TransparentProxyTcpSession {
         // async lock would let callbacks slip through the gap between the
         // check and the actual call.
         *self.callback_active.lock() = false;
+        // Drop the senders so the bridge's `recv()` returns `None` after
+        // draining anything still buffered. This is the natural EOF
+        // signal — no separate watch channel needed.
         self.client_tx = None;
         self.egress_tx = None;
         self.egress_paused = None;
@@ -586,10 +587,6 @@ impl TransparentProxyTcpSession {
             notify.notify_one();
         }
         self.egress_write_notify = None;
-        let _ = self.eof_tx.send(true);
-        if let Some(tx) = self.egress_eof_tx.as_mut() {
-            let _ = tx.send(true);
-        }
         if let Some(tx) = self.flow_stop_tx.take() {
             let _ = tx.send(());
         }
@@ -652,7 +649,6 @@ where
 
     let (client_tx, client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
     let client_paused = Arc::new(AtomicBool::new(false));
-    let (eof_tx, eof_rx) = watch::channel(false);
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<TcpFlow, NwTcpStream>>();
     let server_write_notify = Arc::new(Notify::new());
 
@@ -683,7 +679,6 @@ where
         client_rx,
         client_paused: client_paused.clone(),
         on_client_read_demand: on_client_read_demand_guarded,
-        eof_rx,
         on_server_bytes: on_server_bytes_guarded,
         server_write_notify: server_write_notify.clone(),
         on_server_closed: on_server_closed_guarded,
@@ -698,12 +693,10 @@ where
     SessionFlowAction::Intercept(TransparentProxyTcpSession {
         client_tx: Some(client_tx),
         client_paused,
-        eof_tx,
         saw_client_bytes: false,
         server_write_notify,
         egress_tx: None,
         egress_paused: None,
-        egress_eof_tx: None,
         egress_write_notify: None,
         callback_active,
         flow_stop_tx: Some(flow_stop_tx),
@@ -1023,7 +1016,6 @@ async fn run_tcp_bridge(
     mut client_rx: mpsc::Receiver<Bytes>,
     paused: Arc<AtomicBool>,
     on_read_demand: DemandSink,
-    mut eof_rx: watch::Receiver<bool>,
     on_server_bytes: BytesStatusSink,
     server_write_notify: Arc<Notify>,
     on_server_closed: ClosedSink,
@@ -1069,13 +1061,15 @@ async fn run_tcp_bridge(
         }
 
         tokio::select! {
-            // `biased`: when both `client_rx` has a pending chunk AND
-            // `eof_rx.changed()` is ready (the caller signalled EOF
-            // immediately after the last `on_*_bytes`), drain the channel
-            // first. Without this the unbiased random pick can shut down
-            // the write half before the last chunk reaches the service —
-            // observable as a 4-byte hole at end-of-stream.
-            biased;
+            // No `biased;` directive — both arms must remain fair so that
+            // sustained traffic in one direction can't starve the other
+            // (think a busy h2 connection with continuous response data
+            // arriving while the client also pumps WINDOW_UPDATEs).
+            //
+            // EOF is intentionally signalled by dropping the FFI sender,
+            // not via a side-channel: `recv()` then drains any buffered
+            // chunks and only after that returns `None`, which is the
+            // canonical mpsc EOF.
 
             maybe = client_rx.recv(), if !write_done => {
                 if let Some(bytes) = maybe {
@@ -1105,12 +1099,8 @@ async fn run_tcp_bridge(
                         client_rx.close();
                     }
                 } else {
-                    let _ = write_half.shutdown().await;
-                    write_done = true;
-                }
-            }
-            _ = eof_rx.changed(), if !write_done => {
-                if *eof_rx.borrow() {
+                    // FFI sender dropped (EOF or cancel). Drain done; close
+                    // the write side so the service sees end-of-stream.
                     let _ = write_half.shutdown().await;
                     write_done = true;
                 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -18,6 +18,7 @@ use rama_net::{conn::is_connection_error, proxy::ProxyTarget};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{
+        Notify,
         mpsc::{self, error::TrySendError},
         oneshot, watch,
     },
@@ -57,18 +58,30 @@ const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 64 * 1024; // 64 KiB
 /// demand callback to resume. Each chunk is whatever Swift hands us in one
 /// `flow.readData` / `connection.receive` callback (typically 4–64 KiB).
 ///
-/// 8 chunks is a small multiple of `DEFAULT_TCP_FLOW_BUFFER_SIZE` to keep
-/// per-flow worst-case memory bounded under load: the prior unbounded design
-/// let one slow flow buffer arbitrary amounts of pending bytes, which under
-/// sustained traffic exhausts Apple's per-flow NE kernel buffer and aborts the
-/// shared NEAppProxyProvider director, killing every flow on the extension.
-const DEFAULT_TCP_CHANNEL_CAPACITY: usize = 8;
+/// We bound this to keep per-flow worst-case memory in check: the prior
+/// unbounded design let one slow flow buffer arbitrary pending bytes, which
+/// under sustained traffic exhausted Apple's per-flow NE kernel buffer and
+/// aborted the shared NEAppProxyProvider director, killing every flow on the
+/// extension.
+///
+/// 1024 chunks is sized for HTTP/2 multiplexing: a single TCP flow can carry
+/// hundreds of concurrent streams, each with its own ~1 MiB initial flow
+/// window. With 1024 × 64 KiB = ~64 MiB of headroom per direction we comfortably
+/// absorb a handful of in-flight streams before Swift has to pause kernel
+/// reads. Smaller values starve high-fan-in h2 connections
+/// and cause stalls on large body transfers.
+const DEFAULT_TCP_CHANNEL_CAPACITY: usize = 1024;
 /// Bound on the UDP ingress and egress channels. UDP datagrams are inherently
 /// lossy, so on a full channel we drop the datagram rather than block; the
 /// bound is just a memory cap.
-const DEFAULT_UDP_CHANNEL_CAPACITY: usize = 64;
+const DEFAULT_UDP_CHANNEL_CAPACITY: usize = 1024;
 
 type BytesSink = Arc<dyn Fn(Bytes) + Send + Sync + 'static>;
+/// Variant of [`BytesSink`] used for the response / upstream-write directions
+/// where Swift's writer pump is the consumer. Returns a [`TcpDeliverStatus`]
+/// so the Rust producer (the bridge) can pause when Swift's pending queue is
+/// full and resume only after the matching `signal_*_drain` call from Swift.
+type BytesStatusSink = Arc<dyn Fn(Bytes) -> TcpDeliverStatus + Send + Sync + 'static>;
 type ClosedSink = Arc<dyn Fn() + Send + Sync + 'static>;
 type DemandSink = Arc<dyn Fn() + Send + Sync + 'static>;
 
@@ -154,7 +167,7 @@ where
         on_server_closed: OnClosed,
     ) -> SessionFlowAction<TransparentProxyTcpSession>
     where
-        OnBytes: Fn(Bytes) + Send + Sync + 'static,
+        OnBytes: Fn(Bytes) -> TcpDeliverStatus + Send + Sync + 'static,
         OnDemand: Fn() + Send + Sync + 'static,
         OnClosed: Fn() + Send + Sync + 'static,
     {
@@ -253,7 +266,14 @@ struct TcpSessionPendingData {
     /// Ingress EOF watch; handed to the ingress bridge at activate.
     eof_rx: watch::Receiver<bool>,
     /// Rust→Swift: response bytes back to the intercepted client flow.
-    on_server_bytes: BytesSink,
+    /// Returns a [`TcpDeliverStatus`] so the bridge can pause when Swift's
+    /// writer pump is full and wait for the matching `signal_server_drain`.
+    on_server_bytes: BytesStatusSink,
+    /// Notified by `TransparentProxyTcpSession::signal_server_drain` when the
+    /// Swift writer pump for the intercepted flow has drained capacity.
+    /// The ingress bridge awaits on it after `on_server_bytes` returns
+    /// `Paused`.
+    server_write_notify: Arc<Notify>,
     /// Rust→Swift: ingress response stream done.
     on_server_closed: ClosedSink,
     /// Both ingress and egress duplex buffer size.
@@ -285,6 +305,11 @@ pub struct TransparentProxyTcpSession {
     client_paused: Arc<AtomicBool>,
     eof_tx: watch::Sender<bool>,
     saw_client_bytes: bool,
+    /// Symmetric counterpart of `client_paused` for the response direction
+    /// (Rust → Swift writer pump). Notified by Swift via
+    /// [`Self::signal_server_drain`] when its writer drains capacity, awaited
+    /// by the ingress bridge after `on_server_bytes` returns `Paused`.
+    server_write_notify: Arc<Notify>,
 
     // egress data path (populated by activate)
     egress_tx: Option<mpsc::Sender<Bytes>>,
@@ -292,6 +317,10 @@ pub struct TransparentProxyTcpSession {
     /// channel; populated at `activate`.
     egress_paused: Option<Arc<AtomicBool>>,
     egress_eof_tx: Option<watch::Sender<bool>>,
+    /// Symmetric counterpart for the egress request direction (Rust →
+    /// Swift NWConnection writer pump); populated at `activate`. Notified by
+    /// Swift via [`Self::signal_egress_drain`].
+    egress_write_notify: Option<Arc<Notify>>,
 
     // lifecycle
     callback_active: Arc<parking_lot::Mutex<bool>>,
@@ -364,6 +393,25 @@ impl TransparentProxyTcpSession {
         }
     }
 
+    /// Called by Swift when its `TcpClientWritePump` (response writer) has
+    /// drained capacity after `on_server_bytes` returned `Paused`.
+    ///
+    /// Wakes the ingress bridge so it can resume forwarding response bytes.
+    /// Idempotent — the underlying `Notify` collapses redundant signals into
+    /// a single permit.
+    pub fn signal_server_drain(&self) {
+        self.server_write_notify.notify_one();
+    }
+
+    /// Symmetric counterpart of [`Self::signal_server_drain`] for the egress
+    /// request direction. Called by Swift when its `NwTcpConnectionWritePump`
+    /// has drained capacity after `on_write_to_egress` returned `Paused`.
+    pub fn signal_egress_drain(&self) {
+        if let Some(notify) = &self.egress_write_notify {
+            notify.notify_one();
+        }
+    }
+
     /// Called by Swift when the egress `NWConnection` closes or fails.
     pub fn on_egress_eof(&mut self) {
         if let Some(tx) = self.egress_eof_tx.as_mut() {
@@ -382,8 +430,10 @@ impl TransparentProxyTcpSession {
     /// intercepted flow has been successfully opened.
     ///
     /// * `on_write_to_egress` — Rust→Swift: service bytes destined for the remote server.
+    ///   Returns a [`TcpDeliverStatus`] so the egress bridge can pause when
+    ///   Swift's `NwTcpConnectionWritePump` is full.
     /// * `on_egress_read_demand` — Rust→Swift: signal Swift it can resume reading
-    ///   from the egress `NWConnection` after `on_egress_bytes` returned `false`.
+    ///   from the egress `NWConnection` after `on_egress_bytes` returned `Paused`.
     /// * `on_close_egress` — Rust→Swift: egress stream is done writing.
     pub fn activate<OnEgressWrite, OnEgressDemand, OnEgressClose>(
         &mut self,
@@ -391,7 +441,7 @@ impl TransparentProxyTcpSession {
         on_egress_read_demand: OnEgressDemand,
         on_close_egress: OnEgressClose,
     ) where
-        OnEgressWrite: Fn(Bytes) + Send + Sync + 'static,
+        OnEgressWrite: Fn(Bytes) -> TcpDeliverStatus + Send + Sync + 'static,
         OnEgressDemand: Fn() + Send + Sync + 'static,
         OnEgressClose: Fn() + Send + Sync + 'static,
     {
@@ -409,6 +459,7 @@ impl TransparentProxyTcpSession {
             on_client_read_demand,
             eof_rx,
             on_server_bytes,
+            server_write_notify,
             on_server_closed,
             tcp_flow_buffer_size,
             tcp_channel_capacity,
@@ -435,16 +486,18 @@ impl TransparentProxyTcpSession {
         let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
         let (egress_eof_tx, egress_eof_rx) = watch::channel(false);
         let egress_paused = Arc::new(AtomicBool::new(false));
+        let egress_write_notify = Arc::new(Notify::new());
         self.egress_tx = Some(egress_client_tx);
         self.egress_paused = Some(egress_paused.clone());
         self.egress_eof_tx = Some(egress_eof_tx);
+        self.egress_write_notify = Some(egress_write_notify.clone());
 
         // guard egress callbacks
-        let egress_bytes_sink: BytesSink = Arc::new(on_write_to_egress);
+        let egress_bytes_sink: BytesStatusSink = Arc::new(on_write_to_egress);
         let egress_closed_sink: ClosedSink = Arc::new(on_close_egress);
         let egress_demand_sink: DemandSink = Arc::new(on_egress_read_demand);
         let guarded_egress_bytes =
-            guarded_bytes_sink(self.callback_active.clone(), egress_bytes_sink);
+            guarded_bytes_status_sink(self.callback_active.clone(), egress_bytes_sink);
         let guarded_egress_closed =
             guarded_closed_sink(self.callback_active.clone(), egress_closed_sink);
         let guarded_egress_demand =
@@ -467,6 +520,7 @@ impl TransparentProxyTcpSession {
                     on_client_read_demand,
                     eof_rx,
                     on_server_bytes,
+                    server_write_notify,
                     on_server_closed,
                 )
                 .await;
@@ -484,6 +538,7 @@ impl TransparentProxyTcpSession {
                     guarded_egress_demand,
                     egress_eof_rx,
                     guarded_egress_bytes,
+                    egress_write_notify,
                     guarded_egress_closed,
                 )
                 .await;
@@ -509,6 +564,14 @@ impl TransparentProxyTcpSession {
         self.client_tx = None;
         self.egress_tx = None;
         self.egress_paused = None;
+        // Wake any bridge that's parked in `notify.notified().await` so it
+        // can observe the cancellation and exit promptly. Notify is
+        // sticky — these are no-ops if nobody's waiting.
+        self.server_write_notify.notify_one();
+        if let Some(notify) = &self.egress_write_notify {
+            notify.notify_one();
+        }
+        self.egress_write_notify = None;
         let _ = self.eof_tx.send(true);
         if let Some(tx) = self.egress_eof_tx.as_mut() {
             let _ = tx.send(true);
@@ -550,7 +613,7 @@ async fn new_tcp_session_flow_action<OnBytes, OnDemand, OnClosed, H>(
     handler: H,
 ) -> SessionFlowAction<TransparentProxyTcpSession>
 where
-    OnBytes: Fn(Bytes) + Send + Sync + 'static,
+    OnBytes: Fn(Bytes) -> TcpDeliverStatus + Send + Sync + 'static,
     OnDemand: Fn() + Send + Sync + 'static,
     OnClosed: Fn() + Send + Sync + 'static,
     H: TransparentProxyHandler,
@@ -577,10 +640,11 @@ where
     let client_paused = Arc::new(AtomicBool::new(false));
     let (eof_tx, eof_rx) = watch::channel(false);
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<TcpFlow, NwTcpStream>>();
+    let server_write_notify = Arc::new(Notify::new());
 
     let callback_active = Arc::new(parking_lot::Mutex::new(true));
     let on_server_bytes_guarded =
-        guarded_bytes_sink(callback_active.clone(), Arc::new(on_server_bytes));
+        guarded_bytes_status_sink(callback_active.clone(), Arc::new(on_server_bytes));
     let on_server_closed_guarded =
         guarded_closed_sink(callback_active.clone(), Arc::new(on_server_closed));
     let on_client_read_demand_guarded =
@@ -607,6 +671,7 @@ where
         on_client_read_demand: on_client_read_demand_guarded,
         eof_rx,
         on_server_bytes: on_server_bytes_guarded,
+        server_write_notify: server_write_notify.clone(),
         on_server_closed: on_server_closed_guarded,
         tcp_flow_buffer_size,
         tcp_channel_capacity,
@@ -621,9 +686,11 @@ where
         client_paused,
         eof_tx,
         saw_client_bytes: false,
+        server_write_notify,
         egress_tx: None,
         egress_paused: None,
         egress_eof_tx: None,
+        egress_write_notify: None,
         callback_active,
         flow_stop_tx: Some(flow_stop_tx),
         pending: Some(pending),
@@ -898,15 +965,17 @@ impl<H> TransparentProxyEngine<H> {
     }
 }
 
-fn guarded_bytes_sink(
+fn guarded_bytes_status_sink(
     callback_active: Arc<parking_lot::Mutex<bool>>,
-    user_bytes_sink: BytesSink,
-) -> BytesSink {
-    Arc::new(move |bytes: Bytes| {
+    user_bytes_sink: BytesStatusSink,
+) -> BytesStatusSink {
+    Arc::new(move |bytes: Bytes| -> TcpDeliverStatus {
         if !*callback_active.lock() {
-            return;
+            // Session is being torn down: report Closed so the bridge breaks
+            // its select loop and `on_server_closed` fires once at the end.
+            return TcpDeliverStatus::Closed;
         }
-        user_bytes_sink(bytes);
+        user_bytes_sink(bytes)
     })
 }
 
@@ -934,13 +1003,15 @@ fn guarded_demand_sink(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tcp_bridge(
     internal: tokio::io::DuplexStream,
     mut client_rx: mpsc::Receiver<Bytes>,
     paused: Arc<AtomicBool>,
     on_read_demand: DemandSink,
     mut eof_rx: watch::Receiver<bool>,
-    on_server_bytes: BytesSink,
+    on_server_bytes: BytesStatusSink,
+    server_write_notify: Arc<Notify>,
     on_server_closed: ClosedSink,
 ) {
     let (mut read_half, mut write_half) = tokio::io::split(internal);
@@ -950,8 +1021,14 @@ async fn run_tcp_bridge(
     // response bytes.  Without this flag, a write failure would cause a `break` that
     // races against any already-buffered server response bytes.
     let mut write_done = false;
+    // Set to true once `on_server_bytes` reports the session is gone; we then
+    // exit the loop and fire `on_server_closed` once.
+    let mut server_closed = false;
 
     loop {
+        if server_closed {
+            break;
+        }
         tokio::select! {
             maybe = client_rx.recv(), if !write_done => {
                 if let Some(bytes) = maybe {
@@ -1002,7 +1079,27 @@ async fn run_tcp_bridge(
                         }
                         break;
                     }
-                    Ok(n) => on_server_bytes(Bytes::copy_from_slice(&buf[..n])),
+                    Ok(n) => {
+                        // Symmetric backpressure: Swift's writer pump may be
+                        // full. We must not just hand it more bytes — that's
+                        // what leads to unbounded `pending` growth and
+                        // eventually `ENOBUFS` on `flow.write` /
+                        // `connection.send`. On `Paused`, suspend the bridge
+                        // until Swift signals via `signal_*_drain`.
+                        match on_server_bytes(Bytes::copy_from_slice(&buf[..n])) {
+                            TcpDeliverStatus::Accepted => {}
+                            TcpDeliverStatus::Paused => {
+                                server_write_notify.notified().await;
+                            }
+                            TcpDeliverStatus::Closed => {
+                                // Session torn down on the Swift side; no
+                                // demand will follow. Stop the loop after
+                                // this iteration so `on_server_closed`
+                                // fires exactly once.
+                                server_closed = true;
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
@@ -714,6 +714,189 @@ fn builder_rejects_zero_channel_capacity() {
     engine.stop(0);
 }
 
+/// Pin the load-bearing FFI invariant: when `on_client_bytes` returns
+/// `Paused` the bytes are NOT taken by the Rust side, and a caller that
+/// retains + replays them sees the full byte stream delivered in order.
+///
+/// Capacity 1 means every send after the first is `Paused`, so this test
+/// hammers the pause/resume path on every chunk. A regression that drops
+/// bytes (e.g. discarding the rejected chunk in the `TrySendError::Full`
+/// arm — which is exactly the bug that surfaced as `tls: bad record MAC`
+/// on large h2 transfers) corrupts the recovered byte sequence and fails
+/// the equality check below.
+#[test]
+fn tcp_byte_stream_preserved_under_ingress_backpressure() {
+    let received = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let received_clone = received.clone();
+    let (eof_tx, eof_rx) = std::sync::mpsc::channel::<()>();
+    let eof_tx_handler = Mutex::new(Some(eof_tx));
+
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(move |meta| {
+            let received = received_clone.clone();
+            let eof_tx = eof_tx_handler.lock().take().expect("single intercept");
+            FlowAction::Intercept {
+                meta,
+                service: service_fn(move |bridge: BridgeIo<TcpFlow, NwTcpStream>| {
+                    let received = received.clone();
+                    let eof_tx = eof_tx.clone();
+                    async move {
+                        let BridgeIo(mut ingress, _egress) = bridge;
+                        let mut buf = vec![0u8; 4096];
+                        loop {
+                            match ingress.read(&mut buf).await {
+                                Ok(0) | Err(_) => {
+                                    let _ = eof_tx.send(());
+                                    return Ok(());
+                                }
+                                Ok(n) => {
+                                    received.lock().extend_from_slice(&buf[..n]);
+                                }
+                            }
+                        }
+                    }
+                })
+                .boxed(),
+            }
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+
+    let engine = build_engine_with_tcp_channel_capacity(handler, 1);
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| TcpDeliverStatus::Accepted,
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
+
+    // Deterministic 4000-byte stream split into 1000 4-byte chunks. Each
+    // chunk encodes its own index so any reordering / loss is detectable
+    // by inspection if the equality assertion ever fails in the future.
+    let mut expected = Vec::with_capacity(4000);
+    for i in 0..1000_u16 {
+        let chunk = [
+            (i >> 8) as u8,
+            i as u8,
+            i.wrapping_add(0xa5) as u8,
+            i.wrapping_add(0x5a) as u8,
+        ];
+        expected.extend_from_slice(&chunk);
+        loop {
+            match session.on_client_bytes(&chunk) {
+                TcpDeliverStatus::Accepted => break,
+                TcpDeliverStatus::Paused => {
+                    // Spin lightly — bridge drains in the background. A
+                    // production caller (Swift's `TcpClientReadPump`)
+                    // waits on a demand callback; for the unit test we
+                    // can just yield.
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                TcpDeliverStatus::Closed => panic!("session unexpectedly closed"),
+            }
+        }
+    }
+    session.on_client_eof();
+
+    let _ = eof_rx.recv_timeout(Duration::from_secs(5));
+    let recv = received.lock().clone();
+    assert_eq!(recv.len(), expected.len(), "byte count mismatch");
+    assert_eq!(recv, expected, "byte stream corrupted (gap or reorder)");
+
+    engine.stop(0);
+}
+
+/// Same shape as `tcp_byte_stream_preserved_under_ingress_backpressure`
+/// but for the egress (NWConnection → service) direction. Pins the
+/// `on_egress_bytes` FFI contract: `Paused` does not take ownership and
+/// the caller must replay.
+#[test]
+fn tcp_byte_stream_preserved_under_egress_backpressure() {
+    let received = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let received_clone = received.clone();
+    let (eof_tx, eof_rx) = std::sync::mpsc::channel::<()>();
+    let eof_tx_handler = Mutex::new(Some(eof_tx));
+
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(move |meta| {
+            let received = received_clone.clone();
+            let eof_tx = eof_tx_handler.lock().take().expect("single intercept");
+            FlowAction::Intercept {
+                meta,
+                service: service_fn(move |bridge: BridgeIo<TcpFlow, NwTcpStream>| {
+                    let received = received.clone();
+                    let eof_tx = eof_tx.clone();
+                    async move {
+                        // Drain the egress side (i.e. bytes flowing from the
+                        // NWConnection → service direction).
+                        let BridgeIo(_ingress, mut egress) = bridge;
+                        let mut buf = vec![0u8; 4096];
+                        loop {
+                            match egress.read(&mut buf).await {
+                                Ok(0) | Err(_) => {
+                                    let _ = eof_tx.send(());
+                                    return Ok(());
+                                }
+                                Ok(n) => {
+                                    received.lock().extend_from_slice(&buf[..n]);
+                                }
+                            }
+                        }
+                    }
+                })
+                .boxed(),
+            }
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+    };
+
+    let engine = build_engine_with_tcp_channel_capacity(handler, 1);
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
+        |_| TcpDeliverStatus::Accepted,
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
+
+    let mut expected = Vec::with_capacity(4000);
+    for i in 0..1000_u16 {
+        let chunk = [
+            (i >> 8) as u8,
+            i as u8,
+            i.wrapping_add(0xa5) as u8,
+            i.wrapping_add(0x5a) as u8,
+        ];
+        expected.extend_from_slice(&chunk);
+        loop {
+            match session.on_egress_bytes(&chunk) {
+                TcpDeliverStatus::Accepted => break,
+                TcpDeliverStatus::Paused => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                TcpDeliverStatus::Closed => panic!("session unexpectedly closed"),
+            }
+        }
+    }
+    session.on_egress_eof();
+
+    let _ = eof_rx.recv_timeout(Duration::from_secs(5));
+    let recv = received.lock().clone();
+    assert_eq!(recv.len(), expected.len(), "byte count mismatch");
+    assert_eq!(recv, expected, "byte stream corrupted (gap or reorder)");
+
+    engine.stop(0);
+}
+
 #[test]
 fn app_message_can_return_reply() {
     let engine = build_engine(TestHandler {

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests.rs
@@ -138,7 +138,7 @@ fn tcp_session_passthrough_by_default() {
     let engine = build_engine(TestHandler::passthrough());
     let decision = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         || {},
     );
@@ -166,7 +166,7 @@ fn tcp_session_can_be_blocked() {
     });
     let decision = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         || {},
     );
@@ -217,6 +217,7 @@ fn tcp_bridge_delivers_server_bytes() {
             let mut lock = got_clone.lock();
             lock.extend_from_slice(&bytes);
             let _ = notify_tx.send(());
+            TcpDeliverStatus::Accepted
         },
         || {},
         || {},
@@ -225,7 +226,7 @@ fn tcp_bridge_delivers_server_bytes() {
     };
 
     // Phase 2: activate egress (no-op callbacks) so the service task starts.
-    session.activate(|_| {}, || {}, || {});
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
     let _ = session.on_client_bytes(b"ping");
 
     let _ = notify_rx.recv_timeout(Duration::from_secs(1));
@@ -357,14 +358,14 @@ fn tcp_flow_exposes_meta_extension() {
 
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp).with_source_app_pid(777),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         || {},
     ) else {
         panic!("expected intercept session");
     };
     // Phase 2: activate so the service task runs and reads extensions.
-    session.activate(|_| {}, || {}, || {});
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
     let _ = notify_rx.recv_timeout(Duration::from_secs(1));
     engine.stop(0);
 
@@ -450,6 +451,7 @@ fn tcp_cancel_many_idle_sessions_suppresses_callbacks_and_stops_fast() {
                 .with_remote_endpoint(HostWithPort::example_domain_with_port(443)),
             move |_bytes| {
                 bytes_count.fetch_add(1, Ordering::Relaxed);
+                TcpDeliverStatus::Accepted
             },
             || {},
             move || {
@@ -494,7 +496,7 @@ fn tcp_on_client_bytes_signals_paused_when_ingress_channel_full() {
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
             .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         || {},
     ) else {
@@ -556,7 +558,7 @@ fn tcp_demand_callback_fires_after_ingress_channel_drains() {
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
             .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         move || {
             demand_count_clone.fetch_add(1, Ordering::Relaxed);
             let _ = notify_tx.send(());
@@ -566,7 +568,7 @@ fn tcp_demand_callback_fires_after_ingress_channel_drains() {
         panic!("expected intercept session");
     };
 
-    session.activate(|_| {}, || {}, || {});
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
 
     // Pump until we hit backpressure. With a slow service and capacity=2 we
     // expect this within a handful of iterations.
@@ -613,7 +615,7 @@ fn tcp_bridge_write_failure_closes_ingress_channel() {
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
             .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         move || {
             let _ = closed_tx.send(());
@@ -622,7 +624,7 @@ fn tcp_bridge_write_failure_closes_ingress_channel() {
         panic!("expected intercept session");
     };
 
-    session.activate(|_| {}, || {}, || {});
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
 
     // The service has nothing to do and exits, dropping ingress; the bridge's
     // first `write_all` will fail and close the receiver. Pump bytes until
@@ -665,14 +667,14 @@ fn tcp_on_bytes_signals_closed_after_session_cancel() {
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
             .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),
-        |_| {},
+        |_| TcpDeliverStatus::Accepted,
         || {},
         || {},
     ) else {
         panic!("expected intercept session");
     };
 
-    session.activate(|_| {}, || {}, || {});
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
     session.cancel();
 
     let chunk = vec![0u8; 16];


### PR DESCRIPTION
Stability fixes for the Apple NE transparent proxy. Three failure
modes converging on host-wide outbound networking outages under
load:

- Egress `NWConnection` leak that exhausts the kernel's NECP flow
  slots after ~15h uptime.
- No backpressure on the TCP intercept path: unbounded per-flow
  byte channels overflow Apple's per-flow NE kernel buffer and abort
  the shared `NEAppProxyProvider` director.
- Byte-stream gap on `Paused` returns dropping rejected bytes on
  both sides of the FFI, corrupting the stream on large transfers.

Both directions of the TCP path are now bounded with a Rust → Swift
demand callback. The byte-delivery FFI returns a tri-state
(Accepted / Paused / Closed); `Paused` keeps ownership and both
sides retain and replay. Writer pumps are bounded by byte budget,
ENOBUFS/EAGAIN are retried, and EOF uses mpsc-close. Breaking FFI
change.

Drive-by: refreshed `rama-dns` crate-level docs that still claimed
Hickory was the default and only resolver.