### PR TITLE
rama-error: log-injection hardening + Option<T> parity fixes

### DIFF
--- a/rama-error/src/ext/context.rs
+++ b/rama-error/src/ext/context.rs
@@ -111,17 +111,51 @@ struct LogfmtEscaper<'a, 'b> {
 
 impl<'a, 'b> fmt::Write for LogfmtEscaper<'a, 'b> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        for ch in s.chars() {
-            match ch {
-                '\\' => self.f.write_str("\\\\")?,
-                '"' => self.f.write_str("\\\"")?,
-                '\n' => self.f.write_str("\\n")?,
-                '\r' => self.f.write_str("\\r")?,
-                '\t' => self.f.write_str("\\t")?,
-                c => self.f.write_char(c)?,
+        // Emit runs of "clean" characters in a single write_str, only breaking
+        // out for characters that need escaping. This keeps formatter overhead
+        // low while ensuring control characters (incl. ANSI ESC \x1b and other
+        // C0/C1 controls) are neutralized to prevent terminal-escape / log
+        // injection when error context contains attacker-controlled data.
+        let mut rest = s;
+        loop {
+            let mut found = None;
+            for (i, ch) in rest.char_indices() {
+                if needs_escape(ch) {
+                    found = Some((i, ch));
+                    break;
+                }
             }
+            let Some((i, ch)) = found else {
+                if !rest.is_empty() {
+                    self.f.write_str(rest)?;
+                }
+                return Ok(());
+            };
+            if i > 0 {
+                self.f.write_str(&rest[..i])?;
+            }
+            write_escaped(self.f, ch)?;
+            rest = &rest[i + ch.len_utf8()..];
         }
-        Ok(())
+    }
+}
+
+#[inline]
+fn needs_escape(ch: char) -> bool {
+    // Backslash and quote are the logfmt structural escapes; everything that
+    // is a Unicode control (C0, DEL, C1) is escaped to avoid terminal-escape
+    // injection and to keep log records single-line and printable.
+    matches!(ch, '\\' | '"') || ch.is_control()
+}
+
+fn write_escaped(f: &mut fmt::Formatter<'_>, ch: char) -> fmt::Result {
+    match ch {
+        '\\' => f.write_str("\\\\"),
+        '"' => f.write_str("\\\""),
+        '\n' => f.write_str("\\n"),
+        '\r' => f.write_str("\\r"),
+        '\t' => f.write_str("\\t"),
+        c => write!(f, "\\u{{{:x}}}", c as u32),
     }
 }
 
@@ -211,12 +245,19 @@ impl fmt::Display for ErrorWithContext {
             }
         }
 
+        // Cap the cause-chain walk so a malformed Error impl that returns a
+        // cycle from .source() cannot produce an unbounded loop here.
+        const MAX_CAUSE_DEPTH: usize = 64;
         let mut idx = 0usize;
         let mut cur = self.source.as_ref().source();
         if cur.is_some() {
             writeln!(f, "Caused by:")?;
         }
         while let Some(err) = cur {
+            if idx >= MAX_CAUSE_DEPTH {
+                writeln!(f, "  ... (truncated)")?;
+                break;
+            }
             writeln!(f, "  {idx}: {err}")?;
             idx += 1;
             cur = err.source();
@@ -389,5 +430,71 @@ mod tests {
 
         let src_ref = err.source().expect("source should exist");
         assert_eq!(src_ref.to_string(), "boom");
+    }
+
+    #[test]
+    fn logfmt_escapes_ansi_and_control_chars() {
+        // ANSI ESC (\x1b), NUL, DEL, BEL, C1 CSI — none of these may appear
+        // literally in formatted output, to prevent terminal-escape / log
+        // injection when error context contains attacker-controlled bytes.
+        let src = BoomError;
+        let mut err = ErrorWithContext::new(BoxError::from(src));
+
+        err.insert_key_value("ansi", "\x1b[31mred\x1b[0m");
+        err.insert_key_value("nul", "a\x00b");
+        err.insert_key_value("del", "a\x7fb");
+        err.insert_key_value("bel", "a\x07b");
+        err.insert_key_value("c1", "a\u{9b}b");
+
+        let s = format!("{err}");
+
+        // No literal control bytes leaked through.
+        for bad in ['\x00', '\x07', '\x1b', '\x7f', '\u{9b}'] {
+            assert!(
+                !s.contains(bad),
+                "raw control char {bad:?} leaked into output: {s:?}"
+            );
+        }
+
+        // Escaped forms are present.
+        assert!(s.contains(r"\u{1b}"), "got: {s:?}");
+        assert!(s.contains(r"\u{0}"), "got: {s:?}");
+        assert!(s.contains(r"\u{7f}"), "got: {s:?}");
+        assert!(s.contains(r"\u{7}"), "got: {s:?}");
+        assert!(s.contains(r"\u{9b}"), "got: {s:?}");
+
+        // Existing structural escapes still work.
+        let src2 = BoomError;
+        let mut err2 = ErrorWithContext::new(BoxError::from(src2));
+        err2.insert_key_value("q", "a\"b\\c");
+        let s2 = format!("{err2}");
+        assert!(s2.contains(r#"q="a\"b\\c""#), "got: {s2:?}");
+    }
+
+    #[test]
+    fn cause_chain_is_capped_to_avoid_unbounded_loops() {
+        // A malicious Error impl can return a cycle from .source(); make sure
+        // alternate Display still terminates.
+        struct Cycle;
+        impl fmt::Debug for Cycle {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("cycle")
+            }
+        }
+        impl fmt::Display for Cycle {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("cycle")
+            }
+        }
+        impl StdError for Cycle {
+            fn source(&self) -> Option<&(dyn StdError + 'static)> {
+                // Self-cycle: returns itself as its own source.
+                Some(self)
+            }
+        }
+
+        let err = ErrorWithContext::new(Box::new(Cycle));
+        let s = format!("{err:#}");
+        assert!(s.contains("(truncated)"), "got: {s:?}");
     }
 }

