### PR TITLE
tls-boring: derive AKI keyId from CA pubkey when CA lacks SKI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1949,7 +1949,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc9b815c8dce0288dc1ecebf53039913c82977604766e48b72e80db99b06327"
+checksum = "9c65b2bf5409ff0b5c6f7a60d6253ee8d901cc22205f7213058332c0634c2641"
 dependencies = [
  "bitflags 2.11.1",
  "foreign-types",
@@ -3346,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring-sys"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b68b0916fb03989d677548d40c3e25cd24d16da95d32b8c5861ce9805a03ce"
+checksum = "38b68650132a39b88012aad1ddd6041f38bf8d266d20476afcaa36f4f95088c9"
 dependencies = [
  "bindgen",
  "cmake",
@@ -3358,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "rama-boring-tokio"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff8d421e3e7f5b7a08efcdf1c5292ad11307fb9a97847731f0696e3e15c9047"
+checksum = "21c3fb915e5e11154bf9a009106199ebc69b3d8da90c9e232a95ebf455f53c95"
 dependencies = [
  "rama-boring",
  "rama-boring-sys",
@@ -4297,7 +4297,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4811,7 +4811,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5870,7 +5870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ quickcheck_macros = "1.2"
 quote = "1.0"
 radix_trie = "0.3"
 rama = { version = "0.3.0-rc1", path = ".", default-features = false }
-rama-boring = { version = "0.6.0", default-features = false }
-rama-boring-tokio = { version = "0.6.0", default-features = false }
+rama-boring = { version = "0.6.1", default-features = false }
+rama-boring-tokio = { version = "0.6.1", default-features = false }
 rama-core = { version = "0.3.0-rc1", path = "./rama-core", default-features = false }
 rama-crypto = { version = "0.3.0-rc1", path = "./rama-crypto", default-features = false }
 rama-dns = { version = "0.3.0-rc1", path = "./rama-dns", default-features = false }

--- a/rama-tls-boring/src/server/utils/certs.rs
+++ b/rama-tls-boring/src/server/utils/certs.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    asn1::Asn1Time,
+    asn1::{Asn1Object, Asn1Time},
     bn::{BigNum, MsbOption},
     dsa::Dsa,
     ec::{EcGroup, EcKey},
@@ -9,7 +9,7 @@ use crate::core::{
     rand::rand_bytes,
     rsa::Rsa,
     x509::{
-        X509, X509NameBuilder, X509Ref,
+        X509, X509Extension, X509NameBuilder, X509Ref,
         extension::{BasicConstraints, KeyUsage, SubjectKeyIdentifier},
     },
 };
@@ -17,6 +17,31 @@ use rama_boring::x509::extension::{AuthorityKeyIdentifier, SubjectAlternativeNam
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 use rama_net::{address::Domain, tls::server::SelfSignedData};
+
+/// Build an `AuthorityKeyIdentifier` extension whose `keyIdentifier` is derived from
+/// the CA's public key per RFC 5280 §4.2.1.2 method (1): SHA-1 of the SubjectPublicKey
+/// BIT STRING contents. Used as a fallback when the CA certificate carries no SKI extension.
+fn aki_from_ca_pubkey_keyid(ca_cert: &X509Ref) -> Result<X509Extension, BoxError> {
+    let digest = ca_cert
+        .pubkey_digest(MessageDigest::sha1())
+        .context("compute SHA-1 of CA SubjectPublicKey BIT STRING")?;
+    let keyid: &[u8] = &digest[..];
+    debug_assert_eq!(keyid.len(), 20, "SHA-1 digest must be 20 bytes");
+
+    // AuthorityKeyIdentifier ::= SEQUENCE { [0] IMPLICIT OCTET STRING keyIdentifier }
+    let mut payload = Vec::with_capacity(4 + keyid.len());
+    payload.push(0x30); // SEQUENCE
+    payload.push((2 + keyid.len()) as u8);
+    payload.push(0x80); // [0] IMPLICIT OCTET STRING
+    payload.push(keyid.len() as u8);
+    payload.extend_from_slice(keyid);
+
+    // 2.5.29.35 = id-ce-authorityKeyIdentifier
+    let aki_oid =
+        Asn1Object::from_str("2.5.29.35").context("construct AuthorityKeyIdentifier OID object")?;
+    X509Extension::from_der_payload(aki_oid.as_ref(), false, &payload)
+        .context("build AuthorityKeyIdentifier extension from raw DER payload")
+}
 
 /// Generate a server cert for the [`SelfSignedData`] using the given CA Cert + Key.
 ///
@@ -139,7 +164,10 @@ pub fn self_signed_server_auth_gen_cert(
             .append_extension(auth_key_identifier.as_ref())
             .context("x509 cert builder: set auth key id extension")?;
     } else {
-        tracing::debug!("skipping AuthorityKeyIdentifier emission: CA has no SubjectKeyIdentifier");
+        let auth_key_identifier = aki_from_ca_pubkey_keyid(ca_cert)?;
+        cert_builder
+            .append_extension(auth_key_identifier.as_ref())
+            .context("x509 cert builder: set derived auth key id extension")?;
     }
 
     cert_builder
@@ -290,9 +318,10 @@ pub fn self_signed_server_auth_mirror_cert(
                 .append_extension(auth_key_identifier.as_ref())
                 .context("x509 cert builder: append mirrored authority key identifier")?;
         } else {
-            tracing::debug!(
-                "skipping mirrored AuthorityKeyIdentifier: CA has no SubjectKeyIdentifier"
-            );
+            let auth_key_identifier = aki_from_ca_pubkey_keyid(ca_cert)?;
+            cert_builder
+                .append_extension(auth_key_identifier.as_ref())
+                .context("x509 cert builder: append derived mirrored authority key identifier")?;
         }
     }
 

--- a/rama-tls-boring/src/server/utils/certs_tests.rs
+++ b/rama-tls-boring/src/server/utils/certs_tests.rs
@@ -404,12 +404,13 @@ fn mirror_omits_ski_and_aki_when_source_has_neither() {
 }
 
 #[test]
-fn mirror_omits_aki_when_ca_has_no_ski() {
+fn mirror_derives_aki_keyid_when_ca_has_no_ski() {
     let (ca_cert, ca_key) = build_ca_without_ski("no-ski-ca.rama.test").expect("ca without ski");
     assert!(ca_cert.subject_key_id().is_none());
 
-    // Source cert (self-signed) with both SKI and AKI present, so mirror would normally re-emit
-    // both. The CA-lacks-SKI guard must still kick in and suppress the AKI.
+    // Source cert (self-signed) with both SKI and AKI present, so mirror re-emits both. The
+    // CA-lacks-SKI fallback must populate AKI keyIdentifier via SHA-1 of the CA pubkey BIT
+    // STRING (RFC 5280 §4.2.1.2 method 1), not skip the extension.
     let rsa = Rsa::generate(2048).expect("source rsa");
     let source_pkey = PKey::from_rsa(rsa).expect("source pkey");
     let mut x509_name = X509NameBuilder::new().expect("source name builder");
@@ -469,11 +470,19 @@ fn mirror_omits_aki_when_ca_has_no_ski() {
             .expect("mirror cert succeeds despite CA lacking SKI");
 
     assert!(mirrored_cert.subject_key_id().is_some());
-    assert!(mirrored_cert.authority_key_id().is_none());
+
+    let mirror_aki = mirrored_cert
+        .authority_key_id()
+        .expect("mirror has derived AKI");
+    let expected = ca_cert
+        .pubkey_digest(MessageDigest::sha1())
+        .expect("CA pubkey sha1");
+    assert_eq!(expected.len(), 20);
+    assert_eq!(mirror_aki.as_slice(), &expected[..]);
 }
 
 #[test]
-fn gen_cert_omits_aki_when_ca_has_no_ski() {
+fn gen_cert_derives_aki_keyid_when_ca_has_no_ski() {
     let (ca_cert, ca_key) = build_ca_without_ski("no-ski-ca.rama.test").expect("ca without ski");
     assert!(ca_cert.subject_key_id().is_none());
 
@@ -482,7 +491,13 @@ fn gen_cert_omits_aki_when_ca_has_no_ski() {
         self_signed_server_auth_gen_cert(&leaf_data, &ca_cert, &ca_key).expect("generate leaf");
 
     assert!(leaf_cert.subject_key_id().is_some());
-    assert!(leaf_cert.authority_key_id().is_none());
+
+    let leaf_aki = leaf_cert.authority_key_id().expect("leaf has derived AKI");
+    let expected = ca_cert
+        .pubkey_digest(MessageDigest::sha1())
+        .expect("CA pubkey sha1");
+    assert_eq!(leaf_aki.as_slice(), &expected[..]);
+
     assert_eq!(ca_cert.issued(&leaf_cert), Ok(()));
 }
 


### PR DESCRIPTION
Bumps rama-boring/rama-boring-tokio to 0.6.1 for X509Ref::pubkey_digest, then replaces the previous skip-on-missing-SKI branch in gen_cert and mirror_cert with an AKI whose keyIdentifier is SHA-1 of the CA SubjectPublicKey BIT STRING (RFC 5280 method 1). This produces leaves that satisfy strict AKI checks (e.g. OpenSSL VERIFY_X509_STRICT) even when the supplied proxy CA carries no SKI extension.