### PR TITLE
add http PartialUpdates + html::marker helper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -628,6 +628,10 @@ name = "http_connect_proxy"
 required-features = ["http-full"]
 
 [[example]]
+name = "http_declarative_partial_updates"
+required-features = ["http-full"]
+
+[[example]]
 name = "http_form"
 required-features = ["http-full"]
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -64,6 +64,7 @@
 - [Http Clients](./http/http_clients.md)
 - [gRPC](./http/grpc.md)
 - [Server-Sent Events (SSE)](./http/sse.md)
+- [Declarative Partial Updates](./http/declarative_partial_updates.md)
 - [WebSockets (WS)](./http/ws.md)
 - [HTTP Archive format (HAR)](./http/har.md)
 - [Binary Bodies and Multipart Uploads](./http/multipart.md)

--- a/docs/book/src/http/declarative_partial_updates.md
+++ b/docs/book/src/http/declarative_partial_updates.md
@@ -1,0 +1,104 @@
+# Declarative Partial Updates
+
+<div class="book-article-intro">
+    <div>
+        Declarative Partial Updates let a server stream an HTML "shell" first
+        and then fill in slow fragments out-of-order — in the same response —
+        as each fragment becomes ready. The page lays out instantly; each
+        panel pops in when its data arrives.
+        <p>— <a href="https://developer.chrome.com/blog/declarative-partial-updates">developer.chrome.com</a></p>
+    </div>
+</div>
+
+## Description
+
+This is **not** SSE and **not** a new protocol. It's a plain `text/html`
+streaming response, with two pieces the browser parser knows how to interpret
+incrementally:
+
+- `<?marker name="x">` processing instructions in the shell mark insertion
+  points.
+- `<template for="x">…</template>` blocks emitted later in the same response
+  carry the rendered fragment; the parser swaps each template's contents into
+  the matching marker as it appears.
+
+The wire is just HTTP/1.1 chunked transfer (or HTTP/2 DATA frames):
+
+```
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+Transfer-Encoding: chunked
+
+  -- chunk 1: the shell with <?marker …> placeholders, flushed immediately
+  -- chunk 2: <template for="ping">…</template>   (200ms later)
+  -- chunk 3: <template for="herd">…</template>   (900ms later)
+  -- chunk 4: <template for="recs">…</template>   (1500ms later)
+```
+
+Native support shipped in Chrome 148+ behind
+`chrome://flags/#enable-experimental-web-platform-features`. Since that
+flag is rarely on, the example ships a tiny inline polyfill in the shell
+(synchronous, in `<head>`) that scans for `<?marker …>` comment nodes and
+applies `<template for=…>` blocks via `MutationObserver` as they stream
+in. (The GoogleChromeLabs `template-for-polyfill` exists, but it batches
+body-level swaps until `DOMContentLoaded`, which only fires after the
+streaming body completes — fragments would all appear at once at the end.)
+
+## Rama Support
+
+> 📚 Rust Docs: <https://ramaproxy.org/docs/rama/http/service/web/response/struct.PartialUpdates.html>
+
+Enable the `http` feature and the `html` feature (or even better `http-full` to cover it all),
+then use `PartialUpdates` together with the `marker()` helper from `rama::http::html`:
+
+```rust,ignore
+use rama::http::html::*;
+use rama::http::service::web::response::PartialUpdates;
+use rama::http::Response;
+use std::time::Duration;
+
+async fn dashboard() -> Response {
+    let shell = html!(
+        head!(title!("dashboard")),
+        body!(
+            section!(marker("ping")),
+            section!(marker("herd")),
+            section!(marker("recs")),
+        ),
+    );
+
+    PartialUpdates::new(shell)
+        .fragment("recs", async {
+            tokio::time::sleep(Duration::from_millis(1500)).await;
+            ul!(li!("rec 1"), li!("rec 2"))
+        })
+        .fragment("herd", async {
+            tokio::time::sleep(Duration::from_millis(900)).await;
+            p!("42 alive")
+        })
+        .fragment("ping", async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            p!("ok")
+        })
+        .into_response()
+}
+```
+
+Fragments are raced via `FuturesUnordered` and each completion flushes its
+own `<template for=…>` body chunk — so the browser sees fragments arrive in
+*completion order*, not declaration order.
+
+### Example
+
+[`http_declarative_partial_updates.rs`](https://github.com/plabayo/rama/blob/main/examples/http_declarative_partial_updates.rs)
+serves a llama-themed dashboard with three slow panels and demonstrates
+the UA-driven CDN polyfill injection for non-Chrome-148 browsers.
+
+## Relation to SSE
+
+[Server-Sent Events](./sse.md) push *typed events* on `text/event-stream`
+and are consumed by JS via `EventSource`. Declarative partial updates push
+*HTML fragments* on `text/html` and are consumed by the browser parser
+directly — no JS needed (on Chrome 148+). Use SSE for live data streams
+that the page renders; use partial updates for the first page render itself
+when some panels are slower than others.

--- a/docs/book/src/http/sse.md
+++ b/docs/book/src/http/sse.md
@@ -131,3 +131,11 @@ by introducing hicups while waiting for the next "flush".
 If you do need compression you are best to do it on a per-message base (e.g. compress
 the data property within an SSE event), which is also an extension that is possible
 in WebSockets.
+
+## See also
+
+If your goal is to render an initial HTML page whose slowest panels should not
+hold back the rest, see [Declarative Partial Updates](./declarative_partial_updates.md):
+the server streams an HTML shell first, then `<template for=…>` blocks fill in
+the markers out-of-order on a regular `text/html` response — no `EventSource`
+required.

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,10 @@ See [the gRPC examples README at ./grpc/README.md](./grpc/README.md).
 
 - [`http_nd_json`](./http_nd_json.rs) - example demonstrating how one can expose a json stream endpoint (see test of this example to see how client side works)
 
+### Streaming HTML
+
+- [`http_declarative_partial_updates`](./http_declarative_partial_updates.rs) - stream an HTML shell with `<?marker …>` placeholders, then fill them in out-of-order via `<template for=…>` as each async fragment completes ([Chrome declarative partial updates](https://developer.chrome.com/blog/declarative-partial-updates))
+
 ### Server-Sent Events (SSE)
 - [`http_sse`](./http_sse.rs) - simple example demonstrating how one can expose an SSE endpoint
 - [`http_sse_json`](./http_sse_json.rs) - same as `http_sse` but using structured _json_ data

--- a/examples/http_declarative_partial_updates.rs
+++ b/examples/http_declarative_partial_updates.rs
@@ -1,0 +1,273 @@
+//! Declarative Partial Updates — stream an HTML shell first, fill in
+//! slow fragments out-of-order as each future completes.
+//!
+//! Based on: <https://developer.chrome.com/blog/declarative-partial-updates>
+//!
+//! # Run the example
+//!
+//! ```sh
+//! cargo run --example http_declarative_partial_updates --features=http-full
+//! ```
+//!
+//! # Expected output
+//!
+//! Server listens on `:64805`. Open in a browser:
+//!
+//! ```sh
+//! open http://127.0.0.1:64805
+//! ```
+//!
+//! The 🦙 dashboard shell appears immediately with a "loading…" banner and
+//! three spinning-llama skeletons declared `recs → herd → ping`. Fragments
+//! stream back in the reverse order: `ping` (~500ms), `herd` (~2s),
+//! `recs` (~4s) — each skeleton swaps out as its content lands; the banner
+//! disappears once all three have arrived.
+//!
+//! The shell carries a small inline polyfill (`<script>` in `<head>`,
+//! synchronous) that wires up the `<?marker …>` ↔ `<template for=…>` swap
+//! via `MutationObserver`. We can't reuse GoogleChromeLabs'
+//! `template-for-polyfill` for this — it explicitly batches body-level
+//! template swaps until `DOMContentLoaded` fires, which only happens after
+//! the streaming response closes, so every fragment would appear at once
+//! at the end. Chrome 148+ ships native support behind
+//! `chrome://flags/#enable-experimental-web-platform-features`; the inline
+//! polyfill is harmless when native already swapped.
+//!
+//! The pipeline also layers in [`StreamCompressionLayer`] (so each
+//! fragment chunk is compressed and flushed on its own, not held back
+//! until the body ends) and [`AddRequiredResponseHeadersLayer`] (so the
+//! response carries the usual server/date/request-id headers).
+//!
+//! [`StreamCompressionLayer`]: rama::http::layer::compression::stream::StreamCompressionLayer
+//! [`AddRequiredResponseHeadersLayer`]: rama::http::layer::required_header::AddRequiredResponseHeadersLayer
+
+#![expect(
+    clippy::expect_used,
+    reason = "example: panic-on-error is the standard demo pattern"
+)]
+
+use rama::{
+    Layer,
+    http::{
+        Response,
+        html::{
+            IntoHtml, PreEscaped, body, div, h1, h2, head, html, li, marker, meta, p, script,
+            section, span, style, title, ul,
+        },
+        layer::{
+            compression::stream::StreamCompressionLayer,
+            required_header::AddRequiredResponseHeadersLayer, trace::TraceLayer,
+        },
+        server::HttpServer,
+        service::web::{
+            Router,
+            response::{IntoResponse, PartialUpdates},
+        },
+    },
+    layer::ArcLayer,
+    net::address::SocketAddress,
+    rt::Executor,
+    tcp::server::TcpListener,
+    telemetry::tracing::{
+        self,
+        level_filters::LevelFilter,
+        subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt},
+    },
+};
+use std::time::Duration;
+
+const POLYFILL: &str = "\
+(()=>{\
+  /* Feature-detect native declarative-partial-updates: if the marker is\
+     consumed during fragment parsing, the firstChild of the parsed fragment\
+     is null. When that's the case we skip our marker->template swap and\
+     let the browser do it; we still run the mutation observer so the loaded\
+     state attributes get set the same way for both code paths. */\
+  let native=false;\
+  try{\
+    native=document.createRange()\
+      .createContextualFragment('<?marker name=__dpu_t><template for=__dpu_t></template>')\
+      .firstChild===null;\
+  }catch{}\
+  const findMarker=(name)=>{\
+    const it=document.createNodeIterator(document,NodeFilter.SHOW_COMMENT);\
+    let n;\
+    while((n=it.nextNode())){\
+      const d=n.data||'';\
+      if(/^\\?marker\\b/.test(d)){\
+        const m=d.match(/\\bname *= *\"?([^\"\\s]+)\"?/);\
+        if(m&&m[1]===name)return n;\
+      }\
+    }\
+    return null;\
+  };\
+  const swap=(t)=>{\
+    if(native)return;\
+    const name=t.getAttribute('for');\
+    if(!name)return;\
+    const m=findMarker(name);\
+    if(!m)return;\
+    m.replaceWith(t.content.cloneNode(true));\
+    t.remove();\
+  };\
+  const markLoaded=(panel)=>{\
+    if(panel.hasAttribute('data-dpu-loaded'))return;\
+    panel.setAttribute('data-dpu-loaded','');\
+    const ps=document.querySelectorAll('section.panel');\
+    const ld=document.querySelectorAll('section.panel[data-dpu-loaded]');\
+    if(ps.length>0&&ps.length===ld.length)\
+      document.body.setAttribute('data-dpu-done','');\
+  };\
+  if(!native)document.querySelectorAll('template[for]').forEach(swap);\
+  new MutationObserver(ms=>{\
+    for(const m of ms){\
+      if(!native)for(const n of m.addedNodes)\
+        if(n.nodeType===1&&n.tagName==='TEMPLATE'&&n.hasAttribute('for'))swap(n);\
+      if(m.target instanceof HTMLElement&&m.target.matches('section.panel'))\
+        for(const n of m.addedNodes)\
+          if(n.nodeType===1&&n.tagName!=='H2'&&!(n.classList&&n.classList.contains('spinner'))){\
+            markLoaded(m.target);break;\
+          }\
+    }\
+  }).observe(document,{childList:true,subtree:true});\
+})();\
+";
+
+async fn dashboard() -> Response {
+    let shell = html!(
+        lang = "en",
+        head!(
+            meta!(charset = "utf-8"),
+            title!("🦙 rama partial updates"),
+            style!(PreEscaped(STYLE)),
+            // Synchronous so the MutationObserver is armed before any
+            // body content (and any `<template for=…>`) streams in.
+            script!(PreEscaped(POLYFILL)),
+        ),
+        body!(
+            div!(class = "banner", "loading dashboard… (this can take ~4s)"),
+            h1!("🦙 llama dashboard"),
+            p!(
+                class = "lede",
+                "Three async panels — declared slow → medium → fast — stream \
+                 in reverse as each completes. Their skeletons swap out as \
+                 their fragments arrive.",
+            ),
+            panel("Feed recommendations", "recs"),
+            panel("Herd telemetry", "herd"),
+            panel("Edge ping", "ping"),
+        ),
+    );
+
+    PartialUpdates::new(shell)
+        .fragment("recs", async {
+            tokio::time::sleep(Duration::from_millis(4000)).await;
+            recs()
+        })
+        .fragment("herd", async {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            herd()
+        })
+        .fragment("ping", async {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            ping()
+        })
+        .into_response()
+}
+
+fn panel(heading: &'static str, name: &'static str) -> impl IntoHtml {
+    section!(
+        class = "panel",
+        h2!(heading),
+        div!(class = "spinner", span!(class = "llama", "🦙"), " loading…",),
+        marker(name),
+    )
+}
+
+fn recs() -> impl IntoHtml {
+    ul!(
+        li!("Build a proxy in a weekend"),
+        li!("Llama your TLS termination"),
+        li!("Read the rama book over coffee"),
+    )
+}
+
+fn herd() -> impl IntoHtml {
+    p!(
+        "alive: ",
+        span!(class = "metric", "42"),
+        " · egress: ",
+        span!(class = "metric", "3.7 MB/s"),
+    )
+}
+
+fn ping() -> impl IntoHtml {
+    p!(class = "ok", "all edge nodes responding in <50ms")
+}
+
+#[tokio::main]
+async fn main() {
+    tracing::subscriber::registry()
+        .with(fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::DEBUG.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let graceful = rama::graceful::Shutdown::default();
+    let exec = Executor::graceful(graceful.guard());
+
+    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(64805), exec.clone())
+        .await
+        .expect("tcp port to be bound");
+    let bind_address = listener.local_addr().expect("retrieve bind address");
+
+    tracing::info!(
+        network.local.address = %bind_address.ip(),
+        network.local.port = %bind_address.port(),
+        "http's tcp listener ready to serve",
+    );
+    tracing::info!("open http://{bind_address} in your browser");
+
+    graceful.spawn_task(async move {
+        let app = (
+            TraceLayer::new_for_http(),
+            AddRequiredResponseHeadersLayer::default(),
+            StreamCompressionLayer::new(),
+            ArcLayer::new(),
+        )
+            .into_layer(Router::new().with_get("/", dashboard));
+        listener.serve(HttpServer::auto(exec).service(app)).await;
+    });
+
+    graceful
+        .shutdown_with_limit(Duration::from_secs(30))
+        .await
+        .expect("graceful shutdown");
+}
+
+const STYLE: &str = "\
+body { font-family: system-ui, sans-serif; max-width: 42rem; \
+       margin: 0 auto; padding: 3rem 1rem 2rem; }\
+.banner { position: fixed; top: 1rem; left: 50%; \
+          transform: translateX(-50%); padding: 0.4rem 1rem; \
+          background: #fff3a8; border: 1px solid #c9b400; \
+          border-radius: 999px; font-size: 0.9em; z-index: 100; \
+          transition: opacity 0.25s ease-out; }\
+.lede { color: #555; }\
+.panel { background: #f6f7f9; border-radius: 8px; padding: 1rem; \
+         margin: 1rem 0; min-height: 4rem; }\
+.spinner { display: flex; align-items: center; gap: 0.5em; color: #888; }\
+.spinner .llama { display: inline-block; font-size: 1.6em; \
+                  animation: spin 1.5s linear infinite; }\
+@keyframes spin { from { transform: rotate(0); } \
+                  to   { transform: rotate(360deg); } }\
+.metric { font-family: monospace; font-weight: bold; }\
+.ok { color: #096; }\
+\
+/* the inline polyfill sets these attributes as fragments swap in. */\
+.panel[data-dpu-loaded] .spinner { display: none; }\
+body[data-dpu-done] .banner { opacity: 0; pointer-events: none; }\
+";

