### PR TITLE
socks5: bug fixes, spec gaps, and tests

### DIFF
--- a/rama-socks5/specifications/README.md
+++ b/rama-socks5/specifications/README.md
@@ -12,3 +12,6 @@ relied upon by rama-socks5 or related to.
 
 * [rfc1929.txt](./rfc1929.txt)  
   Username/Password Authentication for SOCKS V5
+
+* [rfc1961.txt](./rfc1961.txt)
+  GSS-API Authentication Method for SOCKS Version 5 (not implemented)

--- a/rama-socks5/specifications/rfc1961.txt
+++ b/rama-socks5/specifications/rfc1961.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Network Working Group                                         P. McMahon
+Request for Comments: 1961                                           ICL
+Category: Standards Track                                      June 1996
+
+
+           GSS-API Authentication Method for SOCKS Version 5
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Table of Contents
+
+         1. Purpose ............................................ 1
+         2. Introduction ....................................... 1
+         3. GSS-API Security Context Establishment ............. 2
+         4. GSS-API Protection-level Options ................... 5
+         5. GSS-API Per-message Protection ..................... 7
+         6. GSS-API Security Context Termination ............... 8
+         7. References ......................................... 8
+         8. Acknowledgments .................................... 8
+         9. Security Considerations ............................ 8
+         10. Author's Address .................................. 9
+
+1. Purpose
+
+   The protocol specification for SOCKS Version 5 specifies a
+   generalized framework for the use of arbitrary authentication
+   protocols in the initial SOCKS connection setup.  This document
+   provides the specification for the SOCKS V5 GSS-API authentication
+   protocol, and defines a GSS-API-based encapsulation for provision of
+   integrity, authentication and optional confidentiality.
+
+2. Introduction
+
+   GSS-API provides an abstract interface which provides security
+   services for use in distributed applications, but isolates callers
+   from specific security mechanisms and implementations.
+
+   GSS-API peers achieve interoperability by establishing a common
+   security mechanism for security context establishment - either
+   through administrative action, or through negotiation.  GSS-API is
+   specified in [RFC 1508], and [RFC 1509].  This specification is
+   intended for use with implementations of GSS-API, and the emerging
+
+
+
+McMahon                     Standards Track                     [Page 1]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+   GSS-API V2 specification.
+
+   The approach for use of GSS-API in SOCKS V5 is to authenticate the
+   client and server by successfully establishing a GSS-API security
+   context - such that the GSS-API encapsulates any negotiation protocol
+   for mechanism selection, and the agreement of security service
+   options.
+
+   The GSS-API enables the context initiator to know what security
+   services the target supports for the chosen mechanism.  The required
+   level of protection is then agreed by negotiation.
+
+   The GSS-API per-message protection calls are subsequently used to
+   encapsulate any further TCP and UDP traffic between client and
+   server.
+
+3. GSS-API Security Context Establishment
+
+3.1 Preparation
+
+   Prior to use of GSS-API primitives, the client and server should be
+   locally authenticated, and have established default GSS-API
+   credentials.
+
+   The client should call gss_import_name to obtain an internal
+   representation of the server name.  For maximal portability the
+   default name_type GSS_C_NULL_OID should be used to specify the
+   default name space, and the input name_string should treated by the
+   client's code as an opaque name-space specific input.
+
+   For example, when using Kerberos V5 naming, the imported name may be
+   of the form "SERVICE:socks@socks_server_hostname" where
+   "socks_server_hostname" is the fully qualified host name of the
+   server with all letters in lower case. Other mechanisms may, however,
+   have different name forms, so the client should not make assumptions
+   about the name syntax.
+
+3.2 Client Context Establishment
+
+   The client should then call gss_init_sec_context, typically passing:
+
+         GSS_C_NO_CREDENTIAL into cred_handle to specify the default
+         credential (for initiator usage),
+
+         GSS_C_NULL_OID into mech_type to specify the default
+         mechanism,
+
+
+
+
+
+McMahon                     Standards Track                     [Page 2]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+         GSS_C_NO_CONTEXT into context_handle to specify a NULL
+         context (initially), and,
+
+         the previously imported server name into target_name.
+
+   The client must also specify its requirements for replay protection,
+   delegation, and sequence protection via the gss_init_sec_context
+   req_flags parameter.  It is required by this specification that the
+   client always requests these service options (i.e. passes
+   GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG | GSS_C_DELEG_FLAG |
+   GSS_C_SEQUENCE_FLAG into req_flags).
+
+   However, GSS_C_SEQUENCE_FLAG should only be passed in for TCP-based
+   clients, not for UDP-based clients.
+
+3.3 Client Context Establishment Major Status codes
+
+   The gss_init_sec_context returned status code can take two different
+   success values:
+
+    - If gss_init_sec_context returns GSS_S_CONTINUE_NEEDED, then the
+      client should expect the server to issue a token in the
+      subsequent subnegotiation response.  The client must pass the
+      token to another call to gss_init_sec_context, and repeat this
+      procedure until "continue" operations are complete.
+
+    - If gss_init_sec_context returns GSS_S_COMPLETE, then the client
+      should respond to the server with any resulting output_token.
+
+      If there is no output_token, the client should proceed to send
+      the protected request details, including any required message
+      protection subnegotiation as specified in sections 4 and 5
+      below.
+
+3.4 Client initial token
+
+   The client's GSS-API implementation then typically responds with the
+   resulting output_token which the client sends in a message to the
+   server.
+
+    +------+------+------+.......................+
+    + ver  | mtyp | len  |       token           |
+    +------+------+------+.......................+
+    + 0x01 | 0x01 | 0x02 | up to 2^16 - 1 octets |
+    +------+------+------+.......................+
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 3]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+    Where:
+
+    - "ver" is the protocol version number, here 1 to represent the
+      first version of the SOCKS/GSS-API protocol
+
+    - "mtyp" is the message type, here 1 to represent an
+      authentication message
+
+    - "len" is the length of the "token" field in octets
+
+    - "token" is the opaque authentication token emitted by GSS-API
+
+3.5 Client GSS-API Initialisation Failure
+
+   If, however, the client's GSS-API implementation failed during
+   gss_init_sec_context, the client must close its connection to the
+   server.
+
+3.6 Server Context Establishment
+
+   For the case where a client successfully sends a token emitted by
+   gss_init_sec_context() to the server, the server must pass the
+   client-supplied token to gss_accept_sec_context as input_token.
+
+   When calling gss_accept_sec_context() for the first time, the
+   context_handle argument is initially set to GSS_C_NO_CONTEXT.
+
+   For portability, verifier_cred_handle is set to GSS_C_NO_CREDENTIAL
+   to specify default credentials (for acceptor usage).
+
+   If gss_accept_sec_context returns GSS_CONTINUE_NEEDED, the server
+   should return the generated output_token to the client, and
+   subsequently pass the resulting client supplied token to another call
+   to gss_accept_sec_context.
+
+   If gss_accept_sec_context returns GSS_S_COMPLETE, then, if an
+   output_token is returned, the server should return it to the client.
+
+   If no token is returned, a zero length token should be sent by the
+   server to signal to the client that it is ready to receive the
+   client's request.
+
+
+
+
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 4]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+3.7 Server Reply
+
+   In all continue/confirmation cases, the server uses the same message
+   type as for the client -> server interaction.
+
+    +------+------+------+.......................+
+    + ver  | mtyp | len  |       token           |
+    +------+------+------+.......................+
+    + 0x01 | 0x01 | 0x02 | up to 2^16 - 1 octets |
+    +------+------+------+.......................+
+
+3.8 Security Context Failure
+
+   If the server refuses the client's connection for any reason (GSS-API
+   authentication failure or otherwise), it will return:
+
+    +------+------+
+    + ver  | mtyp |
+    +------+------+
+    + 0x01 | 0xff |
+    +------+------+
+
+    Where:
+
+    - "ver" is the protocol version number, here 1 to represent the
+      first version of the SOCKS/GSS-API protocol
+
+    - "mtyp" is the message type, here 0xff to represent an abort
+      message
+
+4. GSS-API Protection-level Options
+
+4.1 Message protection
+
+   Establishment of a GSS-API security context enables comunicating
+   peers to determine which per-message protection services are
+   available to them through the gss_init_sec_context() and
+   gss_accept_sec_context() ret_flags GSS_C_INTEG_FLAG and
+   GSS_C_CONF_FLAG which respectively indicate message integrity and
+   confidentiality services.
+
+   It is necessary to ensure that the message protection applied to the
+   traffic is appropriate to the sensitivity of the data, and the
+   severity of the threats.
+
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 5]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+4.2 Message Protection Subnegotiation
+
+   For TCP and UDP clients and servers, different levels of protection
+   are possible in the SOCKS V5 protocol, so an additional
+   subnegotiation stage is needed to agree the message protection level.
+   After successful completion of this subnegotiation, TCP and UDP
+   clients and servers use GSS-API encapsulation as defined in section
+   5.1.
+
+   After successful establishment of a GSS-API security context, the
+   client's GSS-API implementation sends its required security context
+   protection level to the server.  The server then returns the security
+   context protection level which it agrees to - which may or may not
+   take the the client's request into account.
+
+   The security context protection level sent by client and server must
+   be one of the following values:
+
+         1 required per-message integrity
+         2 required per-message integrity and confidentiality
+         3 selective per-message integrity or confidentiality based on
+           local client and server configurations
+
+   It is anticipated that most implementations will agree on level 1 or
+   2 due to the practical difficulties in applying selective controls to
+   messages passed through a socks library.
+
+4.3 Message Protection Subnegotiation Message Format
+
+   The security context protection level is sent from client to server
+   and vice versa using the following protected message format:
+
+    +------+------+------+.......................+
+    + ver  | mtyp | len  |   token               |
+    +------+------+------+.......................+
+    + 0x01 | 0x02 | 0x02 | up to 2^16 - 1 octets |
+    +------+------+------+.......................+
+
+    Where:
+
+    - "ver" is the protocol version number, here 1 to represent the
+      first version of the SOCKS/GSS-API protocol
+
+    - "mtyp" is the message type, here 2 to represent a protection
+      -level negotiation message
+
+    - "len" is the length of the "token" field in octets
+
+
+
+
+McMahon                     Standards Track                     [Page 6]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+    - "token" is the GSS-API encapsulated protection level
+
+4.4 Message Protection Subnegotiation Message Generation
+
+   The token is produced by encapsulating an octet containing the
+   required protection level using gss_seal()/gss_wrap() with conf_req
+   set to FALSE.  The token is verified using gss_unseal()/
+   gss_unwrap().
+
+   If the server's choice of protection level is unacceptable to the
+   client, then the client must close its connection to the server
+
+5. GSS-API Per-message Protection
+
+   For TCP and UDP clients and servers, the GSS-API functions for
+   encapsulation and de-encapsulation shall be used by implementations -
+   i.e. gss_seal()/gss_wrap(), and gss_unseal()/ gss_unwrap().
+
+   The default value of quality of protection shall be specified, and
+   the use of conf_req_flag shall be as determined by the previous
+   subnegotiation step.  If protection level 1 is agreed then
+   conf_req_flag MUST always be FALSE; if protection level 2 is agreed
+   then conf_req_flag MUST always be TRUE; and if protection level 3 is
+   agreed then conf_req is determined on a per-message basis by client
+   and server using local configuration.
+
+   All encapsulated messages are prefixed by the following framing:
+
+    +------+------+------+.......................+
+    + ver  | mtyp | len  |       token           |
+    +------+------+------+.......................+
+    + 0x01 | 0x03 | 0x02 | up to 2^16 - 1 octets |
+    +------+------+------+.......................+
+
+    Where:
+
+    - "ver" is the protocol version number, here 1 to represent the
+      first version of the SOCKS/GSS-API protocol
+
+    - "mtyp" is the message type, here 3 to represent encapulated user
+      data
+
+    - "len" is the length of the "token" field in octets
+
+    - "token" is the user data encapsulated by GSS-API
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 7]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+6. GSS-API Security Context Termination
+
+   The GSS-API context termination message (emitted by
+   gss_delete_sec_context) is not used by this protocol.
+
+   When the connection is closed, each peer invokes
+   gss_delete_sec_context() passing GSS_C_NO_BUFFER into the
+   output_token argument.
+
+7. References
+
+    [RFC 1508] Linn, J., "Generic Security Service API",
+               September 1993.
+
+    [RFC 1509] Wray, J., "Generic Security Service API : C-bindings",
+               September 1993.
+
+    [SOCKS V5] Leech, M., Ganis, M., Lee, Y., Kuris, R., Koblas, D.,
+               and L. Jones, "SOCKS Protocol V5", RFC 1928, April
+               1996.
+
+8. Acknowledgment
+
+   This document builds from a previous memo produced by Marcus Leech
+   (BNR) - whose comments are gratefully acknowleged.  It also reflects
+   input from the AFT WG, and comments arising from implementation
+   experience by Xavier Gosselin (IUT Lyons).
+
+9. Security Considerations
+
+   The security services provided through the GSS-API are entirely
+   dependent on the effectiveness of the underlying security mechanisms,
+   and the correctness of the implementation of the underlying
+   algorithms and protocols.
+
+   The user of a GSS-API service must ensure that the quality of
+   protection provided by the mechanism implementation is consistent
+   with their security policy.
+
+   In addition, where negotiation is supported under the GSS-API,
+   constraints on acceptable mechanisms may be imposed to ensure
+   suitability for application to authenticated firewall traversal.
+
+
+
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 8]
+
+RFC 1961          GSS-API Authentication for SOCKS V5          June 1996
+
+
+10. Author's Address
+
+   P. V. McMahon
+   ICL Enterprises
+   Kings House
+   33 Kings Road
+   Reading, RG1 3PX
+   UK
+
+   EMail: p.v.mcmahon@rea0803.wins.icl.co.uk
+   Phone: +44 1734 634882
+   Fax:   +44 1734 855106
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+McMahon                     Standards Track                     [Page 9]
+