--- a/rama-error/src/ext/mod.rs
+++ b/rama-error/src/ext/mod.rs
@@ -16,10 +16,10 @@ use crate::{
 ///
 /// See the [module level documentation](crate) for more information.
 pub trait ErrorContext: private::SealedErrorContext {
-    /// The resulting contexct type after adding context to the contained error.
+    /// The resulting context type after adding context to the contained error.
     type Context;
 
-    /// The resulting contexct type after turning the error into an opaque error
+    /// The resulting context type after turning the error into an opaque error
     type OpaqueContext;
 
     /// Return a err variant for [`Self::Context`] as [`BoxError`].
@@ -34,13 +34,13 @@ pub trait ErrorContext: private::SealedErrorContext {
         M: fmt::Debug + fmt::Display + Send + Sync + 'static;
 
     /// Add context to the contained error,
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn context_hex<M>(self, value: M) -> Self::Context
     where
         M: fmt::Debug + Send + Sync + 'static;
 
     /// Add context to the contained error,
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn context_debug<M>(self, value: M) -> Self::Context
     where
         M: fmt::Debug + Send + Sync + 'static;
@@ -58,13 +58,13 @@ pub trait ErrorContext: private::SealedErrorContext {
         M: Into<String>;
 
     /// Add keyed context to the contained error
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn context_hex_field<M>(self, key: &'static str, value: M) -> Self::Context
     where
         M: fmt::Debug + Send + Sync + 'static;
 
     /// Add keyed context to the contained error
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn context_debug_field<M>(self, key: &'static str, value: M) -> Self::Context
     where
         M: fmt::Debug + Send + Sync + 'static;
@@ -76,14 +76,14 @@ pub trait ErrorContext: private::SealedErrorContext {
         F: FnOnce() -> C;
 
     /// Lazily add a context to the contained error, if it exists.
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn with_context_hex<C, F>(self, cb: F) -> Self::Context
     where
         C: fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> C;
 
     /// Lazily add a context to the contained error, if it exists.
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn with_context_debug<C, F>(self, cb: F) -> Self::Context
     where
         C: fmt::Debug + Send + Sync + 'static,
@@ -104,14 +104,14 @@ pub trait ErrorContext: private::SealedErrorContext {
         F: FnOnce() -> C;
 
     /// Lazily add keyed context to the contained error, if it exists
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn with_context_hex_field<C, F>(self, key: &'static str, cb: F) -> Self::Context
     where
         C: fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> C;
 
     /// Lazily add keyed context to the contained error, if it exists
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn with_context_debug_field<C, F>(self, key: &'static str, cb: F) -> Self::Context
     where
         C: fmt::Debug + Send + Sync + 'static,
@@ -412,9 +412,9 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => {
-                Err(OpaqueError::from_static_str("Option is None").with_context_str_field(key, cb))
-            }
+            None => Err(OpaqueError::from_static_str("Option is None")
+                .context_debug_field("type", core::any::type_name::<Self>())
+                .with_context_str_field(key, cb)),
         }
     }
 
@@ -425,9 +425,9 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => {
-                Err(OpaqueError::from_static_str("Option is None").with_context_hex_field(key, cb))
-            }
+            None => Err(OpaqueError::from_static_str("Option is None")
+                .context_debug_field("type", core::any::type_name::<Self>())
+                .with_context_hex_field(key, cb)),
         }
     }
 
@@ -438,10 +438,9 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => {
-                Err(OpaqueError::from_static_str("Option is None")
-                    .with_context_debug_field(key, cb))
-            }
+            None => Err(OpaqueError::from_static_str("Option is None")
+                .context_debug_field("type", core::any::type_name::<Self>())
+                .with_context_debug_field(key, cb)),
         }
     }
 }
@@ -466,13 +465,13 @@ pub trait ErrorExt: private::SealedErrorExt {
         M: fmt::Debug + fmt::Display + Send + Sync + 'static;
 
     /// Wrap the error in a context,
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn context_hex<M>(self, value: M) -> BoxError
     where
         M: fmt::Debug + Send + Sync + 'static;
 
     /// Wrap the error in a context,
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn context_debug<M>(self, value: M) -> BoxError
     where
         M: fmt::Debug + Send + Sync + 'static;
@@ -490,13 +489,13 @@ pub trait ErrorExt: private::SealedErrorExt {
         M: Into<String>;
 
     /// Wrap the error in a keyed context,
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn context_hex_field<M>(self, key: &'static str, value: M) -> BoxError
     where
         M: fmt::Debug + Send + Sync + 'static;
 
     /// Wrap the error in a keyed context,
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn context_debug_field<M>(self, key: &'static str, value: M) -> BoxError
     where
         M: fmt::Debug + Send + Sync + 'static;
@@ -508,14 +507,14 @@ pub trait ErrorExt: private::SealedErrorExt {
         F: FnOnce() -> C;
 
     /// Lazily wrap the error with a context,
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn with_context_hex<C, F>(self, cb: F) -> BoxError
     where
         C: fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> C;
 
     /// Lazily wrap the error with a context,
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn with_context_debug<C, F>(self, cb: F) -> BoxError
     where
         C: fmt::Debug + Send + Sync + 'static,
@@ -536,14 +535,14 @@ pub trait ErrorExt: private::SealedErrorExt {
         F: FnOnce() -> C;
 
     /// Lazily wrap the error with keyed context
-    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and `[fmt::Display`].
+    /// using [`fmt::LowerHex`] as [`fmt::Debug`] and [`fmt::Display`].
     fn with_context_hex_field<C, F>(self, key: &'static str, cb: F) -> BoxError
     where
         C: fmt::Debug + Send + Sync + 'static,
         F: FnOnce() -> C;
 
     /// Lazily wrap the error with keyed context
-    /// using [`fmt::Debug`] as `[fmt::Display`].
+    /// using [`fmt::Debug`] as [`fmt::Display`].
     fn with_context_debug_field<C, F>(self, key: &'static str, cb: F) -> BoxError
     where
         C: fmt::Debug + Send + Sync + 'static,
@@ -716,6 +715,11 @@ impl<Error: Into<BoxError>> ErrorExt for Error {
 }
 
 mod private {
+    // These sealed traits document intent rather than enforce hard closure:
+    // because the blanket impls cover every type that satisfies the public
+    // trait bounds, any downstream type that meets those bounds will satisfy
+    // the seal too. The seal exists to discourage hand-rolled impls and to
+    // keep the surface listed in one place — not as an unbypassable boundary.
     pub trait SealedErrorContext {}
 
     impl<T, E> SealedErrorContext for Result<T, E> where E: Into<crate::BoxError> {}
@@ -910,6 +914,48 @@ mod tests {
         // Source chain still points to underlying error
         let src = err.source().expect("source exists");
         assert_eq!(src.to_string(), "boom");
+    }
+
+    #[test]
+    fn option_with_context_str_field_none_includes_type_debug_field() {
+        let opt: Option<i32> = None;
+        let err = opt
+            .with_context_str_field("k", || "v".to_owned())
+            .unwrap_err();
+        let s = format!("{err}");
+
+        assert!(s.starts_with("Option is None"), "got: {s:?}");
+        // The `type` debug field is attached on every Option<None> error path,
+        // including the lazy str/hex/debug field variants.
+        assert!(s.contains("type="), "got: {s:?}");
+        assert!(s.contains("Option<i32>"), "got: {s:?}");
+        assert!(s.contains(r#"k="v""#), "got: {s:?}");
+    }
+
+    #[test]
+    fn option_with_context_hex_field_none_includes_type_debug_field() {
+        let opt: Option<i32> = None;
+        let err = opt.with_context_hex_field("addr", || 0xfeu8).unwrap_err();
+        let s = format!("{err}");
+
+        assert!(s.starts_with("Option is None"), "got: {s:?}");
+        assert!(s.contains("type="), "got: {s:?}");
+        assert!(s.contains("Option<i32>"), "got: {s:?}");
+        assert!(s.contains("addr="), "got: {s:?}");
+    }
+
+    #[test]
+    fn option_with_context_debug_field_none_includes_type_debug_field() {
+        let opt: Option<i32> = None;
+        let err = opt
+            .with_context_debug_field("payload", || ("a", 1u32))
+            .unwrap_err();
+        let s = format!("{err}");
+
+        assert!(s.starts_with("Option is None"), "got: {s:?}");
+        assert!(s.contains("type="), "got: {s:?}");
+        assert!(s.contains("Option<i32>"), "got: {s:?}");
+        assert!(s.contains("payload="), "got: {s:?}");
     }
 
     #[test]


### PR DESCRIPTION
Escape all Unicode control chars in LogfmtEscaper (ANSI ESC, NUL, DEL, C1) to prevent terminal-escape/log-injection; fix three Option<T>::with_context_{str,hex,debug}_field impls that dropped the type debug field; cap source-chain walk at depth 64; fix rustdoc typos and broken backticks; document seal intent.