### PR TITLE
Switch to res_nsearch

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -188,7 +188,7 @@ Other locations that demonstrate how to make and run a Transparent Proxy:
 - [`native_dns.rs`](./native_dns.rs) - Resolve domains using Rama's native DNS resolver,
   - with Apple-native DNS-SD support on Apple platforms
   - `DnsQueryEx` on Windows
-  - `res_nquery` on gnu/bsd
+  - `res_nsearch` on gnu/bsd
   - `getaddrinfo` on other Linux platforms,
   - and tokio's basic `lookup_host` on everything else
 - [`tcp_listener_fd_passing.rs`](./tcp_listener_fd_passing.rs) - FD passing via SCM_RIGHTS for zero-downtime restarts (Unix-only)

--- a/rama-dns/build.rs
+++ b/rama-dns/build.rs
@@ -11,12 +11,12 @@ fn main() {
 
     let target_os = env::var("CARGO_CFG_TARGET_OS").ok();
     let target_env = env::var("CARGO_CFG_TARGET_ENV").ok();
-    let uses_res_nquery = matches!(
+    let uses_res_nsearch = matches!(
         (target_os.as_deref(), target_env.as_deref()),
         (Some("linux"), Some("gnu")) | (Some("freebsd" | "openbsd" | "netbsd"), _)
     );
 
-    if !uses_res_nquery {
+    if !uses_res_nsearch {
         return;
     }
 

--- a/rama-dns/src/client/linux/legacy.rs
+++ b/rama-dns/src/client/linux/legacy.rs
@@ -65,7 +65,7 @@ where
                         %err,
                         "linux::getaddrinfo: item failed to resolve on time: return timeout error",
                     );
-                    // `res_nquery` is a blocking libc call, so timing out here only stops
+                    // `getaddrinfo` is a blocking libc call, so timing out here only stops
                     // waiting for the worker result; it does not cancel the underlying OS
                     // resolver call once it has started.
                     yielder

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -1,7 +1,10 @@
 //! Linux-native DNS resolver.
 //!
-//! On targets with `res_nquery` support, `A` / `AAAA` / `TXT` lookups are
-//! backed by the native resolver stub.
+//! On targets with `res_nsearch` support, `A` / `AAAA` / `TXT` lookups are
+//! backed by the native resolver stub. `res_nsearch` (not `res_nquery`) is
+//! used so the resolver walks the `search` list from `/etc/resolv.conf` and
+//! respects `ndots`, matching the behavior of `getaddrinfo` and hickory's
+//! system resolver.
 //!
 //! On other Linux libc environments, address lookups fall back to
 //! `getaddrinfo`, while TXT lookups return a stable unsupported error.
@@ -44,13 +47,13 @@ mod legacy;
     target_os = "openbsd",
     target_os = "netbsd",
 ))]
-mod res_nquery;
+mod res_nsearch;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
 const DEFAULT_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(30);
 const DEFAULT_CACHE_CAPACITY: u64 = 65_536;
-/// Default `res_nquery` response buffer size.
+/// Default `res_nsearch` response buffer size.
 ///
 /// Most DNS responses fit comfortably in 4 KiB, but large TXT/AAAA fan-outs
 /// (DKIM, long SPF, multi-record AAAA sets) can exceed that. 16 KiB matches
