### PR TITLE
tproxy apple: drop per-flow duplex + bridge tasks (less memory, fewer copies)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
 dependencies = [
+ "atomic-waker",
  "bindgen",
  "cc",
  "dial9-tokio-telemetry",

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
@@ -2160,6 +2160,7 @@ dependencies = [
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
 dependencies = [
+ "atomic-waker",
  "bindgen",
  "cc",
  "libc",

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -2491,6 +2491,7 @@ dependencies = [
 name = "rama-net-apple-networkextension"
 version = "0.3.0-rc1"
 dependencies = [
+ "atomic-waker",
  "bindgen",
  "cc",
  "dial9-tokio-telemetry",

--- a/rama-net-apple-networkextension/Cargo.toml
+++ b/rama-net-apple-networkextension/Cargo.toml
@@ -32,6 +32,7 @@ default = []
 dial9 = ["dep:dial9-tokio-telemetry", "dep:dial9-trace-format", "rama-core/dial9"]
 
 [dependencies]
+atomic-waker = { workspace = true }
 dial9-tokio-telemetry = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 libc = { workspace = true }
@@ -49,7 +50,7 @@ bindgen = { workspace = true }
 cc = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [lints]
 workspace = true

--- a/rama-net-apple-networkextension/src/nw_tcp_stream.rs
+++ b/rama-net-apple-networkextension/src/nw_tcp_stream.rs
@@ -6,24 +6,27 @@ use std::{
 
 use pin_project_lite::pin_project;
 use rama_core::extensions::{Extensions, ExtensionsRef};
-use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::tproxy::engine::ffi_stream::FfiBridgeStream;
 
 pin_project! {
     /// Egress TCP stream backed by a pre-established `NWConnection`.
     ///
     /// Unlike [`crate::TcpFlow`], this type carries no intercepted-flow metadata.
-    /// It wraps the Rust side of a `tokio::io::duplex` pair whose other half is
-    /// bridged to a Swift-managed `NWConnection`.
+    /// The read side drains the upstream→service channel (bytes the Swift
+    /// `NWConnection` delivered); the write side hands service→upstream bytes
+    /// straight to the Swift egress-write sink.
     pub struct NwTcpStream {
         #[pin]
-        inner: DuplexStream,
+        inner: FfiBridgeStream,
         extensions: Extensions,
     }
 }
 
 impl NwTcpStream {
     #[must_use]
-    pub(crate) fn new(inner: DuplexStream) -> Self {
+    pub(crate) fn new(inner: FfiBridgeStream) -> Self {
         Self {
             inner,
             extensions: Extensions::new(),

--- a/rama-net-apple-networkextension/src/tcp.rs
+++ b/rama-net-apple-networkextension/src/tcp.rs
@@ -6,20 +6,23 @@ use std::{
 
 use pin_project_lite::pin_project;
 use rama_core::{
-    ServiceInput,
     extensions::{Extensions, ExtensionsRef},
     rt::Executor,
 };
-use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadBuf};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::tproxy::engine::ffi_stream::FfiBridgeStream;
 
 pin_project! {
     /// A per-flow stream presented to the Rama user.
     ///
     /// This behaves like a normal bidirectional byte stream and implements
-    /// tokio [`AsyncRead`] + [`AsyncWrite`] + Rama [`Extensions`].
+    /// tokio [`AsyncRead`] + [`AsyncWrite`] + Rama [`Extensions`]. The read
+    /// side drains the client→service channel; the write side hands
+    /// service→client bytes straight to the Swift response sink.
     pub struct TcpFlow {
         #[pin]
-        inner: DuplexStream,
+        inner: FfiBridgeStream,
         extensions: Extensions,
         executor: Option<Executor>,
     }
@@ -27,26 +30,11 @@ pin_project! {
 
 impl TcpFlow {
     #[must_use]
-    pub(crate) fn new(inner: DuplexStream, executor: Option<Executor>) -> Self {
+    pub(crate) fn new(inner: FfiBridgeStream, executor: Option<Executor>) -> Self {
         Self {
             inner,
             extensions: Extensions::new(),
             executor,
-        }
-    }
-
-    /// Consume the [`TcpFlow`] by mapping the input and
-    /// returning this as a new generic [`ServiceInput`].
-    pub fn map_input<Input>(self, map: impl FnOnce(DuplexStream) -> Input) -> ServiceInput<Input> {
-        let Self {
-            inner: duplex_stream,
-            extensions,
-            executor: _,
-        } = self;
-
-        ServiceInput {
-            input: map(duplex_stream),
-            extensions,
         }
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -81,12 +81,8 @@ where
     RF: TransparentProxyAsyncRuntimeFactory,
 {
     rama_utils::macros::generate_set_and_with! {
-        /// Per-direction TCP duplex buffer size.
-        ///
-        /// **Inert.** The duplex was removed (#5) in favor of
-        /// channel/callback-backed per-flow streams; per-flow buffering is
-        /// now bounded by [`Self::tcp_channel_capacity`]. Retained for
-        /// ABI stability — setting it has no effect on the data path.
+        /// No effect; per-flow buffering is bounded by
+        /// [`Self::tcp_channel_capacity`].
         pub fn tcp_flow_buffer_size(mut self, size: Option<usize>) -> Self
         {
             self.tcp_flow_buffer_size = size;

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -81,7 +81,12 @@ where
     RF: TransparentProxyAsyncRuntimeFactory,
 {
     rama_utils::macros::generate_set_and_with! {
-        /// Per-direction TCP duplex buffer size. `None` uses the default.
+        /// Per-direction TCP duplex buffer size.
+        ///
+        /// **Inert.** The duplex was removed (#5) in favor of
+        /// channel/callback-backed per-flow streams; per-flow buffering is
+        /// now bounded by [`Self::tcp_channel_capacity`]. Retained for
+        /// ABI stability — setting it has no effect on the data path.
         pub fn tcp_flow_buffer_size(mut self, size: Option<usize>) -> Self
         {
             self.tcp_flow_buffer_size = size;

--- a/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
@@ -1,0 +1,559 @@
+//! Channel/callback-backed per-flow stream that replaces the
+//! `tokio::io::duplex` + `run_tcp_bridge` task pair.
+//!
+//! Each TCP flow has two of these (one per direction-pair):
+//!
+//! * the **read** side drains the per-flow `mpsc` channel that the FFI
+//!   peer (Swift) feeds via `on_*_bytes[_owned]` — i.e. FFI peer →
+//!   service — firing the read-demand callback when a channel slot frees;
+//! * the **write** side hands bytes straight to the FFI status sink
+//!   (`on_server_bytes` / `on_write_to_egress`) — i.e. service → FFI peer
+//!   — parking on `Paused` until the matching `signal_*_drain` wakes the
+//!   registered waker (or a backstop timer fires).
+//!
+//! Removing the duplex deletes a whole `BytesMut` per direction plus two
+//! copies per chunk; removing the bridge task deletes a per-flow read
+//! buffer and two task hops per chunk. Idle-timeout and shutdown-on-cancel
+//! are owned one level up by the forwarder's select loop, so this stream
+//! deliberately does NOT watch the flow guard itself.
+
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    sync::Arc,
+    sync::atomic::{AtomicU64, Ordering},
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use rama_core::bytes::{Buf, Bytes};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::mpsc,
+    time::Sleep,
+};
+
+use super::{
+    BridgeDirection, BytesStatusSink, ClosedSink, DemandSink, TcpDeliverStatus, TcpPerFlowSignals,
+};
+
+/// Per-flow byte tallies, indexed by [`BridgeDirection`]. Shared (via
+/// `Arc`) between the two streams that increment them and the service
+/// task that reads them when emitting the flow's close event.
+///
+/// Orientation matches the legacy per-bridge counters:
+/// * Ingress: `received` = client→service, `sent` = service→client
+/// * Egress:  `received` = upstream→service, `sent` = service→upstream
+#[derive(Debug, Default)]
+pub(crate) struct TcpFlowByteCounters {
+    ingress_received: AtomicU64,
+    ingress_sent: AtomicU64,
+    egress_received: AtomicU64,
+    egress_sent: AtomicU64,
+}
+
+impl TcpFlowByteCounters {
+    fn received(&self, dir: BridgeDirection) -> &AtomicU64 {
+        match dir {
+            BridgeDirection::Ingress => &self.ingress_received,
+            BridgeDirection::Egress => &self.egress_received,
+        }
+    }
+
+    fn sent(&self, dir: BridgeDirection) -> &AtomicU64 {
+        match dir {
+            BridgeDirection::Ingress => &self.ingress_sent,
+            BridgeDirection::Egress => &self.egress_sent,
+        }
+    }
+
+    /// `(received, sent)` for the given direction.
+    pub(crate) fn snapshot(&self, dir: BridgeDirection) -> (u64, u64) {
+        (
+            self.received(dir).load(Ordering::Relaxed),
+            self.sent(dir).load(Ordering::Relaxed),
+        )
+    }
+
+    /// Total bytes across both directions — used as a monotonic
+    /// progress signal by the flow-level idle backstop.
+    pub(crate) fn total(&self) -> u64 {
+        self.ingress_received.load(Ordering::Relaxed)
+            + self.ingress_sent.load(Ordering::Relaxed)
+            + self.egress_received.load(Ordering::Relaxed)
+            + self.egress_sent.load(Ordering::Relaxed)
+    }
+}
+
+pub(crate) struct FfiBridgeStream {
+    // ── read side (FFI peer → service) ──
+    rx: mpsc::Receiver<Bytes>,
+    /// The chunk currently being drained into reader buffers; `Bytes` is
+    /// advanced as it is consumed and cleared when empty.
+    read_cursor: Option<Bytes>,
+    on_read_demand: DemandSink,
+
+    // ── write side (service → FFI peer) ──
+    sink: BytesStatusSink,
+    on_closed: ClosedSink,
+    closed_fired: bool,
+    paused_drain_max_wait: Duration,
+    /// Armed on first `Paused`, disarmed on progress; backstops a peer
+    /// whose drain signal never arrives so a wedged write can't park
+    /// forever (mirrors the bridge's `paused_drain_max_wait`).
+    paused_backstop: Option<Pin<Box<Sleep>>>,
+
+    // ── shared per-flow state ──
+    signals: Arc<TcpPerFlowSignals>,
+    counters: Arc<TcpFlowByteCounters>,
+    direction: BridgeDirection,
+}
+
+impl FfiBridgeStream {
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "per-flow stream wiring; a builder/struct would add noise without simplifying the single call site in `activate`"
+    )]
+    pub(crate) fn new(
+        rx: mpsc::Receiver<Bytes>,
+        sink: BytesStatusSink,
+        on_read_demand: DemandSink,
+        on_closed: ClosedSink,
+        signals: Arc<TcpPerFlowSignals>,
+        counters: Arc<TcpFlowByteCounters>,
+        direction: BridgeDirection,
+        paused_drain_max_wait: Duration,
+    ) -> Self {
+        Self {
+            rx,
+            read_cursor: None,
+            on_read_demand,
+            sink,
+            on_closed,
+            closed_fired: false,
+            paused_drain_max_wait,
+            paused_backstop: None,
+            signals,
+            counters,
+            direction,
+        }
+    }
+}
+
+impl AsyncRead for FfiBridgeStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        // `FfiBridgeStream` is `Unpin` (every field is), so unrestricted
+        // `&mut` access through the pin is sound.
+        let this = self.get_mut();
+        loop {
+            if let Some(chunk) = this.read_cursor.as_mut() {
+                let n = chunk.len().min(buf.remaining());
+                if n > 0 {
+                    buf.put_slice(&chunk[..n]);
+                    chunk.advance(n);
+                    this.counters
+                        .received(this.direction)
+                        .fetch_add(n as u64, Ordering::Relaxed);
+                }
+                if chunk.is_empty() {
+                    this.read_cursor = None;
+                }
+                return Poll::Ready(Ok(()));
+            }
+
+            match this.rx.poll_recv(cx) {
+                Poll::Ready(Some(bytes)) => {
+                    // A channel slot just freed — wake the FFI reader if it
+                    // paused waiting for capacity. Edge-triggered: only the
+                    // true→false swap fires the callback, so we never spam
+                    // the peer with redundant demand while the channel drains.
+                    if this
+                        .signals
+                        .paused(this.direction)
+                        .swap(false, Ordering::AcqRel)
+                    {
+                        (this.on_read_demand)();
+                    }
+                    // A zero-length chunk carries no data (e.g. a coalesced
+                    // empty write); skip it rather than report a spurious EOF.
+                    if bytes.is_empty() {
+                        continue;
+                    }
+                    this.read_cursor = Some(bytes);
+                    // loop to serve from the new cursor
+                }
+                // Sender dropped (`on_*_eof`, promote cutover, or cancel) —
+                // natural end-of-stream, surfaced as a 0-byte read.
+                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl AsyncWrite for FfiBridgeStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        // Register the drain waker BEFORE invoking the sink. The peer can
+        // only fire `signal_*_drain` at-or-after the sink observes the
+        // `Paused` condition, so registering first guarantees such a wake
+        // can never be lost in the window between the sink returning
+        // `Paused` and us parking. A spurious wake on the `Accepted` path
+        // just costs one extra poll.
+        this.signals.drain(this.direction).register(cx.waker());
+
+        match (this.sink)(buf) {
+            TcpDeliverStatus::Accepted => {
+                this.counters
+                    .sent(this.direction)
+                    .fetch_add(buf.len() as u64, Ordering::Relaxed);
+                // Progress — disarm any backstop so the next stall starts
+                // a fresh deadline.
+                this.paused_backstop = None;
+                Poll::Ready(Ok(buf.len()))
+            }
+            // Peer is gone; surface as a broken pipe so the forwarder tears
+            // the flow down. (`copy_one_way` treats this as a write error.)
+            TcpDeliverStatus::Closed => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "transparent proxy: ffi peer closed the write side",
+            ))),
+            TcpDeliverStatus::Paused => {
+                // Park until the drain waker fires (re-poll → retry the
+                // sink with the same buffer — `write_all` re-presents it)
+                // or the backstop deadline elapses.
+                let max_wait = this.paused_drain_max_wait;
+                let backstop = this
+                    .paused_backstop
+                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(max_wait)));
+                match backstop.as_mut().poll(cx) {
+                    Poll::Ready(()) => {
+                        this.paused_backstop = None;
+                        // Backstop expired: this write direction is dead.
+                        // Fire the close callback now (mirrors the old
+                        // bridge's `PausedTimeout → on_server_closed`) so
+                        // the FFI peer is notified even if the service
+                        // ignores the write error we return.
+                        if !this.closed_fired {
+                            this.closed_fired = true;
+                            (this.on_closed)();
+                        }
+                        Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "transparent proxy: paused-drain backstop — peer drain signal lost?",
+                        )))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // No intermediate buffer on our side — bytes go straight to the
+        // sink in `poll_write`, so there is nothing to flush.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // Fire the FFI "write side done" callback exactly once. The sink is
+        // already wrapped by the `callback_active` gate, so a shutdown that
+        // races teardown is a no-op rather than a use-after-free.
+        if !this.closed_fired {
+            this.closed_fired = true;
+            (this.on_closed)();
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for FfiBridgeStream {
+    fn drop(&mut self) {
+        // A force-close (idle backstop / shutdown drops the stream before a
+        // clean `poll_shutdown`) still owes the FFI peer its "write side
+        // done" signal. Exactly-once via `closed_fired`; the guarded sink
+        // no-ops if teardown already disarmed callbacks.
+        if !self.closed_fired {
+            self.closed_fired = true;
+            (self.on_closed)();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU8, AtomicUsize};
+    use std::task::{Context, Wake, Waker};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+    /// Waker that counts how many times it was woken.
+    struct CountWaker(AtomicUsize);
+    impl Wake for CountWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    fn count_waker() -> (Arc<CountWaker>, Waker) {
+        let w = Arc::new(CountWaker(AtomicUsize::new(0)));
+        let waker: Waker = w.clone().into();
+        (w, waker)
+    }
+
+    fn accept_sink() -> BytesStatusSink {
+        Arc::new(|_: &[u8]| TcpDeliverStatus::Accepted)
+    }
+    fn const_sink(status: TcpDeliverStatus) -> BytesStatusSink {
+        Arc::new(move |_: &[u8]| status)
+    }
+    /// Sink whose status is read from a shared `AtomicU8` the test flips.
+    fn dynamic_sink(code: Arc<AtomicU8>) -> BytesStatusSink {
+        Arc::new(move |_: &[u8]| TcpDeliverStatus::from_ffi_u8(code.load(Ordering::SeqCst)))
+    }
+    fn noop() -> DemandSink {
+        Arc::new(|| {})
+    }
+    fn counter_cb(c: Arc<AtomicUsize>) -> Arc<dyn Fn() + Send + Sync + 'static> {
+        Arc::new(move || {
+            c.fetch_add(1, Ordering::SeqCst);
+        })
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn stream(
+        rx: mpsc::Receiver<Bytes>,
+        sink: BytesStatusSink,
+        demand: DemandSink,
+        closed: ClosedSink,
+        dir: BridgeDirection,
+        max_wait: Duration,
+        signals: Arc<TcpPerFlowSignals>,
+        counters: Arc<TcpFlowByteCounters>,
+    ) -> FfiBridgeStream {
+        FfiBridgeStream::new(rx, sink, demand, closed, signals, counters, dir, max_wait)
+    }
+
+    #[tokio::test]
+    async fn read_reports_eof_when_sender_dropped() {
+        let (tx, rx) = mpsc::channel::<Bytes>(4);
+        let mut s = stream(
+            rx,
+            accept_sink(),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        drop(tx);
+        let mut buf = [0u8; 8];
+        // `read` resolves immediately to 0 (EOF) once the channel closes.
+        let n = s.read(&mut buf).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn read_delivers_chunk_and_counts_received() {
+        let (tx, rx) = mpsc::channel::<Bytes>(4);
+        tx.try_send(Bytes::from_static(b"hello")).unwrap();
+        drop(tx);
+        let counters = Arc::new(TcpFlowByteCounters::default());
+        let mut s = stream(
+            rx,
+            accept_sink(),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            counters.clone(),
+        );
+        let mut buf = [0u8; 8];
+        let n = s.read(&mut buf).await.unwrap();
+        assert_eq!(&buf[..n], b"hello");
+        assert_eq!(counters.snapshot(BridgeDirection::Ingress).0, 5);
+    }
+
+    #[tokio::test]
+    async fn read_fires_demand_once_when_peer_paused() {
+        let (tx, rx) = mpsc::channel::<Bytes>(4);
+        tx.try_send(Bytes::from_static(b"x")).unwrap();
+        let demand_calls = Arc::new(AtomicUsize::new(0));
+        let signals = Arc::new(TcpPerFlowSignals::new());
+        let mut s = stream(
+            rx,
+            accept_sink(),
+            counter_cb(demand_calls.clone()),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            signals.clone(),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        signals
+            .paused(BridgeDirection::Ingress)
+            .store(true, Ordering::Release);
+        let mut buf = [0u8; 8];
+        let _ = s.read(&mut buf).await.unwrap();
+        assert_eq!(demand_calls.load(Ordering::SeqCst), 1, "demand fired once");
+        assert!(
+            !signals
+                .paused(BridgeDirection::Ingress)
+                .load(Ordering::Acquire),
+            "paused flag cleared"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_accepted_counts_sent() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let counters = Arc::new(TcpFlowByteCounters::default());
+        let mut s = stream(
+            rx,
+            accept_sink(),
+            noop(),
+            noop(),
+            BridgeDirection::Egress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            counters.clone(),
+        );
+        s.write_all(b"abcd").await.unwrap();
+        assert_eq!(counters.snapshot(BridgeDirection::Egress).1, 4);
+    }
+
+    #[tokio::test]
+    async fn write_closed_is_broken_pipe() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let mut s = stream(
+            rx,
+            const_sink(TcpDeliverStatus::Closed),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        let err = s.write_all(b"abc").await.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    #[tokio::test]
+    async fn write_paused_parks_then_drain_signal_wakes_and_retry_succeeds() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let code = Arc::new(AtomicU8::new(TcpDeliverStatus::Paused as u8));
+        let signals = Arc::new(TcpPerFlowSignals::new());
+        let mut s = stream(
+            rx,
+            dynamic_sink(code.clone()),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            signals.clone(),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        let (w, waker) = count_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // First poll: sink Paused → Pending, our waker registered, not yet woken.
+        let p = Pin::new(&mut s).poll_write(&mut cx, b"abc");
+        assert!(p.is_pending());
+        assert_eq!(w.0.load(Ordering::SeqCst), 0);
+
+        // `signal_*_drain` wakes the registered waker.
+        signals.drain(BridgeDirection::Ingress).wake();
+        assert_eq!(w.0.load(Ordering::SeqCst), 1, "drain woke our waker");
+
+        // Capacity freed → retry is accepted.
+        code.store(TcpDeliverStatus::Accepted as u8, Ordering::SeqCst);
+        let p = Pin::new(&mut s).poll_write(&mut cx, b"abc");
+        assert!(matches!(p, Poll::Ready(Ok(3))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn write_paused_backstop_times_out() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let mut s = stream(
+            rx,
+            const_sink(TcpDeliverStatus::Paused),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_millis(50),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        let (_w, waker) = count_waker();
+        let mut cx = Context::from_waker(&waker);
+        // Arms the backstop.
+        assert!(Pin::new(&mut s).poll_write(&mut cx, b"abc").is_pending());
+        tokio::time::advance(Duration::from_millis(60)).await;
+        // Backstop elapsed → write errors out so the forwarder reaps the flow.
+        match Pin::new(&mut s).poll_write(&mut cx, b"abc") {
+            Poll::Ready(Err(e)) => assert_eq!(e.kind(), io::ErrorKind::TimedOut),
+            other => panic!("expected TimedOut, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn shutdown_fires_closed_once_and_drop_does_not_double() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let closed_calls = Arc::new(AtomicUsize::new(0));
+        let mut s = stream(
+            rx,
+            accept_sink(),
+            noop(),
+            counter_cb(closed_calls.clone()),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        s.shutdown().await.unwrap();
+        assert_eq!(closed_calls.load(Ordering::SeqCst), 1);
+        drop(s);
+        assert_eq!(
+            closed_calls.load(Ordering::SeqCst),
+            1,
+            "drop must not re-fire"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_without_shutdown_fires_closed() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let closed_calls = Arc::new(AtomicUsize::new(0));
+        let s = stream(
+            rx,
+            accept_sink(),
+            noop(),
+            counter_cb(closed_calls.clone()),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        drop(s);
+        assert_eq!(closed_calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
@@ -18,7 +18,9 @@ use std::{
     time::Duration,
 };
 
+use parking_lot::Mutex;
 use rama_core::bytes::{Buf, Bytes};
+use rama_net::proxy::BridgeCloseReason;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     sync::mpsc,
@@ -28,6 +30,10 @@ use tokio::{
 use super::{
     BridgeDirection, BytesStatusSink, ClosedSink, DemandSink, TcpDeliverStatus, TcpPerFlowSignals,
 };
+
+/// First terminal close reason observed for one direction's stream; read by
+/// the service task to label that direction's close event.
+pub(crate) type CloseReasonCell = Arc<Mutex<Option<BridgeCloseReason>>>;
 
 /// Per-flow byte tallies, indexed by [`BridgeDirection`]; read by the
 /// service task to emit the flow's close event.
@@ -92,6 +98,7 @@ pub(crate) struct FfiBridgeStream {
     // ── shared per-flow state ──
     signals: Arc<TcpPerFlowSignals>,
     counters: Arc<TcpFlowByteCounters>,
+    close_reason: CloseReasonCell,
     direction: BridgeDirection,
 }
 
@@ -104,6 +111,7 @@ impl FfiBridgeStream {
         on_closed: ClosedSink,
         signals: Arc<TcpPerFlowSignals>,
         counters: Arc<TcpFlowByteCounters>,
+        close_reason: CloseReasonCell,
         direction: BridgeDirection,
         paused_drain_max_wait: Duration,
     ) -> Self {
@@ -118,8 +126,14 @@ impl FfiBridgeStream {
             paused_backstop: None,
             signals,
             counters,
+            close_reason,
             direction,
         }
+    }
+
+    /// Record this direction's terminal close reason (first wins).
+    fn record_reason(&self, reason: BridgeCloseReason) {
+        self.close_reason.lock().get_or_insert(reason);
     }
 }
 
@@ -165,7 +179,10 @@ impl AsyncRead for FfiBridgeStream {
                     this.read_cursor = Some(bytes);
                 }
                 // Sender dropped → EOF.
-                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Ready(None) => {
+                    this.record_reason(BridgeCloseReason::PeerEofLeft);
+                    return Poll::Ready(Ok(()));
+                }
                 Poll::Pending => return Poll::Pending,
             }
         }
@@ -197,10 +214,13 @@ impl AsyncWrite for FfiBridgeStream {
                 Poll::Ready(Ok(buf.len()))
             }
             // Peer gone → broken pipe; the forwarder tears the flow down.
-            TcpDeliverStatus::Closed => Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::BrokenPipe,
-                "transparent proxy: ffi peer closed the write side",
-            ))),
+            TcpDeliverStatus::Closed => {
+                this.record_reason(BridgeCloseReason::PeerEofRight);
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "transparent proxy: ffi peer closed the write side",
+                )))
+            }
             TcpDeliverStatus::Paused => {
                 // Park for a drain wake (re-poll retries the same buffer) or
                 // the backstop deadline.
@@ -211,6 +231,7 @@ impl AsyncWrite for FfiBridgeStream {
                 match backstop.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         this.paused_backstop = None;
+                        this.record_reason(BridgeCloseReason::PausedTimeout);
                         // Drain never came: fire close (the service may
                         // ignore the error) and fail the write.
                         if !this.closed_fired {
@@ -307,7 +328,39 @@ mod tests {
         signals: Arc<TcpPerFlowSignals>,
         counters: Arc<TcpFlowByteCounters>,
     ) -> FfiBridgeStream {
-        FfiBridgeStream::new(rx, sink, demand, closed, signals, counters, dir, max_wait)
+        FfiBridgeStream::new(
+            rx,
+            sink,
+            demand,
+            closed,
+            signals,
+            counters,
+            Arc::new(Mutex::new(None)),
+            dir,
+            max_wait,
+        )
+    }
+
+    /// Stream with sane defaults + an inspectable close-reason cell.
+    fn stream_with_reason(
+        rx: mpsc::Receiver<Bytes>,
+        sink: BytesStatusSink,
+        dir: BridgeDirection,
+        max_wait: Duration,
+    ) -> (FfiBridgeStream, CloseReasonCell) {
+        let cell: CloseReasonCell = Arc::new(Mutex::new(None));
+        let s = FfiBridgeStream::new(
+            rx,
+            sink,
+            noop(),
+            noop(),
+            Arc::new(TcpPerFlowSignals::new()),
+            Arc::new(TcpFlowByteCounters::default()),
+            cell.clone(),
+            dir,
+            max_wait,
+        );
+        (s, cell)
     }
 
     #[tokio::test]
@@ -515,5 +568,55 @@ mod tests {
         );
         drop(s);
         assert_eq!(closed_calls.load(Ordering::SeqCst), 1);
+    }
+
+    // ── close-reason recording (so a write failure isn't logged as clean EOF) ──
+
+    #[tokio::test]
+    async fn read_eof_records_peer_eof_left() {
+        let (tx, rx) = mpsc::channel::<Bytes>(4);
+        drop(tx);
+        let (mut s, cell) = stream_with_reason(
+            rx,
+            accept_sink(),
+            BridgeDirection::Ingress,
+            Duration::from_secs(60),
+        );
+        let mut buf = [0u8; 8];
+        let _ = s.read(&mut buf).await.unwrap();
+        assert_eq!(*cell.lock(), Some(BridgeCloseReason::PeerEofLeft));
+    }
+
+    #[tokio::test]
+    async fn write_closed_records_peer_eof_right() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let (mut s, cell) = stream_with_reason(
+            rx,
+            const_sink(TcpDeliverStatus::Closed),
+            BridgeDirection::Egress,
+            Duration::from_secs(60),
+        );
+        assert!(s.write_all(b"abc").await.is_err());
+        assert_eq!(*cell.lock(), Some(BridgeCloseReason::PeerEofRight));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn backstop_records_paused_timeout() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let (mut s, cell) = stream_with_reason(
+            rx,
+            const_sink(TcpDeliverStatus::Paused),
+            BridgeDirection::Ingress,
+            Duration::from_millis(50),
+        );
+        let (_w, waker) = count_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(Pin::new(&mut s).poll_write(&mut cx, b"abc").is_pending());
+        tokio::time::advance(Duration::from_millis(60)).await;
+        assert!(matches!(
+            Pin::new(&mut s).poll_write(&mut cx, b"abc"),
+            Poll::Ready(Err(_))
+        ));
+        assert_eq!(*cell.lock(), Some(BridgeCloseReason::PausedTimeout));
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
@@ -1,21 +1,12 @@
-//! Channel/callback-backed per-flow stream that replaces the
-//! `tokio::io::duplex` + `run_tcp_bridge` task pair.
+//! Per-flow stream bridging a Swift FFI peer to the in-Rust service.
 //!
-//! Each TCP flow has two of these (one per direction-pair):
+//! Read side drains the per-flow `mpsc` channel (FFI peer → service),
+//! firing the read-demand callback when a slot frees. Write side calls the
+//! FFI status sink (service → FFI peer), parking on `Paused` until
+//! `signal_*_drain` wakes the registered waker, with a backstop deadline.
 //!
-//! * the **read** side drains the per-flow `mpsc` channel that the FFI
-//!   peer (Swift) feeds via `on_*_bytes[_owned]` — i.e. FFI peer →
-//!   service — firing the read-demand callback when a channel slot frees;
-//! * the **write** side hands bytes straight to the FFI status sink
-//!   (`on_server_bytes` / `on_write_to_egress`) — i.e. service → FFI peer
-//!   — parking on `Paused` until the matching `signal_*_drain` wakes the
-//!   registered waker (or a backstop timer fires).
-//!
-//! Removing the duplex deletes a whole `BytesMut` per direction plus two
-//! copies per chunk; removing the bridge task deletes a per-flow read
-//! buffer and two task hops per chunk. Idle-timeout and shutdown-on-cancel
-//! are owned one level up by the forwarder's select loop, so this stream
-//! deliberately does NOT watch the flow guard itself.
+//! Idle-timeout and cancellation are owned by the forwarder, so this stream
+//! does not watch the flow guard.
 
 use std::{
     future::Future,
@@ -38,11 +29,8 @@ use super::{
     BridgeDirection, BytesStatusSink, ClosedSink, DemandSink, TcpDeliverStatus, TcpPerFlowSignals,
 };
 
-/// Per-flow byte tallies, indexed by [`BridgeDirection`]. Shared (via
-/// `Arc`) between the two streams that increment them and the service
-/// task that reads them when emitting the flow's close event.
-///
-/// Orientation matches the legacy per-bridge counters:
+/// Per-flow byte tallies, indexed by [`BridgeDirection`]; read by the
+/// service task to emit the flow's close event.
 /// * Ingress: `received` = client→service, `sent` = service→client
 /// * Egress:  `received` = upstream→service, `sent` = service→upstream
 #[derive(Debug, Default)]
@@ -76,8 +64,7 @@ impl TcpFlowByteCounters {
         )
     }
 
-    /// Total bytes across both directions — used as a monotonic
-    /// progress signal by the flow-level idle backstop.
+    /// Total bytes both directions; progress signal for the idle backstop.
     pub(crate) fn total(&self) -> u64 {
         self.ingress_received.load(Ordering::Relaxed)
             + self.ingress_sent.load(Ordering::Relaxed)
@@ -89,8 +76,7 @@ impl TcpFlowByteCounters {
 pub(crate) struct FfiBridgeStream {
     // ── read side (FFI peer → service) ──
     rx: mpsc::Receiver<Bytes>,
-    /// The chunk currently being drained into reader buffers; `Bytes` is
-    /// advanced as it is consumed and cleared when empty.
+    /// Current chunk; advanced as consumed, cleared when empty.
     read_cursor: Option<Bytes>,
     on_read_demand: DemandSink,
 
@@ -99,9 +85,8 @@ pub(crate) struct FfiBridgeStream {
     on_closed: ClosedSink,
     closed_fired: bool,
     paused_drain_max_wait: Duration,
-    /// Armed on first `Paused`, disarmed on progress; backstops a peer
-    /// whose drain signal never arrives so a wedged write can't park
-    /// forever (mirrors the bridge's `paused_drain_max_wait`).
+    /// Reaps a write parked on `Paused` whose drain never arrives. Armed on
+    /// `Paused`, cleared on progress.
     paused_backstop: Option<Pin<Box<Sleep>>>,
 
     // ── shared per-flow state ──
@@ -111,10 +96,7 @@ pub(crate) struct FfiBridgeStream {
 }
 
 impl FfiBridgeStream {
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "per-flow stream wiring; a builder/struct would add noise without simplifying the single call site in `activate`"
-    )]
+    #[expect(clippy::too_many_arguments, reason = "per-flow wiring; one call site")]
     pub(crate) fn new(
         rx: mpsc::Receiver<Bytes>,
         sink: BytesStatusSink,
@@ -147,8 +129,7 @@ impl AsyncRead for FfiBridgeStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        // `FfiBridgeStream` is `Unpin` (every field is), so unrestricted
-        // `&mut` access through the pin is sound.
+        // All fields are `Unpin`, so `get_mut` is sound.
         let this = self.get_mut();
         loop {
             if let Some(chunk) = this.read_cursor.as_mut() {
@@ -168,10 +149,8 @@ impl AsyncRead for FfiBridgeStream {
 
             match this.rx.poll_recv(cx) {
                 Poll::Ready(Some(bytes)) => {
-                    // A channel slot just freed — wake the FFI reader if it
-                    // paused waiting for capacity. Edge-triggered: only the
-                    // true→false swap fires the callback, so we never spam
-                    // the peer with redundant demand while the channel drains.
+                    // Slot freed: wake the FFI reader if it paused for
+                    // capacity. Edge-triggered so we don't re-spam demand.
                     if this
                         .signals
                         .paused(this.direction)
@@ -179,16 +158,13 @@ impl AsyncRead for FfiBridgeStream {
                     {
                         (this.on_read_demand)();
                     }
-                    // A zero-length chunk carries no data (e.g. a coalesced
-                    // empty write); skip it rather than report a spurious EOF.
+                    // Skip empty chunks (a 0-byte read would look like EOF).
                     if bytes.is_empty() {
                         continue;
                     }
                     this.read_cursor = Some(bytes);
-                    // loop to serve from the new cursor
                 }
-                // Sender dropped (`on_*_eof`, promote cutover, or cancel) —
-                // natural end-of-stream, surfaced as a 0-byte read.
+                // Sender dropped → EOF.
                 Poll::Ready(None) => return Poll::Ready(Ok(())),
                 Poll::Pending => return Poll::Pending,
             }
@@ -207,12 +183,9 @@ impl AsyncWrite for FfiBridgeStream {
             return Poll::Ready(Ok(0));
         }
 
-        // Register the drain waker BEFORE invoking the sink. The peer can
-        // only fire `signal_*_drain` at-or-after the sink observes the
-        // `Paused` condition, so registering first guarantees such a wake
-        // can never be lost in the window between the sink returning
-        // `Paused` and us parking. A spurious wake on the `Accepted` path
-        // just costs one extra poll.
+        // Register before calling the sink: `signal_*_drain` can only fire
+        // after the sink returns `Paused`, so registering first can't lose
+        // it. A spurious wake on `Accepted` just costs one poll.
         this.signals.drain(this.direction).register(cx.waker());
 
         match (this.sink)(buf) {
@@ -220,21 +193,17 @@ impl AsyncWrite for FfiBridgeStream {
                 this.counters
                     .sent(this.direction)
                     .fetch_add(buf.len() as u64, Ordering::Relaxed);
-                // Progress — disarm any backstop so the next stall starts
-                // a fresh deadline.
-                this.paused_backstop = None;
+                this.paused_backstop = None; // progress: re-arm fresh next time
                 Poll::Ready(Ok(buf.len()))
             }
-            // Peer is gone; surface as a broken pipe so the forwarder tears
-            // the flow down. (`copy_one_way` treats this as a write error.)
+            // Peer gone → broken pipe; the forwarder tears the flow down.
             TcpDeliverStatus::Closed => Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::BrokenPipe,
                 "transparent proxy: ffi peer closed the write side",
             ))),
             TcpDeliverStatus::Paused => {
-                // Park until the drain waker fires (re-poll → retry the
-                // sink with the same buffer — `write_all` re-presents it)
-                // or the backstop deadline elapses.
+                // Park for a drain wake (re-poll retries the same buffer) or
+                // the backstop deadline.
                 let max_wait = this.paused_drain_max_wait;
                 let backstop = this
                     .paused_backstop
@@ -242,18 +211,15 @@ impl AsyncWrite for FfiBridgeStream {
                 match backstop.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         this.paused_backstop = None;
-                        // Backstop expired: this write direction is dead.
-                        // Fire the close callback now (mirrors the old
-                        // bridge's `PausedTimeout → on_server_closed`) so
-                        // the FFI peer is notified even if the service
-                        // ignores the write error we return.
+                        // Drain never came: fire close (the service may
+                        // ignore the error) and fail the write.
                         if !this.closed_fired {
                             this.closed_fired = true;
                             (this.on_closed)();
                         }
                         Poll::Ready(Err(io::Error::new(
                             io::ErrorKind::TimedOut,
-                            "transparent proxy: paused-drain backstop — peer drain signal lost?",
+                            "transparent proxy: paused-drain backstop",
                         )))
                     }
                     Poll::Pending => Poll::Pending,
@@ -263,16 +229,12 @@ impl AsyncWrite for FfiBridgeStream {
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        // No intermediate buffer on our side — bytes go straight to the
-        // sink in `poll_write`, so there is nothing to flush.
-        Poll::Ready(Ok(()))
+        Poll::Ready(Ok(())) // nothing buffered; bytes go straight to the sink
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
-        // Fire the FFI "write side done" callback exactly once. The sink is
-        // already wrapped by the `callback_active` gate, so a shutdown that
-        // races teardown is a no-op rather than a use-after-free.
+        // Fire the "write done" callback once (gated against teardown).
         if !this.closed_fired {
             this.closed_fired = true;
             (this.on_closed)();
@@ -283,10 +245,8 @@ impl AsyncWrite for FfiBridgeStream {
 
 impl Drop for FfiBridgeStream {
     fn drop(&mut self) {
-        // A force-close (idle backstop / shutdown drops the stream before a
-        // clean `poll_shutdown`) still owes the FFI peer its "write side
-        // done" signal. Exactly-once via `closed_fired`; the guarded sink
-        // no-ops if teardown already disarmed callbacks.
+        // Force-close (dropped before a clean `poll_shutdown`) still fires
+        // the gated "write done" callback, once.
         if !self.closed_fired {
             self.closed_fired = true;
             (self.on_closed)();

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -631,6 +631,12 @@ impl TransparentProxyTcpSession {
                 TcpDeliverStatus::Accepted
             }
             Err(TrySendError::Full(())) => {
+                // TODO(backpressure): lost-wakeup race. If the reader drains the
+                // channel empty between this `try_reserve` and the store, it
+                // clears `paused` before we set it, so the read-demand callback
+                // never re-fires and the flow stalls until the idle backstop.
+                // Pre-existing, rare at the default capacity; fix + a
+                // capacity-1 test deferred (mirror in `try_enqueue_egress`).
                 self.signals.ingress_paused.store(true, Ordering::Release);
                 TcpDeliverStatus::Paused
             }

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -2,7 +2,7 @@ use std::{
     future::Future,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::Duration,
 };
@@ -15,18 +15,15 @@ use rama_core::{
     rt::Executor,
     service::Service,
 };
-use rama_net::{
-    conn::is_connection_error,
-    proxy::{BridgeCloseReason, IdleGuard, ProxyTarget},
+use rama_net::proxy::{BridgeCloseReason, IdleGuard, ProxyTarget};
+
+use atomic_waker::AtomicWaker;
+use tokio::sync::{
+    mpsc::{self, error::TrySendError},
+    oneshot,
 };
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    sync::{
-        Notify,
-        mpsc::{self, error::TrySendError},
-        oneshot,
-    },
-};
+
+use self::ffi_stream::{FfiBridgeStream, TcpFlowByteCounters};
 
 use std::net::SocketAddr;
 
@@ -37,6 +34,8 @@ use crate::{
 
 mod svc_context;
 pub use self::svc_context::TransparentProxyServiceContext;
+
+pub(crate) mod ffi_stream;
 
 mod boxed;
 pub use self::boxed::{
@@ -116,15 +115,14 @@ impl std::fmt::Display for DecisionDeadlineAction {
     }
 }
 
-/// Default duplex buffer size between the per-flow bridge and the service.
-/// Two duplexes per TCP flow (ingress + egress) at this size each, fixed
-/// at flow creation, so this is a per-flow memory floor of `2× this`.
+/// Legacy default for the per-flow duplex buffer.
 ///
-/// 16 KiB matches the bridge's own read buffer ([`run_tcp_bridge`]). For
-/// L4 transparent forwarding this is plenty of burst absorption — the
-/// bridge always copies out before the next read. Handlers that terminate
-/// HTTP/2 (or other heavy fan-in protocols) should raise this via
-/// [`TransparentProxyEngineBuilder::tcp_flow_buffer_size`].
+/// **No longer affects the data path.** The `tokio::io::duplex` + bridge
+/// task were removed in favor of channel/callback-backed streams
+/// ([`ffi_stream::FfiBridgeStream`]); per-flow buffering is now bounded by
+/// the mpsc channel capacity ([`DEFAULT_TCP_CHANNEL_CAPACITY`]). Retained
+/// only as the default for the still-exposed (now inert)
+/// [`TransparentProxyEngineBuilder::tcp_flow_buffer_size`] setting.
 const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 16 * 1024;
 /// Number of `Bytes` chunks each TCP per-flow channel (ingress and egress)
 /// will buffer before backpressuring Swift. Each chunk is whatever Swift
@@ -132,11 +130,12 @@ const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 16 * 1024;
 /// (typically 4–64 KiB).
 ///
 /// 8 chunks is sized for L4 transparent forwarding (the design centre of
-/// this engine): the bridge copies each chunk out into the duplex
-/// immediately, so deep per-flow queues buy little and just pin memory.
-/// At ~16 KiB per chunk that is ~128 KiB of worst-case headroom per
-/// direction, ~256 KiB per flow under saturation. Handlers that terminate
-/// HTTP/2 (or other heavy fan-in protocols) should raise this via
+/// this engine): the per-flow stream serves each chunk straight to the
+/// service / FFI sink, so this channel is the *only* per-flow buffer (the
+/// duplex is gone, #5) and deep queues just pin memory. At ~16 KiB per
+/// chunk that is ~128 KiB of worst-case headroom per direction, ~256 KiB
+/// per flow under saturation. Handlers that terminate HTTP/2 (or other
+/// heavy fan-in protocols) should raise this via
 /// [`TransparentProxyEngineBuilder::tcp_channel_capacity`].
 const DEFAULT_TCP_CHANNEL_CAPACITY: usize = 8;
 /// Bound on the UDP ingress and egress channels. UDP datagrams are inherently
@@ -494,39 +493,34 @@ where
 struct TcpSessionPendingData {
     /// Delivers the completed `BridgeIo` to the waiting service task.
     bridge_tx: oneshot::Sender<BridgeIo<TcpFlow, NwTcpStream>>,
-    /// Ingress (client→Rust) bytes; handed to the ingress bridge at activate.
+    /// Ingress (client→Rust) bytes; becomes the `TcpFlow` read side at activate.
     client_rx: mpsc::Receiver<Bytes>,
-    /// Shared per-flow paused flags + drain notifications.
+    /// Shared per-flow paused flags + drain wakers.
     signals: Arc<TcpPerFlowSignals>,
     /// Rust→Swift: signal Swift it can resume reading from the intercepted flow.
-    /// Fired by the ingress bridge after it drained a chunk while
+    /// Fired by the `TcpFlow` read side after it drains a chunk while
     /// `signals.ingress_paused` was set.
     on_client_read_demand: DemandSink,
     /// Rust→Swift: response bytes back to the intercepted client flow.
-    /// Returns a [`TcpDeliverStatus`] so the bridge can pause when Swift's
-    /// writer pump is full and wait for the matching `signal_server_drain`.
+    /// Returns a [`TcpDeliverStatus`] so the `TcpFlow` write side can pause
+    /// when Swift's writer pump is full and wait for `signal_server_drain`.
     on_server_bytes: BytesStatusSink,
     /// Rust→Swift: ingress response stream done.
     on_server_closed: ClosedSink,
-    /// Both ingress and egress duplex buffer size.
-    tcp_flow_buffer_size: usize,
     /// Capacity of the bounded ingress and egress mpsc channels (in chunks).
     tcp_channel_capacity: usize,
-    /// Optional per-flow idle timeout. `None` disables idle detection.
-    tcp_idle_timeout: Option<Duration>,
-    /// Optional override for [`DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT`] applied to both
-    /// per-flow bridges. `None` means "use the engine default".
+    /// Optional override for [`DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT`] applied to
+    /// both per-flow stream write sides. `None` means "use the engine default".
     tcp_paused_drain_max_wait: Option<Duration>,
+    /// Per-flow byte tallies shared with the streams; read by the service
+    /// task to emit the flow's close event.
+    byte_counters: Arc<TcpFlowByteCounters>,
     /// Per-flow metadata inserted into `TcpFlow` extensions at activate.
     meta: TransparentProxyFlowMeta,
-    /// Flow-scoped guard; held by bridge tasks to delay shutdown until they finish.
+    /// Flow-scoped guard, cloned into the per-flow stream executor.
     flow_guard: ShutdownGuard,
-    /// Runtime handle used to spawn bridge tasks from outside the async context.
-    ///
-    /// `activate` is called by Swift from an external (non-Tokio) thread after the
-    /// egress `NWConnection` is ready.  We cannot use `tokio::spawn` from there —
-    /// it requires an active runtime context.  Storing a `Handle` lets us call
-    /// `Handle::spawn`, which works from any thread on multi-thread runtimes.
+    /// Runtime handle, used to back the promote handle from `activate`
+    /// (which Swift may call from an external, non-Tokio thread).
     rt_handle: tokio::runtime::Handle,
     /// Handler-supplied egress options (may be `None` for NW defaults).
     egress_connect_options: Option<NwTcpConnectOptions>,
@@ -569,8 +563,6 @@ pub struct TransparentProxyTcpSession {
     pending: Option<TcpSessionPendingData>,
 
     // tasks
-    ingress_bridge_task: Option<tokio::task::JoinHandle<()>>,
-    egress_bridge_task: Option<tokio::task::JoinHandle<()>>,
     service_task: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -732,14 +724,14 @@ impl TransparentProxyTcpSession {
     /// Idempotent — the underlying `Notify` collapses redundant signals into
     /// a single permit.
     pub fn signal_server_drain(&self) {
-        self.signals.ingress_drain.notify_one();
+        self.signals.ingress_drain.wake();
     }
 
     /// Symmetric counterpart of [`Self::signal_server_drain`] for the egress
     /// request direction. Called by Swift when its `NwTcpConnectionWritePump`
     /// has drained capacity after `on_write_to_egress` returned `Paused`.
     pub fn signal_egress_drain(&self) {
-        self.signals.egress_drain.notify_one();
+        self.signals.egress_drain.wake();
     }
 
     /// Called by Swift when the egress `NWConnection` closes or fails.
@@ -795,44 +787,56 @@ impl TransparentProxyTcpSession {
             on_client_read_demand,
             on_server_bytes,
             on_server_closed,
-            tcp_flow_buffer_size,
             tcp_channel_capacity,
-            tcp_idle_timeout,
             tcp_paused_drain_max_wait,
+            byte_counters,
             meta,
             flow_guard,
             rt_handle,
             egress_connect_options: _,
         } = pending;
 
-        // ingress stream (client ↔ service)
-        let (ingress_user, ingress_internal) = tokio::io::duplex(tcp_flow_buffer_size);
-        let ingress_stream =
-            TcpFlow::new(ingress_user, Some(Executor::graceful(flow_guard.clone())));
+        let paused_drain_wait =
+            tcp_paused_drain_max_wait.unwrap_or(DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT);
         let remote_endpoint = meta.remote_endpoint.clone();
         let meta_arc = Arc::new(meta);
-        ingress_stream.extensions().insert_arc(meta_arc.clone());
+
+        // ── ingress stream (client ↔ service) ──
+        // read side drains `client_rx` (client→service); write side hands
+        // service→client bytes straight to `on_server_bytes`. No duplex, no
+        // bridge task — the forwarder drives this stream directly.
+        let ingress_inner = FfiBridgeStream::new(
+            client_rx,
+            on_server_bytes,
+            on_client_read_demand,
+            on_server_closed,
+            signals.clone(),
+            byte_counters.clone(),
+            BridgeDirection::Ingress,
+            paused_drain_wait,
+        );
+        let ingress_stream = TcpFlow::new(ingress_inner, Some(Executor::graceful(flow_guard)));
+        ingress_stream.extensions().insert_arc(meta_arc);
         if let Some(remote) = remote_endpoint {
             ingress_stream.extensions().insert(ProxyTarget(remote));
         }
         // Service-initiated hand-off back to Swift; see [`PromoteHandle`].
         // The handle is backed by the session's `PromoteRegistry` so
         // `into_passthrough` fires the FFI-registered Swift callback,
-        // awaits Swift's `confirm_promoted` ACK, and on success drops
-        // both ingress + egress senders so the bridges EOF the
-        // service after draining in-flight bytes.
+        // awaits Swift's `confirm_promoted` ACK, and on success drops both
+        // ingress + egress senders so the stream read sides EOF the service
+        // after draining in-flight bytes.
         ingress_stream
             .extensions()
-            .insert(self.promote_registry.clone().into_handle(rt_handle.clone()));
+            .insert(self.promote_registry.clone().into_handle(rt_handle));
 
-        // egress stream (service ↔ NWConnection)
-        let (egress_user, egress_internal) = tokio::io::duplex(tcp_flow_buffer_size);
-        let egress_stream = NwTcpStream::new(egress_user);
-
+        // ── egress stream (service ↔ NWConnection) ──
+        // read side drains `egress_client_rx` (upstream→service); write side
+        // hands service→upstream bytes straight to `on_write_to_egress`.
         let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
         *self.egress_tx.lock() = Some(egress_client_tx);
 
-        // guard egress callbacks
+        // guard egress callbacks against the post-cancel teardown race
         let egress_bytes_sink: BytesStatusSink = Arc::new(on_write_to_egress);
         let egress_closed_sink: ClosedSink = Arc::new(on_close_egress);
         let egress_demand_sink: DemandSink = Arc::new(on_egress_read_demand);
@@ -843,79 +847,28 @@ impl TransparentProxyTcpSession {
         let guarded_egress_demand =
             guarded_demand_sink(self.callback_active.clone(), egress_demand_sink);
 
-        // Spawn bridge tasks via the stored runtime handle so that `activate` can be
-        // called from an external (non-Tokio) thread — e.g. a Swift dispatch queue.
-        // We clone the flow_guard into each task to keep the shutdown barrier alive
-        // until the task completes, matching the semantics of `spawn_task`.
-        //
-        // Note: we deliberately do NOT route this spawn through dial9's
-        // per-future wake-tracking. `dial9_tokio_telemetry::spawn` reads
-        // `TelemetryHandle::current()` from a thread-local, which is only
-        // populated on dial9 worker threads. `activate` runs on a Swift
-        // dispatch queue, so even with the `dial9` feature on the wrapper
-        // would silently fall through to plain `tokio::spawn`. Runtime-level
-        // events (poll start/end, wake, scheduling delay) are still emitted
-        // on every poll because dial9 hooks the worker thread, so the loss
-        // is the per-future wake graph for these two bridge tasks only.
-
-        let paused_drain_wait =
-            tcp_paused_drain_max_wait.unwrap_or(DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT);
-        // spawn ingress bridge (client ↔ service)
-        self.ingress_bridge_task = Some({
-            let guard = flow_guard.clone();
-            let meta = meta_arc.clone();
-            let signals = signals.clone();
-            rt_handle.spawn(async move {
-                run_tcp_bridge(
-                    ingress_internal,
-                    client_rx,
-                    signals,
-                    on_client_read_demand,
-                    on_server_bytes,
-                    on_server_closed,
-                    guard,
-                    meta,
-                    tcp_idle_timeout,
-                    paused_drain_wait,
-                    BridgeDirection::Ingress,
-                )
-                .await;
-            })
-        });
-
-        // spawn egress bridge (service ↔ NWConnection)
-        self.egress_bridge_task = Some({
-            let guard = flow_guard;
-            let meta = meta_arc;
-            rt_handle.spawn(async move {
-                run_tcp_bridge(
-                    egress_internal,
-                    egress_client_rx,
-                    signals,
-                    guarded_egress_demand,
-                    guarded_egress_bytes,
-                    guarded_egress_closed,
-                    guard,
-                    meta,
-                    tcp_idle_timeout,
-                    paused_drain_wait,
-                    BridgeDirection::Egress,
-                )
-                .await;
-            })
-        });
+        let egress_inner = FfiBridgeStream::new(
+            egress_client_rx,
+            guarded_egress_bytes,
+            guarded_egress_demand,
+            guarded_egress_closed,
+            signals,
+            byte_counters,
+            BridgeDirection::Egress,
+            paused_drain_wait,
+        );
+        let egress_stream = NwTcpStream::new(egress_inner);
 
         // deliver BridgeIo to the waiting service task
         if bridge_tx
             .send(BridgeIo(ingress_stream, egress_stream))
             .is_err()
         {
-            // Same situation as the UDP path: service task ended
-            // before activate (parent_guard cancelled, panic). The
-            // BridgeIo we built is dropped on send failure, which
-            // closes the per-flow ingress / egress channels —
-            // subsequent `on_client_bytes` etc. will report
-            // `Closed`.
+            // Same situation as the UDP path: service task ended before
+            // activate (parent_guard cancelled, panic). The BridgeIo we
+            // built is dropped on send failure, which closes the per-flow
+            // ingress / egress channels — subsequent `on_client_bytes` etc.
+            // will report `Closed`.
             tracing::debug!(
                 target: "rama_apple_ne::tproxy",
                 "tcp activate: bridge_tx.send dropped — service task ended before activate",
@@ -982,17 +935,19 @@ impl TransparentProxyTcpSession {
         // Order matters. See `guarded_datagram_sink` for the
         // callback_active contract.
         //
-        //   1. callback_active = false — any in-flight bridge dispatch
+        //   1. callback_active = false — any in-flight stream dispatch
         //      blocks here on the same sync mutex; further dispatches
         //      short-circuit.
         //   2. flow_stop_tx — fires `flow_guard.cancelled()` so the
-        //      bridge's biased select picks the shutdown arm.
-        //   3. notify_one — wake any bridge parked on Paused-wait so
-        //      it observes (1) and (2).
-        //   4. drop senders — natural EOF for `recv()` arms.
-        //   5. detach bridge tasks (let them finish their close
-        //      epilogue for dial9 / tracing); abort the service task
-        //      as a fallback for user code wedged outside bridge IO.
+        //      forwarder's biased select picks the shutdown arm and the
+        //      flow-level idle watcher exits.
+        //   3. drain wakers — wake any stream write side parked on a
+        //      `Paused` so it re-polls, observes (1) via the gated sink
+        //      (now `Closed`), and unwinds.
+        //   4. drop senders — natural EOF for the stream read sides.
+        //   5. abort the service task as a fallback for user code wedged
+        //      outside stream IO (its streams' `Drop` still fires the
+        //      gated close callbacks, no-op'd by (1)).
         *self.callback_active.lock() = false;
         // The receiver lives inside `flow_shutdown`'s inner future
         // and is dropped only when that future ends — which itself
@@ -1008,8 +963,8 @@ impl TransparentProxyTcpSession {
                 "tcp cancel: flow_stop_tx receiver already gone (engine shutdown raced ahead)",
             );
         }
-        self.signals.ingress_drain.notify_one();
-        self.signals.egress_drain.notify_one();
+        self.signals.ingress_drain.wake();
+        self.signals.egress_drain.wake();
         *self.client_tx.lock() = None;
         *self.egress_tx.lock() = None;
         self.pending = None;
@@ -1018,8 +973,6 @@ impl TransparentProxyTcpSession {
         // `EngineShuttingDown` instead of hanging on the ACK
         // forever.
         self.promote_registry.abort_pending();
-        _ = self.ingress_bridge_task.take();
-        _ = self.egress_bridge_task.take();
         if let Some(task) = self.service_task.take() {
             task.abort();
         }
@@ -1040,7 +993,10 @@ async fn new_tcp_session_flow_action<OnBytes, OnDemand, OnClosed, H>(
     parent_guard: ShutdownGuard,
     exec: Executor,
     meta: TransparentProxyFlowMeta,
-    tcp_flow_buffer_size: usize,
+    // The duplex is gone (#5): the duplex buffer size no longer applies to
+    // the in-Rust data path. Kept as a parameter for engine/builder ABI
+    // stability; the per-flow mpsc channel capacity now bounds buffering.
+    _tcp_flow_buffer_size: usize,
     tcp_channel_capacity: usize,
     tcp_idle_timeout: Option<Duration>,
     tcp_paused_drain_max_wait: Option<Duration>,
@@ -1104,6 +1060,7 @@ where
     let (client_tx, client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<TcpFlow, NwTcpStream>>();
     let signals = Arc::new(TcpPerFlowSignals::new());
+    let byte_counters = Arc::new(TcpFlowByteCounters::default());
 
     let callback_active = Arc::new(parking_lot::Mutex::new(true));
     let on_server_bytes_guarded =
@@ -1113,58 +1070,116 @@ where
     let on_client_read_demand_guarded =
         guarded_demand_sink(callback_active.clone(), Arc::new(on_client_read_demand));
 
-    // Capture the current runtime handle so `activate` can spawn bridge tasks from
-    // any thread (including an external Swift thread) via `Handle::spawn`.
+    // Capture the current runtime handle so `activate` (which Swift may
+    // call from an external, non-Tokio thread) can back the promote handle.
     let rt_handle = tokio::runtime::Handle::current();
 
     tracing::debug!(protocol = ?meta.protocol, "new tcp session (pending egress connection)");
 
-    // Service task waits for BridgeIo, then serves it.
+    // Service task waits for BridgeIo, then serves it under a flow-level
+    // idle backstop + cancellation watch.
     //
     // Spawn through the rama `Executor` (graceful-aware) instead of
     // `flow_guard.spawn_task` directly, so that with the `dial9`
     // feature on the inner `tokio::spawn` is replaced by
     // `dial9_tokio_telemetry::spawn` — giving per-future wake-event
     // tracking on this long-lived per-flow service task.
-    let meta_for_synthetic_close = meta.clone();
+    let meta_for_close = meta.clone();
+    let counters_for_close = byte_counters.clone();
+    let idle_guard = flow_guard.clone();
     let service_task = Executor::graceful(flow_guard.clone()).spawn_task(async move {
         let Ok(bridge) = bridge_rx.await else {
             // Cancelled before `activate`. Emit a synthetic close so
             // every `record_flow_opened` has a matching close in the
             // logs / dial9 trace. Mirrors the UDP path.
-            let age_ms =
-                u64::try_from(meta_for_synthetic_close.age().as_millis()).unwrap_or(u64::MAX);
+            let age_ms = u64::try_from(meta_for_close.age().as_millis()).unwrap_or(u64::MAX);
             tracing::info!(
                 target: "rama_apple_ne::tproxy",
-                flow_id = meta_for_synthetic_close.flow_id,
-                protocol = %meta_for_synthetic_close.protocol,
+                flow_id = meta_for_close.flow_id,
+                protocol = %meta_for_close.protocol,
                 reason = %BridgeCloseReason::Shutdown,
                 age_ms,
                 bytes_received = 0_u64,
                 bytes_sent = 0_u64,
-                pid = meta_for_synthetic_close.source_app_pid,
-                bundle_id = meta_for_synthetic_close.source_app_bundle_identifier.as_deref(),
-                signing_id = meta_for_synthetic_close.source_app_signing_identifier.as_deref(),
-                decision = meta_for_synthetic_close
-                    .intercept_decision
-                    .map(tracing::field::display),
+                pid = meta_for_close.source_app_pid,
+                bundle_id = meta_for_close.source_app_bundle_identifier.as_deref(),
+                signing_id = meta_for_close.source_app_signing_identifier.as_deref(),
+                decision = meta_for_close.intercept_decision.map(tracing::field::display),
                 "transparent proxy tcp flow closed before activate",
             );
             #[cfg(feature = "dial9")]
-            crate::tproxy::dial9::record_flow_closed(
-                meta_for_synthetic_close.flow_id,
-                age_ms,
-                0,
-                0,
-            );
+            crate::tproxy::dial9::record_flow_closed(meta_for_close.flow_id, age_ms, 0, 0);
             return;
         };
-        // `serve` is `Result<(), Infallible>`; the `let Ok(())` form
-        // depends on the `irrefutable_let_patterns` lint rather than
-        // language-level pattern irrefutability for `Result<_,
-        // Infallible>`. Drop the pattern entirely so future toolchain
-        // bumps can't silently break this.
-        _ = service.serve(bridge).await;
+
+        // Drive the service to completion, but apply the engine's
+        // `tcp_idle_timeout` and watch the flow guard at this level (the
+        // per-flow streams deliberately don't, leaving lifecycle to us +
+        // the forwarder). `serve` is `Result<(), Infallible>`; the value
+        // is irrelevant — we only care that it finished. On idle/shutdown
+        // we drop `serve`, whose stream `Drop` fires the gated close
+        // callbacks.
+        let reason = {
+            let mut serve = std::pin::pin!(service.serve(bridge));
+            let mut idle = tcp_idle_timeout.map(IdleGuard::new);
+            let mut last_progress = counters_for_close.total();
+            loop {
+                tokio::select! {
+                    biased;
+                    () = idle_guard.cancelled() => break BridgeCloseReason::Shutdown,
+                    _ = async {
+                        match idle.as_mut() {
+                            Some(g) => g.tick().await,
+                            None => std::future::pending::<()>().await,
+                        }
+                    } => {
+                        let cur = counters_for_close.total();
+                        if cur != last_progress {
+                            last_progress = cur;
+                            if let Some(g) = idle.as_mut() {
+                                g.reset();
+                            }
+                            continue;
+                        }
+                        break BridgeCloseReason::IdleTimeout;
+                    }
+                    _ = serve.as_mut() => break BridgeCloseReason::PeerEofLeft,
+                }
+            }
+            // `serve` (and its streams) drop here on a force-close, firing
+            // the gated `on_*_closed` callbacks before we log the close.
+        };
+
+        let (ingress_received, ingress_sent) =
+            counters_for_close.snapshot(BridgeDirection::Ingress);
+        let (egress_received, egress_sent) = counters_for_close.snapshot(BridgeDirection::Egress);
+        emit_tcp_bridge_close_event(
+            BridgeDirection::Ingress,
+            reason,
+            &meta_for_close,
+            ingress_received,
+            ingress_sent,
+        );
+        emit_tcp_bridge_close_event(
+            BridgeDirection::Egress,
+            reason,
+            &meta_for_close,
+            egress_received,
+            egress_sent,
+        );
+        // dial9 collapses the two directions into one record using the
+        // INGRESS orientation (received = client→service, sent =
+        // service→client), matching the legacy bridge behavior.
+        #[cfg(feature = "dial9")]
+        {
+            let age_ms = u64::try_from(meta_for_close.age().as_millis()).unwrap_or(u64::MAX);
+            crate::tproxy::dial9::record_flow_closed(
+                meta_for_close.flow_id,
+                age_ms,
+                ingress_received,
+                ingress_sent,
+            );
+        }
     });
 
     let pending = TcpSessionPendingData {
@@ -1174,10 +1189,9 @@ where
         on_client_read_demand: on_client_read_demand_guarded,
         on_server_bytes: on_server_bytes_guarded,
         on_server_closed: on_server_closed_guarded,
-        tcp_flow_buffer_size,
         tcp_channel_capacity,
-        tcp_idle_timeout,
         tcp_paused_drain_max_wait,
+        byte_counters,
         meta,
         flow_guard,
         rt_handle,
@@ -1202,8 +1216,6 @@ where
         callback_active,
         flow_stop_tx: Some(flow_stop_tx),
         pending: Some(pending),
-        ingress_bridge_task: None,
-        egress_bridge_task: None,
         service_task: Some(service_task),
     })
 }
@@ -2000,9 +2012,10 @@ fn guarded_datagram_sink(
     })
 }
 
-/// Direction tag for [`run_tcp_bridge`] used in close-log emission.
+/// Direction tag selecting per-direction signals/counters and used in
+/// close-log emission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BridgeDirection {
+pub(crate) enum BridgeDirection {
     /// Client ↔ service ingress bridge (FFI client_rx ↔ service duplex).
     Ingress,
     /// Service ↔ NWConnection egress bridge.
@@ -2018,23 +2031,29 @@ impl std::fmt::Display for BridgeDirection {
     }
 }
 
-/// Per-flow backpressure flags and drain notifications, shared between the
-/// session's FFI surface and its two bridge tasks via a single `Arc`. One
-/// allocation instead of four (two `AtomicBool` + two `Notify`).
-struct TcpPerFlowSignals {
+/// Per-flow backpressure flags and drain wakers, shared between the
+/// session's FFI surface and its two per-flow streams via a single `Arc`.
+/// One allocation instead of four (two `AtomicBool` + two `AtomicWaker`).
+///
+/// `*_paused` is set by `on_*_bytes` when the ingress channel is full and
+/// cleared (edge-triggered, firing the read-demand callback) by the
+/// matching stream's `poll_read` when it drains a slot. `*_drain` is
+/// registered by the matching stream's `poll_write` while parked on
+/// `Paused` and woken by `signal_*_drain`.
+pub(crate) struct TcpPerFlowSignals {
     ingress_paused: AtomicBool,
-    ingress_drain: Notify,
+    ingress_drain: AtomicWaker,
     egress_paused: AtomicBool,
-    egress_drain: Notify,
+    egress_drain: AtomicWaker,
 }
 
 impl TcpPerFlowSignals {
     fn new() -> Self {
         Self {
             ingress_paused: AtomicBool::new(false),
-            ingress_drain: Notify::new(),
+            ingress_drain: AtomicWaker::new(),
             egress_paused: AtomicBool::new(false),
-            egress_drain: Notify::new(),
+            egress_drain: AtomicWaker::new(),
         }
     }
 
@@ -2045,265 +2064,12 @@ impl TcpPerFlowSignals {
         }
     }
 
-    fn drain(&self, dir: BridgeDirection) -> &Notify {
+    fn drain(&self, dir: BridgeDirection) -> &AtomicWaker {
         match dir {
             BridgeDirection::Ingress => &self.ingress_drain,
             BridgeDirection::Egress => &self.egress_drain,
         }
     }
-}
-
-#[expect(clippy::too_many_arguments)]
-async fn run_tcp_bridge(
-    internal: tokio::io::DuplexStream,
-    mut client_rx: mpsc::Receiver<Bytes>,
-    signals: Arc<TcpPerFlowSignals>,
-    on_read_demand: DemandSink,
-    on_server_bytes: BytesStatusSink,
-    on_server_closed: ClosedSink,
-    flow_guard: ShutdownGuard,
-    meta: Arc<TransparentProxyFlowMeta>,
-    idle_timeout: Option<Duration>,
-    paused_drain_max_wait: Duration,
-    direction: BridgeDirection,
-) {
-    let paused = signals.paused(direction);
-    let server_write_notify = signals.drain(direction);
-    let (mut read_half, mut write_half) = tokio::io::split(internal);
-    let mut buf = vec![0u8; 16 * 1024];
-    // Set to true once the write side is finished so we keep draining read_half even
-    // if the service dropped its read side before the bridge had a chance to read its
-    // response bytes.  Without this flag, a write failure would cause a `break` that
-    // races against any already-buffered server response bytes.
-    let mut write_done = false;
-    // Set to true once `on_server_bytes` reports the session is gone; we then
-    // exit the loop and fire `on_server_closed` once.
-    let mut server_closed = false;
-    // Bytes that `on_server_bytes` rejected with `Paused`. Swift does NOT
-    // take ownership on a `Paused` return, so we MUST replay this chunk
-    // after `server_write_notify` fires before reading any more from the
-    // duplex — otherwise we punch a hole in the byte stream and the
-    // downstream TLS layer surfaces "bad record MAC" once the gap reaches
-    // the decryptor. Symmetric to the Swift-side `pendingData` retain
-    // pattern for the Swift → Rust direction.
-    let mut pending_to_server: Option<Bytes> = None;
-
-    // Direction-relative byte counters. See `emit_tcp_bridge_close_event`
-    // for how the Ingress / Egress orientations resolve at log time.
-    let mut bytes_received: u64 = 0; // FFI peer → duplex (this side received)
-    let mut bytes_sent: u64 = 0; // duplex → FFI peer  (this side sent)
-    let progress = Arc::new(AtomicU64::new(0));
-    let mut last_progress: u64 = 0;
-    let mut idle = idle_timeout.map(IdleGuard::new);
-
-    let close_reason = loop {
-        if server_closed {
-            break BridgeCloseReason::PeerEofRight;
-        }
-
-        // Drain any pending replay before reading more from the duplex.
-        if let Some(bytes) = pending_to_server.take() {
-            let chunk_len = bytes.len() as u64;
-            match on_server_bytes(&bytes) {
-                TcpDeliverStatus::Accepted => {
-                    // Count this chunk against `bytes_sent` here, on
-                    // the replay's accepted return — the original
-                    // read in the main loop only counts for the first
-                    // successful delivery, never for chunks that
-                    // paused and were replayed.
-                    bytes_sent += chunk_len;
-                    progress.fetch_add(1, Ordering::Relaxed);
-                }
-                TcpDeliverStatus::Paused => {
-                    pending_to_server = Some(bytes);
-                    // Wait for drain or shutdown — never block here forever.
-                    // The `paused_drain_max_wait` arm catches a stuck
-                    // peer-side drain signal (lost / never invoked) so
-                    // the bridge can't wedge waiting for a notification
-                    // that never arrives.
-                    tokio::select! {
-                        biased;
-                        () = flow_guard.cancelled() => {
-                            break BridgeCloseReason::Shutdown;
-                        }
-                        () = server_write_notify.notified() => {
-                            continue;
-                        }
-                        () = tokio::time::sleep(paused_drain_max_wait) => {
-                            tracing::warn!(
-                                target: "rama_apple_ne::tproxy",
-                                flow_id = meta.flow_id,
-                                direction = %direction,
-                                wait_ms = u64::try_from(paused_drain_max_wait.as_millis()).unwrap_or(u64::MAX),
-                                "transparent proxy bridge: paused-wait timeout (replay) — peer drain signal lost?",
-                            );
-                            break BridgeCloseReason::PausedTimeout;
-                        }
-                    }
-                }
-                TcpDeliverStatus::Closed => {
-                    server_closed = true;
-                    continue;
-                }
-            }
-        }
-
-        tokio::select! {
-            // Biased: shutdown + idle drain immediately, and the write
-            // arm is preferred when both data arms are simultaneously
-            // ready. Accepted trade-off — the read arm yields a poll to
-            // the kernel buffer, which absorbs short backlog while the
-            // write side bursts. Cancel determinism wins over perfect
-            // read/write fairness for proxy traffic.
-            biased;
-
-            // Per-flow shutdown — drain immediately.
-            () = flow_guard.cancelled() => {
-                break BridgeCloseReason::Shutdown;
-            }
-
-            // Idle timeout — re-arm if progress observed; otherwise close.
-            _ = async {
-                match idle.as_mut() {
-                    Some(g) => g.tick().await,
-                    None => std::future::pending::<()>().await,
-                }
-            } => {
-                let cur = progress.load(Ordering::Relaxed);
-                if cur != last_progress {
-                    last_progress = cur;
-                    if let Some(g) = idle.as_mut() {
-                        g.reset();
-                    }
-                    continue;
-                }
-                break BridgeCloseReason::IdleTimeout;
-            }
-
-            maybe = client_rx.recv(), if !write_done => {
-                if let Some(bytes) = maybe {
-                    // We just freed a slot — if Swift was paused waiting for capacity,
-                    // wake it once. Edge-triggered: only the swap from `true` actually
-                    // fires the callback, so we never spam Swift with redundant demand
-                    // signals while the channel is draining.
-                    if paused.swap(false, Ordering::AcqRel) {
-                        on_read_demand();
-                    }
-                    let n = bytes.len() as u64;
-                    if let Err(err) = write_half.write_all(&bytes).await {
-                        if is_connection_error(&err) {
-                            tracing::trace!(direction = %direction, %err, "tcp bridge write_all conn error");
-                        } else {
-                            tracing::debug!(direction = %direction, %err, "tcp bridge write_all failed");
-                        }
-                        // The service dropped its read side (e.g. it already wrote its
-                        // response and returned).  Stop writing, but keep reading so
-                        // any buffered response bytes still reach the client.
-                        //
-                        // Close the receiver: any subsequent `try_send` from the FFI
-                        // side returns `TrySendError::Closed` so Swift stops queueing
-                        // bytes that no one will ever read. Without this the FFI tx
-                        // accumulates Bytes until the task aborts, which under
-                        // sustained load lets a single broken flow keep buffering.
-                        write_done = true;
-                        client_rx.close();
-                    } else {
-                        bytes_received += n;
-                        progress.fetch_add(1, Ordering::Relaxed);
-                    }
-                } else {
-                    // FFI sender dropped (EOF or cancel). Drain done; close
-                    // the write side so the service sees end-of-stream.
-                    _ = write_half.shutdown().await;
-                    write_done = true;
-                }
-            }
-            read_res = read_half.read(&mut buf) => {
-                match read_res {
-                    Ok(0) => {
-                        break BridgeCloseReason::PeerEofLeft;
-                    }
-                    Err(err) => {
-                        let conn_err = is_connection_error(&err);
-                        if conn_err {
-                            tracing::trace!(direction = %direction, %err, "tcp bridge read_half conn error");
-                        } else {
-                            tracing::debug!(direction = %direction, %err, "tcp bridge read_half failed");
-                        }
-                        break BridgeCloseReason::ReadErrorLeft;
-                    }
-                    Ok(n) => {
-                        // Symmetric backpressure: Swift's writer pump may be
-                        // full. We must not just hand it more bytes — that's
-                        // what leads to unbounded `pending` growth and
-                        // eventually `ENOBUFS` on `flow.write` /
-                        // `connection.send`. On `Paused`, hold the chunk
-                        // (Swift did NOT take it) and suspend the bridge
-                        // until `signal_*_drain` fires.
-                        //
-                        // The sink only borrows `&[u8]` — Swift copies into
-                        // its own `Data` synchronously — so the common
-                        // (Accepted) path needs no owned allocation. We only
-                        // copy into a `Bytes` on `Paused`, where the chunk
-                        // must outlive `buf` across the drain await.
-                        match on_server_bytes(&buf[..n]) {
-                            TcpDeliverStatus::Accepted => {
-                                bytes_sent += n as u64;
-                                progress.fetch_add(1, Ordering::Relaxed);
-                            }
-                            TcpDeliverStatus::Paused => {
-                                pending_to_server = Some(Bytes::copy_from_slice(&buf[..n]));
-                                // See `paused_drain_max_wait` doc; mirrors
-                                // the bound on the replay-side wait above.
-                                tokio::select! {
-                                    biased;
-                                    () = flow_guard.cancelled() => {
-                                        break BridgeCloseReason::Shutdown;
-                                    }
-                                    () = server_write_notify.notified() => {}
-                                    () = tokio::time::sleep(paused_drain_max_wait) => {
-                                        tracing::warn!(
-                                            target: "rama_apple_ne::tproxy",
-                                            flow_id = meta.flow_id,
-                                            direction = %direction,
-                                            wait_ms = u64::try_from(paused_drain_max_wait.as_millis()).unwrap_or(u64::MAX),
-                                            "transparent proxy bridge: paused-wait timeout — peer drain signal lost?",
-                                        );
-                                        break BridgeCloseReason::PausedTimeout;
-                                    }
-                                }
-                            }
-                            TcpDeliverStatus::Closed => {
-                                // Session torn down on the Swift side; no
-                                // demand will follow. Stop the loop after
-                                // this iteration so `on_server_closed`
-                                // fires exactly once.
-                                server_closed = true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    };
-
-    emit_tcp_bridge_close_event(direction, close_reason, &meta, bytes_received, bytes_sent);
-    // Emit the dial9 close event only from the Ingress direction so
-    // the flow appears once in the trace. The structured `tracing`
-    // event above is per-direction (each bridge logs its own
-    // direction-relative `bytes_received` / `bytes_sent`); dial9
-    // collapses the two views into a single record using the
-    // INGRESS bridge's counts, which on the ingress side mean:
-    //   - bytes_received = client → service (this side received)
-    //   - bytes_sent     = service → client (this side sent)
-    // For a faithful relay these match the egress view modulo MITM
-    // transformations.
-    #[cfg(feature = "dial9")]
-    if matches!(direction, BridgeDirection::Ingress) {
-        let age_ms = u64::try_from(meta.age().as_millis()).unwrap_or(u64::MAX);
-        crate::tproxy::dial9::record_flow_closed(meta.flow_id, age_ms, bytes_received, bytes_sent);
-    }
-    on_server_closed();
 }
 
 fn emit_udp_session_close_event(reason: BridgeCloseReason, meta: &TransparentProxyFlowMeta) {

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -23,7 +23,7 @@ use tokio::sync::{
     oneshot,
 };
 
-use self::ffi_stream::{FfiBridgeStream, TcpFlowByteCounters};
+use self::ffi_stream::{CloseReasonCell, FfiBridgeStream, TcpFlowByteCounters};
 
 use std::net::SocketAddr;
 
@@ -505,6 +505,10 @@ struct TcpSessionPendingData {
     /// Per-flow byte tallies shared with the streams; read by the service
     /// task to emit the flow's close event.
     byte_counters: Arc<TcpFlowByteCounters>,
+    /// Per-direction terminal close reason, recorded by each stream and read
+    /// by the service task to label that direction's close event.
+    ingress_close_reason: CloseReasonCell,
+    egress_close_reason: CloseReasonCell,
     /// Per-flow metadata inserted into `TcpFlow` extensions at activate.
     meta: TransparentProxyFlowMeta,
     /// Flow-scoped guard, cloned into the per-flow stream executor.
@@ -775,6 +779,8 @@ impl TransparentProxyTcpSession {
             tcp_channel_capacity,
             tcp_paused_drain_max_wait,
             byte_counters,
+            ingress_close_reason,
+            egress_close_reason,
             meta,
             flow_guard,
             rt_handle,
@@ -795,6 +801,7 @@ impl TransparentProxyTcpSession {
             on_server_closed,
             signals.clone(),
             byte_counters.clone(),
+            ingress_close_reason,
             BridgeDirection::Ingress,
             paused_drain_wait,
         );
@@ -836,6 +843,7 @@ impl TransparentProxyTcpSession {
             guarded_egress_closed,
             signals,
             byte_counters,
+            egress_close_reason,
             BridgeDirection::Egress,
             paused_drain_wait,
         );
@@ -1041,6 +1049,8 @@ where
     let (bridge_tx, bridge_rx) = oneshot::channel::<BridgeIo<TcpFlow, NwTcpStream>>();
     let signals = Arc::new(TcpPerFlowSignals::new());
     let byte_counters = Arc::new(TcpFlowByteCounters::default());
+    let ingress_close_reason: CloseReasonCell = Arc::new(parking_lot::Mutex::new(None));
+    let egress_close_reason: CloseReasonCell = Arc::new(parking_lot::Mutex::new(None));
 
     let callback_active = Arc::new(parking_lot::Mutex::new(true));
     let on_server_bytes_guarded =
@@ -1066,6 +1076,8 @@ where
     // tracking on this long-lived per-flow service task.
     let meta_for_close = meta.clone();
     let counters_for_close = byte_counters.clone();
+    let ingress_reason_cell = ingress_close_reason.clone();
+    let egress_reason_cell = egress_close_reason.clone();
     let idle_guard = flow_guard.clone();
     let service_task = Executor::graceful(flow_guard.clone()).spawn_task(async move {
         let Ok(bridge) = bridge_rx.await else {
@@ -1127,16 +1139,21 @@ where
         let (ingress_received, ingress_sent) =
             counters_for_close.snapshot(BridgeDirection::Ingress);
         let (egress_received, egress_sent) = counters_for_close.snapshot(BridgeDirection::Egress);
+        let (ingress_reason, egress_reason) = resolve_tcp_close_reasons(
+            reason,
+            *ingress_reason_cell.lock(),
+            *egress_reason_cell.lock(),
+        );
         emit_tcp_bridge_close_event(
             BridgeDirection::Ingress,
-            reason,
+            ingress_reason,
             &meta_for_close,
             ingress_received,
             ingress_sent,
         );
         emit_tcp_bridge_close_event(
             BridgeDirection::Egress,
-            reason,
+            egress_reason,
             &meta_for_close,
             egress_received,
             egress_sent,
@@ -1165,6 +1182,8 @@ where
         tcp_channel_capacity,
         tcp_paused_drain_max_wait,
         byte_counters,
+        ingress_close_reason,
+        egress_close_reason,
         meta,
         flow_guard,
         rt_handle,
@@ -2083,6 +2102,62 @@ fn emit_decision_deadline_event(
         reason = %BridgeCloseReason::HandlerDeadline,
         "transparent proxy flow handler exceeded decision deadline",
     );
+}
+
+/// Resolve the per-direction close reasons for a flow's two close events.
+///
+/// `flow_reason` is the service task's outcome: `Shutdown` / `IdleTimeout`
+/// are flow-wide and apply to both directions; otherwise each direction
+/// reports the reason its own stream recorded (defaulting to a clean
+/// `PeerEofLeft` if it terminated without recording one).
+fn resolve_tcp_close_reasons(
+    flow_reason: BridgeCloseReason,
+    ingress: Option<BridgeCloseReason>,
+    egress: Option<BridgeCloseReason>,
+) -> (BridgeCloseReason, BridgeCloseReason) {
+    match flow_reason {
+        BridgeCloseReason::Shutdown | BridgeCloseReason::IdleTimeout => (flow_reason, flow_reason),
+        _ => (
+            ingress.unwrap_or(BridgeCloseReason::PeerEofLeft),
+            egress.unwrap_or(BridgeCloseReason::PeerEofLeft),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod close_reason_resolution {
+    use super::resolve_tcp_close_reasons;
+    use rama_net::proxy::BridgeCloseReason::*;
+
+    #[test]
+    fn flow_level_reasons_apply_to_both_directions() {
+        assert_eq!(
+            resolve_tcp_close_reasons(Shutdown, Some(PeerEofRight), None),
+            (Shutdown, Shutdown)
+        );
+        assert_eq!(
+            resolve_tcp_close_reasons(IdleTimeout, None, Some(PausedTimeout)),
+            (IdleTimeout, IdleTimeout)
+        );
+    }
+
+    #[test]
+    fn serve_completed_uses_per_direction_recorded_reason() {
+        // A write-side failure on one direction must NOT be logged as a
+        // clean EOF — this is the bug the per-direction cells fix.
+        assert_eq!(
+            resolve_tcp_close_reasons(PeerEofLeft, Some(PausedTimeout), Some(PeerEofRight)),
+            (PausedTimeout, PeerEofRight)
+        );
+    }
+
+    #[test]
+    fn serve_completed_defaults_unrecorded_direction_to_clean_eof() {
+        assert_eq!(
+            resolve_tcp_close_reasons(PeerEofLeft, None, None),
+            (PeerEofLeft, PeerEofLeft)
+        );
+    }
 }
 
 fn emit_tcp_bridge_close_event(

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -115,27 +115,18 @@ impl std::fmt::Display for DecisionDeadlineAction {
     }
 }
 
-/// Legacy default for the per-flow duplex buffer.
-///
-/// **No longer affects the data path.** The `tokio::io::duplex` + bridge
-/// task were removed in favor of channel/callback-backed streams
-/// ([`ffi_stream::FfiBridgeStream`]); per-flow buffering is now bounded by
-/// the mpsc channel capacity ([`DEFAULT_TCP_CHANNEL_CAPACITY`]). Retained
-/// only as the default for the still-exposed (now inert)
-/// [`TransparentProxyEngineBuilder::tcp_flow_buffer_size`] setting.
+/// Default for the [`TransparentProxyEngineBuilder::tcp_flow_buffer_size`]
+/// setter, which has no effect — per-flow buffering is bounded by
+/// [`DEFAULT_TCP_CHANNEL_CAPACITY`].
 const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 16 * 1024;
 /// Number of `Bytes` chunks each TCP per-flow channel (ingress and egress)
-/// will buffer before backpressuring Swift. Each chunk is whatever Swift
-/// hands us in one `flow.readData` / `connection.receive` callback
-/// (typically 4–64 KiB).
+/// buffers before backpressuring Swift. Each chunk is whatever Swift hands
+/// us in one `flow.readData` / `connection.receive` callback (typically
+/// 4–64 KiB).
 ///
-/// 8 chunks is sized for L4 transparent forwarding (the design centre of
-/// this engine): the per-flow stream serves each chunk straight to the
-/// service / FFI sink, so this channel is the *only* per-flow buffer (the
-/// duplex is gone, #5) and deep queues just pin memory. At ~16 KiB per
-/// chunk that is ~128 KiB of worst-case headroom per direction, ~256 KiB
-/// per flow under saturation. Handlers that terminate HTTP/2 (or other
-/// heavy fan-in protocols) should raise this via
+/// This channel is the only per-flow buffer, so deep queues just pin
+/// memory; 8 suits L4 forwarding (~128 KiB/direction at 16 KiB chunks).
+/// Handlers terminating HTTP/2 (or other heavy fan-in) should raise it via
 /// [`TransparentProxyEngineBuilder::tcp_channel_capacity`].
 const DEFAULT_TCP_CHANNEL_CAPACITY: usize = 8;
 /// Bound on the UDP ingress and egress channels. UDP datagrams are inherently
@@ -152,10 +143,9 @@ const DEFAULT_UDP_CHANNEL_CAPACITY: usize = 32;
 /// expiry.
 pub const DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT: Duration = Duration::from_mins(1);
 
-/// TCP response / upstream-write sink. Returns a [`TcpDeliverStatus`]
-/// so the Rust producer (the bridge) can pause when Swift's pending
-/// queue is full and resume only after the matching `signal_*_drain`
-/// call from Swift.
+/// TCP response / upstream-write sink. Returns a [`TcpDeliverStatus`] so the
+/// stream's write side can pause when Swift's pending queue is full and
+/// resume after the matching `signal_*_drain`.
 type BytesStatusSink = Arc<dyn Fn(&[u8]) -> TcpDeliverStatus + Send + Sync + 'static>;
 /// UDP datagram sink. Carries the per-datagram peer in addition to
 /// the payload — see [`crate::Datagram`] for the direction-dependent
@@ -548,8 +538,8 @@ pub struct TransparentProxyTcpSession {
     // wedge forever after cutover.
     egress_tx: Arc<parking_lot::Mutex<Option<mpsc::Sender<Bytes>>>>,
 
-    /// Shared paused flags + drain notifications for both directions.
-    /// One allocation, used by `on_*_bytes`, the bridges, and `signal_*_drain`.
+    /// Shared paused flags + drain wakers for both directions; used by
+    /// `on_*_bytes`, the per-flow streams, and `signal_*_drain`.
     signals: Arc<TcpPerFlowSignals>,
 
     // promote
@@ -646,18 +636,13 @@ impl TransparentProxyTcpSession {
 
     /// Called by Swift when the intercepted flow signals read-EOF.
     ///
-    /// We drop the per-flow ingress sender so the bridge's `recv()` drains
-    /// any buffered chunks and then returns `None`, which is its natural
-    /// EOF signal. Using a side-channel (e.g. a `watch::Sender<bool>`)
-    /// would create a select-fairness race against `read_half.read()`
-    /// that can either drop the last chunk (too-eager EOF) or starve the
-    /// response direction (over-prioritised EOF).
+    /// Drop the per-flow ingress sender: the stream's read side drains any
+    /// buffered chunks then sees `None` (EOF). Dropping the sender (vs a
+    /// side-channel flag) keeps the final chunk and the EOF strictly ordered.
     ///
     /// If the client EOFs without ever sending a byte (`!saw_client_bytes`),
-    /// route through `cancel()`: there's nothing for the service to do, and
-    /// dragging the bridges through a normal half-close just adds latency
-    /// before teardown. Note this is asymmetric with [`Self::on_egress_eof`]
-    /// — see that method.
+    /// route through `cancel()` — nothing for the service to do. Asymmetric
+    /// with [`Self::on_egress_eof`]; see there.
     pub fn on_client_eof(&mut self) {
         if !self.saw_client_bytes {
             self.cancel();
@@ -801,10 +786,8 @@ impl TransparentProxyTcpSession {
         let remote_endpoint = meta.remote_endpoint.clone();
         let meta_arc = Arc::new(meta);
 
-        // ── ingress stream (client ↔ service) ──
-        // read side drains `client_rx` (client→service); write side hands
-        // service→client bytes straight to `on_server_bytes`. No duplex, no
-        // bridge task — the forwarder drives this stream directly.
+        // ── ingress stream ──
+        // read = client→service channel; write = service→client sink.
         let ingress_inner = FfiBridgeStream::new(
             client_rx,
             on_server_bytes,
@@ -830,9 +813,8 @@ impl TransparentProxyTcpSession {
             .extensions()
             .insert(self.promote_registry.clone().into_handle(rt_handle));
 
-        // ── egress stream (service ↔ NWConnection) ──
-        // read side drains `egress_client_rx` (upstream→service); write side
-        // hands service→upstream bytes straight to `on_write_to_egress`.
+        // ── egress stream ──
+        // read = upstream→service channel; write = service→upstream sink.
         let (egress_client_tx, egress_client_rx) = mpsc::channel::<Bytes>(tcp_channel_capacity);
         *self.egress_tx.lock() = Some(egress_client_tx);
 
@@ -993,9 +975,7 @@ async fn new_tcp_session_flow_action<OnBytes, OnDemand, OnClosed, H>(
     parent_guard: ShutdownGuard,
     exec: Executor,
     meta: TransparentProxyFlowMeta,
-    // The duplex is gone (#5): the duplex buffer size no longer applies to
-    // the in-Rust data path. Kept as a parameter for engine/builder ABI
-    // stability; the per-flow mpsc channel capacity now bounds buffering.
+    // No effect; channel capacity bounds per-flow buffering.
     _tcp_flow_buffer_size: usize,
     tcp_channel_capacity: usize,
     tcp_idle_timeout: Option<Duration>,
@@ -1112,13 +1092,9 @@ where
             return;
         };
 
-        // Drive the service to completion, but apply the engine's
-        // `tcp_idle_timeout` and watch the flow guard at this level (the
-        // per-flow streams deliberately don't, leaving lifecycle to us +
-        // the forwarder). `serve` is `Result<(), Infallible>`; the value
-        // is irrelevant — we only care that it finished. On idle/shutdown
-        // we drop `serve`, whose stream `Drop` fires the gated close
-        // callbacks.
+        // Run the service, applying the idle timeout and watching the flow
+        // guard here (the streams don't). On idle/shutdown we drop `serve`,
+        // whose streams' `Drop` fires the gated close callbacks.
         let reason = {
             let mut serve = std::pin::pin!(service.serve(bridge));
             let mut idle = tcp_idle_timeout.map(IdleGuard::new);
@@ -1146,8 +1122,6 @@ where
                     _ = serve.as_mut() => break BridgeCloseReason::PeerEofLeft,
                 }
             }
-            // `serve` (and its streams) drop here on a force-close, firing
-            // the gated `on_*_closed` callbacks before we log the close.
         };
 
         let (ingress_received, ingress_sent) =
@@ -1167,9 +1141,8 @@ where
             egress_received,
             egress_sent,
         );
-        // dial9 collapses the two directions into one record using the
-        // INGRESS orientation (received = client→service, sent =
-        // service→client), matching the legacy bridge behavior.
+        // dial9 records one row per flow using the INGRESS orientation
+        // (received = client→service, sent = service→client).
         #[cfg(feature = "dial9")]
         {
             let age_ms = u64::try_from(meta_for_close.age().as_millis()).unwrap_or(u64::MAX);
@@ -2016,9 +1989,9 @@ fn guarded_datagram_sink(
 /// close-log emission.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BridgeDirection {
-    /// Client ↔ service ingress bridge (FFI client_rx ↔ service duplex).
+    /// Client ↔ service direction.
     Ingress,
-    /// Service ↔ NWConnection egress bridge.
+    /// Service ↔ NWConnection (upstream) direction.
     Egress,
 }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/promote.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/promote.rs
@@ -662,7 +662,11 @@ where
             );
         } else if let Some(handle) = extensions.get_ref::<PromoteHandle>().cloned() {
             if let Err(err) = handle.into_passthrough().await {
-                tracing::warn!(
+                // Falling back to the in-Rust path is always safe (traffic
+                // keeps flowing), and the common cases are benign — no Swift
+                // promote callback registered, or the engine is shutting
+                // down — so this is debug, not warn.
+                tracing::debug!(
                     target: "rama_apple_ne::tproxy::promote",
                     error = %err,
                     "promote.into_passthrough failed; falling back to in-Rust data path",

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
@@ -658,12 +658,10 @@ fn engine_promote_ok_drains_inflight_bytes_then_emits_eof_to_service() {
         on_wake: None,
     };
 
-    // The service parks in `into_passthrough().await` (not reading)
-    // while we push every in-flight byte BEFORE confirming. Those bytes
-    // must all be ACCEPTED (buffered) so they drain to the service after
-    // cutover. Buffering is now the per-flow channel (the duplex is gone,
-    // #5); the test uses tiny 64-byte chunks, so size the channel to hold
-    // the whole payload (default cap-8 would only hold 512 B).
+    // The service parks in `into_passthrough().await` (not reading) while we
+    // push every in-flight byte before confirming, so all must buffer in the
+    // channel to drain after cutover. Size it for the whole payload (tiny
+    // 64-byte chunks here would overflow the default capacity).
     let engine = build_engine_with_tcp_channel_capacity(handler, 64);
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
@@ -658,7 +658,13 @@ fn engine_promote_ok_drains_inflight_bytes_then_emits_eof_to_service() {
         on_wake: None,
     };
 
-    let engine = build_engine(handler);
+    // The service parks in `into_passthrough().await` (not reading)
+    // while we push every in-flight byte BEFORE confirming. Those bytes
+    // must all be ACCEPTED (buffered) so they drain to the service after
+    // cutover. Buffering is now the per-flow channel (the duplex is gone,
+    // #5); the test uses tiny 64-byte chunks, so size the channel to hold
+    // the whole payload (default cap-8 would only hold 512 B).
+    let engine = build_engine_with_tcp_channel_capacity(handler, 64);
     let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
         TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
             .with_remote_endpoint(HostWithPort::example_domain_with_port(80)),

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -82,7 +82,7 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
 pub mod dial9;
 
-mod engine;
+pub(crate) mod engine;
 
 mod types;
 


### PR DESCRIPTION
Per-flow TCP streams read from the mpsc channel and write to the Swift sink directly — no duplex, no bridge tasks. 2 buffers + 2 tasks gone/flow, copies 4→1/dir. Backpressure/teardown/close-events preserved. 