--- a/rama-socks5/src/client/core.rs
+++ b/rama-socks5/src/client/core.rs
@@ -129,18 +129,18 @@ impl fmt::Display for HandshakeError {
         let context = self.context.unwrap_or("no context");
         match &self.kind {
             HandshakeErrorKind::IO(error) => {
-                write!(f, "client: handshake eror: I/O: {error} ({context})")
+                write!(f, "client: handshake error: I/O: {error} ({context})")
             }
             HandshakeErrorKind::Protocol(error) => {
                 write!(
                     f,
-                    "client: handshake eror: protocol error: {error} ({context})"
+                    "client: handshake error: protocol error: {error} ({context})"
                 )
             }
             HandshakeErrorKind::MethodMismatch(method) => {
                 write!(
                     f,
-                    "client: handshake error: method mistmatch: {method:?} ({context})"
+                    "client: handshake error: method mismatch: {method:?} ({context})"
                 )
             }
             HandshakeErrorKind::Reply(reply) => {
@@ -156,7 +156,7 @@ impl fmt::Display for HandshakeError {
                 )
             }
             HandshakeErrorKind::Other(error) => {
-                write!(f, "client: handshake eror: other: {error} ({context})")
+                write!(f, "client: handshake error: other: {error} ({context})")
             }
         }
     }

