### PR TITLE
rama-cli: stream RSS/Atom feed responses into an interactive TUI reader

### DIFF
--- a/rama-cli/src/cmd/send/http/client/logger_body_res.rs
+++ b/rama-cli/src/cmd/send/http/client/logger_body_res.rs
@@ -1,22 +1,26 @@
 use rama::{
     Service,
     error::{BoxError, ErrorContext},
-    http::{Request, Response, StreamingBody, body::util::BodyExt},
+    http::{Body, Request, Response, StreamingBody, body::util::BodyExt},
 };
 
+use super::super::feed::{self, FeedKind, FeedTuiCandidate};
 use super::writer::Writer;
 
 #[derive(Debug, Clone)]
 pub(super) struct ResponseBodyLogger<S> {
     pub(super) inner: S,
     pub(super) writer: Writer,
+    /// When set, feed responses are passed through unwritten (tagged with
+    /// [`FeedTuiCandidate`]) so the caller can render them in the reader.
+    pub(super) feed_tui: bool,
 }
 
 impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ResponseBodyLogger<S>
 where
     S: Service<Request<ReqBody>, Output = Response<ResBody>, Error: Into<BoxError>>,
     ReqBody: Send + 'static,
-    ResBody: StreamingBody<Data: Send + 'static, Error: Into<BoxError> + Send + Sync + 'static>
+    ResBody: StreamingBody<Data = rama::bytes::Bytes, Error: Into<BoxError> + Send + Sync + 'static>
         + Send
         + 'static,
 {
@@ -27,6 +31,19 @@ where
         let res = self.inner.serve(req).await.into_box_error()?;
 
         let (parts, body) = res.into_parts();
+
+        // A feed bound for an interactive terminal must reach the reader
+        // unconsumed — don't write it, just tag it and pass the body through.
+        if self.feed_tui
+            && let Some(kind) = feed::feed_kind(&parts.headers)
+        {
+            parts.extensions.insert(FeedTuiCandidate {
+                generic: kind == FeedKind::GenericXml,
+            });
+            let res = Response::from_parts(parts, Body::from_stream(body.into_data_stream()));
+            return Ok(res);
+        }
+
         let bytes = body
             .collect()
             .await

--- a/rama-cli/src/cmd/send/http/client/mod.rs
+++ b/rama-cli/src/cmd/send/http/client/mod.rs
@@ -54,6 +54,7 @@ mod writer;
 
 pub(super) async fn new(
     cfg: &SendCommand,
+    feed_tui: bool,
 ) -> Result<impl Service<Request, Output = Response, Error = OpaqueError>, BoxError> {
     let writer = writer::try_new(cfg).await?;
 
@@ -67,6 +68,7 @@ pub(super) async fn new(
             move |inner| logger_body_res::ResponseBodyLogger {
                 inner,
                 writer: writer.clone(),
+                feed_tui,
             }
         }),
         cfg.emulate

--- a/rama-cli/src/cmd/send/http/feed/mod.rs
+++ b/rama-cli/src/cmd/send/http/feed/mod.rs
@@ -1,0 +1,172 @@
+//! RSS / Atom feed reader TUI for the web client.
+//!
+//! When the web client receives a feed response and the output is an
+//! interactive terminal — i.e. stdout/stdin are a TTY, `-o`/`--output` is not
+//! set and this isn't a `--curl` dry-run — the body is rendered in a
+//! scrollable reader instead of being dumped to stdout. Detection is fully
+//! automatic: it keys off the response `Content-Type` (`application/rss+xml`
+//! and `application/atom+xml` always; generic `*/xml` is parsed and only shown
+//! as a feed if it actually is one, otherwise the raw bytes are written as
+//! before).
+
+use rama::{
+    error::{BoxError, ErrorContext as _},
+    extensions::{Extension, ExtensionsRef as _},
+    http::{
+        Body, HeaderMap, Response,
+        body::util::BodyExt as _,
+        headers::{ContentType, HeaderMapExt as _},
+        mime,
+        protocols::rss::{Feed, FeedStream},
+    },
+    telemetry::tracing,
+};
+use tokio::io::AsyncWriteExt as _;
+
+use super::super::SendCommand;
+
+mod tui;
+
+/// Marker the response body logger inserts when it decides a response is a
+/// feed-reader candidate and therefore must NOT be written to stdout. It is
+/// read back in [`super::run_inner`] to launch the reader. `generic` records
+/// whether the content-type was a canonical feed type or a generic XML type
+/// that still needs to be parsed to confirm it is a feed.
+#[derive(Debug, Clone, Copy, Extension)]
+pub(super) struct FeedTuiCandidate {
+    pub(super) generic: bool,
+}
+
+/// How feed-like a response content-type is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FeedKind {
+    /// `application/rss+xml` / `application/atom+xml` — definitely a feed.
+    Canonical,
+    /// `application/xml` / `text/xml` — maybe a feed; the body must be parsed
+    /// to be sure.
+    GenericXml,
+}
+
+/// Classify a response by its typed [`ContentType`] header. Returns `None` for
+/// any content-type that is not a feed candidate. Comparisons go through the
+/// parsed [`mime`] parts, so charset (and other) parameters are ignored and the
+/// type/subtype/suffix matching is case-insensitive.
+pub(super) fn feed_kind(headers: &HeaderMap) -> Option<FeedKind> {
+    let ct = headers.typed_get::<ContentType>()?.into_mime();
+    let (ty, sub, suffix) = (ct.type_(), ct.subtype(), ct.suffix());
+
+    // application/rss+xml | application/atom+xml
+    if ty == mime::APPLICATION && suffix == Some(mime::XML) && (sub == "rss" || sub == "atom") {
+        return Some(FeedKind::Canonical);
+    }
+    // application/xml | text/xml — could be a feed; confirmed by parsing.
+    if sub == mime::XML && suffix.is_none() && (ty == mime::APPLICATION || ty == mime::TEXT) {
+        return Some(FeedKind::GenericXml);
+    }
+    None
+}
+
+/// Whether the web client may launch the feed reader for this invocation:
+/// interactive shell (stdout and stdin are both a TTY), output not redirected
+/// to a file, and not a `--curl` dry-run.
+pub(super) fn tui_gate_open(cfg: &SendCommand) -> bool {
+    use std::io::IsTerminal as _;
+    cfg.output.is_none()
+        && !cfg.curl
+        && std::io::stdout().is_terminal()
+        && std::io::stdin().is_terminal()
+}
+
+/// Render the feed response in the reader. For canonical feed content-types the
+/// body is streamed and entries appear as they parse. For generic XML the body
+/// is parsed first; if it turns out not to be a feed the raw bytes are written
+/// to stdout, preserving the non-feed behavior.
+pub(super) async fn run(resp: Response, candidate: FeedTuiCandidate) -> Result<(), BoxError> {
+    let (_parts, body) = resp.into_parts();
+
+    if candidate.generic {
+        let bytes = body
+            .collect()
+            .await
+            .context("collect feed response body")?
+            .to_bytes();
+        match Feed::from_body(Body::from(bytes.clone())).await {
+            Ok(feed) => tui::run_buffered(feed).await,
+            Err(err) => {
+                tracing::debug!(
+                    "generic xml response is not a parseable feed ({err}); writing raw bytes"
+                );
+                write_stdout(&bytes).await
+            }
+        }
+    } else {
+        let stream = FeedStream::from_body(body)
+            .await
+            .context("parse feed response header")?;
+        tui::run_streaming(stream).await
+    }
+}
+
+async fn write_stdout(bytes: &[u8]) -> Result<(), BoxError> {
+    let mut out = tokio::io::stdout();
+    out.write_all(bytes)
+        .await
+        .context("write response bytes to stdout")?;
+    out.flush().await.context("flush stdout")?;
+    Ok(())
+}
+
+/// Convenience used by [`super::run_inner`]: pull the candidate marker (if any)
+/// off a response.
+pub(super) fn candidate_of(resp: &Response) -> Option<FeedTuiCandidate> {
+    resp.extensions().get_ref::<FeedTuiCandidate>().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama::http::{HeaderMap, header};
+
+    fn headers_with_ct(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(header::CONTENT_TYPE, value.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn feed_kind_canonical_types() {
+        assert_eq!(
+            feed_kind(&headers_with_ct("application/rss+xml")),
+            Some(FeedKind::Canonical)
+        );
+        assert_eq!(
+            feed_kind(&headers_with_ct("application/atom+xml")),
+            Some(FeedKind::Canonical)
+        );
+        // case-insensitive + parameters are tolerated
+        assert_eq!(
+            feed_kind(&headers_with_ct("Application/RSS+XML; charset=utf-8")),
+            Some(FeedKind::Canonical)
+        );
+    }
+
+    #[test]
+    fn feed_kind_generic_xml() {
+        assert_eq!(
+            feed_kind(&headers_with_ct("application/xml")),
+            Some(FeedKind::GenericXml)
+        );
+        assert_eq!(
+            feed_kind(&headers_with_ct("text/xml; charset=utf-8")),
+            Some(FeedKind::GenericXml)
+        );
+    }
+
+    #[test]
+    fn feed_kind_non_feed() {
+        assert_eq!(feed_kind(&headers_with_ct("text/html")), None);
+        assert_eq!(feed_kind(&headers_with_ct("application/json")), None);
+        assert_eq!(feed_kind(&headers_with_ct("text/plain")), None);
+        assert_eq!(feed_kind(&HeaderMap::new()), None);
+    }
+}

--- a/rama-cli/src/cmd/send/http/feed/tui.rs
+++ b/rama-cli/src/cmd/send/http/feed/tui.rs
@@ -1,0 +1,1319 @@
+//! ratatui-based reader for RSS / Atom feeds.
+//!
+//! Two screens: a scrollable list of entries and a per-entry detail view that
+//! surfaces the body text plus any enclosures (podcast audio, etc.). Entries
+//! can be appended live from a [`FeedStream`] so a large feed renders as it
+//! arrives.
+//!
+//! The rendering and key handling live on [`AppState`], which holds no terminal
+//! and is therefore unit-testable with ratatui's `TestBackend`. [`App`] wraps
+//! it with the real terminal + event loop.
+
+use rama::{
+    error::{BoxError, ErrorContext as _},
+    futures::{FutureExt as _, StreamExt as _},
+    http::protocols::rss::{Feed, FeedItem, FeedStream},
+    telemetry::tracing,
+};
+
+use jiff::Timestamp;
+use ratatui::{
+    DefaultTerminal, Frame,
+    crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers},
+    prelude::*,
+    widgets::{Block, Borders, HighlightSpacing, List, ListItem, ListState, Paragraph, Wrap},
+};
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+/// Run the reader over a live feed stream, appending entries as they parse.
+pub(super) async fn run_streaming(stream: FeedStream) -> Result<(), BoxError> {
+    let header = FeedHeader::from_stream(&stream);
+    run_app(header, Vec::new(), Some(stream)).await
+}
+
+/// Run the reader over a fully-parsed feed.
+pub(super) async fn run_buffered(feed: Feed) -> Result<(), BoxError> {
+    let header = FeedHeader::from_feed(&feed);
+    let items: Vec<FeedItem> = match feed {
+        Feed::Rss2(f) => f.items.into_iter().map(FeedItem::from).collect(),
+        Feed::Atom(f) => f.entries.into_iter().map(FeedItem::from).collect(),
+    };
+    run_app(header, items, None).await
+}
+
+async fn run_app(
+    header: FeedHeader,
+    items: Vec<FeedItem>,
+    source: Option<FeedStream>,
+) -> Result<(), BoxError> {
+    let mut state = AppState::new(header);
+    for item in items {
+        state.push(item);
+    }
+
+    let terminal = ratatui::init();
+    let _guard = TerminalGuard;
+    let mut app = App {
+        terminal,
+        state,
+        source,
+    };
+    app.event_loop().await
+}
+
+/// Restores the terminal out of raw mode / the alternate screen on drop, even
+/// if the event loop returns early or panics.
+struct TerminalGuard;
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        ratatui::restore();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// App: terminal + event loop
+// ---------------------------------------------------------------------------
+
+struct App {
+    terminal: DefaultTerminal,
+    state: AppState,
+    source: Option<FeedStream>,
+}
+
+impl App {
+    async fn event_loop(&mut self) -> Result<(), BoxError> {
+        let mut needs_redraw = true;
+        loop {
+            if self.drain_source() {
+                needs_redraw = true;
+            }
+            self.state.loading = self.source.is_some();
+
+            if needs_redraw {
+                let state = &mut self.state;
+                self.terminal
+                    .draw(|frame| state.render(frame))
+                    .context("draw feed reader")?;
+                needs_redraw = false;
+            }
+
+            if event::poll(Duration::ZERO).context("poll terminal events")?
+                && let Event::Key(key) = event::read().context("read terminal event")?
+                && key.kind == KeyEventKind::Press
+            {
+                match self.state.on_key(key) {
+                    Action::Quit => return Ok(()),
+                    Action::Open(url) => {
+                        open_url(&url);
+                        needs_redraw = true;
+                    }
+                    Action::Redraw => needs_redraw = true,
+                    Action::None => {}
+                }
+            }
+
+            let tick = if self.source.is_some() {
+                Duration::from_millis(16)
+            } else {
+                Duration::from_millis(50)
+            };
+            tokio::time::sleep(tick).await;
+        }
+    }
+
+    /// Drain whatever feed items are ready without blocking. Returns true if
+    /// anything changed (items pushed or stream completed).
+    fn drain_source(&mut self) -> bool {
+        let Some(stream) = self.source.as_mut() else {
+            return false;
+        };
+        let mut changed = false;
+        // Bound the work per tick so a fast feed can't starve rendering/input.
+        for _ in 0..128 {
+            match stream.next().now_or_never() {
+                Some(Some(Ok(item))) => {
+                    self.state.push(item);
+                    changed = true;
+                }
+                Some(Some(Err(err))) => {
+                    tracing::debug!("skip unparseable feed item: {err}");
+                    changed = true;
+                }
+                Some(None) => {
+                    self.source = None;
+                    changed = true;
+                    break;
+                }
+                None => break,
+            }
+        }
+        changed
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AppState: data + rendering + key handling (terminal-free, testable)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Screen {
+    List,
+    Detail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeedFormat {
+    Rss,
+    Atom,
+}
+
+impl FeedFormat {
+    fn badge(self) -> &'static str {
+        match self {
+            Self::Rss => " RSS ",
+            Self::Atom => " ATOM ",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::Rss => Color::Rgb(0xF2, 0x6E, 0x22),
+            Self::Atom => Color::Rgb(0x3B, 0x7D, 0xDD),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct FeedHeader {
+    title: String,
+    subtitle: Option<String>,
+    format: FeedFormat,
+}
+
+impl FeedHeader {
+    fn from_stream(stream: &FeedStream) -> Self {
+        Self {
+            title: nonempty(stream.title()).unwrap_or_else(|| "(untitled feed)".to_owned()),
+            subtitle: stream
+                .description()
+                .and_then(plain_nonempty)
+                .or_else(|| stream.link().and_then(nonempty)),
+            format: match stream {
+                FeedStream::Atom(_) => FeedFormat::Atom,
+                FeedStream::Rss2(_) => FeedFormat::Rss,
+            },
+        }
+    }
+
+    fn from_feed(feed: &Feed) -> Self {
+        Self {
+            title: nonempty(feed.title()).unwrap_or_else(|| "(untitled feed)".to_owned()),
+            subtitle: feed
+                .description()
+                .and_then(plain_nonempty)
+                .or_else(|| feed.link().and_then(nonempty)),
+            format: if feed.is_rss2() {
+                FeedFormat::Rss
+            } else {
+                FeedFormat::Atom
+            },
+        }
+    }
+}
+
+/// Outcome of handling a key press.
+enum Action {
+    None,
+    Redraw,
+    Open(String),
+    Quit,
+}
+
+struct AppState {
+    header: FeedHeader,
+    items: Vec<FeedItem>,
+    list: ListState,
+    screen: Screen,
+    detail_scroll: u16,
+    loading: bool,
+}
+
+impl AppState {
+    fn new(header: FeedHeader) -> Self {
+        Self {
+            header,
+            items: Vec::new(),
+            list: ListState::default(),
+            screen: Screen::List,
+            detail_scroll: 0,
+            loading: false,
+        }
+    }
+
+    fn push(&mut self, item: FeedItem) {
+        self.items.push(item);
+        if self.list.selected().is_none() {
+            self.list.select(Some(0));
+        }
+    }
+
+    fn selected_index(&self) -> usize {
+        self.list.selected().unwrap_or(0)
+    }
+
+    fn selected(&self) -> Option<&FeedItem> {
+        self.items.get(self.selected_index())
+    }
+
+    // --- key handling ---
+
+    fn on_key(&mut self, key: KeyEvent) -> Action {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+            return Action::Quit;
+        }
+        match self.screen {
+            Screen::List => self.on_key_list(key.code),
+            Screen::Detail => self.on_key_detail(key.code),
+        }
+    }
+
+    fn on_key_list(&mut self, code: KeyCode) -> Action {
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.select_next();
+                Action::Redraw
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.select_prev();
+                Action::Redraw
+            }
+            KeyCode::Char('g') | KeyCode::Home => {
+                self.select_first();
+                Action::Redraw
+            }
+            KeyCode::Char('G') | KeyCode::End => {
+                self.select_last();
+                Action::Redraw
+            }
+            KeyCode::Enter | KeyCode::Char('l') | KeyCode::Right => {
+                if !self.items.is_empty() {
+                    self.screen = Screen::Detail;
+                    self.detail_scroll = 0;
+                }
+                Action::Redraw
+            }
+            KeyCode::Char('o') => self.open_selected_link(),
+            _ => Action::None,
+        }
+    }
+
+    fn on_key_detail(&mut self, code: KeyCode) -> Action {
+        match code {
+            KeyCode::Char('q') => Action::Quit,
+            KeyCode::Esc | KeyCode::Char('h') | KeyCode::Left | KeyCode::Backspace => {
+                self.screen = Screen::List;
+                Action::Redraw
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.detail_scroll = self.detail_scroll.saturating_add(1);
+                Action::Redraw
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.detail_scroll = self.detail_scroll.saturating_sub(1);
+                Action::Redraw
+            }
+            KeyCode::Char('g') | KeyCode::Home => {
+                self.detail_scroll = 0;
+                Action::Redraw
+            }
+            KeyCode::Char('n') => {
+                self.select_next();
+                self.detail_scroll = 0;
+                Action::Redraw
+            }
+            KeyCode::Char('p') => {
+                self.select_prev();
+                self.detail_scroll = 0;
+                Action::Redraw
+            }
+            KeyCode::Char('o') => self.open_selected_link(),
+            KeyCode::Char('e') => self.open_selected_enclosure(),
+            _ => Action::None,
+        }
+    }
+
+    fn select_next(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let next = self
+            .list
+            .selected()
+            .map_or(0, |i| (i + 1).min(self.items.len() - 1));
+        self.list.select(Some(next));
+    }
+
+    fn select_prev(&mut self) {
+        if self.items.is_empty() {
+            return;
+        }
+        let prev = self.list.selected().map_or(0, |i| i.saturating_sub(1));
+        self.list.select(Some(prev));
+    }
+
+    fn select_first(&mut self) {
+        if !self.items.is_empty() {
+            self.list.select(Some(0));
+        }
+    }
+
+    fn select_last(&mut self) {
+        if !self.items.is_empty() {
+            self.list.select(Some(self.items.len() - 1));
+        }
+    }
+
+    fn open_selected_link(&self) -> Action {
+        match self.selected().and_then(FeedItem::link) {
+            Some(url) => Action::Open(url.to_owned()),
+            None => Action::None,
+        }
+    }
+
+    fn open_selected_enclosure(&self) -> Action {
+        match self
+            .selected()
+            .and_then(|item| item.enclosures().next().map(|e| e.url.to_owned()))
+        {
+            Some(url) => Action::Open(url),
+            None => self.open_selected_link(),
+        }
+    }
+
+    // --- rendering ---
+
+    fn render(&mut self, frame: &mut Frame) {
+        match self.screen {
+            Screen::List => self.render_list(frame),
+            Screen::Detail => self.render_detail(frame),
+        }
+    }
+
+    fn render_list(&mut self, frame: &mut Frame) {
+        let area = frame.area();
+
+        // Size the header to fit the (wrapped) description, but never let it
+        // crowd out the list — keep at least a few entry rows.
+        let subtitle_rows = match &self.header.subtitle {
+            Some(subtitle) => {
+                let budget = area.height.saturating_sub(1 + 1 + 1 + 3);
+                wrapped_height(subtitle, area.width).clamp(1, budget.max(1))
+            }
+            None => 0,
+        };
+        let header_height = 1 + subtitle_rows + 1; // title + subtitle + bottom border
+
+        let [header_area, list_area, footer_area] = Layout::vertical([
+            Constraint::Length(header_height),
+            Constraint::Fill(1),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+
+        self.render_header(frame, header_area);
+
+        let items: Vec<ListItem> = self
+            .items
+            .iter()
+            .map(|item| {
+                let date = fmt_date(item.published().or_else(|| item.updated()));
+                let title = item.title().unwrap_or("(untitled)");
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("{date:>10}  "),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                    Span::raw(title.to_owned()),
+                ]);
+                ListItem::new(line)
+            })
+            .collect();
+
+        let list = List::new(items)
+            .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+            .highlight_symbol("› ")
+            .highlight_spacing(HighlightSpacing::Always);
+        StatefulWidget::render(list, list_area, frame.buffer_mut(), &mut self.list);
+
+        let footer = format!(
+            " {count} entr{plural}{loading}   j/k move · enter open · o browser · q quit ",
+            count = self.items.len(),
+            plural = if self.items.len() == 1 { "y" } else { "ies" },
+            loading = if self.loading { " · loading…" } else { "" },
+        );
+        Paragraph::new(footer)
+            .style(Style::default().fg(Color::Gray))
+            .render(footer_area, frame.buffer_mut());
+    }
+
+    fn render_header(&self, frame: &mut Frame, area: Rect) {
+        let block = Block::new().borders(Borders::BOTTOM);
+        let inner = block.inner(area);
+        block.render(area, frame.buffer_mut());
+
+        let [title_area, subtitle_area] =
+            Layout::vertical([Constraint::Length(1), Constraint::Fill(1)]).areas(inner);
+
+        let title = Line::from(vec![
+            Span::styled(
+                self.header.format.badge(),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(self.header.format.color())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                self.header.title.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+        ]);
+        Paragraph::new(title).render(title_area, frame.buffer_mut());
+
+        // Wrap the description onto the next line(s) instead of clipping it.
+        if let Some(subtitle) = &self.header.subtitle {
+            Paragraph::new(subtitle.clone())
+                .style(Style::default().fg(Color::Gray))
+                .wrap(Wrap { trim: true })
+                .render(subtitle_area, frame.buffer_mut());
+        }
+    }
+
+    fn render_detail(&self, frame: &mut Frame) {
+        let [body_area, footer_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(frame.area());
+
+        let block = Block::bordered().title(format!(" {} ", self.header.title));
+
+        let Some(item) = self.items.get(self.selected_index()) else {
+            Paragraph::new("no entry selected")
+                .block(block)
+                .render(body_area, frame.buffer_mut());
+            return;
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(Span::styled(
+            item.title().unwrap_or("(untitled)").to_owned(),
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )));
+        lines.push(Line::raw(""));
+
+        if let Some(ts) = item.published() {
+            lines.push(meta("published", &fmt_datetime(ts)));
+        }
+        if let Some(ts) = item.updated() {
+            lines.push(meta("updated", &fmt_datetime(ts)));
+        }
+        let authors: Vec<&str> = item.authors().collect();
+        if !authors.is_empty() {
+            lines.push(meta("by", &authors.join(", ")));
+        }
+        let topics: Vec<&str> = item.categories().collect();
+        if !topics.is_empty() {
+            lines.push(meta("topics", &topics.join(", ")));
+        }
+        if let Some(link) = item.link() {
+            lines.push(meta("link", link));
+        }
+        for enc in item.enclosures() {
+            let mime = enc.mime.unwrap_or("?");
+            let detail = match enc.length {
+                Some(len) => format!("{} [{}, {}]", enc.url, mime, human_size(len)),
+                None => format!("{} [{}]", enc.url, mime),
+            };
+            lines.push(meta("media", &detail));
+        }
+
+        if let Some(raw) = item.content().or_else(|| item.summary()) {
+            let body = html_to_lines(raw);
+            if !body.is_empty() {
+                lines.push(Line::raw(""));
+                lines.extend(body);
+            }
+        }
+
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false })
+            .scroll((self.detail_scroll, 0))
+            .render(body_area, frame.buffer_mut());
+
+        let position = format!(
+            " {}/{} ",
+            self.selected_index() + 1,
+            self.items.len().max(1)
+        );
+        let footer =
+            format!("{position}  j/k scroll · n/p entry · o link · e media · esc back · q quit ",);
+        Paragraph::new(footer)
+            .style(Style::default().fg(Color::Gray))
+            .render(footer_area, frame.buffer_mut());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn meta(key: &str, value: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{key}: "), Style::default().fg(Color::Cyan)),
+        Span::raw(value.to_owned()),
+    ])
+}
+
+fn nonempty(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_owned())
+}
+
+/// Flatten (possibly HTML) text to a single whitespace-collapsed plain line —
+/// used for the compact feed-description blurb in the list header.
+fn plain_nonempty(s: &str) -> Option<String> {
+    nonempty(&html_to_plain(s))
+}
+
+fn html_to_plain(input: &str) -> String {
+    let joined = html_to_lines(input)
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    joined.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Approximate the number of rows `text` needs when word-wrapped to `width`
+/// (matching ratatui's `Wrap { trim: true }`), so the header can be sized to
+/// fit the description instead of clipping it.
+fn wrapped_height(text: &str, width: u16) -> u16 {
+    let width = width.max(1) as usize;
+    let mut rows: u16 = 1;
+    let mut col: usize = 0;
+    for word in text.split_whitespace() {
+        let len = word.chars().count();
+        if col != 0 && col + 1 + len > width {
+            rows = rows.saturating_add(1);
+            col = 0;
+        }
+        if col == 0 {
+            // A word longer than the line wraps across several rows.
+            let extra_rows = len.saturating_sub(1) / width;
+            rows = rows.saturating_add(extra_rows as u16);
+            col = len - extra_rows * width;
+        } else {
+            col += 1 + len;
+        }
+    }
+    rows
+}
+
+fn fmt_date(ts: Option<Timestamp>) -> String {
+    match ts {
+        Some(ts) => ts
+            .to_string()
+            .split('T')
+            .next()
+            .unwrap_or_default()
+            .to_owned(),
+        None => String::new(),
+    }
+}
+
+fn fmt_datetime(ts: Timestamp) -> String {
+    let s = ts.to_string();
+    let no_frac = s.split('.').next().unwrap_or(&s);
+    no_frac.trim_end_matches('Z').replace('T', " ")
+}
+
+fn human_size(n: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+    let n_f = n as f64;
+    if n_f >= GB {
+        format!("{:.1} GB", n_f / GB)
+    } else if n_f >= MB {
+        format!("{:.1} MB", n_f / MB)
+    } else if n_f >= KB {
+        format!("{:.1} KB", n_f / KB)
+    } else {
+        format!("{n} B")
+    }
+}
+
+/// Render (possibly HTML) feed body text into styled terminal lines.
+///
+/// A small, dependency-free HTML-to-[`Line`] converter — not a real HTML
+/// engine. It applies the formatting feeds actually use: paragraphs, line
+/// breaks, headings, lists, blockquotes, inline emphasis / code, and links
+/// (whose target is appended in parentheses since a terminal can't click).
+/// `<script>` / `<style>` content and unknown tags are dropped, and common
+/// entities are decoded. Width-wrapping is left to the rendering `Paragraph`,
+/// so each returned line is a single logical line.
+fn html_to_lines(input: &str) -> Vec<Line<'static>> {
+    let mut renderer = HtmlRenderer::default();
+    renderer.run(input);
+    renderer.finish()
+}
+
+#[derive(Clone, Copy)]
+enum ListMarker {
+    Bullet,
+    Number(u32),
+}
+
+#[derive(Default)]
+struct HtmlRenderer {
+    lines: Vec<Line<'static>>,
+    spans: Vec<Span<'static>>,
+    style: Style,
+    style_stack: Vec<Style>,
+    href_stack: Vec<Option<String>>,
+    list_stack: Vec<ListMarker>,
+    in_pre: usize,
+    skip_text: usize,
+    line_has_content: bool,
+}
+
+impl HtmlRenderer {
+    fn run(&mut self, input: &str) {
+        let mut rest = input;
+        while !rest.is_empty() {
+            let Some(lt) = rest.find('<') else {
+                self.text(rest);
+                break;
+            };
+            if lt > 0 {
+                self.text(&rest[..lt]);
+            }
+            rest = &rest[lt..];
+
+            if let Some(after) = rest.strip_prefix("<!--") {
+                rest = after.find("-->").map_or("", |i| &after[i + 3..]);
+                continue;
+            }
+            if rest.starts_with("<!") || rest.starts_with("<?") {
+                rest = rest.find('>').map_or("", |i| &rest[i + 1..]);
+                continue;
+            }
+
+            // Find the tag's closing '>', respecting quoted attribute values
+            // so a '>' inside an attribute doesn't end the tag early.
+            let mut quote: Option<char> = None;
+            let mut end = None;
+            for (i, ch) in rest.char_indices().skip(1) {
+                match ch {
+                    c @ ('"' | '\'') if quote == Some(c) => quote = None,
+                    c @ ('"' | '\'') if quote.is_none() => quote = Some(c),
+                    '>' if quote.is_none() => {
+                        end = Some(i);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            let Some(end) = end else { break };
+            self.tag(&rest[1..end]);
+            rest = &rest[end + 1..];
+        }
+    }
+
+    fn tag(&mut self, raw: &str) {
+        let raw = raw.trim();
+        let closing = raw.starts_with('/');
+        let body = raw.strip_prefix('/').unwrap_or(raw);
+        let name: String = body
+            .chars()
+            .take_while(char::is_ascii_alphanumeric)
+            .flat_map(char::to_lowercase)
+            .collect();
+        if name.is_empty() {
+            return;
+        }
+        if closing {
+            self.close_tag(&name);
+        } else {
+            self.open_tag(&name, &body[name.len()..]);
+        }
+    }
+
+    fn open_tag(&mut self, name: &str, attrs: &str) {
+        match name {
+            "script" | "style" => self.skip_text += 1,
+            "br" => self.flush_line(),
+            "hr" => self.rule(),
+            "p" | "div" | "section" | "article" | "header" | "footer" | "figure" | "figcaption"
+            | "main" | "aside" | "table" | "tr" => self.ensure_blank(),
+            "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
+                self.ensure_blank();
+                self.push_style(self.style.add_modifier(Modifier::BOLD));
+            }
+            "b" | "strong" => self.push_style(self.style.add_modifier(Modifier::BOLD)),
+            "i" | "em" | "cite" | "dfn" => {
+                self.push_style(self.style.add_modifier(Modifier::ITALIC));
+            }
+            "u" | "ins" => self.push_style(self.style.add_modifier(Modifier::UNDERLINED)),
+            "s" | "strike" | "del" => {
+                self.push_style(self.style.add_modifier(Modifier::CROSSED_OUT));
+            }
+            "code" | "tt" | "kbd" | "samp" | "var" => self.push_style(self.style.fg(Color::Cyan)),
+            "pre" => {
+                self.ensure_blank();
+                self.in_pre += 1;
+                self.push_style(self.style.fg(Color::Cyan));
+            }
+            "blockquote" => {
+                self.ensure_blank();
+                self.push_style(self.style.fg(Color::Gray).add_modifier(Modifier::ITALIC));
+            }
+            "ul" => {
+                self.ensure_blank();
+                self.list_stack.push(ListMarker::Bullet);
+            }
+            "ol" => {
+                self.ensure_blank();
+                self.list_stack.push(ListMarker::Number(1));
+            }
+            "li" => self.start_list_item(),
+            "a" => {
+                self.href_stack.push(extract_attr(attrs, "href"));
+                self.push_style(
+                    self.style
+                        .fg(Color::Blue)
+                        .add_modifier(Modifier::UNDERLINED),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn close_tag(&mut self, name: &str) {
+        match name {
+            "script" | "style" => self.skip_text = self.skip_text.saturating_sub(1),
+            "p" | "div" | "section" | "article" | "header" | "footer" | "figure" | "figcaption"
+            | "main" | "aside" | "table" | "tr" => self.ensure_blank(),
+            "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote" => {
+                self.pop_style();
+                self.ensure_blank();
+            }
+            "b" | "strong" | "i" | "em" | "cite" | "dfn" | "u" | "ins" | "s" | "strike" | "del"
+            | "code" | "tt" | "kbd" | "samp" | "var" => self.pop_style(),
+            "pre" => {
+                self.in_pre = self.in_pre.saturating_sub(1);
+                self.pop_style();
+                self.ensure_blank();
+            }
+            "ul" | "ol" => {
+                self.list_stack.pop();
+                self.ensure_blank();
+            }
+            "li" => self.flush_line(),
+            "a" => {
+                let href = self.href_stack.pop().flatten();
+                self.pop_style();
+                if let Some(href) = href.filter(|h| !h.is_empty()) {
+                    self.spans.push(Span::styled(
+                        format!(" ({href})"),
+                        Style::default().add_modifier(Modifier::DIM),
+                    ));
+                    self.line_has_content = true;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn push_style(&mut self, style: Style) {
+        self.style_stack.push(self.style);
+        self.style = style;
+    }
+
+    fn pop_style(&mut self) {
+        if let Some(style) = self.style_stack.pop() {
+            self.style = style;
+        }
+    }
+
+    fn start_list_item(&mut self) {
+        if !self.spans.is_empty() {
+            self.flush_line();
+        }
+        let depth = self.list_stack.len().max(1);
+        let marker = match self.list_stack.last_mut() {
+            Some(ListMarker::Number(n)) => {
+                let marker = format!("{n}. ");
+                *n += 1;
+                marker
+            }
+            _ => "• ".to_owned(),
+        };
+        self.spans.push(Span::styled(
+            format!("{}{marker}", "  ".repeat(depth - 1)),
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+        // The marker carries its own trailing space; trim the item's leading ws.
+        self.line_has_content = false;
+    }
+
+    fn rule(&mut self) {
+        self.ensure_blank();
+        self.lines.push(Line::from(Span::styled(
+            "────────",
+            Style::default().fg(Color::DarkGray),
+        )));
+        self.line_has_content = false;
+    }
+
+    fn text(&mut self, raw: &str) {
+        if self.skip_text > 0 {
+            return;
+        }
+        let decoded = decode_entities(raw);
+
+        if self.in_pre > 0 {
+            for (i, piece) in decoded.split('\n').enumerate() {
+                if i > 0 {
+                    self.flush_line();
+                }
+                if !piece.is_empty() {
+                    self.spans.push(Span::styled(piece.to_owned(), self.style));
+                    self.line_has_content = true;
+                }
+            }
+            return;
+        }
+
+        // Collapse runs of whitespace to a single space, trimming any leading
+        // whitespace at the start of a line.
+        let mut buf = String::new();
+        let mut prev_ws = !self.line_has_content;
+        for ch in decoded.chars() {
+            if ch.is_whitespace() {
+                if !prev_ws {
+                    buf.push(' ');
+                    prev_ws = true;
+                }
+            } else {
+                buf.push(ch);
+                prev_ws = false;
+            }
+        }
+        if buf.is_empty() || (buf == " " && !self.line_has_content) {
+            return;
+        }
+        let has_content = buf.contains(|c: char| !c.is_whitespace());
+        self.spans.push(Span::styled(buf, self.style));
+        if has_content {
+            self.line_has_content = true;
+        }
+    }
+
+    fn flush_line(&mut self) {
+        let spans = std::mem::take(&mut self.spans);
+        self.lines.push(Line::from(spans));
+        self.line_has_content = false;
+    }
+
+    fn ensure_blank(&mut self) {
+        if !self.spans.is_empty() {
+            self.flush_line();
+        }
+        if self.lines.last().is_some_and(|line| !line_is_empty(line)) {
+            self.lines.push(Line::from(""));
+        }
+    }
+
+    fn finish(mut self) -> Vec<Line<'static>> {
+        if !self.spans.is_empty() {
+            self.flush_line();
+        }
+        while self.lines.first().is_some_and(line_is_empty) {
+            self.lines.remove(0);
+        }
+        while self.lines.last().is_some_and(line_is_empty) {
+            self.lines.pop();
+        }
+        self.lines
+    }
+}
+
+fn line_is_empty(line: &Line<'_>) -> bool {
+    line.spans.iter().all(|span| span.content.trim().is_empty())
+}
+
+/// Extract a (decoded) attribute value from a tag body, e.g. `href` from
+/// `a href="https://example.com"`. Tolerant of single/double/unquoted values.
+fn extract_attr(body: &str, name: &str) -> Option<String> {
+    let lower = body.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(name) {
+        let at = from + rel;
+        let preceded_ok = at == 0 || body.as_bytes()[at - 1].is_ascii_whitespace();
+        let after = body[at + name.len()..].trim_start();
+        if preceded_ok && let Some(value) = after.strip_prefix('=') {
+            let value = value.trim_start();
+            let raw = if let Some(rest) = value.strip_prefix('"') {
+                rest.split('"').next().unwrap_or("")
+            } else if let Some(rest) = value.strip_prefix('\'') {
+                rest.split('\'').next().unwrap_or("")
+            } else {
+                value.split_whitespace().next().unwrap_or("")
+            };
+            return Some(decode_entities(raw));
+        }
+        from = at + name.len();
+    }
+    None
+}
+
+/// Decode the HTML entities that show up in feeds (named subset + numeric
+/// `&#nn;` / `&#xhh;`). Unrecognized entities are left as-is.
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_owned();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(amp) = rest.find('&') {
+        out.push_str(&rest[..amp]);
+        let after = &rest[amp..];
+        if let Some(rel) = after[1..].find(';')
+            && rel < 32
+            && let Some(ch) = decode_one_entity(&after[1..rel + 1])
+        {
+            out.push(ch);
+            rest = &after[rel + 2..];
+        } else {
+            out.push('&');
+            rest = &after[1..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn decode_one_entity(entity: &str) -> Option<char> {
+    if let Some(num) = entity.strip_prefix('#') {
+        let code = match num.strip_prefix(['x', 'X']) {
+            Some(hex) => u32::from_str_radix(hex, 16).ok()?,
+            None => num.parse::<u32>().ok()?,
+        };
+        return char::from_u32(code);
+    }
+    Some(match entity {
+        "amp" => '&',
+        "lt" => '<',
+        "gt" => '>',
+        "quot" => '"',
+        "apos" => '\'',
+        "nbsp" => ' ',
+        "hellip" => '…',
+        "mdash" => '—',
+        "ndash" => '–',
+        "lsquo" => '\u{2018}',
+        "rsquo" => '\u{2019}',
+        "ldquo" => '\u{201C}',
+        "rdquo" => '\u{201D}',
+        "laquo" => '«',
+        "raquo" => '»',
+        "copy" => '©',
+        "reg" => '®',
+        "trade" => '™',
+        "deg" => '°',
+        "middot" | "bull" => '•',
+        "euro" => '€',
+        "pound" => '£',
+        "cent" => '¢',
+        "sect" => '§',
+        "times" => '×',
+        "divide" => '÷',
+        _ => return None,
+    })
+}
+
+fn open_url(url: &str) {
+    use std::process::{Command, Stdio};
+
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut c = Command::new("open");
+        c.arg(url);
+        c
+    };
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut c = Command::new("cmd");
+        c.args(["/C", "start", "", url]);
+        c
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut command = {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+
+    if let Err(err) = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        tracing::debug!("failed to open url {url} in browser: {err}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama::http::Body;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    const RSS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Rust Podcast</title>
+    <link>https://example.com</link>
+    <description>All things Rust</description>
+    <item>
+      <title>Episode One</title>
+      <link>https://example.com/ep1</link>
+      <description>The very first episode.</description>
+      <pubDate>Tue, 02 Jan 2024 08:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/ep1.mp3" length="12345678" type="audio/mpeg"/>
+    </item>
+    <item>
+      <title>Episode Two</title>
+      <link>https://example.com/ep2</link>
+      <description>The second episode.</description>
+      <pubDate>Tue, 09 Jan 2024 08:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>"#;
+
+    const ATOM: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Blog</title>
+  <subtitle>thoughts in atoms</subtitle>
+  <id>urn:uuid:feed</id>
+  <updated>2024-01-02T08:00:00Z</updated>
+  <link href="https://atom.example.com"/>
+  <entry>
+    <title>Hello Atom</title>
+    <id>urn:uuid:entry-1</id>
+    <updated>2024-01-02T08:00:00Z</updated>
+    <published>2024-01-02T08:00:00Z</published>
+    <link href="https://atom.example.com/hello"/>
+    <summary>An atom entry summary.</summary>
+  </entry>
+</feed>"#;
+
+    async fn feed_from(xml: &'static str) -> Feed {
+        Feed::from_body(Body::from(xml)).await.expect("parse feed")
+    }
+
+    fn state_from(feed: Feed) -> AppState {
+        let header = FeedHeader::from_feed(&feed);
+        let mut state = AppState::new(header);
+        let items: Vec<FeedItem> = match feed {
+            Feed::Rss2(f) => f.items.into_iter().map(FeedItem::from).collect(),
+            Feed::Atom(f) => f.entries.into_iter().map(FeedItem::from).collect(),
+        };
+        for item in items {
+            state.push(item);
+        }
+        state
+    }
+
+    fn render_to_string(state: &mut AppState, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| state.render(frame)).unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        buffer
+            .content
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect::<String>()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[tokio::test]
+    async fn rss_list_renders_title_and_entries() {
+        let mut state = state_from(feed_from(RSS).await);
+        let screen = render_to_string(&mut state, 80, 20);
+        assert!(screen.contains("RSS"), "format badge missing:\n{screen}");
+        assert!(
+            screen.contains("Rust Podcast"),
+            "feed title missing:\n{screen}"
+        );
+        assert!(screen.contains("Episode One"), "entry 1 missing:\n{screen}");
+        assert!(screen.contains("Episode Two"), "entry 2 missing:\n{screen}");
+        assert!(screen.contains("2 entries"), "count missing:\n{screen}");
+    }
+
+    #[tokio::test]
+    async fn rss_detail_shows_body_and_enclosure() {
+        let mut state = state_from(feed_from(RSS).await);
+        // Enter detail on the first entry.
+        assert!(matches!(state.on_key(key(KeyCode::Enter)), Action::Redraw));
+        assert_eq!(state.screen, Screen::Detail);
+
+        let screen = render_to_string(&mut state, 100, 24);
+        assert!(screen.contains("Episode One"), "title missing:\n{screen}");
+        assert!(
+            screen.contains("The very first episode."),
+            "body missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("example.com/ep1.mp3"),
+            "enclosure url missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("audio/mpeg"),
+            "enclosure mime missing:\n{screen}"
+        );
+    }
+
+    #[tokio::test]
+    async fn navigation_moves_selection() {
+        let mut state = state_from(feed_from(RSS).await);
+        assert_eq!(state.selected_index(), 0);
+        state.on_key(key(KeyCode::Char('j')));
+        assert_eq!(state.selected_index(), 1);
+        // clamped at the end
+        state.on_key(key(KeyCode::Char('j')));
+        assert_eq!(state.selected_index(), 1);
+        state.on_key(key(KeyCode::Char('k')));
+        assert_eq!(state.selected_index(), 0);
+    }
+
+    #[tokio::test]
+    async fn open_returns_selected_link() {
+        let mut state = state_from(feed_from(RSS).await);
+        match state.on_key(key(KeyCode::Char('o'))) {
+            Action::Open(url) => assert_eq!(url, "https://example.com/ep1"),
+            _ => panic!("expected Action::Open"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_quits() {
+        let mut state = state_from(feed_from(RSS).await);
+        let event = KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(matches!(state.on_key(event), Action::Quit));
+    }
+
+    #[tokio::test]
+    async fn atom_feed_renders() {
+        let mut state = state_from(feed_from(ATOM).await);
+        let screen = render_to_string(&mut state, 80, 20);
+        assert!(screen.contains("ATOM"), "atom badge missing:\n{screen}");
+        assert!(
+            screen.contains("Atom Blog"),
+            "atom title missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("Hello Atom"),
+            "atom entry missing:\n{screen}"
+        );
+    }
+
+    fn lines_text(lines: &[Line<'_>]) -> String {
+        lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn html_to_lines_renders_inline_styles_and_links() {
+        let lines =
+            html_to_lines(r#"<p>Hello <b>bold</b> &amp; <a href="https://x.test">link</a></p>"#);
+        let text = lines_text(&lines);
+        assert!(text.contains("Hello bold & link"), "text: {text:?}");
+        // a terminal can't click, so the target is surfaced inline
+        assert!(
+            text.contains("(https://x.test)"),
+            "href not appended: {text:?}"
+        );
+
+        let bold = lines
+            .iter()
+            .flat_map(|line| &line.spans)
+            .find(|span| span.content.as_ref() == "bold")
+            .expect("bold span present");
+        assert!(
+            bold.style.add_modifier.contains(Modifier::BOLD),
+            "bold text is not styled bold"
+        );
+    }
+
+    #[test]
+    fn html_to_lines_lists_breaks_entities_and_drops_script() {
+        let lines = html_to_lines(
+            "<ul><li>one</li><li>two</li></ul><script>alert(1)</script>line1<br>line2 &mdash; end",
+        );
+        let text = lines_text(&lines);
+        assert!(text.contains("• one"), "first bullet missing: {text:?}");
+        assert!(text.contains("• two"), "second bullet missing: {text:?}");
+        assert!(!text.contains("alert"), "script content leaked: {text:?}");
+        assert!(
+            text.contains("line1\nline2 — end"),
+            "br/entity not handled: {text:?}"
+        );
+    }
+
+    #[test]
+    fn html_to_plain_strips_tags_and_collapses_whitespace() {
+        assert_eq!(
+            html_to_plain("<p>Hello  &amp; <b>world</b></p>\n<p>again</p>"),
+            "Hello & world again"
+        );
+    }
+
+    #[test]
+    fn wrapped_height_counts_rows() {
+        assert_eq!(wrapped_height("hello world", 20), 1);
+        assert_eq!(wrapped_height("hello world", 6), 2);
+        assert_eq!(wrapped_height("", 10), 1);
+        // a word longer than the width spills onto extra rows
+        assert_eq!(wrapped_height("abcdefghij", 5), 2);
+    }
+}

--- a/rama-cli/src/cmd/send/http/mod.rs
+++ b/rama-cli/src/cmd/send/http/mod.rs
@@ -13,6 +13,7 @@ use super::SendCommand;
 pub mod arg;
 
 mod client;
+mod feed;
 mod request;
 mod trace;
 mod ws;
@@ -35,7 +36,12 @@ pub async fn run(cfg: SendCommand, is_ws: bool) -> Result<(), BoxError> {
 }
 
 pub async fn run_inner(cfg: &SendCommand, is_ws: bool) -> Result<(), BoxError> {
-    let https_client = client::new(cfg).await?;
+    // The feed reader only applies to plain HTTP responses going to an
+    // interactive terminal; ws has its own TUI and redirected/file output is
+    // left untouched.
+    let feed_tui = !is_ws && feed::tui_gate_open(cfg);
+
+    let https_client = client::new(cfg, feed_tui).await?;
     let request = request::build(cfg, is_ws).await?;
 
     if is_ws {
@@ -64,6 +70,12 @@ pub async fn run_inner(cfg: &SendCommand, is_ws: bool) -> Result<(), BoxError> {
                     code: 22,
                 }));
             }
+        }
+
+        // The body logger leaves feed responses unwritten and tags them so we
+        // can hand the (still-streaming) body to the reader here.
+        if let Some(candidate) = feed::candidate_of(&resp) {
+            feed::run(resp, candidate).await?;
         }
     }
 

--- a/test-files/atom.xml
+++ b/test-files/atom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atomic Notes</title>
+  <subtitle>small posts, atom format</subtitle>
+  <id>urn:uuid:atomic-notes</id>
+  <updated>2024-01-02T08:00:00Z</updated>
+  <link href="https://example.com/atom"/>
+  <entry>
+    <title>Hello from Atom</title>
+    <id>urn:uuid:atom-entry-1</id>
+    <updated>2024-01-02T08:00:00Z</updated>
+    <published>2024-01-02T08:00:00Z</published>
+    <link href="https://example.com/atom/hello"/>
+    <summary>The first atomic note.</summary>
+  </entry>
+</feed>

--- a/test-files/feed.xml
+++ b/test-files/feed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Rust Insights</title>
+    <link>https://example.com/rust</link>
+    <description>News and notes from the Rust world</description>
+    <item>
+      <title>Async streams explained</title>
+      <link>https://example.com/rust/async-streams</link>
+      <description>A tour of Stream and friends.</description>
+      <pubDate>Tue, 02 Jan 2024 08:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/rust/async-streams.mp3" length="4096" type="audio/mpeg"/>
+    </item>
+    <item>
+      <title>Lifetimes without tears</title>
+      <link>https://example.com/rust/lifetimes</link>
+      <description>Borrow checker intuition.</description>
+      <pubDate>Tue, 09 Jan 2024 08:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/tests/integration/cli/cli_tests/mod.rs
+++ b/tests/integration/cli/cli_tests/mod.rs
@@ -14,4 +14,5 @@ mod serve_stunnel;
 
 mod probe;
 mod resolve;
+mod send_feed;
 mod send_file;

--- a/tests/integration/cli/cli_tests/send_feed.rs
+++ b/tests/integration/cli/cli_tests/send_feed.rs
@@ -1,0 +1,70 @@
+//! E2E tests for the web client's feed handling.
+//!
+//! The interactive RSS/Atom reader only engages when stdout is a real
+//! terminal. These tests run the binary with its output captured (a pipe, not
+//! a TTY), so they assert the *non-interactive* contract: a feed response is
+//! written to stdout verbatim and the reader never takes over. That is the
+//! important regression guard — piping or redirecting a feed must keep
+//! behaving like curl. The reader's rendering itself is covered by unit tests
+//! in `rama-cli` using ratatui's `TestBackend`.
+
+use super::utils;
+use std::path::PathBuf;
+
+#[tokio::test]
+#[ignore]
+async fn test_send_rss_feed_piped_is_raw_not_tui() {
+    utils::init_tracing();
+
+    let _guard = utils::RamaService::serve_fs(63140, Some(PathBuf::from("test-files")));
+
+    let (ok, stdout, stderr) =
+        utils::RamaService::run_capture(&["-k", "https://127.0.0.1:63140/feed.xml"])
+            .expect("spawn rama send");
+    assert!(ok, "rama send failed; stderr:\n{stderr}");
+
+    // Output is a pipe, not a terminal: the body must be the raw feed.
+    assert!(
+        stdout.contains("<rss"),
+        "expected raw rss in stdout, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Rust Insights"),
+        "expected feed title in raw output, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Async streams explained"),
+        "expected entry title in raw output, got:\n{stdout}"
+    );
+    // The reader must not have engaged: no alternate-screen / raw-mode escapes.
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "terminal escape sequence leaked into piped output:\n{stdout:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_send_atom_feed_piped_is_raw_not_tui() {
+    utils::init_tracing();
+
+    let _guard = utils::RamaService::serve_fs(63141, Some(PathBuf::from("test-files")));
+
+    let (ok, stdout, stderr) =
+        utils::RamaService::run_capture(&["-k", "https://127.0.0.1:63141/atom.xml"])
+            .expect("spawn rama send");
+    assert!(ok, "rama send failed; stderr:\n{stderr}");
+
+    assert!(
+        stdout.contains("<feed"),
+        "expected raw atom in stdout, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Atomic Notes"),
+        "expected feed title in raw output, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "terminal escape sequence leaked into piped output:\n{stdout:?}"
+    );
+}


### PR DESCRIPTION
## What does this PR do?

Engages only on an interactive TTY (not piped/redirected/-o/--curl); detects feeds via typed Content-Type and falls back to raw output otherwise.

## Checklist

- [ ] This change is linked to an issue we have discussed (see above).
- [x] `just qa` passes locally (or I have explained below what I could not run).
- [x] Code is formatted (`just fmt`).
- [x] Commit history is clean and commit messages are descriptive.
- [x] I agree to the [contribution terms](../CONTRIBUTING.md#contribution-terms)
      and the Developer Certificate of Origin.
