### PR TITLE
Connection Health

### DIFF
--- a/rama-http-backend/src/client/conn.rs
+++ b/rama-http-backend/src/client/conn.rs
@@ -17,10 +17,7 @@ use rama_http_types::{
     conn::{H2ClientContextParams, Http1ClientContextParams},
     proto::h2::PseudoHeaderOrder,
 };
-use rama_net::{
-    client::{ConnectorService, EstablishedClientConnection},
-    conn::ConnectionHealth,
-};
+use rama_net::client::{ConnectorService, EstablishedClientConnection};
 use tokio::sync::Mutex;
 
 use rama_core::telemetry::tracing::{self, Instrument};
@@ -69,11 +66,6 @@ where
     BodyConnection:
         StreamingBody<Data: Send + 'static, Error: Into<BoxError>> + Unpin + Send + 'static,
 {
-    // TODO this is way to tricky, this needs to be here on the io extensions
-    // Not the ones we clone, ideally the exentions should all just use the same store
-    // We can solve this by making them clonable
-    io.extensions().get_ref_or_insert(ConnectionHealth::default);
-
     let extensions = io.extensions().clone();
 
     let server_address: Cow<'_, str> = req

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -11,7 +11,7 @@ use rama_http_types::{
     header::{CONNECTION, HOST, KEEP_ALIVE, PROXY_CONNECTION, TRANSFER_ENCODING, UPGRADE},
     uri::PathAndQuery,
 };
-use rama_net::{address::ProxyAddress, http::RequestContext};
+use rama_net::{address::ProxyAddress, conn::ConnectionHealthWatcher, http::RequestContext};
 use std::fmt;
 use tokio::sync::Mutex;
 
@@ -72,6 +72,7 @@ where
             SendRequest::Http1(sender) => {
                 let mut sender = sender.lock().await;
                 if let Err(err) = sender.ready().await {
+                    mark_broken_if_closed(sender.is_closed(), &self.extensions);
                     tracing::debug!(
                         sender_closed = sender.is_closed(),
                         "http1 upstream sender ready failed: {err}"
@@ -81,6 +82,7 @@ where
                 match sender.send_request(req).await {
                     Ok(resp) => resp,
                     Err(err) => {
+                        mark_broken_if_closed(sender.is_closed(), &self.extensions);
                         tracing::debug!(
                             sender_closed = sender.is_closed(),
                             "http1 upstream send_request failed: {err}"
@@ -92,6 +94,7 @@ where
             SendRequest::Http2(sender) => {
                 let mut sender = sender.clone();
                 if let Err(err) = sender.ready().await {
+                    mark_broken_if_closed(sender.is_closed(), &self.extensions);
                     tracing::debug!(
                         sender_closed = sender.is_closed(),
                         "http2 upstream sender ready failed: {err}"
@@ -101,6 +104,7 @@ where
                 match sender.send_request(req).await {
                     Ok(resp) => resp,
                     Err(err) => {
+                        mark_broken_if_closed(sender.is_closed(), &self.extensions);
                         tracing::debug!(
                             sender_closed = sender.is_closed(),
                             "http2 upstream send_request failed: {err}"
@@ -112,6 +116,14 @@ where
         };
 
         Ok(resp.map(rama_http_types::Body::new))
+    }
+}
+
+fn mark_broken_if_closed(is_closed: bool, extensions: &Extensions) {
+    if is_closed {
+        extensions
+            .get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
     }
 }
 

--- a/rama-http-core/src/h2/proto/streams/recv.rs
+++ b/rama-http-core/src/h2/proto/streams/recv.rs
@@ -8,6 +8,7 @@ use rama_http_types::proto::h2::frame::{
     DEFAULT_INITIAL_WINDOW_SIZE, PushPromiseHeaderError, Reason,
 };
 use rama_http_types::{HeaderMap, Request, Response};
+use rama_net::conn::ConnectionHealthWatcher;
 
 use std::cmp::Ordering;
 use std::task::{Context, Poll, Waker};
@@ -981,6 +982,11 @@ impl Recv {
 
         // Notify the stream
         stream.state.recv_reset(frame, stream.is_pending_send);
+        // Mark this specific stream as broken
+        stream
+            .extensions
+            .self_get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
 
         stream.notify_send();
         stream.notify_recv();

--- a/rama-http-core/src/h2/proto/streams/streams.rs
+++ b/rama-http-core/src/h2/proto/streams/streams.rs
@@ -17,7 +17,7 @@ use rama_http_types::proto::h2::PseudoHeaderOrder;
 use rama_http_types::proto::h2::ext::Protocol;
 use rama_http_types::proto::h2::frame::{self, Frame, Reason, Settings};
 use rama_http_types::{HeaderMap, Request, Response};
-use rama_net::conn::{ConnectionHealth, ConnectionHealthStatus};
+use rama_net::conn::ConnectionHealthWatcher;
 use std::task::{Context, Poll, Waker};
 use tokio::io::AsyncWrite;
 
@@ -130,6 +130,8 @@ where
         extensions: Extensions,
     ) -> Result<Self, crate::h2::proto::Error> {
         let peer = P::r#dyn();
+
+        extensions.get_ref_or_insert(ConnectionHealthWatcher::default);
 
         Ok(Self {
             inner: Inner::try_new(peer, config, extensions)?,
@@ -760,10 +762,6 @@ impl Inner {
 
         let actions = &mut self.actions;
 
-        if let Some(health) = self.extensions.get_ref::<ConnectionHealth>() {
-            health.set_status(ConnectionHealthStatus::Broken)
-        }
-
         self.counts.transition(stream, |counts, stream| {
             actions.recv.recv_reset(frame, stream, counts)?;
             actions.send.handle_error(send_buffer, stream, counts);
@@ -829,9 +827,9 @@ impl Inner {
 
         let last_processed_id = actions.recv.last_processed_id();
 
-        if let Some(health) = self.extensions.get_ref::<ConnectionHealth>() {
-            health.set_status(ConnectionHealthStatus::Broken)
-        }
+        self.extensions
+            .get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
 
         self.store.for_each(|stream| {
             counts.transition(stream, |counts, stream| {
@@ -858,9 +856,9 @@ impl Inner {
 
         let last_stream_id = frame.last_stream_id();
 
-        if let Some(health) = self.extensions.get_ref::<ConnectionHealth>() {
-            health.set_status(ConnectionHealthStatus::Broken)
-        }
+        self.extensions
+            .get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
 
         actions.send.recv_go_away(last_stream_id)?;
 
@@ -994,6 +992,10 @@ impl Inner {
                 .into(),
             );
         }
+
+        self.extensions
+            .get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
 
         tracing::trace!("Streams::recv_eof");
 

--- a/rama-http-core/src/proto/h1/conn.rs
+++ b/rama-http-core/src/proto/h1/conn.rs
@@ -15,7 +15,7 @@ use rama_http_types::body::Frame;
 use rama_http_types::header::{CONNECTION, TE};
 use rama_http_types::proto::h1::ext::informational::OnInformational;
 use rama_http_types::{HeaderMap, HeaderValue, Method, Version};
-use rama_net::conn::{ConnectionHealth, ConnectionHealthStatus};
+use rama_net::conn::ConnectionHealthWatcher;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::{Instant, Sleep};
 
@@ -48,6 +48,9 @@ where
     T: Http1Transaction,
 {
     pub(crate) fn new(io: I) -> Self {
+        io.extensions()
+            .get_ref_or_insert(ConnectionHealthWatcher::default);
+
         Self {
             io: Buffered::new(io),
             state: State {
@@ -801,9 +804,11 @@ where
     }
 
     pub(crate) fn poll_shutdown(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        if let Some(health) = self.io.extensions().get_ref::<ConnectionHealth>() {
-            health.set_status(ConnectionHealthStatus::Broken);
-        }
+        self.io
+            .extensions()
+            .get_ref_or_insert(ConnectionHealthWatcher::default)
+            .mark_broken();
+
         match ready!(Pin::new(self.io.io_mut()).poll_shutdown(cx)) {
             Ok(()) => {
                 trace!("shut down IO complete");

--- a/rama-net/src/client/pool/mod.rs
+++ b/rama-net/src/client/pool/mod.rs
@@ -1,6 +1,6 @@
 use super::conn::{ConnectorService, EstablishedClientConnection};
 use crate::address::SocketAddress;
-use crate::conn::{ConnectionHealth, ConnectionHealthStatus};
+use crate::conn::{ConnectionHealth, ConnectionHealthWatcher};
 use crate::stream::Socket;
 use parking_lot::Mutex;
 use rama_core::error::extra::OpaqueError;
@@ -360,8 +360,10 @@ where
             let pooled_conn = storage.remove(idx)?;
 
             // This will make sure we skip and drop broken connections
-            if let Some(health) = pooled_conn.extensions().get_ref::<ConnectionHealth>()
-                && health.status() == ConnectionHealthStatus::Broken
+            if let Some(watcher) = pooled_conn
+                .extensions()
+                .get_ref::<ConnectionHealthWatcher>()
+                && watcher.health() == ConnectionHealth::Broken
             {
                 continue;
             }
@@ -510,8 +512,8 @@ impl<C: ExtensionsRef, ID> Drop for LeasedConnection<C, ID> {
                 unsafe { ManuallyDrop::drop(&mut self.pooled_conn) };
                 return;
             }
-            if let Some(health) = self.extensions().get_ref::<ConnectionHealth>()
-                && health.status() == ConnectionHealthStatus::Broken
+            if let Some(watcher) = self.extensions().get_ref::<ConnectionHealthWatcher>()
+                && watcher.health() == ConnectionHealth::Broken
             {
                 trace!("LRU connection pool: dropping pooled connection that was marked as failed");
 
@@ -1054,7 +1056,7 @@ mod tests {
         async fn serve(&self, input: Input) -> Result<Self::Output, Self::Error> {
             let conn = InnerService::default();
 
-            conn.extensions().insert(ConnectionHealth::default());
+            conn.extensions().insert(ConnectionHealthWatcher::default());
 
             self.created_connection.fetch_add(1, Ordering::Relaxed);
             Ok(EstablishedClientConnection { input, conn })
@@ -1081,9 +1083,9 @@ mod tests {
             // Once this service is broken it will stay in this state, similar to a closed tcp connection
             if should_error {
                 self.extensions
-                    .get_ref::<ConnectionHealth>()
+                    .get_ref::<ConnectionHealthWatcher>()
                     .unwrap()
-                    .set_status(ConnectionHealthStatus::Broken);
+                    .mark_broken();
                 self.should_error.store(true, Ordering::Relaxed);
             }
 
@@ -1234,9 +1236,9 @@ mod tests {
         // Normally the connection would edit this in extensions but since we dont have ownership here
         // we just clone the extensions and edit it like this
         conn_extensions
-            .get_ref::<ConnectionHealth>()
+            .get_ref::<ConnectionHealthWatcher>()
             .unwrap()
-            .set_status(ConnectionHealthStatus::Broken);
+            .mark_broken();
 
         // We should get a new working connection here since health check has detect that the stored one was broken
         let conn = svc

--- a/rama-net/src/conn.rs
+++ b/rama-net/src/conn.rs
@@ -1,13 +1,8 @@
 //! Connection utilities
 
 use rama_core::extensions::Extension;
-use std::{
-    io,
-    sync::{
-        Arc,
-        atomic::{AtomicU8, Ordering},
-    },
-};
+use std::io;
+use tokio::sync::watch;
 
 /// Check if the error is a connection error,
 /// in which case the error can be ignored.
@@ -25,45 +20,66 @@ pub fn is_connection_error(e: &io::Error) -> bool {
     )
 }
 
-#[derive(Clone, Default, Extension)]
+#[derive(Clone, Debug, Extension)]
 #[extension(tags(net))]
-/// Health of this connection
+/// Watcher that can update and read the [`ConnectionHealth`]
 ///
 /// Note: this should only be added once to extensions and
-/// be edited by all connection / health checks.
-pub struct ConnectionHealth {
-    status: Arc<AtomicU8>,
+/// be used by all connection / health checks.
+pub struct ConnectionHealthWatcher {
+    sender: watch::Sender<ConnectionHealth>,
+    receiver: watch::Receiver<ConnectionHealth>,
 }
 
-impl ConnectionHealth {
-    #[must_use]
-    /// Get the [`ConnectionHealthStatus`]
-    pub fn status(&self) -> ConnectionHealthStatus {
-        let val = self.status.load(Ordering::Relaxed);
-        // SAFETY: ConnectionHealthStatus is stored with repr u8
-        unsafe { std::mem::transmute::<u8, ConnectionHealthStatus>(val) }
+impl ConnectionHealthWatcher {
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Set status to provided [`ConnectionHealthStatus`]
-    pub fn set_status(&self, status: ConnectionHealthStatus) {
-        // SAFETY: ConnectionHealthStatus is stored with repr u8
-        let val = unsafe { std::mem::transmute::<ConnectionHealthStatus, u8>(status) };
-        self.status.store(val, Ordering::Relaxed);
+    /// Set the [`ConnectionHealth`] to health
+    pub fn mark_healthy(&self) {
+        self.update_health(ConnectionHealth::Healthy);
+    }
+
+    /// Set the [`ConnectionHealth`] to broken
+    pub fn mark_broken(&self) {
+        self.update_health(ConnectionHealth::Broken);
+    }
+
+    /// Set the [`ConnectionHealth`]
+    pub fn update_health(&self, health: ConnectionHealth) {
+        self.sender.send_replace(health);
+    }
+
+    /// Get the [`ConnectionHealth`]
+    pub fn health(&self) -> ConnectionHealth {
+        *self.receiver.borrow()
+    }
+
+    /// Reference the [`watch::Sender<ConnectionHealth>`]
+    pub fn sender(&self) -> &watch::Sender<ConnectionHealth> {
+        &self.sender
+    }
+
+    /// Reference the [`watch::Sender<ConnectionHealth>`]
+    ///
+    /// Note: for keeping track of changes, prefer to clone this
+    /// receiver so it has it's own subscribe logic
+    pub fn receiver(&self) -> &watch::Receiver<ConnectionHealth> {
+        &self.receiver
     }
 }
 
-impl std::fmt::Debug for ConnectionHealth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ConnectionHealth")
-            .field("status", &self.status())
-            .finish()
+impl Default for ConnectionHealthWatcher {
+    fn default() -> Self {
+        let (sender, receiver) = watch::channel(ConnectionHealth::Healthy);
+        Self { sender, receiver }
     }
 }
 
-#[repr(u8)]
 #[derive(Debug, PartialEq, Clone, Copy, Eq)]
-pub enum ConnectionHealthStatus {
-    Unknown = 0,
-    Broken = 1,
-    Healthy = 2,
+/// Health of the connection
+pub enum ConnectionHealth {
+    Broken,
+    Healthy,
 }


### PR DESCRIPTION
New connectionHealthWatcher:
- Use tokio watch, support similar sync logic like we did before, but this also allows other users to subscribe/listen to state changes (eg pools could do active cleanup if wanted, or some other sort of bookkeeping)
- New extensions allow use to create this in places where needed. We also create this in H1/H2 connections in case rama-http-backend is skipped
- When reset_stream is received, dont break connection -> break stream (nested connection)
- Also break h2 stream on EOF
- Also break connection if request fails because connection is closed. Should already be flagged, but is there as extra safety in case we missed a path