--- a/rama-socks5/src/client/udp.rs
+++ b/rama-socks5/src/client/udp.rs
@@ -180,7 +180,7 @@ impl<S: rama_core::io::Io + Unpin> UdpSocketRelay<S> {
         self.socket
             .poll_send(cx, &self.write_buffer[..])
             .map_err(Into::into)
-            .map_ok(|n| n - header.serialized_len() + 1)
+            .map_ok(|n| n - header.serialized_len())
     }
 
     /// Receives a single datagram message from the socks5 udp associate proxy.
@@ -251,7 +251,7 @@ fn validate_udp_header(header: UdpHeader) -> Result<(usize, SocketAddress), BoxE
         .context_field("fragment_number", header.fragment_number));
     }
 
-    let header_offset = header.serialized_len() - 1;
+    let header_offset = header.serialized_len();
 
     let HostWithPort { host, port } = header.destination;
     let from: SocketAddress = match host {

--- a/rama-socks5/src/proto/enums.rs
+++ b/rama-socks5/src/proto/enums.rs
@@ -31,13 +31,21 @@ enum_builder! {
         ///
         /// Reference: [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)
         NoAuthenticationRequired => 0x00,
-        /// Generic Security Services Application Program Interface
+        /// Generic Security Services Application Program Interface.
         ///
-        /// Reference: [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)
+        /// The method code is assigned in [RFC 1928]; the subnegotiation
+        /// protocol is defined in [RFC 1961].
+        ///
+        /// **Not implemented**: rama does not implement GSSAPI authentication.
+        /// Servers will reply with [`NoAcceptableMethods`] when a client
+        /// proposes only this method.
+        ///
+        /// [RFC 1928]: https://datatracker.ietf.org/doc/html/rfc1928
+        /// [RFC 1961]: https://datatracker.ietf.org/doc/html/rfc1961
         GSSAPI => 0x01,
         /// Username/Password Authentication for SOCKS V5
         ///
-        /// Reference: [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1929)
+        /// Reference: [RFC 1929](https://datatracker.ietf.org/doc/html/rfc1929)
         UsernamePassword => 0x02,
         /// Challenge-Handshake Authentication Protocol
         ///
@@ -95,7 +103,7 @@ enum_builder! {
         /// Used to establish an association within
         /// the UDP relay process to handle UDP datagrams.
         ///
-        /// Reference: [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1929)
+        /// Reference: [RFC 1928](https://datatracker.ietf.org/doc/html/rfc1928)
         UdpAssociate => 0x03,
     }
 }

--- a/rama-socks5/src/proto/server.rs
+++ b/rama-socks5/src/proto/server.rs
@@ -69,7 +69,7 @@ impl Header {
     where
         W: AsyncWrite + Unpin,
     {
-        tracing::trace!("write socks5 server headerr: on stack (w=2)");
+        tracing::trace!("write socks5 server header: on stack (w=2)");
         let mut buf = [0u8; 2];
         self.write_to_buf(&mut buf.as_mut_slice());
         w.write_all(&buf[..]).await
@@ -308,9 +308,9 @@ impl UsernamePasswordResponse {
 }
 
 impl UsernamePasswordResponse {
-    /// Read the server [`UsernamePasswordResponse`], decoded from binary format as specified by [RFC 1928] from the reader.
+    /// Read the server [`UsernamePasswordResponse`], decoded from binary format as specified by [RFC 1929] from the reader.
     ///
-    /// [RFC 1928]: https://datatracker.ietf.org/doc/html/rfc1928
+    /// [RFC 1929]: https://datatracker.ietf.org/doc/html/rfc1929
     pub async fn read_from<R>(r: &mut R) -> Result<Self, ProtocolError>
     where
         R: AsyncRead + Unpin,
@@ -328,22 +328,22 @@ impl UsernamePasswordResponse {
         Ok(Self { version, status })
     }
 
-    /// Write the server [`UsernamePasswordResponse`] in binary format as specified by [RFC 1928] into the writer.
+    /// Write the server [`UsernamePasswordResponse`] in binary format as specified by [RFC 1929] into the writer.
     ///
-    /// [RFC 1928]: https://datatracker.ietf.org/doc/html/rfc1928
+    /// [RFC 1929]: https://datatracker.ietf.org/doc/html/rfc1929
     pub async fn write_to<W>(&self, w: &mut W) -> Result<(), std::io::Error>
     where
         W: AsyncWrite + Unpin,
     {
-        tracing::trace!("write socks5 server headerr: on stack (w=2)");
+        tracing::trace!("write socks5 server header: on stack (w=2)");
         let mut buf = [0u8; 2];
         self.write_to_buf(&mut buf.as_mut_slice());
         w.write_all(&buf[..]).await
     }
 
-    /// Write the server [`UsernamePasswordResponse`] in binary format as specified by [RFC 1928] into the buffer.
+    /// Write the server [`UsernamePasswordResponse`] in binary format as specified by [RFC 1929] into the buffer.
     ///
-    /// [RFC 1928]: https://datatracker.ietf.org/doc/html/rfc1928
+    /// [RFC 1929]: https://datatracker.ietf.org/doc/html/rfc1929
     pub fn write_to_buf<B: BufMut>(&self, buf: &mut B) {
         buf.put_u8(self.version.into());
         buf.put_u8(self.status);

--- a/rama-socks5/src/proto/udp.rs
+++ b/rama-socks5/src/proto/udp.rs
@@ -141,7 +141,7 @@ impl UdpHeader {
     }
 
     pub(crate) fn serialized_len(&self) -> usize {
-        5 + authority_length(&self.destination)
+        4 + authority_length(&self.destination)
     }
 }
 
@@ -155,7 +155,7 @@ mod tests {
     use crate::proto::{test_write_read_eq, test_write_read_sync_eq};
 
     impl UdpHeader {
-        // to expensive in production, so only enable in tests
+        // too expensive in production, so only enable in tests
         pub async fn write_to<W>(&self, w: &mut W) -> Result<(), std::io::Error>
         where
             W: AsyncWrite + Unpin,
@@ -165,7 +165,7 @@ mod tests {
             w.write_all(&buf).await
         }
 
-        // to expensive in production, so only enable in tests
+        // too expensive in production, so only enable in tests
         pub fn write_to_sync<W>(&self, w: &mut W) -> Result<(), std::io::Error>
         where
             W: Write,
@@ -196,5 +196,37 @@ mod tests {
             },
             UdpHeader
         );
+    }
+
+    // Regression test for Bug 4: serialized_len() was off by +1 (returned 5+auth
+    // instead of the correct 4+auth, where 4 = RSV(2)+FRAG(1)+ATYP(1)).
+    #[test]
+    fn test_serialized_len_matches_write_to_buf() {
+        use rama_net::address::Host;
+
+        let cases: &[UdpHeader] = &[
+            UdpHeader {
+                fragment_number: 0,
+                destination: HostWithPort::local_ipv4(80),
+            },
+            UdpHeader {
+                fragment_number: 7,
+                destination: HostWithPort::local_ipv6(443),
+            },
+            UdpHeader {
+                fragment_number: 0,
+                destination: HostWithPort::new(Host::EXAMPLE_NAME, 8080),
+            },
+        ];
+
+        for h in cases {
+            let mut buf = BytesMut::new();
+            h.write_to_buf(&mut buf);
+            assert_eq!(
+                buf.len(),
+                h.serialized_len(),
+                "serialized_len() must equal actual bytes written by write_to_buf() for {h:?}",
+            );
+        }
     }
 }

--- a/rama-socks5/src/server/mod.rs
+++ b/rama-socks5/src/server/mod.rs
@@ -314,16 +314,16 @@ impl fmt::Display for Error {
         let context = &self.context;
         match &self.kind {
             ErrorKind::IO => {
-                write!(f, "server: handshake eror: I/O ({context})")
+                write!(f, "server: handshake error: I/O ({context})")
             }
             ErrorKind::Protocol => {
-                write!(f, "server: handshake eror: protocol error ({context})")
+                write!(f, "server: handshake error: protocol error ({context})")
             }
             ErrorKind::Aborted(reason) => {
-                write!(f, "server: handshake eror: aborted: {reason} ({context})")
+                write!(f, "server: handshake error: aborted: {reason} ({context})")
             }
             ErrorKind::Service => {
-                write!(f, "server: service eror ({context})")
+                write!(f, "server: service error ({context})")
             }
         }
     }

--- a/rama-socks5/src/server/udp/inspect.rs
+++ b/rama-socks5/src/server/udp/inspect.rs
@@ -184,7 +184,7 @@ where
                             .map_err(Error::service)?,
                         None => {
                             tracing::trace!(
-                                "block request: north -> south @ {server_address}: inspecter blocked"
+                                "block request: north -> south @ {server_address}: inspector blocked"
                             );
                         }
                     }
@@ -220,12 +220,12 @@ where
 
                     match maybe_payload {
                         Some(payload) => relay
-                            .send_to_south(Some(payload), server_address)
+                            .send_to_north(Some(payload), server_address)
                             .await
                             .map_err(Error::service)?,
                         None => {
                             tracing::trace!(
-                                "block request: north -> south @ {server_address}: inspecter blocked"
+                                "block request: south @ {server_address} -> north: inspector blocked"
                             );
                         }
                     }
@@ -350,7 +350,7 @@ where
                         }
                         UdpInspectAction::Block => {
                             tracing::trace!(
-                                "block request: north -> south @ {server_address}: inspecter blocked"
+                                "block request: north -> south @ {server_address}: inspector blocked"
                             );
                         }
                         UdpInspectAction::Modify(bytes) => {
@@ -395,7 +395,7 @@ where
                         }
                         UdpInspectAction::Block => {
                             tracing::trace!(
-                                "block request: south @ {server_address} -> north: inspecter blocked"
+                                "block request: south @ {server_address} -> north: inspector blocked"
                             );
                         }
                         UdpInspectAction::Modify(bytes) => {
@@ -413,6 +413,79 @@ where
                 None => {
                     tracing::trace!("ignore dropped packet: nothing to inspect or relay");
                 }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama_core::error::BoxError;
+    use rama_core::service::service_fn;
+
+    // Regression for Bug 1: AsyncUdpInspector's south→north arm was calling
+    // relay.send_to_south() instead of relay.send_to_north(), so server→client
+    // traffic was routed back to the server rather than forwarded to the client.
+    #[tokio::test]
+    async fn test_async_inspector_south_to_north_routes_to_client() {
+        // Layout:
+        //   server → south_socket → [relay] → north_socket → client_socket
+        //
+        // We send from server→south and verify client_socket receives the packet.
+        // Before the fix, the packet was sent back to server (south direction), so
+        // client_socket would time out.
+
+        let client_socket = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_addr: std::net::SocketAddr = client_socket.local_addr().unwrap();
+        let client_socket_addr: SocketAddress = client_addr.into();
+
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south_addr = south.local_addr().unwrap();
+
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        // Pass-through inspector: always forwards the payload unchanged
+        let inspector = AsyncUdpInspector(service_fn(async move |req: RelayRequest| {
+            Ok::<_, BoxError>(RelayResponse {
+                maybe_payload: Some(req.payload),
+                extensions: req.extensions,
+            })
+        }));
+
+        let payload = b"south_to_north_regression";
+        server.send_to(payload, south_addr).await.unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let inspect_fut = inspector.proxy_udp_packets(
+            Extensions::new(),
+            client_socket_addr,
+            north,
+            4096,
+            south,
+            4096,
+            None,
+        );
+
+        // Run the inspector concurrently with the client recv; the first select arm
+        // to complete wins — we expect client_socket to receive the relayed packet.
+        tokio::select! {
+            _ = inspect_fut => {
+                panic!("inspector exited unexpectedly before packet arrived");
+            }
+            result = tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                client_socket.recv_from(&mut buf),
+            ) => {
+                let (n, _) = result
+                    .expect("timed out: south→north packet did not arrive at client (north side)")
+                    .unwrap();
+                let received = &buf[..n];
+                assert!(
+                    received.ends_with(payload),
+                    "south→north: payload must arrive at client (north side)"
+                );
             }
         }
     }

--- a/rama-socks5/src/server/udp/mod.rs
+++ b/rama-socks5/src/server/udp/mod.rs
@@ -129,8 +129,8 @@ impl<B> UdpRelay<B, DirectUdpRelay> {
             dns_resolver: None,
             bind_north_address: SocketAddress::default_ipv4(0),
             bind_south_address: SocketAddress::default_ipv4(0),
-            north_buffer_size: 2048,
-            south_buffer_size: 2048,
+            north_buffer_size: 4096,
+            south_buffer_size: 4096,
             relay_timeout: None,
         }
     }
