### PR TITLE
Typed ContentType + CacheControl shortcuts

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,4 @@
-exclude_path = ["./target", "./docs/book/book", "./test-files"]
+exclude_path = ["./target", "./docs/book/book", "./test-files", "(^|/)specifications/"]
 exclude = [
     "^https://api.star-history.com",
     "hub.docker.com",

--- a/rama-http-headers/src/common/cache_control.rs
+++ b/rama-http-headers/src/common/cache_control.rs
@@ -98,59 +98,101 @@ impl CacheControl {
         }
     }
 
+    // presets
+
+    /// `public, immutable, max-age=31536000` — for content-hashed /
+    /// versioned URLs (e.g. `/theme.css?v=<git-sha>`).
+    ///
+    /// The URL changes whenever the content changes, so the cached response
+    /// is safe to keep for a year; `immutable` additionally stops the browser
+    /// from revalidating on reload. Reach for this only on content-hashed
+    /// URLs — on a stable URL whose body can change in place, use
+    /// [`Self::no_cache`] or [`Self::short_shared_revalidate`] instead.
+    #[must_use]
+    pub fn immutable_one_year() -> Self {
+        Self::new()
+            .with_public()
+            .with_immutable()
+            .with_max_age_seconds(31_536_000)
+    }
+
+    /// `no-cache` — the response is cacheable but must be revalidated with
+    /// the origin before reuse.
+    ///
+    /// The right default for service-worker scripts, HTML, or anything whose
+    /// URL is stable but whose body may change in place.
+    #[must_use]
+    pub fn no_cache() -> Self {
+        Self::new().with_no_cache()
+    }
+
+    /// `public, max-age=<secs>, must-revalidate` — a short shared cache for
+    /// non-fingerprinted but rarely-changing files (`robots.txt`,
+    /// `sitemap.xml`, `security.txt`).
+    ///
+    /// Lets a CDN absorb crawler bursts without making content updates
+    /// invisible for long.
+    #[must_use]
+    pub fn short_shared_revalidate(max_age_seconds: u32) -> Self {
+        Self::new()
+            .with_public()
+            .with_max_age_seconds(u64::from(max_age_seconds))
+            .with_must_revalidate()
+    }
+
     // getters
 
     /// Check if the `no-cache` directive is set.
     #[must_use]
