### PR TITLE
docs: fix broken links reported by lychee CI

### DIFF
--- a/docs/book/src/http/multipart.md
+++ b/docs/book/src/http/multipart.md
@@ -77,7 +77,7 @@ layer you stack on top.
   for any HTTP client
 
 The full API lives under
-[`rama::http::service::web::extract::multipart`](https://ramaproxy.org/docs/rama/http/service/web/extract/multipart/index.html)
+[`rama::http::service::web::extract::Multipart`](https://ramaproxy.org/docs/rama/http/service/web/extract/struct.Multipart.html)
 on the server side and
 [`rama::http::service::client::multipart`](https://ramaproxy.org/docs/rama/http/service/client/multipart/index.html)
 on the client side.

--- a/docs/book/src/proxies/intro.md
+++ b/docs/book/src/proxies/intro.md
@@ -7,7 +7,7 @@
          for the purpose of making requests on behalf of other clients.
          Requests are serviced internally or by passing them on, with
          possible translation, to other servers.
-        <p>— <a href="https://www.rfc-editor.org/rfc/pdfrfc/rfc3507.txt.pdf">RFC 3507 (ICAP)</a></p>
+        <p>— <a href="https://www.rfc-editor.org/rfc/rfc3507">RFC 3507 (ICAP)</a></p>
     </div>
 </div>
 

--- a/docs/book/src/web_servers.md
+++ b/docs/book/src/web_servers.md
@@ -49,7 +49,7 @@ For HTML responses, Rama ships a small templating library exposed under
 behind the `html` feature (included in `http-full`). It is a permanent
 fork of [`vy`](https://github.com/JonahLund/vy), reshaped to integrate
 with the rest of the rama ecosystem (using
-[`rama_core::combinators::Either`](https://ramaproxy.org/docs/rama_core/combinators/enum.Either.html)
+[`rama::combinators::Either`](https://ramaproxy.org/docs/rama/combinators/enum.Either.html)
 for branching, and producing a value that already implements
 [`IntoResponse`](https://ramaproxy.org/docs/rama/http/service/web/response/trait.IntoResponse.html)).
 

--- a/docs/book/src/xpc.md
+++ b/docs/book/src/xpc.md
@@ -196,7 +196,7 @@ Network Extension style control-plane flows.
 
 Feature flag: `net-apple-xpc`. Only compiled on `target_vendor = "apple"`.
 
-Crate docs: <https://ramaproxy.org/docs/rama_net_apple_xpc/index.html>
+Crate docs: <https://docs.rs/rama-net-apple-xpc/latest/rama_net_apple_xpc/index.html>
 
 Apple XPC reference: <https://developer.apple.com/documentation/xpc>
 

--- a/rama-http-headers/specifications/fetch.whatwg.org.md
+++ b/rama-http-headers/specifications/fetch.whatwg.org.md
@@ -7,7 +7,7 @@ Fetch
 
 Living Standard — Last Updated 8 May 2026
 
-Participate: [GitHub whatwg/fetch](https://github.com/whatwg/fetch) ([new issue](https://github.com/whatwg/fetch/issues/new/choose), [open issues](https://github.com/whatwg/fetch/issues)): [Chat on Matrix](https://whatwg.org/chat) Commits: [GitHub whatwg/fetch/commits](https://github.com/whatwg/fetch/commits): [Snapshot as of this commit](/commit-snapshots/301650c6d9ee932f126d6598262966242eb3d838/): [@fetchstandard](https://twitter.com/fetchstandard) Tests: [web-platform-tests fetch/](https://github.com/web-platform-tests/wpt/tree/master/fetch) ([ongoing work](https://github.com/web-platform-tests/wpt/labels/fetch)) Translations (non-normative): [日本語](https://triple-underscore.github.io/Fetch-ja.html): [简体中文](https://htmlspecs.com/fetch/): [한국어](https://ko.htmlspecs.com/fetch/)
+Participate: [GitHub whatwg/fetch](https://github.com/whatwg/fetch) ([new issue](https://github.com/whatwg/fetch/issues/new/choose), [open issues](https://github.com/whatwg/fetch/issues)): [Chat on Matrix](https://whatwg.org/chat) Commits: [GitHub whatwg/fetch/commits](https://github.com/whatwg/fetch/commits): [Snapshot as of this commit](https://fetch.spec.whatwg.org/commit-snapshots/301650c6d9ee932f126d6598262966242eb3d838/): [@fetchstandard](https://twitter.com/fetchstandard) Tests: [web-platform-tests fetch/](https://github.com/web-platform-tests/wpt/tree/master/fetch) ([ongoing work](https://github.com/web-platform-tests/wpt/labels/fetch)) Translations (non-normative): [日本語](https://triple-underscore.github.io/Fetch-ja.html): [简体中文](https://htmlspecs.com/fetch/): [한국어](https://ko.htmlspecs.com/fetch/)
 
 Abstract
 --------
@@ -7202,7 +7202,7 @@ portions in the source code are licensed under the [BSD 3-Clause License](https:
 
 This is the Living Standard. Those
 interested in the patent-review version should view the
-[Living Standard Review Draft](/review-drafts/2025-12/).
+[Living Standard Review Draft](https://fetch.spec.whatwg.org/review-drafts/2025-12/).
 
 Index
 -----

--- a/rama-net/specifications/fingerprint/README.md
+++ b/rama-net/specifications/fingerprint/README.md
@@ -50,7 +50,8 @@ spec is always one click from the code that materialises it.
 ## Akamai HTTP/2 fingerprint
 
 * Upstream whitepaper: *Passive Fingerprinting of HTTP/2 Clients*
-  (<https://www.akamai.com/site/en/documents/research-paper/passive-fingerprinting-of-http2-clients-white-paper.pdf>),
+  (<https://blackhat.com/docs/eu-17/materials/eu-17-Shuster-Passive-Fingerprinting-Of-HTTP2-Clients-wp.pdf>,
+  presented at Black Hat Europe 2017),
   copyright Akamai Technologies. Not freely redistributable, so not
   vendored here.
 * Format (re-implemented from the whitepaper): four pipe-separated


### PR DESCRIPTION
Fixes the 8 broken links flagged by the link-checker cronjob (multipart/Either/xpc docs paths, RFC 3507 PDF, WHATWG site-relative URLs, Akamai paper now login-gated).

rama-fastcgi docs.rs link now resolves via the freshly published 0.0.0-reserved placeholder, so no change needed there.