--- a/rama-http/src/html/core.rs
+++ b/rama-http/src/html/core.rs
@@ -114,12 +114,52 @@ pub fn escape_into(output: &mut String, input: &str) {
     }
 }
 
-/// HTML-escape `input` and return the resulting `String`.
+/// HTML-escape `input`, returning a [`Cow::Borrowed`] of the original
+/// when nothing needs escaping — common in practice — and otherwise a
+/// freshly allocated [`Cow::Owned`] with the escaped form.
 #[inline]
-pub fn escape(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
+pub fn escape(input: &str) -> Cow<'_, str> {
+    // All escapables are ASCII, so a byte scan on UTF-8 is correct.
+    if !input
+        .bytes()
+        .any(|b| matches!(b, b'&' | b'<' | b'>' | b'"' | b'\''))
+    {
+        return Cow::Borrowed(input);
+    }
+    let mut output = String::with_capacity(input.len() + 8);
     escape_into(&mut output, input);
-    output
+    Cow::Owned(output)
+}
+
+/// Emit a `<?marker name="…">` processing instruction for use as a
+/// placeholder in a [Chrome declarative partial updates] shell. The name is
+/// HTML-escaped via [`escape_into`] on render.
+///
+/// [Chrome declarative partial updates]: https://developer.chrome.com/blog/declarative-partial-updates
+#[inline]
+pub fn marker<S: AsRef<str>>(name: S) -> Marker<S> {
+    Marker(name)
+}
+
+/// Renderer for [`marker`]. Holds the name by-value and writes the PI
+/// directly into the output buffer at render time.
+#[derive(Debug, Clone, Copy)]
+pub struct Marker<S>(pub S);
+
+impl<S: AsRef<str>> IntoHtml for Marker<S> {
+    #[inline]
+    fn into_html(self) -> impl IntoHtml {
+        self
+    }
+    fn escape_and_write(self, buf: &mut String) {
+        buf.push_str(r#"<?marker name=""#);
+        escape_into(buf, self.0.as_ref());
+        buf.push_str(r#"">"#);
+    }
+    fn size_hint(&self) -> usize {
+        // length of `<?marker name="">` + name; escape may grow it a bit.
+        17 + self.0.as_ref().len()
+    }
 }
 
 /// Wrapper that marks its inner value as already-escaped HTML — i.e. it

--- a/rama-http/src/html/mod.rs
+++ b/rama-http/src/html/mod.rs
@@ -71,7 +71,7 @@ mod rama_impls;
 mod response;
 
 #[doc(inline)]
-pub use self::core::{IntoHtml, PreEscaped, escape, escape_into};
+pub use self::core::{IntoHtml, Marker, PreEscaped, escape, escape_into, marker};
 #[doc(inline)]
 pub use self::response::HtmlBuf;
 

--- a/rama-http/src/html/tests/escape.rs
+++ b/rama-http/src/html/tests/escape.rs
@@ -1,11 +1,26 @@
 //! `escape` / `escape_into` are public helpers — exercise them so that
 //! the publicly documented surface keeps working.
 
-use crate::html::{escape, escape_into};
+use std::borrow::Cow;
+
+use crate::html::{IntoHtml, escape, escape_into, marker};
 
 #[test]
-fn escape_returns_owned_string() {
+fn escape_returns_owned_when_needed() {
     assert_eq!(escape("a<b&c"), "a&lt;b&amp;c");
+    assert!(matches!(escape("a<b&c"), Cow::Owned(_)));
+}
+
+#[test]
+fn escape_borrows_when_no_escape_needed() {
+    let input = "alphanumeric-and_safe.0";
+    let out = escape(input);
+    assert_eq!(out, input);
+    // Borrowed Cow points at the same buffer — verify with pointer identity.
+    match out {
+        Cow::Borrowed(s) => assert_eq!(s.as_ptr(), input.as_ptr()),
+        Cow::Owned(_) => panic!("escape allocated for already-safe input"),
+    }
 }
 
 #[test]
@@ -29,4 +44,25 @@ fn escape_single_quote_for_attribute_context() {
 #[test]
 fn escape_all_html_specials() {
     assert_eq!(escape("&<>\"'"), "&amp;&lt;&gt;&quot;&#x27;");
+}
+
+#[test]
+fn marker_emits_processing_instruction() {
+    assert_eq!(marker("cart").into_string(), r#"<?marker name="cart">"#);
+    assert_eq!(
+        marker("herd_42-a").into_string(),
+        r#"<?marker name="herd_42-a">"#
+    );
+}
+
+#[test]
+fn marker_escapes_unsafe_chars() {
+    assert_eq!(
+        marker(r#"a"<&>b"#).into_string(),
+        r#"<?marker name="a&quot;&lt;&amp;&gt;b">"#
+    );
+    assert_eq!(
+        marker(String::from(" with space ")).into_string(),
+        r#"<?marker name=" with space ">"#
+    );
 }

--- a/rama-http/src/service/web/endpoint/response/mod.rs
+++ b/rama-http/src/service/web/endpoint/response/mod.rs
@@ -60,6 +60,13 @@ pub use redirect::Redirect;
 pub mod sse;
 pub use sse::Sse;
 
+#[cfg(feature = "html")]
+#[cfg_attr(docsrs, doc(cfg(feature = "html")))]
+pub mod partial_updates;
+#[cfg(feature = "html")]
+#[cfg_attr(docsrs, doc(cfg(feature = "html")))]
+pub use partial_updates::PartialUpdates;
+
 /// An [`IntoResponse`]-based result type that uses [`ErrorResponse`] as the error type.
 ///
 /// All types which implement [`IntoResponse`] can be converted to an [`ErrorResponse`]. This makes

--- a/rama-http/src/service/web/endpoint/response/partial_updates.rs
+++ b/rama-http/src/service/web/endpoint/response/partial_updates.rs
@@ -1,0 +1,242 @@
+//! Streaming HTML response for [Chrome declarative partial updates].
+//!
+//! Flushes a shell (with `<?marker name="…">` placeholders) immediately,
+//! then emits one `<template for="name">…</template>` body chunk per
+//! fragment as each fragment future resolves — in completion order, not
+//! declaration order.
+//!
+//! [Chrome declarative partial updates]: https://developer.chrome.com/blog/declarative-partial-updates
+
+use rama_core::bytes::Bytes;
+use rama_core::error::BoxError;
+use rama_core::futures::FutureExt;
+use rama_core::futures::future::BoxFuture;
+use rama_core::futures::stream::{self, StreamExt};
+use rama_http_headers::ContentType;
+use rama_http_types::{Body, Response};
+
+use crate::html::{IntoHtml, template};
+
+use super::{Headers, IntoResponse};
+
+/// A streaming HTML response that fills `<?marker name="…">` placeholders
+/// out-of-order as fragment futures complete.
+///
+/// Pair the shell with [`crate::html::marker`] to emit the processing
+/// instructions; this response wraps each fragment's rendered HTML in a
+/// `<template for="name">…</template>` block as it resolves.
+#[must_use]
+pub struct PartialUpdates<H> {
+    shell: H,
+    fragments: Vec<Fragment>,
+}
+
+/// Type-erased renderer: a closure that writes the rendered HTML of a
+/// resolved fragment into a target buffer. Implements [`IntoHtml`] (via
+/// the blanket impl for `FnOnce(&mut String)`), so it slots straight into
+/// the `template!` macro at chunk-emit time — no early `into_string()`,
+/// no manual escaping.
+type FragmentRender = Box<dyn FnOnce(&mut String) + Send + 'static>;
+
+struct Fragment {
+    name: &'static str,
+    future: BoxFuture<'static, Result<FragmentRender, BoxError>>,
+}
+
+impl<H: IntoHtml> PartialUpdates<H> {
+    /// Wrap an HTML `shell` for streaming.
+    pub fn new(shell: H) -> Self {
+        Self {
+            shell,
+            fragments: Vec::new(),
+        }
+    }
+
+    /// Add a fragment whose rendered HTML will be flushed inside a
+    /// `<template for="name">…</template>` block once `fut` resolves.
+    ///
+    /// Whatever the future yields is rendered through [`IntoHtml`] — i.e.
+    /// scalar strings are HTML-escaped, [`PreEscaped`] passes through verbatim,
+    /// and macro-built nodes compose normally.
+    ///
+    /// [`PreEscaped`]: crate::html::PreEscaped
+    pub fn fragment<F, T>(mut self, name: &'static str, fut: F) -> Self
+    where
+        F: Future<Output = T> + Send + 'static,
+        T: IntoHtml + Send + 'static,
+    {
+        self.fragments.push(Fragment {
+            name,
+            future: async move {
+                let value = fut.await;
+                let render: FragmentRender = Box::new(move |buf| value.escape_and_write(buf));
+                Ok(render)
+            }
+            .boxed(),
+        });
+        self
+    }
+
+    /// Like [`Self::fragment`] but the future returns a `Result`; on `Err`
+    /// the body stream terminates with that error.
+    pub fn try_fragment<F, T, E>(mut self, name: &'static str, fut: F) -> Self
+    where
+        F: Future<Output = Result<T, E>> + Send + 'static,
+        T: IntoHtml + Send + 'static,
+        E: Into<BoxError> + Send + 'static,
+    {
+        self.fragments.push(Fragment {
+            name,
+            future: async move {
+                let value = fut.await.map_err(Into::into)?;
+                let render: FragmentRender = Box::new(move |buf| value.escape_and_write(buf));
+                Ok(render)
+            }
+            .boxed(),
+        });
+        self
+    }
+}
+
+impl<H> IntoResponse for PartialUpdates<H>
+where
+    H: IntoHtml + Send + 'static,
+{
+    fn into_response(self) -> Response {
+        let shell = self.shell.into_string();
+        let shell_chunk = stream::once(async move { Ok::<_, BoxError>(Bytes::from(shell)) });
+
+        let frag_count = self.fragments.len().max(1);
+        let fragment_chunks = stream::iter(self.fragments)
+            .map(|Fragment { name, future }| async move {
+                let render = future.await?;
+                Ok::<_, BoxError>(Bytes::from(template!(r#for = name, render).into_string()))
+            })
+            .buffer_unordered(frag_count);
+
+        (
+            Headers::single(ContentType::html_utf8()),
+            Body::from_stream(shell_chunk.chain(fragment_chunks)),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::html::{html, marker, p};
+    use std::time::Duration;
+    use tokio::time::{Instant, sleep};
+
+    #[tokio::test(start_paused = true)]
+    async fn shell_arrives_before_slowest_fragment() {
+        let shell = html!(p!(marker("slow")));
+        let res = PartialUpdates::new(shell)
+            .fragment("slow", async {
+                sleep(Duration::from_millis(500)).await;
+                "ok"
+            })
+            .into_response();
+
+        let mut body = res.into_body();
+        let t0 = Instant::now();
+        let first = body.chunk().await.unwrap().unwrap();
+        let t_first = t0.elapsed();
+
+        assert!(
+            t_first < Duration::from_millis(50),
+            "shell should flush immediately, got {t_first:?}"
+        );
+        let first = std::str::from_utf8(&first).unwrap();
+        assert!(first.contains(r#"<?marker name="slow">"#));
+        assert!(!first.contains("<template for="));
+
+        let second = body.chunk().await.unwrap().unwrap();
+        let t_second = t0.elapsed();
+        assert!(
+            t_second >= Duration::from_millis(500),
+            "fragment should wait for its delay, got {t_second:?}"
+        );
+        assert_eq!(
+            std::str::from_utf8(&second).unwrap(),
+            r#"<template for="slow">ok</template>"#
+        );
+
+        assert!(body.chunk().await.unwrap().is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fragment_macro_node_keeps_tags() {
+        // A macro-built node must NOT have its element tags escaped — only
+        // the dynamic string content inside should be escaped.
+        let shell = html!(p!(marker("x")));
+        let res = PartialUpdates::new(shell)
+            .fragment("x", async { p!("<not-a-tag>") })
+            .into_response();
+        let mut body = res.into_body();
+        let _shell = body.chunk().await.unwrap().unwrap();
+        let tpl = body.chunk().await.unwrap().unwrap();
+        assert_eq!(
+            std::str::from_utf8(&tpl).unwrap(),
+            r#"<template for="x"><p>&lt;not-a-tag&gt;</p></template>"#
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fragment_name_is_html_escaped() {
+        let shell = html!(p!(marker("a<b")));
+        let res = PartialUpdates::new(shell)
+            .fragment("a<b", async { "ok" })
+            .into_response();
+        let mut body = res.into_body();
+        let _shell = body.chunk().await.unwrap().unwrap();
+        let tpl = body.chunk().await.unwrap().unwrap();
+        assert_eq!(
+            std::str::from_utf8(&tpl).unwrap(),
+            r#"<template for="a&lt;b">ok</template>"#
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fragments_stream_in_completion_order() {
+        let shell = html!(p!(marker("a"), marker("b"), marker("c")));
+        let res = PartialUpdates::new(shell)
+            .fragment("a", async {
+                sleep(Duration::from_millis(600)).await;
+                "A"
+            })
+            .fragment("b", async {
+                sleep(Duration::from_millis(100)).await;
+                "B"
+            })
+            .fragment("c", async {
+                sleep(Duration::from_millis(300)).await;
+                "C"
+            })
+            .into_response();
+
+        let mut body = res.into_body();
+        let t0 = Instant::now();
+
+        let mut chunks: Vec<(Duration, String)> = Vec::new();
+        while let Some(chunk) = body.chunk().await.unwrap() {
+            chunks.push((
+                t0.elapsed(),
+                String::from_utf8(chunk.to_vec()).expect("utf8"),
+            ));
+        }
+
+        assert_eq!(chunks.len(), 4, "shell + 3 fragments");
+        assert!(chunks[0].1.contains(r#"<?marker name="a">"#));
+        assert_eq!(chunks[1].1, r#"<template for="b">B</template>"#);
+        assert_eq!(chunks[2].1, r#"<template for="c">C</template>"#);
+        assert_eq!(chunks[3].1, r#"<template for="a">A</template>"#);
+
+        let spread = chunks[3].0.checked_sub(chunks[1].0).unwrap();
+        assert!(
+            spread >= Duration::from_millis(400),
+            "fragment chunks must arrive spread out over time, got {spread:?}"
+        );
+    }
+}

--- a/tests/integration/examples/example_tests/http_declarative_partial_updates.rs
+++ b/tests/integration/examples/example_tests/http_declarative_partial_updates.rs
@@ -1,0 +1,83 @@
+use super::utils;
+use rama::{
+    futures::StreamExt,
+    http::{
+        StatusCode,
+        headers::{ContentType, HeaderMapExt},
+        mime,
+    },
+};
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+#[ignore]
+async fn test_http_declarative_partial_updates() {
+    utils::init_tracing();
+
+    let runner = utils::ExampleRunner::interactive("http_declarative_partial_updates", None);
+
+    let response = runner.get("http://127.0.0.1:64805").send().await.unwrap();
+    assert_eq!(StatusCode::OK, response.status());
+    assert!(
+        response
+            .headers()
+            .typed_get::<ContentType>()
+            .map(|ct| ct.mime().eq(&mime::TEXT_HTML_UTF_8))
+            .unwrap_or_default()
+    );
+
+    let mut body = response.into_body().into_data_stream();
+    let first = body.next().await.unwrap().unwrap();
+    let t0 = Instant::now();
+    let first_str = std::str::from_utf8(&first).unwrap();
+    for m in ["recs", "herd", "ping"] {
+        assert!(
+            first_str.contains(&format!(r#"<?marker name="{m}">"#)),
+            "shell missing marker {m}"
+        );
+    }
+    for m in ["recs", "herd", "ping"] {
+        assert!(
+            !first_str.contains(&format!(r#"<template for="{m}">"#)),
+            "shell must not yet contain the {m} fragment template"
+        );
+    }
+
+    let mut fragments: Vec<(Duration, String)> = Vec::new();
+    while let Some(chunk) = body.next().await {
+        let bytes = chunk.unwrap();
+        fragments.push((
+            t0.elapsed(),
+            String::from_utf8(bytes.to_vec()).expect("utf8"),
+        ));
+    }
+
+    // Fragment chunks must arrive in completion order — fastest first —
+    // each within a generous window around its server-side delay. Wide
+    // tolerances (-300ms / +1500ms) survive CI scheduler jitter and the
+    // streaming compressor's per-chunk overhead, while still failing if
+    // chunks get pre-buffered, batched, or arrive in declaration order.
+    assert_eq!(
+        fragments.len(),
+        3,
+        "expected exactly 3 fragment chunks after the shell, got {}",
+        fragments.len()
+    );
+    let expected = [
+        ("ping", Duration::from_millis(500)),
+        ("herd", Duration::from_millis(2000)),
+        ("recs", Duration::from_millis(4000)),
+    ];
+    for ((arrival, body), (name, want)) in fragments.iter().zip(expected.iter()) {
+        let lower = want.saturating_sub(Duration::from_millis(300));
+        let upper = *want + Duration::from_millis(1500);
+        assert!(
+            *arrival >= lower && *arrival <= upper,
+            "fragment {name} arrived at {arrival:?}, want within [{lower:?}, {upper:?}]"
+        );
+        assert!(
+            body.contains(&format!(r#"<template for="{name}">"#)),
+            "chunk at {arrival:?} should be the {name} fragment, got: {body:?}"
+        );
+    }
+}

--- a/tests/integration/examples/example_tests/mod.rs
+++ b/tests/integration/examples/example_tests/mod.rs
@@ -13,6 +13,8 @@ mod http_anti_bot_zip_bomb;
 #[cfg(feature = "http-full")]
 mod http_connect_proxy;
 #[cfg(feature = "http-full")]
+mod http_declarative_partial_updates;
+#[cfg(feature = "http-full")]
 mod http_form;
 #[cfg(feature = "http-full")]
 mod http_har_replay;


### PR DESCRIPTION
streams shell + <template for=...> fragments
out of order — Chrome declarative partial updates

support + (tested) example