### PR TITLE
rama-net: serde Serialize/Deserialize for Uri

### DIFF
--- a/examples/grpc/tests/compile/root_file_path.rs
+++ b/examples/grpc/tests/compile/root_file_path.rs
@@ -1,6 +1,6 @@
 #[derive(Clone, PartialEq, ::rama::http::grpc::protobuf::prost::Message)]
 #[prost(prost_path = ":: rama :: http :: grpc::protobuf::prost")]
-struct Animal {
+pub struct Animal {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::rama::http::grpc::protobuf::prost::alloc::string::String>,
 }

--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -817,8 +817,7 @@ impl serde::Serialize for Authority {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/domain_address.rs
+++ b/rama-net/src/address/domain_address.rs
@@ -161,8 +161,7 @@ impl serde::Serialize for DomainAddress {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -872,8 +872,7 @@ impl serde::Serialize for Host {
     where
         S: serde::Serializer,
     {
-        let host = self.to_string();
-        host.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -609,8 +609,7 @@ impl serde::Serialize for HostWithOptPort {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -361,8 +361,7 @@ impl serde::Serialize for HostWithPort {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -111,8 +111,7 @@ impl serde::Serialize for ProxyAddress {
     where
         S: serde::Serializer,
     {
-        let addr = self.to_string();
-        addr.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -394,8 +394,7 @@ impl serde::Serialize for SocketAddress {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -417,8 +417,7 @@ impl serde::Serialize for NodeId {
     where
         S: serde::Serializer,
     {
-        let address = self.to_string();
-        address.serialize(serializer)
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -989,6 +989,30 @@ macro_rules! uri_try_from {
 
 uri_try_from!(&str, String, &[u8], Vec<u8>, rama_core::bytes::Bytes,);
 
+// Serde routes through `Display` / `Uri::parse`. Graceful mode on the
+// deserialize side matches the input grace of every other rama type that
+// implements `Deserialize` via `FromStr`. URIs constructed via
+// [`Uri::parse_authority_form`] or [`Uri::parse_reference`] are out of
+// scope for round-trip — those forms aren't reachable through `parse`.
+impl serde::Serialize for Uri {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Uri {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+        Self::parse(s.as_ref()).map_err(serde::de::Error::custom)
+    }
+}
+
 impl Uri {
     /// Shared walker for [`Display`](std::fmt::Display) and
     /// [`Debug`](std::fmt::Debug). With `redact_userinfo = true` the

--- a/rama-net/src/uri/parser/tests/mod.rs
+++ b/rama-net/src/uri/parser/tests/mod.rs
@@ -59,6 +59,7 @@ pub(super) mod query_mut;
 pub(super) mod query_pairs;
 pub(super) mod resolve;
 pub(super) mod rfc3986_examples;
+pub(super) mod serde;
 pub(super) mod smoke;
 pub(super) mod strict_mode;
 pub(super) mod utf8;

--- a/rama-net/src/uri/parser/tests/serde.rs
+++ b/rama-net/src/uri/parser/tests/serde.rs
@@ -1,0 +1,31 @@
+//! Serde `Serialize` / `Deserialize` round-trip for [`Uri`].
+
+use crate::uri::Uri;
+
+#[test]
+fn serde_round_trip() {
+    for input in [
+        "/",
+        "/foo/bar?q=1#f",
+        "*",
+        "https://example.com/",
+        "https://user:pass@example.com:8443/path?q=1#frag",
+        "urn:isbn:0451450523",
+        "mailto:user@example.com",
+        "ws://example.com/socket",
+    ] {
+        let uri = Uri::parse(input).expect(input);
+        let json = serde_json::to_string(&uri).expect(input);
+        assert_eq!(json, format!("\"{input}\""), "serialize: {input}");
+        let back: Uri = serde_json::from_str(&json).expect(input);
+        assert_eq!(back, uri, "deserialize: {input}");
+        assert_eq!(back.to_string(), input, "round-trip Display: {input}");
+    }
+}
+
+#[test]
+fn deserialize_rejects_invalid() {
+    // ASCII control byte — graceful parser rejects.
+    let err = serde_json::from_str::<Uri>("\"http://exa\\u0001mple.com/\"").unwrap_err();
+    assert!(err.to_string().contains("control"), "got: {err}");
+}


### PR DESCRIPTION
Implements `serde::Serialize` (via `Display`) and `Deserialize` (via `Uri::parse`, graceful) for `Uri`. Round-trip unit test included.