@@ -113,7 +116,7 @@ impl LinuxDnsResolverBuilder {
     }
 
     generate_set_and_with! {
-        /// Per-query response buffer size used by `res_nquery`. Responses that
+        /// Per-query response buffer size used by `res_nsearch`. Responses that
         /// exceed this bound are reported as an error; bump this for workloads
         /// that legitimately receive large TXT/AAAA fan-outs.
         pub fn response_buffer_size(mut self, response_buffer_size: usize) -> Self {
@@ -267,14 +270,14 @@ impl DnsResolver for LinuxDnsResolver {}
 /// Events emitted by uncached lookup streams.
 ///
 /// `AuthoritativeNegative` is only emitted by backends that can distinguish
-/// "the zone says there is no such record" (the `res_nquery` path) from
+/// "the zone says there is no such record" (the `res_nsearch` path) from
 /// "this lookup returned nothing for unrelated reasons" (the legacy
 /// `getaddrinfo` path, where `AI_ADDRCONFIG` can suppress whole families
 /// based on local interface state). Only the former is safe to cache as a
 /// negative entry.
 pub(super) enum LookupEvent<T> {
     Record(T, u32),
-    // Only constructed by the `res_nquery` backend (glibc / BSDs). The
+    // Only constructed by the `res_nsearch` backend (glibc / BSDs). The
     // legacy `getaddrinfo` fallback (used on e.g. musl) cannot distinguish
     // authoritative DNS negatives from local-policy empties — see
     // `legacy.rs` — so it never emits this variant. The `cfg_attr` only
@@ -287,7 +290,7 @@ pub(super) enum LookupEvent<T> {
             target_os = "openbsd",
             target_os = "netbsd",
         )),
-        expect(dead_code, reason = "only constructed by the res_nquery backend")
+        expect(dead_code, reason = "only constructed by the res_nsearch backend")
     )]
     AuthoritativeNegative {
         soa_ttl: Option<u32>,
@@ -379,7 +382,7 @@ fn lookup_ipv4_uncached_stream(
     timeout: Duration,
     response_buffer_size: usize,
 ) -> impl Stream<Item = Result<LookupEvent<Ipv4Addr>, BoxError>> + Send {
-    res_nquery::lookup_ipv4_stream(domain, timeout, response_buffer_size)
+    res_nsearch::lookup_ipv4_stream(domain, timeout, response_buffer_size)
 }
 
 #[cfg(not(any(
@@ -407,7 +410,7 @@ fn lookup_ipv6_uncached_stream(
     timeout: Duration,
     response_buffer_size: usize,
 ) -> impl Stream<Item = Result<LookupEvent<Ipv6Addr>, BoxError>> + Send {
-    res_nquery::lookup_ipv6_stream(domain, timeout, response_buffer_size)
+    res_nsearch::lookup_ipv6_stream(domain, timeout, response_buffer_size)
 }
 
 #[cfg(not(any(
@@ -435,7 +438,7 @@ fn lookup_txt_uncached_stream(
     timeout: Duration,
     response_buffer_size: usize,
 ) -> impl Stream<Item = Result<LookupEvent<Bytes>, BoxError>> + Send {
-    res_nquery::lookup_txt_stream(domain, timeout, response_buffer_size)
+    res_nsearch::lookup_txt_stream(domain, timeout, response_buffer_size)
 }
 
 #[cfg(not(any(

--- a/rama-dns/src/client/linux/res_nsearch.rs
+++ b/rama-dns/src/client/linux/res_nsearch.rs
@@ -77,7 +77,7 @@ where
     P: Fn(&[u8], &mut dyn FnMut(T, u32)) -> Result<(), BoxError> + Send + 'static,
 {
     stream_fn(async move |mut yielder| {
-        tracing::debug!(?timeout, %domain, rrtype, "dns::linux: res_nquery");
+        tracing::debug!(?timeout, %domain, rrtype, "dns::linux: res_nsearch");
 
         let (tx, rx) = mpsc::channel(8);
         let join = tokio::task::spawn_blocking(move || {
@@ -114,9 +114,9 @@ where
                 Err(err) => {
                     tracing::debug!(
                         %err,
-                        "linux::res_nquery: item failed to resolve on time: return timeout error",
+                        "linux::res_nsearch: item failed to resolve on time: return timeout error",
                     );
-                    // `res_nquery` is a blocking libc call, so timing out here only stops
+                    // `res_nsearch` is a blocking libc call, so timing out here only stops
                     // waiting for the worker result; it does not cancel the underlying OS
                     // resolver call once it has started.
                     yielder
@@ -132,14 +132,14 @@ where
             Ok(Err(err)) => {
                 yielder
                     .yield_item(Err(LinuxDnsResolverError::message(format!(
-                        "linux dns res_nquery task failed: {err}"
+                        "linux dns res_nsearch task failed: {err}"
                     ))
                     .into()))
                     .await;
             }
             Err(err) => {
                 tracing::debug!(
-                    "linux::res_nquery: lookup_record_stream error = {err} (report as timeout)"
+                    "linux::res_nsearch: lookup_record_stream error = {err} (report as timeout)"
                 );
                 yielder
                     .yield_item(Err(LinuxDnsResolverError::timeout(timeout).into()))
@@ -173,8 +173,13 @@ fn lookup_record_packet(
     // - `state` is initialized by `res_ninit`.
     // - `name` is a valid NUL-terminated DNS name.
     // - `buffer` is writable response storage.
+    //
+    // `res_nsearch` (vs `res_nquery`) walks the search list from
+    // `/etc/resolv.conf` and applies the `ndots` rule, so short / unqualified
+    // names resolve the same way `getaddrinfo` and hickory's system resolver
+    // would resolve them.
     let response_len = unsafe {
-        ffi::res_nquery(
+        ffi::res_nsearch(
             &mut state,
             name.as_ptr(),
             ffi::NS_C_IN as libc::c_int,
@@ -187,9 +192,9 @@ fn lookup_record_packet(
     if response_len < 0 {
         let h_errno = state.res_h_errno;
         if matches!(h_errno, 0 | ffi::HOST_NOT_FOUND | ffi::NO_DATA) {
-            tracing::debug!(%domain, rrtype, h_errno, "dns::linux: res_nquery empty result");
+            tracing::debug!(%domain, rrtype, h_errno, "dns::linux: res_nsearch empty result");
             // glibc copies the wire response into `buffer` before classifying
-            // the rcode and returning -1 (see `__libc_res_nquery` in
+            // the rcode and returning -1 (see `__libc_res_nsearch` in
             // `resolv/res_query.c`). The exact response length isn't surfaced,
             // but the parser walks via DNS header counts and bounds itself on
             // `packet.len()`, so handing over the full capacity is safe — any
@@ -200,14 +205,14 @@ fn lookup_record_packet(
             return Ok(Some(buffer));
         }
         return Err(LinuxDnsResolverError::message(format!(
-            "res_nquery failed (h_errno={h_errno})",
+            "res_nsearch failed (h_errno={h_errno})",
         ))
         .into());
     }
 
     if response_len as usize > buffer.len() {
         return Err(LinuxDnsResolverError::message(format!(
-            "res_nquery response exceeds buffer: required={response_len} capacity={}",
+            "res_nsearch response exceeds buffer: required={response_len} capacity={}",
             buffer.len()
         ))
         .into());
@@ -499,7 +504,7 @@ mod ffi {
     // GNU/Linux symbol mapping:
     // - `res_ninit` is exported as `__res_ninit`
     // - `res_nclose` is exported as `__res_nclose`
-    // - `res_nquery` is exported as `res_nquery`
+    // - `res_nsearch` is exported as `res_nsearch`
     //
     // Sources:
     // - https://codebrowser.dev/glibc/glibc/resolv/res_init.c.html
@@ -513,7 +518,7 @@ mod ffi {
         pub(super) fn res_ninit(state: *mut ResState) -> c_int;
         #[link_name = "__res_nclose"]
         pub(super) fn res_nclose(state: *mut ResState);
-        pub(super) fn res_nquery(
+        pub(super) fn res_nsearch(
             state: *mut ResState,
             dname: *const c_char,
             class: c_int,
@@ -535,7 +540,7 @@ mod ffi {
     unsafe extern "C" {
         pub(super) fn res_ninit(state: *mut ResState) -> c_int;
         pub(super) fn res_nclose(state: *mut ResState);
-        pub(super) fn res_nquery(
+        pub(super) fn res_nsearch(
             state: *mut ResState,
             dname: *const c_char,
             class: c_int,
@@ -636,7 +641,7 @@ mod soa_ttl_tests {
 
     #[test]
     fn tolerates_trailing_zeros_after_response() {
-        // Simulates `res_nquery` returning -1 with the wire response copied
+        // Simulates `res_nsearch` returning -1 with the wire response copied
         // into a larger zeroed buffer: the parser must terminate via header
         // counts, not run off into the padding.
         let mut packet = build_negative_response(120, 90);

--- a/rama-dns/src/lib.rs
+++ b/rama-dns/src/lib.rs
@@ -31,7 +31,7 @@
 //! are fully asynchronous and scale naturally — no tokio blocking-pool
 //! traffic.
 //!
-//! `LinuxDnsResolver` (via `res_nquery` / `getaddrinfo`) and
+//! `LinuxDnsResolver` (via `res_nsearch` / `getaddrinfo`) and
 //! [`client::TokioDnsResolver`] (via `getaddrinfo`) are different: each
 //! lookup occupies a tokio blocking-pool thread for the duration of the
 //! libc call. Under sustained high-concurrency DNS load (typical for


### PR DESCRIPTION
Switch from `res_nquery` to `res_nsearch`:
- `res_nquery` only does fqdn lookups
- `res_nsearch` respects "search" and "ndots" in resolv.conf

The latter is consistent with `getaddrinfo` and `HickoryDnsResolver::try_new_system()` and will be drop in replacement. For fqdn one can still just use a domain ending in "."