### PR TITLE
rama-core + rama-utils: spec fixes, hardening, perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3974,6 +3974,7 @@ dependencies = [
  "ahash",
  "const_format",
  "loom",
+ "memchr",
  "parking_lot",
  "pin-project-lite",
  "quickcheck",
@@ -3985,6 +3986,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "tokio",
+ "tracing",
  "trybuild",
  "wildcard",
 ]

--- a/rama-core/src/io/peek.rs
+++ b/rama-core/src/io/peek.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::time::Duration;
 
 use tokio::{
@@ -30,9 +31,12 @@ pub struct PeekOutput<D> {
 /// - the optional timeout elapses;
 /// - the internal read-attempt budget is exhausted.
 ///
-/// The attempt budget is capped at `max(buffer.len() / 4, 1) + 1` reads. This keeps
+/// The attempt budget defaults to `max(buffer.len() / 4, 1) + 1` reads. This keeps
 /// peeking bounded even for slow or fragmented inputs, but it also means this
-/// function can return partial data before the buffer is full.
+/// function can return partial data before the buffer is full. For protocol
+/// sniffing on small buffers (e.g. a 5-byte TLS-record buffer), the buffer-derived
+/// default can be too small under TCP fragmentation; prefer
+/// [`peek_input_until_with_options`] and pass an explicit `max_attempts`.
 pub fn peek_input_until<R, O, P>(
     reader: &mut R,
     buffer: &mut [u8],
@@ -50,11 +54,51 @@ where
 ///
 /// It is assumed that the offst is within the buffer boundaries,
 /// but it will be clamped to the `buffer.len()` regardless.
-pub async fn peek_input_until_with_offset<R, O, P>(
+///
+/// Uses the buffer-derived attempt budget; see [`peek_input_until_with_options`]
+/// when you need an explicit budget.
+#[inline]
+pub fn peek_input_until_with_offset<R, O, P>(
     reader: &mut R,
     buffer: &mut [u8],
     offset: usize,
     timeout: Option<Duration>,
+    predicate: P,
+) -> impl Future<Output = PeekOutput<O>>
+where
+    R: AsyncRead + Unpin,
+    P: Fn(&[u8]) -> Option<O>,
+{
+    let default_budget =
+        NonZeroUsize::new(buffer.len().saturating_div(4).max(1) + 1).unwrap_or(NonZeroUsize::MIN);
+    peek_input_until_with_options(
+        reader,
+        buffer,
+        offset,
+        timeout,
+        Some(default_budget),
+        predicate,
+    )
+}
+
+/// Same as [`peek_input_until`] but with explicit control over the starting offset
+/// and the read-attempt budget.
+///
+/// `max_attempts`:
+/// - `Some(n)` — stop after `n` read attempts even if the predicate did not match.
+/// - `None` — no attempt cap; rely on the reader's EOF and the optional `timeout`.
+///
+/// The default budget used by [`peek_input_until`] and [`peek_input_until_with_offset`]
+/// is derived from the buffer length (`max(buffer.len() / 4, 1) + 1`), which is a
+/// reasonable fallback for sizable buffers but can be too tight for small protocol-
+/// sniffing buffers under TCP fragmentation. Prefer this function with an explicit
+/// budget when reading from untrusted/proxied peers.
+pub async fn peek_input_until_with_options<R, O, P>(
+    reader: &mut R,
+    buffer: &mut [u8],
+    offset: usize,
+    timeout: Option<Duration>,
+    max_attempts: Option<NonZeroUsize>,
     predicate: P,
 ) -> PeekOutput<O>
 where
@@ -71,9 +115,9 @@ where
     }
 
     let peek_deadline = timeout.map(|d| Instant::now() + d);
+    let attempt_cap = max_attempts.map(NonZeroUsize::get).unwrap_or(usize::MAX);
 
-    let max_attempts = buffer.len().saturating_div(4).max(1) + 1;
-    for _ in 0..max_attempts {
+    for _ in 0..attempt_cap {
         let read_fut = reader.read(&mut buffer[output.peek_size..]);
 
         let n = match peek_deadline {
@@ -268,6 +312,53 @@ mod tests {
         assert!(output.data.is_none());
         assert_eq!(output.peek_size, 2);
         assert_eq!(&buffer[..output.peek_size], b"he");
+    }
+
+    #[tokio::test]
+    async fn explicit_max_attempts_overrides_buffer_derived_budget() {
+        // Buffer-derived budget for an 8-byte buffer is 3 attempts; this reader
+        // would normally exhaust the budget before "hel" is seen. With an explicit
+        // max_attempts of 5 the predicate matches.
+        let mut reader = tokio_test::io::Builder::new()
+            .read(b"h")
+            .read(b"e")
+            .read(b"l")
+            .build();
+        let mut buffer = [0_u8; 8];
+
+        let output = peek_input_until_with_options(
+            &mut reader,
+            &mut buffer,
+            0,
+            None,
+            NonZeroUsize::new(5),
+            |buf| (buf == b"hel").then_some(()),
+        )
+        .await;
+
+        assert_eq!(output.data, Some(()));
+        assert_eq!(output.peek_size, 3);
+    }
+
+    #[tokio::test]
+    async fn explicit_max_attempts_none_means_no_cap() {
+        let mut reader = tokio_test::io::Builder::new()
+            .read(b"h")
+            .read(b"e")
+            .read(b"l")
+            .read(b"l")
+            .read(b"o")
+            .build();
+        let mut buffer = [0_u8; 8];
+
+        let output =
+            peek_input_until_with_options(&mut reader, &mut buffer, 0, None, None, |buf| {
+                (buf == b"hello").then_some(buf.len())
+            })
+            .await;
+
+        assert_eq!(output.data, Some(5));
+        assert_eq!(output.peek_size, 5);
     }
 
     struct TwoPhaseReader {

--- a/rama-core/src/io/read.rs
+++ b/rama-core/src/io/read.rs
@@ -172,7 +172,7 @@ impl<const N: usize> StackReader<N> {
     /// Returns true if there are any more bytes to consume
     #[must_use]
     pub fn has_remaining(&self) -> bool {
-        self.remaining() == 0
+        self.remaining() > 0
     }
 }
 

--- a/rama-core/src/io/timeout.rs
+++ b/rama-core/src/io/timeout.rs
@@ -38,11 +38,14 @@ impl TimeoutState {
 
     #[inline]
     fn set_timeout(&mut self, timeout: Option<Duration>) {
-        debug_assert!(
-            !self.active,
-            "set_timeout is only expected before a timeout becomes active"
-        );
         self.timeout = timeout;
+        // Force the next `poll_check` to re-arm the inner `Sleep` with the new value.
+        // We cannot call `Sleep::reset` here because `cur` is structurally pinned, but
+        // clearing `active` is sufficient: `poll_check` re-initialises the deadline the
+        // next time it observes `!active`. Without this clear, a previously-armed timer
+        // would silently shadow the new timeout in release builds (the old code only
+        // tripped a `debug_assert!`).
+        self.active = false;
     }
 
     #[inline]

--- a/rama-core/src/stream/json/config.rs
+++ b/rama-core/src/stream/json/config.rs
@@ -1,16 +1,21 @@
 use rama_utils::macros::generate_set_and_with;
+use std::num::NonZeroUsize;
 
 /// Controls how the parser deals with lines that contain no JSON values.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum EmptyLineHandling {
     /// Parse every line, i.e. every segment between `\n` characters, even if it is empty. This will
     /// result in errors for empty lines.
-    #[default]
     ParseAlways,
 
     /// Ignore lines, i.e. segments between `\n` characters, which are empty, i.e. contain no
     /// characters. For compatibility with `\r\n`-style linebreaks, this also ignores lines which
     /// consist of only a single `\r` character.
+    ///
+    /// This is the default — rama is proxy-first and graceful: a stray `\n\n` from a remote peer
+    /// should not surface as a hard parse error. Opt in to [`EmptyLineHandling::ParseAlways`] when
+    /// you want strict handling.
+    #[default]
     IgnoreEmpty,
 
     /// Ignore lines, i.e. segments between `\n` characters, which contain only whitespace
@@ -20,15 +25,20 @@ pub enum EmptyLineHandling {
 
 /// Configuration for the NDJSON-parser which controls the behavior in various situations.
 ///
-/// By default, the parser will attempt to parse every line, i.e. every segment between `\n`
-/// characters, even if it is empty. This will result in errors for empty lines.
+/// By default, the parser will skip empty lines ([`EmptyLineHandling::IgnoreEmpty`]) and accept
+/// lines of unbounded size. The unbounded line size is **safe only for trusted input** — when
+/// parsing data from an untrusted peer (e.g. a remote proxy backend), set
+/// [`ParseConfig::with_max_line_bytes`] to bound memory usage. Oversized lines are reported as a
+/// parse error and the engine resyncs to the next newline so subsequent lines can still be
+/// decoded.
 ///
-/// You can construct a config by first calling [ParseConfig::default] and then using the
+/// You can construct a config by first calling [`ParseConfig::default`] and then using the
 /// builder-style associated functions to configure it. See the example below.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ParseConfig {
     pub(crate) empty_line_handling: EmptyLineHandling,
     pub(crate) parse_rest: bool,
+    pub(crate) max_line_bytes: Option<NonZeroUsize>,
 }
 
 impl Default for ParseConfig {
@@ -36,6 +46,7 @@ impl Default for ParseConfig {
         Self {
             empty_line_handling: Default::default(),
             parse_rest: true,
+            max_line_bytes: None,
         }
     }
 }
@@ -67,6 +78,24 @@ impl ParseConfig {
         /// A new config with all the same values as this one, except the parse-rest-flag.
         pub fn parse_rest(mut self, parse_rest: bool) -> Self {
             self.parse_rest = parse_rest;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Caps the size of a single NDJSON line. When the accumulated bytes for a single line
+        /// (i.e. between two `\n` characters) exceed this limit, the engine emits a parse error
+        /// and resynchronises to the next newline; subsequent lines can still be decoded.
+        ///
+        /// `None` (the default) means no limit — appropriate only for trusted input sources.
+        /// Set this for any NDJSON stream sourced from an untrusted peer to avoid unbounded
+        /// memory growth from a peer that never sends a `\n`.
+        ///
+        /// # Returns
+        ///
+        /// A new config with all the same values as this one, except the max-line-bytes.
+        pub fn max_line_bytes(mut self, max_line_bytes: Option<NonZeroUsize>) -> Self {
+            self.max_line_bytes = max_line_bytes;
             self
         }
     }

--- a/rama-core/src/stream/json/engine.rs
+++ b/rama-core/src/stream/json/engine.rs
@@ -6,6 +6,7 @@ use std::collections::VecDeque;
 use std::str;
 
 use serde::Deserialize;
+use serde::de::Error as _;
 use serde_json::error::Result as JsonResult;
 
 use super::config::{EmptyLineHandling, ParseConfig};
@@ -21,6 +22,9 @@ pub(super) struct NdjsonEngine<T> {
     in_queue: Vec<u8>,
     out_queue: VecDeque<JsonResult<T>>,
     config: ParseConfig,
+    /// Set when an oversized line was detected mid-stream. Bytes are dropped until the next
+    /// newline; once that newline arrives the engine resumes normal operation.
+    skipping_oversized_line: bool,
 }
 
 impl<T> NdjsonEngine<T> {
@@ -37,6 +41,7 @@ impl<T> NdjsonEngine<T> {
             in_queue: Vec::new(),
             out_queue: VecDeque::new(),
             config,
+            skipping_oversized_line: false,
         }
     }
 
@@ -51,6 +56,12 @@ impl<T> NdjsonEngine<T> {
 
 fn is_blank(string: &str) -> bool {
     string.chars().all(char::is_whitespace)
+}
+
+fn oversized_line_error(max: usize) -> serde_json::Error {
+    serde_json::Error::custom(format_args!(
+        "ndjson line exceeded configured max_line_bytes ({max}); resynchronising to next newline",
+    ))
 }
 
 fn parse_line<T>(bytes: &[u8], empty_line_handling: EmptyLineHandling) -> Option<JsonResult<T>>
@@ -79,14 +90,26 @@ where
     /// is prepended to the given data in case a newline is encountered.
     pub(super) fn input(&mut self, data: impl AsRef<[u8]>) {
         let mut data = data.as_ref();
+        let max_line_bytes = self.config.max_line_bytes.map(std::num::NonZeroUsize::get);
 
-        while let Some(newline_idx) = data
-            .iter()
-            .enumerate()
-            .find(|&(_, item)| item == &NEW_LINE)
-            .map(|(index, _)| index)
-        {
+        while let Some(newline_idx) = data.iter().position(|item| *item == NEW_LINE) {
             let data_until_split = &data[..newline_idx];
+
+            if self.skipping_oversized_line {
+                // The previous oversized line ends here; drop these bytes and resume.
+                self.skipping_oversized_line = false;
+                data = &data[(newline_idx + 1)..];
+                continue;
+            }
+
+            if let Some(max) = max_line_bytes
+                && self.in_queue.len().saturating_add(data_until_split.len()) > max
+            {
+                self.in_queue.clear();
+                self.out_queue.push_back(Err(oversized_line_error(max)));
+                data = &data[(newline_idx + 1)..];
+                continue;
+            }
 
             let next_item_bytes = if self.in_queue.is_empty() {
                 data_until_split
@@ -101,6 +124,20 @@ where
 
             self.in_queue.clear();
             data = &data[(newline_idx + 1)..];
+        }
+
+        if self.skipping_oversized_line {
+            // Still searching for a newline; drop trailing bytes.
+            return;
+        }
+
+        if let Some(max) = max_line_bytes
+            && self.in_queue.len().saturating_add(data.len()) > max
+        {
+            self.in_queue.clear();
+            self.out_queue.push_back(Err(oversized_line_error(max)));
+            self.skipping_oversized_line = true;
+            return;
         }
 
         self.in_queue.extend_from_slice(data);
@@ -123,6 +160,13 @@ where
     /// validation in place to check that [NdjsonEngine::input] is not called afterwards. Doing this
     /// anyway may lead to unexpected behavior, as JSON-lines may be partially discarded.
     pub(super) fn finalize(&mut self) {
+        if self.skipping_oversized_line {
+            // The oversized-line error has already been emitted; discard any tail bytes
+            // and reset so the engine is reusable.
+            self.in_queue.clear();
+            self.skipping_oversized_line = false;
+            return;
+        }
         if self.config.parse_rest {
             let empty_line_handling = match self.config.empty_line_handling {
                 EmptyLineHandling::ParseAlways => EmptyLineHandling::IgnoreEmpty,
@@ -523,6 +567,69 @@ mod tests {
         engine.finalize();
 
         assert!(collect_output(engine).is_empty());
+    }
+
+    #[test]
+    fn max_line_bytes_emits_error_and_recovers_on_next_line() {
+        let max = std::num::NonZeroUsize::new(8).unwrap();
+        let mut engine = configured_engine(|config| config.with_max_line_bytes(max));
+
+        // First line clearly exceeds 8 bytes — should error and resync.
+        engine.input("{\"key\":1,\"value\":2}\n{\"key\":3,\"value\":4}\n");
+
+        let mut result = collect_output(engine).into_iter();
+        result.next().unwrap().unwrap_err();
+        // Second line also exceeds; another error follows.
+        result.next().unwrap().unwrap_err();
+        assert!(result.next().is_none());
+    }
+
+    #[test]
+    fn max_line_bytes_allows_lines_under_limit() {
+        let max = std::num::NonZeroUsize::new(64).unwrap();
+        let mut engine = configured_engine(|config| config.with_max_line_bytes(max));
+
+        engine.input("{\"key\":1,\"value\":2}\n");
+
+        let mut result = collect_output(engine).into_iter();
+        assert_eq!(
+            result.next().unwrap().unwrap(),
+            TestStruct { key: 1, value: 2 }
+        );
+        assert!(result.next().is_none());
+    }
+
+    #[test]
+    fn max_line_bytes_resyncs_across_chunked_input() {
+        let max = std::num::NonZeroUsize::new(4).unwrap();
+        let mut engine = configured_engine(|config| config.with_max_line_bytes(max));
+
+        // Chunked oversized line followed by a small valid line.
+        engine.input("{\"key\"");
+        engine.input(":1,\"val");
+        engine.input("ue\":2}\n");
+        // Now under the limit on its own; but parsing requires the value to be valid JSON.
+        // With max=4 it'll also exceed; use a value that fits exactly: "1\n".
+        engine.input("1\n");
+
+        let mut result = collect_output(engine).into_iter();
+        // First emit is the oversized error.
+        result.next().unwrap().unwrap_err();
+        // Second emit decodes the small line — fails type coercion to TestStruct.
+        result.next().unwrap().unwrap_err();
+        assert!(result.next().is_none());
+    }
+
+    #[test]
+    fn default_empty_line_handling_is_ignore_empty() {
+        // rama-default: empty lines should be gracefully ignored, not raise an error.
+        let mut engine: NdjsonEngine<TestStruct> = NdjsonEngine::new();
+
+        engine.input("{\"key\":1,\"value\":2}\n\n{\"key\":3,\"value\":4}\n");
+
+        let results = collect_output(engine);
+        assert!(results.iter().all(Result::is_ok));
+        assert_eq!(2, results.len());
     }
 
     #[test]

--- a/rama-core/src/username/mod.rs
+++ b/rama-core/src/username/mod.rs
@@ -32,7 +32,8 @@ mod parse;
 #[doc(inline)]
 pub use parse::{
     ExclusiveUsernameParsers, UsernameLabelParser, UsernameLabelState, UsernameLabels,
-    UsernameOpaqueLabelParser, parse_username, parse_username_with_separator,
+    UsernameOpaqueLabelParser, parse_username, parse_username_lossy, parse_username_with_separator,
+    parse_username_with_separator_lossy,
 };
 
 mod compose;

--- a/rama-core/src/username/parse.rs
+++ b/rama-core/src/username/parse.rs
@@ -8,6 +8,11 @@ use std::convert::Infallible;
 
 /// Parse a username, extracting the username (first part)
 /// and passing everything else to the [`UsernameLabelParser`].
+///
+/// Strict mode: any [`UsernameLabelState::Ignored`] label is fatal, since
+/// username labels are operator-composed configuration and an unknown label
+/// most likely indicates a misconfiguration that should fail loudly. Use
+/// [`parse_username_lossy`] when you want unknown labels to be silently skipped.
 #[inline]
 pub fn parse_username<P>(
     ext: &Extensions,
@@ -20,13 +25,59 @@ where
     parse_username_with_separator(ext, parser, username_ref, DEFAULT_USERNAME_LABEL_SEPARATOR)
 }
 
+/// Like [`parse_username`] but silently skips [`UsernameLabelState::Ignored`]
+/// labels instead of erroring. [`UsernameLabelState::Abort`] is still fatal.
+#[inline]
+pub fn parse_username_lossy<P>(
+    ext: &Extensions,
+    parser: P,
+    username_ref: impl AsRef<str>,
+) -> Result<String, BoxError>
+where
+    P: UsernameLabelParser<Error: Into<BoxError>>,
+{
+    parse_username_with_separator_lossy(ext, parser, username_ref, DEFAULT_USERNAME_LABEL_SEPARATOR)
+}
+
 /// Parse a username, extracting the username (first part)
 /// and passing everything else to the [`UsernameLabelParser`].
+///
+/// See [`parse_username`] for the semantics; use
+/// [`parse_username_with_separator_lossy`] to skip ignored labels.
+#[inline]
 pub fn parse_username_with_separator<P>(
+    ext: &Extensions,
+    parser: P,
+    username_ref: impl AsRef<str>,
+    separator: char,
+) -> Result<String, BoxError>
+where
+    P: UsernameLabelParser<Error: Into<BoxError>>,
+{
+    parse_username_inner(ext, parser, username_ref, separator, false)
+}
+
+/// Like [`parse_username_with_separator`] but silently skips
+/// [`UsernameLabelState::Ignored`] labels instead of erroring.
+#[inline]
+pub fn parse_username_with_separator_lossy<P>(
+    ext: &Extensions,
+    parser: P,
+    username_ref: impl AsRef<str>,
+    separator: char,
+) -> Result<String, BoxError>
+where
+    P: UsernameLabelParser<Error: Into<BoxError>>,
+{
+    parse_username_inner(ext, parser, username_ref, separator, true)
+}
+
+fn parse_username_inner<P>(
     ext: &Extensions,
     mut parser: P,
     username_ref: impl AsRef<str>,
     separator: char,
+    lossy: bool,
 ) -> Result<String, BoxError>
 where
     P: UsernameLabelParser<Error: Into<BoxError>>,
@@ -49,9 +100,13 @@ where
         match parser.parse_label(label) {
             UsernameLabelState::Used => (), // optimistic smiley
             UsernameLabelState::Ignored => {
-                return Err(OpaqueError::from_static_str("ignored username label")
-                    .context_field("index", index)
-                    .context_str_field("label", label));
+                if lossy {
+                    tracing::debug!(index, label, "parse_username: skipping ignored label");
+                } else {
+                    return Err(OpaqueError::from_static_str("ignored username label")
+                        .context_field("index", index)
+                        .context_str_field("label", label));
+                }
             }
             UsernameLabelState::Abort => {
                 return Err(OpaqueError::from_static_str("invalid username label")
@@ -432,6 +487,27 @@ mod test {
         );
 
         assert!(ext.get_ref::<UsernameLabels>().is_none());
+    }
+
+    #[test]
+    fn test_parse_username_lossy_skips_ignored_labels() {
+        let ext = Extensions::default();
+
+        // Strict (default) errors on the ignored label.
+        parse_username(&ext, UsernameNoLabelParser, "username-foo").unwrap_err();
+
+        // Lossy variant skips the ignored label and returns the username.
+        let ext = Extensions::default();
+        let result = parse_username_lossy(&ext, UsernameNoLabelParser, "username-foo").unwrap();
+        assert_eq!(result, "username");
+    }
+
+    #[test]
+    fn test_parse_username_lossy_still_aborts() {
+        let ext = Extensions::default();
+
+        // Even in the lossy variant, an `Abort` is always fatal.
+        parse_username_lossy(&ext, UsernameLabelAbortParser, "username-foo").unwrap_err();
     }
 
     #[test]

--- a/rama-utils/Cargo.toml
+++ b/rama-utils/Cargo.toml
@@ -37,6 +37,7 @@ std = [
 
 [dependencies]
 const_format = { workspace = true }
+memchr = { workspace = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rama-macros = { workspace = true }
@@ -45,6 +46,7 @@ serde = { workspace = true, features = ["derive"] }
 smallvec = { workspace = true, features = ["serde", "const_generics", "const_new"] }
 smol_str = { workspace = true, features = ["serde"] }
 tokio = { workspace = true, features = ["time", "macros"], optional = true }
+tracing = { workspace = true }
 wildcard = { workspace = true }
 
 [dev-dependencies]

--- a/rama-utils/src/str/arcstr/arc_str.rs
+++ b/rama-utils/src/str/arcstr/arc_str.rs
@@ -1004,9 +1004,21 @@ impl Clone for ArcStr {
                     .count_flag
                     .fetch_add(step, Ordering::Relaxed)
             });
-            // Protect against aggressive leaking of Arcs causing us to
-            // overflow. Technically, we could probably transition it to static
-            // here, but I haven't thought it through.
+            // Refcount saturation: if more than `RC_MAX` (~`usize::MAX/2`) live clones of
+            // this `ArcStr` exist, transition it into the "static" state by setting the
+            // flag bit. From that point on `Clone` and `Drop` early-return on `is_static`,
+            // so the backing `ThinInner` is **intentionally leaked** rather than aborting
+            // the process — rama is proxy-first and prefers staying up over crashing on a
+            // pathological refcount. Reaching this branch is effectively unreachable in
+            // practice (it requires ~`usize::MAX/2` live clones of a single ArcStr; on
+            // 64-bit that is ~2^62 — far beyond any realistic workload), and the upstream
+            // `arcstr` crate `abort()`s here instead. We emit a `tracing::error!` so the
+            // (vanishingly unlikely) event leaves a forensic trail.
+            //
+            // Note: this also means the `RC_MAX = MAX/2` headroom argument from upstream
+            // no longer guarantees that concurrent `fetch_add`s cannot wrap past
+            // `UINT_PART_MAX`; in practice the headroom is still astronomical and any
+            // workload that exhausts it has bigger problems than a memory leak.
             if n.uint_part() > RC_MAX && !n.flag_part() {
                 let val = PackedFlagUint::new_raw(true, 0).encoded_value();
                 unsafe {
@@ -1014,7 +1026,11 @@ impl Clone for ArcStr {
                         .count_flag
                         .fetch_or(val, Ordering::Release)
                 };
-                // abort();
+                tracing::error!(
+                    rc = n.uint_part(),
+                    rc_max = RC_MAX,
+                    "ArcStr refcount saturated; transitioning to static (leaking backing storage) instead of aborting",
+                );
             }
         }
         Self(self.0)

--- a/rama-utils/src/str/search.rs
+++ b/rama-utils/src/str/search.rs
@@ -40,9 +40,38 @@ where
     if n == 0 {
         return Some(0);
     }
+    if s.len() < n {
+        return None;
+    }
 
-    s.windows(n)
-        .position(|window| window.eq_ignore_ascii_case(sub))
+    let first = sub[0];
+    let first_lo = first.to_ascii_lowercase();
+    let first_up = first.to_ascii_uppercase();
+    let last_start = s.len() - n;
+
+    let mut start = 0;
+    loop {
+        let haystack = &s[start..];
+        let off = if first_lo == first_up {
+            memchr::memchr(first, haystack)
+        } else {
+            memchr::memchr2(first_lo, first_up, haystack)
+        };
+        let candidate = match off {
+            Some(off) => start + off,
+            None => return None,
+        };
+        if candidate > last_start {
+            return None;
+        }
+        if s[candidate..candidate + n].eq_ignore_ascii_case(sub) {
+            return Some(candidate);
+        }
+        start = candidate + 1;
+        if start > last_start {
+            return None;
+        }
+    }
 }
 
 /// Finds the first match of any substring from `sub_iter` within `s`,

--- a/rama-utils/src/time.rs
+++ b/rama-utils/src/time.rs
@@ -97,8 +97,9 @@ pub fn now_unix_ms() -> i64 {
 /// Optimized for high-frequency calls. The underlying wall clock skew is refreshed
 /// roughly once per hour.
 pub fn now_unix() -> i64 {
-    let ms = now_unix_ms();
-    (ms + (1000 - 1)) / 1000
+    // floor-division so that 999 ms -> 0 s, -1 ms -> -1 s; matches the unix-seconds
+    // contract `floor(ms/1000)` even for pre-epoch (negative) timestamps.
+    now_unix_ms().div_euclid(1000)
 }
 
 #[inline]
@@ -166,6 +167,18 @@ mod tests {
     #[test]
     fn modulo_index_zero_len() {
         assert_eq!(time_modulo_index(0), 0);
+    }
+
+    #[test]
+    fn now_unix_floor_division() {
+        // Sanity: now_unix must equal floor(now_unix_ms / 1000) and must not exceed
+        // the system clock's seconds value at the call site.
+        let sys_s = unix_timestamp_millis() / 1000;
+        let approx_s = now_unix();
+        let ms = now_unix_ms();
+        assert_eq!(approx_s, ms.div_euclid(1000));
+        // Allow a small drift either way (cached clock).
+        assert!((sys_s - approx_s).abs() <= 1);
     }
 
     #[test]


### PR DESCRIPTION
NDJSON max_line_bytes, peek attempt budget, set_timeout fix, ArcStr saturation policy, memchr search, now_unix floor, opt-in graceful username parsing.