### PR TITLE
Keep extensions on upgrade

### DIFF
--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/connector.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/connector.rs
@@ -4,7 +4,7 @@
 
 use super::HttpProxyError;
 use rama_core::error::{BoxError, ErrorContext};
-use rama_core::extensions::{Extension, ExtensionsRef};
+use rama_core::extensions::{Extension, Extensions, ExtensionsRef};
 use rama_core::io::Io;
 use rama_core::rt::Executor;
 use rama_core::telemetry::tracing;
@@ -58,7 +58,18 @@ impl InnerHttpProxyConnector {
     }
 
     rama_utils::macros::generate_set_and_with! {
-        /// Add a header to the request.
+        /// Set the extensions for the connector.
+        pub(super) fn extensions(
+            mut self,
+            exts: Extensions,
+        ) -> Self {
+            self.req.set_extensions_mut(exts);
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Add an extension to the request.
         pub(super) fn extension(
             mut self,
             value: impl Extension,

--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
@@ -205,7 +205,8 @@ where
             });
         }
 
-        let mut connector = InnerHttpProxyConnector::new(transport_ctx.authority.clone())?;
+        let mut connector = InnerHttpProxyConnector::new(transport_ctx.authority.clone())?
+            .with_extensions(conn.extensions().clone().fork());
 
         if let Some(version) = self.version {
             connector.set_version(version);


### PR DESCRIPTION
Currently, extensions get lost on proxy CONNECT because `InnerHttpProxyConnector` starts out with a new, empty set of extensions. This PR makes it fork from the connection's extensions instead.