@@ -167,7 +167,7 @@ impl<B> UdpRelay<B, DirectUdpRelay> {
 }
 
 impl<B, I> UdpRelay<B, I> {
-    /// Overwrite the [`UdpRelay`]'s bind [`SocketService],
+    /// Overwrite the [`UdpRelay`]'s bind [`SocketService`],
     /// used to open a socket, return the address and
     /// wait for an incoming connection which it will return.
     pub fn with_binder<T>(self, binder: T) -> UdpRelay<T, I> {
@@ -280,6 +280,7 @@ impl Default for DefaultUdpRelay {
             Duration::from_secs(30),
         ))
         .with_default_dns_resolver()
+        .with_relay_timeout(Duration::from_secs(300))
     }
 }
 

--- a/rama-socks5/src/server/udp/relay.rs
+++ b/rama-socks5/src/server/udp/relay.rs
@@ -96,7 +96,12 @@ impl UdpSocketRelay {
                             "north socket: received packet (len = {len}; src = {src})",
                         );
 
-                        if !self.client_address.eq(&src) {
+                        // Per RFC 1928 §7 the client MAY send all-zeros when it does not
+                        // know its own address/port yet; in that case we skip source
+                        // filtering and accept packets from any sender.
+                        if !self.client_address.ip_addr.is_unspecified()
+                            && !self.client_address.eq(&src)
+                        {
                             tracing::debug!(
                                 network.peer.address = %self.client_address.ip_addr,
                                 network.peer.port = %self.client_address.port,
@@ -149,7 +154,7 @@ impl UdpSocketRelay {
                         Ok(Some(UdpRelayState::ReadNorth(server_address)))
                     }
 
-                    Err(err) if is_fatal_io_error(&err) => {
+                    Err(err) if is_transient_udp_io_error(&err) => {
                         tracing::debug!("north socket: non-fatal error: retry again: {err:?}");
                         Ok(None)
                     }
@@ -170,7 +175,7 @@ impl UdpSocketRelay {
                         Ok(Some(UdpRelayState::ReadSouth(src.into())))
                     }
 
-                    Err(err) if is_fatal_io_error(&err) => {
+                    Err(err) if is_transient_udp_io_error(&err) => {
                         tracing::debug!("south socket: non-fatal error: retry again: {err:?}");
                         Ok(None)
                     }
@@ -240,15 +245,15 @@ impl UdpSocketRelay {
             }
 
             Err(err) => match err.downcast::<std::io::Error>() {
-                Ok(err) if is_fatal_io_error(&err) => {
-                    tracing::debug!(?err, "south socket: fatal I/O write error: {err:?}");
-                    Err(err.context("south socket fatal I/O write error"))
-                }
-                Ok(err) => {
+                Ok(err) if is_transient_udp_io_error(&err) => {
                     tracing::debug!(
                         "south socket: write error: packet lost but relay continues: {err:?}"
                     );
                     Ok(())
+                }
+                Ok(err) => {
+                    tracing::debug!(?err, "south socket: fatal I/O write error: {err:?}");
+                    Err(err.context("south socket fatal I/O write error"))
                 }
                 Err(err) => {
                     tracing::debug!("south socket: fatal unknown write error: {err:?}");
@@ -302,10 +307,8 @@ impl UdpSocketRelay {
                 server.address = %server_address.ip_addr,
                 server.port = %server_address.port,
                 "send packet north: data from south socket (len = {})",
-                self.north_read_buf.len(),
+                self.south_read_buf.len(),
             );
-            self.north_write_buf
-                .resize(self.south_read_buf.len() + header.serialized_len(), 0);
             header.write_to_buf(&mut self.north_write_buf);
             self.north_write_buf.extend_from_slice(&self.south_read_buf);
         };
@@ -329,15 +332,15 @@ impl UdpSocketRelay {
             }
 
             Err(err) => match err.downcast::<std::io::Error>() {
-                Ok(err) if is_fatal_io_error(&err) => {
-                    tracing::debug!("north socket: fatal I/O write error: {err:?}");
-                    Err(err.context("north socket fatal I/O write error"))
-                }
-                Ok(err) => {
+                Ok(err) if is_transient_udp_io_error(&err) => {
                     tracing::debug!(
                         "north socket: write error: packet lost but relay continues: {err:?}"
                     );
                     Ok(())
+                }
+                Ok(err) => {
+                    tracing::debug!("north socket: fatal I/O write error: {err:?}");
+                    Err(err.context("north socket fatal I/O write error"))
                 }
                 Err(err) => {
                     tracing::debug!("north socket: fatal unknown write error: {err:?}");
@@ -348,7 +351,7 @@ impl UdpSocketRelay {
     }
 }
 
-fn is_fatal_io_error(err: &std::io::Error) -> bool {
+fn is_transient_udp_io_error(err: &std::io::Error) -> bool {
     matches!(
         err.kind(),
         ErrorKind::WouldBlock
@@ -357,7 +360,6 @@ fn is_fatal_io_error(err: &std::io::Error) -> bool {
             | ErrorKind::ConnectionReset
             | ErrorKind::AddrNotAvailable
             | ErrorKind::PermissionDenied
-            | ErrorKind::Other
     )
 }
 
@@ -470,5 +472,110 @@ impl UdpSocketRelay {
             Host::Address(ip_addr) => ip_addr,
         };
         Ok((ip_addr, port).into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression for Bug 2: send_to_north(None) was calling BytesMut::resize() after
+    // truncate(0), which filled the buffer with N zeros before appending header+data,
+    // producing [zeros][header][data] instead of the correct [header][data].
+    #[tokio::test]
+    async fn test_send_to_north_none_produces_header_then_data_no_leading_zeros() {
+        // client_socket receives north-bound packets
+        let client = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let client_addr: std::net::SocketAddr = client.local_addr().unwrap();
+        let client_socket_addr: SocketAddress = client_addr.into();
+
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south_addr = south.local_addr().unwrap();
+
+        // server sends raw payload to south socket (simulates south data)
+        let server = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = server.local_addr().unwrap();
+        let server_socket_addr: SocketAddress = server_addr.into();
+
+        let payload = b"regression bug2 payload";
+        server.send_to(payload, south_addr).await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_socket_addr, north, 4096, south, 4096);
+
+        // recv() reads south packet and stores raw payload in south_read_buf
+        let state = relay.recv().await.unwrap().unwrap();
+        assert!(
+            matches!(state, UdpRelayState::ReadSouth(addr) if addr == server_socket_addr),
+            "expected ReadSouth from server address"
+        );
+
+        // send_to_north(None) should relay [socks5_header][payload] to client, no leading zeros
+        relay.send_to_north(None, server_socket_addr).await.unwrap();
+
+        let mut buf = vec![0u8; 4096];
+        let (n, _) = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            client.recv_from(&mut buf),
+        )
+        .await
+        .expect("timed out waiting for north packet")
+        .unwrap();
+        let received = &buf[..n];
+
+        let expected_header = UdpHeader {
+            fragment_number: 0,
+            destination: server_socket_addr.into(),
+        };
+        let mut expected = BytesMut::new();
+        expected_header.write_to_buf(&mut expected);
+        expected.extend_from_slice(payload);
+
+        assert_eq!(
+            received,
+            &expected[..],
+            "send_to_north(None) must produce exactly [header][data]; \
+             got {} bytes, expected {} bytes",
+            received.len(),
+            expected.len(),
+        );
+    }
+
+    // Regression for Bug 3: when the client sends 0.0.0.0:0 in the UDP ASSOCIATE
+    // request (RFC 1928 §7 allows this when the client doesn't know its address),
+    // the relay was dropping ALL north packets because no source ever matches 0.0.0.0.
+    #[tokio::test]
+    async fn test_recv_north_unspecified_client_addr_accepts_any_source() {
+        // client_address = 0.0.0.0:0 — the RFC 1928 §7 all-zeros sentinel
+        let client_addr = SocketAddress::default_ipv4(0);
+
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let north_addr = north.local_addr().unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096);
+
+        // Any sender (127.0.0.1:OS-assigned) sends a valid SOCKS5 UDP packet to north
+        let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let target: SocketAddress = SocketAddress::local_ipv4(9999);
+        let header = UdpHeader {
+            fragment_number: 0,
+            destination: target.into(),
+        };
+        let mut packet = BytesMut::new();
+        header.write_to_buf(&mut packet);
+        packet.extend_from_slice(b"data");
+        sender.send_to(&packet, north_addr).await.unwrap();
+
+        let state = tokio::time::timeout(std::time::Duration::from_millis(500), relay.recv())
+            .await
+            .expect("timed out")
+            .unwrap()
+            .expect("packet must not be dropped when client_address is 0.0.0.0:0");
+
+        assert!(
+            matches!(state, UdpRelayState::ReadNorth(_)),
+            "RFC 1928 §7: packets from any source must be accepted when client_address is 0.0.0.0:0"
+        );
     }
 }


### PR DESCRIPTION
- **4 critical/medium bugs fixed** in the UDP relay path (wrong send direction, leading-zero corruption, 0.0.0.0 source filter, serialized_len off-by-one)
- **Bug 5**: `is_fatal_io_error` renamed to `is_transient_udp_io_error` (name was inverted), `ErrorKind::Other` removed, send-path error arm semantics corrected
- **Defaults**: relay idle timeout added (5 min), default UDP buffer bumped 2048→4096
- **Spec**: RFC 1961 vendored; GSSAPI documented as not implemented; wrong RFC URLs in doc comments fixed
- **Typos**: `eror`, `headerr`, `inspecter`, `mistmatch`
- **Tests**: regression test for each of the four critical/medium bugs