### PR TITLE
fix HttpExporter use runtime

### DIFF
--- a/rama-grpc/src/service/opentelemetry/http.rs
+++ b/rama-grpc/src/service/opentelemetry/http.rs
@@ -66,6 +66,7 @@ pub struct HttpExporter<S = ()> {
     temporality: Temporality,
     resource: Arc<ArcSwap<transform::ResourceAttributesWithSchema>>,
     shutdown: Arc<AtomicBool>,
+    runtime: Option<tokio::runtime::Handle>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -112,6 +113,7 @@ impl<S> HttpExporter<S> {
                 transform::ResourceAttributesWithSchema::default(),
             )),
             shutdown: Arc::new(AtomicBool::new(false)),
+            runtime: tokio::runtime::Handle::try_current().ok(),
         }
     }
 
@@ -225,6 +227,18 @@ impl<S> HttpExporter<S> {
         }
     );
 
+    generate_set_and_with!(
+        /// Override the tokio runtime used to drive each export.
+        ///
+        /// `new` captures `Handle::try_current()` automatically. Use this to
+        /// pin the exporter to a specific runtime, or pass `None` to require
+        /// the caller to provide a tokio context for every `export` call.
+        pub fn runtime(mut self, runtime: Option<tokio::runtime::Handle>) -> Self {
+            self.runtime = runtime;
+            self
+        }
+    );
+
     fn apply_env(&mut self) -> Result<(), OtelExporterConfigError> {
         if let Some(endpoint) = env_endpoint(OTEL_EXPORTER_OTLP_ENDPOINT)? {
             self.env.base.endpoint = Some(endpoint);
@@ -299,7 +313,7 @@ where
     ) -> Result<Resp, OTelSdkError>
     where
         Req: Message,
-        Resp: Message + Default,
+        Resp: Message + Default + Send + 'static,
     {
         if self.shutdown.load(Ordering::Acquire) {
             return Err(OTelSdkError::AlreadyShutdown);
@@ -333,17 +347,29 @@ where
         merge_headers(request.headers_mut(), &config.headers);
 
         let service = self.service.clone();
-        let response_fut = service.serve(request);
-        let response = match config.timeout {
-            Some(timeout) => match tokio::time::timeout(timeout, response_fut).await {
-                Ok(result) => result,
-                Err(_) => return Err(OTelSdkError::Timeout(timeout)),
-            },
-            None => response_fut.await,
-        }
-        .map_err(|err| OTelSdkError::InternalFailure(err.into().to_string()))?;
+        let timeout = config.timeout;
+        let work = async move {
+            let response = match timeout {
+                Some(timeout) => {
+                    match tokio::time::timeout(timeout, service.serve(request)).await {
+                        Ok(result) => result,
+                        Err(_) => return Err(OTelSdkError::Timeout(timeout)),
+                    }
+                }
+                None => service.serve(request).await,
+            }
+            .map_err(|err| OTelSdkError::InternalFailure(err.into().to_string()))?;
 
-        decode_response(response).await
+            decode_response(response).await
+        };
+
+        match self.runtime.as_ref() {
+            Some(handle) => handle
+                .spawn(work)
+                .await
+                .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?,
+            None => work.await,
+        }
     }
 }
 

--- a/tests/integration/examples/example_tests/http_telemetry.rs
+++ b/tests/integration/examples/example_tests/http_telemetry.rs
@@ -1,10 +1,32 @@
 use super::utils;
-use rama::http::BodyExtractExt;
+
+use rama::{
+    Layer,
+    extensions::{Extension, Extensions},
+    http::{BodyExtractExt, StatusCode, server::HttpServer, service::web::WebService},
+    layer::AddInputExtensionLayer,
+    rt::Executor,
+    tcp::server::TcpListener,
+};
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Extension)]
+struct CollectorState {
+    metrics_received: AtomicU32,
+}
 
 #[tokio::test]
 #[ignore]
 async fn test_http_telemetry() {
     utils::init_tracing();
+
+    let state = Arc::new(CollectorState {
+        metrics_received: AtomicU32::new(0),
+    });
+    spawn_fake_otlp_collector(Arc::clone(&state)).await;
 
     let runner = utils::ExampleRunner::interactive("http_telemetry", Some("opentelemetry"));
 
@@ -17,4 +39,32 @@ async fn test_http_telemetry() {
         .await
         .unwrap();
     assert!(homepage.contains("<h1>Hello!</h1>"));
+
+    // Give enough time for everything to flush and export
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while state.metrics_received.load(Ordering::SeqCst) == 0 {
+        if Instant::now() > deadline {
+            panic!("no OTLP /v1/metrics POST reached the fake collector within 10s");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn spawn_fake_otlp_collector(state: Arc<CollectorState>) {
+    let exec = Executor::default();
+    let web = WebService::default().with_post("/v1/metrics", async |ext: Extensions| {
+        ext.get_ref::<CollectorState>()
+            .unwrap()
+            .metrics_received
+            .fetch_add(1, Ordering::SeqCst);
+        StatusCode::OK
+    });
+    let http_service = HttpServer::auto(exec.clone()).service(web);
+
+    let listener = TcpListener::build(exec)
+        .bind_address("127.0.0.1:4318")
+        .await
+        .expect("bind fake OTLP collector on 127.0.0.1:4318 (port already in use?)");
+
+    tokio::spawn(listener.serve(AddInputExtensionLayer::new_arc(state).into_layer(http_service)));
 }


### PR DESCRIPTION
- Store tokio runtime so HttpExporter can spawn on tokio. Otherwise this exporter will not work
- Also add integration test for this example so we know this is working (also confirmed that this was initially broken)