### PR TITLE
Patch/docrs improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,9 +1433,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1478,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,13 @@ resolver = "3"
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [package.metadata.cargo-machete]
 ignored = ["rustversion"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ futures = "0.3"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 hex = "0.4"
-hickory-resolver = { version = "0.26.0", default-features = false, features = ["tokio", "system-config", "serde"] }
+hickory-resolver = { version = "0.26.1", default-features = false, features = ["tokio", "system-config", "serde"] }
 honggfuzz = "0.5"
 http = "1"
 http-body = "1"

--- a/rama-core/Cargo.toml
+++ b/rama-core/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 # TODO: support nostd

--- a/rama-crypto/Cargo.toml
+++ b/rama-crypto/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-dns/Cargo.toml
+++ b/rama-dns/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [package.metadata.cargo-machete]
 ignored = ["bindgen"]

--- a/rama-error/Cargo.toml
+++ b/rama-error/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = ["std"]

--- a/rama-grpc-build/Cargo.toml
+++ b/rama-grpc-build/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = ["protobuf", "vendor-protoc"]

--- a/rama-grpc/Cargo.toml
+++ b/rama-grpc/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = ["protobuf", "vendor-protoc"]

--- a/rama-haproxy/Cargo.toml
+++ b/rama-haproxy/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-http-backend/Cargo.toml
+++ b/rama-http-backend/Cargo.toml
@@ -21,6 +21,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-http-core/Cargo.toml
+++ b/rama-http-core/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-http-headers/Cargo.toml
+++ b/rama-http-headers/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [dependencies]
 ahash = { workspace = true }

--- a/rama-http-types/Cargo.toml
+++ b/rama-http-types/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [package.metadata.cargo-machete]
 ignored = ["tracing-subscriber"]

--- a/rama-macros/Cargo.toml
+++ b/rama-macros/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [lib]
 proc-macro = true

--- a/rama-net-apple-networkextension/Cargo.toml
+++ b/rama-net-apple-networkextension/Cargo.toml
@@ -16,6 +16,8 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+default-target = "x86_64-apple-darwin"
+targets = ["x86_64-apple-darwin"]
 
 [features]
 default = []

--- a/rama-net-apple-xpc/Cargo.toml
+++ b/rama-net-apple-xpc/Cargo.toml
@@ -16,6 +16,11 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+default-target = "x86_64-apple-darwin"
+targets = [
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+]
 
 [features]
 default = []

--- a/rama-net/Cargo.toml
+++ b/rama-net/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-proxy/Cargo.toml
+++ b/rama-proxy/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-socks5/Cargo.toml
+++ b/rama-socks5/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-tcp/Cargo.toml
+++ b/rama-tcp/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-tls-acme/Cargo.toml
+++ b/rama-tls-acme/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [dependencies]
 base64 = { workspace = true }

--- a/rama-tls-boring/Cargo.toml
+++ b/rama-tls-boring/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-tls-rustls/Cargo.toml
+++ b/rama-tls-rustls/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-tower/Cargo.toml
+++ b/rama-tower/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-ua/Cargo.toml
+++ b/rama-ua/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-udp/Cargo.toml
+++ b/rama-udp/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-unix/Cargo.toml
+++ b/rama-unix/Cargo.toml
@@ -16,6 +16,12 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/rama-utils/Cargo.toml
+++ b/rama-utils/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = ["std"]

--- a/rama-ws/Cargo.toml
+++ b/rama-ws/Cargo.toml
@@ -16,6 +16,13 @@ allowed = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-msvc",
+    "x86_64-apple-darwin",
+    "aarch64-apple-ios",
+    "aarch64-linux-android",
+]
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,10 +297,6 @@ pub use ::rama_udp as udp;
 pub mod telemetry;
 
 #[cfg(any(feature = "rustls", feature = "boring", feature = "acme"))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(feature = "rustls", feature = "boring", feature = "acme")))
-)]
 pub mod tls;
 
 #[cfg(feature = "dns")]
@@ -327,24 +323,16 @@ pub mod net {
             any(feature = "net-apple-networkextension", feature = "net-apple-xpc")
         )
     ))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(all(
-            target_vendor = "apple",
-            any(feature = "net-apple-networkextension", feature = "net-apple-xpc")
-        )))
-    )]
+    #[cfg_attr(docsrs, doc(cfg(target_vendor = "apple")))]
     pub mod apple {
         //! Apple (vendor) specific network modules
 
         #[cfg(feature = "net-apple-networkextension")]
         #[cfg_attr(docsrs, doc(cfg(feature = "net-apple-networkextension")))]
-        #[doc(inline)]
         pub use ::rama_net_apple_networkextension as networkextension;
 
         #[cfg(feature = "net-apple-xpc")]
         #[cfg_attr(docsrs, doc(cfg(feature = "net-apple-xpc")))]
-        #[doc(inline)]
         pub use ::rama_net_apple_xpc as xpc;
     }
 }
@@ -354,10 +342,6 @@ pub mod net {
 pub mod http;
 
 #[cfg(any(feature = "proxy", feature = "haproxy", feature = "socks5"))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(any(feature = "proxy", feature = "haproxy", feature = "socks5")))
-)]
 pub mod proxy {
     //! rama proxy support
 


### PR DESCRIPTION
- fix targets for docrs
   ctx: <https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets/>
- fix compounding dep imports