-    pub fn no_cache(self) -> bool {
+    pub fn has_no_cache(self) -> bool {
         self.flags.contains(Flags::NO_CACHE)
     }
 
     /// Check if the `no-store` directive is set.
     #[must_use]
-    pub fn no_store(self) -> bool {
+    pub fn has_no_store(self) -> bool {
         self.flags.contains(Flags::NO_STORE)
     }
 
     /// Check if the `no-transform` directive is set.
     #[must_use]
-    pub fn no_transform(self) -> bool {
+    pub fn has_no_transform(self) -> bool {
         self.flags.contains(Flags::NO_TRANSFORM)
     }
 
     /// Check if the `only-if-cached` directive is set.
     #[must_use]
-    pub fn only_if_cached(self) -> bool {
+    pub fn has_only_if_cached(self) -> bool {
         self.flags.contains(Flags::ONLY_IF_CACHED)
     }
 
     /// Check if the `public` directive is set.
     #[must_use]
-    pub fn public(self) -> bool {
+    pub fn has_public(self) -> bool {
         self.flags.contains(Flags::PUBLIC)
     }
 
     /// Check if the `private` directive is set.
     #[must_use]
-    pub fn private(self) -> bool {
+    pub fn has_private(self) -> bool {
         self.flags.contains(Flags::PRIVATE)
     }
 
     /// Check if the `immutable` directive is set.
     #[must_use]
-    pub fn immutable(self) -> bool {
+    pub fn has_immutable(self) -> bool {
         self.flags.contains(Flags::IMMUTABLE)
     }
 
     /// Check if the `must-revalidate` directive is set.
     #[must_use]
-    pub fn must_revalidate(&self) -> bool {
+    pub fn has_must_revalidate(&self) -> bool {
         self.flags.contains(Flags::MUST_REVALIDATE)
     }
 
     /// Check if the `must-understand` directive is set.
     #[must_use]
-    pub fn must_understand(self) -> bool {
+    pub fn has_must_understand(self) -> bool {
         self.flags.contains(Flags::MUST_UNDERSTAND)
     }
 
@@ -623,7 +665,7 @@ mod tests {
         let headers = test_encode(cc.clone());
         assert_eq!(headers["cache-control"], "immutable");
         assert_eq!(test_decode::<CacheControl>(&["immutable"]).unwrap(), cc);
-        assert!(cc.immutable());
+        assert!(cc.has_immutable());
     }
 
     #[test]
@@ -635,7 +677,7 @@ mod tests {
             test_decode::<CacheControl>(&["must-revalidate"]).unwrap(),
             cc
         );
-        assert!(cc.must_revalidate());
+        assert!(cc.has_must_revalidate());
     }
 
     #[test]
@@ -647,7 +689,7 @@ mod tests {
             test_decode::<CacheControl>(&["must-understand"]).unwrap(),
             cc
         );
-        assert!(cc.must_understand());
+        assert!(cc.has_must_understand());
     }
 
     #[test]
@@ -682,5 +724,29 @@ mod tests {
                 .with_max_age_seconds(100),
         );
         assert_eq!(headers["cache-control"], "no-cache, max-age=100");
+    }
+
+    #[test]
+    fn preset_immutable_one_year() {
+        let headers = test_encode(CacheControl::immutable_one_year());
+        assert_eq!(
+            headers["cache-control"],
+            "public, immutable, max-age=31536000"
+        );
+    }
+
+    #[test]
+    fn preset_no_cache() {
+        let headers = test_encode(CacheControl::no_cache());
+        assert_eq!(headers["cache-control"], "no-cache");
+    }
+
+    #[test]
+    fn preset_short_shared_revalidate() {
+        let headers = test_encode(CacheControl::short_shared_revalidate(3600));
+        assert_eq!(
+            headers["cache-control"],
+            "must-revalidate, public, max-age=3600"
+        );
     }
 }

--- a/rama-http-headers/src/common/content_type.rs
+++ b/rama-http-headers/src/common/content_type.rs
@@ -251,6 +251,99 @@ impl ContentType {
         )
     }
 
+    /// A constructor to easily create a `Content-Type: image/svg+xml` header.
+    ///
+    /// ```
+    /// use rama_http_headers::ContentType;
+    ///
+    /// assert_eq!(ContentType::svg().to_string(), "image/svg+xml");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn svg() -> Self {
+        Self(mime::IMAGE_SVG)
+    }
+
+    /// A constructor to easily create a `Content-Type: application/xml; charset=utf-8` header.
+    ///
+    /// Distinct from [`Self::xml`] (which is `text/xml`): per
+    /// [RFC 7303](https://datatracker.ietf.org/doc/html/rfc7303) `application/xml`
+    /// is preferred for sitemaps/RSS/Atom, and the charset is stated explicitly
+    /// so the document's XML prolog and the HTTP `Content-Type` agree.
+    ///
+    /// ```
+    /// use rama_http_headers::ContentType;
+    ///
+    /// assert_eq!(
+    ///     ContentType::xml_utf8().to_string(),
+    ///     "application/xml; charset=utf-8",
+    /// );
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn xml_utf8() -> Self {
+        #[expect(
+            clippy::expect_used,
+            reason = "static value which is expected to work, and validated with a unit-test"
+        )]
+        Self(
+            Mime::from_str("application/xml; charset=utf-8")
+                .expect("application/xml; charset=utf-8 to be a valid mime"),
+        )
+    }
+
+    /// A constructor to easily create a `Content-Type: application/wasm` header.
+    ///
+    /// The spec mandates this exact value for `WebAssembly.instantiateStreaming`
+    /// to accept the response.
+    ///
+    /// ```
+    /// use rama_http_headers::ContentType;
+    ///
+    /// assert_eq!(ContentType::wasm().to_string(), "application/wasm");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn wasm() -> Self {
+        #[expect(
+            clippy::expect_used,
+            reason = "static value which is expected to work, and validated with a unit-test"
+        )]
+        Self(Mime::from_str("application/wasm").expect("application/wasm to be a valid mime"))
+    }
+
+    /// A constructor to easily create a `Content-Type: font/woff2` header.
+    ///
+    /// ```
+    /// use rama_http_headers::ContentType;
+    ///
+    /// assert_eq!(ContentType::woff2().to_string(), "font/woff2");
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn woff2() -> Self {
+        Self(mime::FONT_WOFF2)
+    }
+
+    /// A constructor to easily create a `Content-Type: application/manifest+json` header.
+    ///
+    /// Alias of [`Self::manifest_json`], named after the `.webmanifest` file
+    /// extension that web app manifests actually use; both coexist.
+    ///
+    /// ```
+    /// use rama_http_headers::ContentType;
+    ///
+    /// assert_eq!(
+    ///     ContentType::webmanifest().to_string(),
+    ///     "application/manifest+json",
+    /// );
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn webmanifest() -> Self {
+        Self::manifest_json()
+    }
+
     /// Reference to the internal [`Mime`].
     #[must_use]
     pub fn mime(&self) -> &Mime {
@@ -345,6 +438,29 @@ mod tests {
             test_decode::<ContentType>(&["application/manifest+json"]),
             Some(ContentType::manifest_json()),
         );
+    }
+
+    #[test]
+    fn xml_utf8_is_valid() {
+        _ = ContentType::xml_utf8();
+    }
+
+    #[test]
+    fn xml_utf8_roundtrip() {
+        assert_eq!(
+            test_decode::<ContentType>(&["application/xml; charset=utf-8"]),
+            Some(ContentType::xml_utf8()),
+        );
+    }
+
+    #[test]
+    fn wasm_is_valid() {
+        _ = ContentType::wasm();
+    }
+
+    #[test]
+    fn webmanifest_matches_manifest_json() {
+        assert_eq!(ContentType::webmanifest(), ContentType::manifest_json());
     }
 
     #[test]


### PR DESCRIPTION
Add ContentType svg/xml_utf8/wasm/woff2/webmanifest constructors and CacheControl immutable_one_year/no_cache/short_shared_revalidate presets (with a has_* rename of the CacheControl bool getters).