### PR TITLE
mdbook workflow: use rust-cache composite action for Windows retry

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: Conditional save (forwarded to rust-cache)
     required: false
     default: "true"
+  cache-bin:
+    description: Whether to cache ~/.cargo/bin (forwarded to rust-cache)
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -28,6 +32,7 @@ runs:
           key: ${{ inputs.key }}
           env-vars: ${{ inputs.env-vars }}
           save-if: ${{ inputs.save-if }}
+          cache-bin: ${{ inputs.cache-bin }}
 
     - name: Rust cache
       if: runner.os != 'Windows'
@@ -36,3 +41,4 @@ runs:
         key: ${{ inputs.key }}
         env-vars: ${{ inputs.env-vars }}
         save-if: ${{ inputs.save-if }}
+        cache-bin: ${{ inputs.cache-bin }}

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -47,10 +47,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      - uses: ./.github/actions/rust-cache
         with:
           key: doc-linux
-          cache-bin: false
+          cache-bin: "false"
       - name: cargo doc (linux)
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
@@ -68,10 +68,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      - uses: ./.github/actions/rust-cache
         with:
           key: doc-macos
-          cache-bin: false
+          cache-bin: "false"
       - name: cargo doc (macos)
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
@@ -90,10 +90,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      - uses: ./.github/actions/rust-cache
         with:
           key: doc-windows
-          cache-bin: false
+          cache-bin: "false"
       - name: cargo doc (windows)
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
@@ -117,10 +117,10 @@ jobs:
         with:
           toolchain: nightly
           targets: aarch64-linux-android
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      - uses: ./.github/actions/rust-cache
         with:
           key: doc-android
-          cache-bin: false
+          cache-bin: "false"
       - name: Configure Android toolchain env
         shell: bash
         run: |
@@ -174,10 +174,10 @@ jobs:
         with:
           toolchain: nightly
           targets: aarch64-apple-ios
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+      - uses: ./.github/actions/rust-cache
         with:
           key: doc-ios
-          cache-bin: false
+          cache-bin: "false"
       - name: cargo doc (ios)
         run: cargo +nightly doc --all-features --no-deps -p rama --target $TARGET_TRIPLE
         env:


### PR DESCRIPTION
Swap the 5 direct `Swatinem/rust-cache@…` calls in `mdbook.yml` for the shared `./.github/actions/rust-cache` composite, so the Windows doc job gets the same 3× retry on tar flakiness as the rest of CI. Adds a `cache-bin` input to the composite (default `"true"`) so the mdbook jobs can keep `cache-bin: false`.