### PR TITLE
tls: default rama tls clients to native system trust store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,15 +3546,20 @@ dependencies = [
 name = "rama-crypto"
 version = "0.3.0-rc1"
 dependencies = [
+ "ahash",
  "aws-lc-rs",
  "base64",
+ "openssl-probe",
  "rama-core",
  "rama-utils",
  "rcgen",
  "rustls-pki-types",
+ "schannel",
+ "security-framework",
  "serde",
  "serde_json",
  "tokio-test",
+ "webpki-root-certs",
  "x509-parser",
 ]
 
@@ -4011,11 +4016,11 @@ dependencies = [
  "rama-boring",
  "rama-boring-tokio",
  "rama-core",
+ "rama-crypto",
  "rama-http-types",
  "rama-net",
  "rama-ua",
  "rama-utils",
- "schannel",
  "tokio",
  "tracing-test",
  "zstd",
@@ -4035,7 +4040,6 @@ dependencies = [
  "rama-utils",
  "rcgen",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki-roots",
@@ -4455,18 +4459,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -5884,6 +5876,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ mime_guess = { version = "2", default-features = false }
 moka = "0.12"
 multer = "3.1"
 nom = "8.0.0"
+openssl-probe = "0.2"
 opentelemetry = { version = "0.31", default-features = false, features = ["trace", "internal-logs"] }
 opentelemetry-semantic-conventions = { version = "0.31", features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "rt-tokio"] }
@@ -209,10 +210,10 @@ rawzip = { version = "0.4" }
 rcgen = { version = "0.14", default-features = false, features = ["pem", "x509-parser"] }
 regex = { version = "1.12", default-features = false }
 rustls = { version = "0.23", default-features = false, features = ["logging", "std", "tls12"] }
-rustls-native-certs = "0.8"
 rustls-pki-types = "^1"
 rustversion = "1.0"
 schannel = "0.1"
+security-framework = "3"
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_html_form = "0.4"
 serde_json = "1.0"
@@ -252,6 +253,7 @@ uuid = "1.23"
 venndb = "0.6"
 walkdir = "2.5"
 want = "0.3"
+webpki-root-certs = "1.0"
 webpki-roots = "1.0"
 wildcard = "0.3"
 windows-sys = "0.61"

--- a/docs/thirdparty/fork/README.md
+++ b/docs/thirdparty/fork/README.md
@@ -189,6 +189,22 @@ of the rama ecosystem.
     - Original: <https://github.com/thomcc/arcstr/blob/faa7692b0d6662bb177b3aefa80a6a13f897554d/LICENSE-MIT>
     - Type: MIT
     - Copy: [./licenses/arcstr](./licenses/arcstr)
+- <https://github.com/rustls/rustls-native-certs/tree/9d1f11e5da42f061c9a5aebbcde48a1b843afff2>
+  - Forked into [`rama-crypto::native_certs`](https://github.com/plabayo/rama/tree/main/rama-crypto/src/native_certs)
+    as rama's tls-implementation agnostic native trust store loader, used by
+    both the rustls and boring client connectors.
+  - Reasons for forking:
+    - Reshape the public surface around rama's `pki_types` re-export, error and
+      tracing conventions, and add a cached `shared_native_trust_anchors()` with
+      a bundled webpki root fallback.
+    - Fold in the pending upstream permission-skip fix
+      (<https://github.com/rustls/rustls-native-certs/pull/228>).
+    - Broaden the Windows reader to both the current-user and local-machine
+      ROOT + CA stores (carried over from rama's previous boring-only logic).
+  - License:
+    - Original: <https://github.com/rustls/rustls-native-certs/blob/9d1f11e5da42f061c9a5aebbcde48a1b843afff2/LICENSE-MIT>
+    - Type: MIT (offered as Apache-2.0 OR ISC OR MIT)
+    - Copy: [./licenses/rustls-native-certs](./licenses/rustls-native-certs)
 
 ## Vendored Test Corpora
 

--- a/docs/thirdparty/licenses/rustls-native-certs
+++ b/docs/thirdparty/licenses/rustls-native-certs
@@ -1,0 +1,25 @@
+Copyright (c) 2016 Joseph Birr-Pixton <jpixton@gmail.com>
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rama-crypto/Cargo.toml
+++ b/rama-crypto/Cargo.toml
@@ -28,6 +28,13 @@ targets = [
 default = []
 aws-lc = ["dep:aws-lc-rs", "rcgen/aws_lc_rs", "x509-parser/verify-aws"]
 ring = ["rcgen/ring", "x509-parser/verify"]
+native-certs = [
+    "dep:webpki-root-certs",
+    "dep:security-framework",
+    "dep:schannel",
+    "dep:openssl-probe",
+    "dep:ahash",
+]
 
 [dependencies]
 aws-lc-rs = { workspace = true, optional = true }
@@ -38,7 +45,18 @@ rcgen = { workspace = true, optional = true }
 rustls-pki-types = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
+webpki-root-certs = { workspace = true, optional = true }
 x509-parser = { workspace = true }
+
+[target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
+openssl-probe = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+ahash = { workspace = true, optional = true }
+security-framework = { workspace = true, optional = true }
+
+[target.'cfg(windows)'.dependencies]
+schannel = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/rama-crypto/src/lib.rs
+++ b/rama-crypto/src/lib.rs
@@ -35,6 +35,10 @@ pub mod pki_types {
     pub use rustls_pki_types::*;
 }
 
+#[cfg(feature = "native-certs")]
+#[cfg_attr(docsrs, doc(cfg(feature = "native-certs")))]
+pub mod native_certs;
+
 pub mod dep {
     //! Dependencies for rama crypto modules.
     //!

--- a/rama-crypto/src/native_certs/macos.rs
+++ b/rama-crypto/src/native_certs/macos.rs
@@ -1,0 +1,67 @@
+use ahash::HashMap;
+use security_framework::trust_settings::{Domain, TrustSettings, TrustSettingsForCertificate};
+
+use super::CertificateResult;
+use crate::pki_types::CertificateDer;
+
+pub(super) fn load_native_certs() -> CertificateResult {
+    // The various domains are designed to interact like this:
+    //
+    // "Per-user Trust Settings override locally administered Trust Settings,
+    //  which in turn override the System Trust Settings."
+    //
+    // So we collect the certificates in this order; as a map of their DER
+    // encoding to what we'll do with them. We don't overwrite existing
+    // elements, which means User settings trump Admin trump System, as desired.
+
+    let mut result = CertificateResult::default();
+    let mut all_certs = HashMap::default();
+    for domain in &[Domain::User, Domain::Admin, Domain::System] {
+        let ts = TrustSettings::new(*domain);
+        let iter = match ts.iter() {
+            Ok(iter) => iter,
+            Err(err) => {
+                result.os_error(
+                    err.into(),
+                    match domain {
+                        Domain::User => "failed to load user trust settings",
+                        Domain::Admin => "failed to load admin trust settings",
+                        Domain::System => "failed to load system trust settings",
+                    },
+                );
+                continue;
+            }
+        };
+
+        for cert in iter {
+            let der = cert.to_der();
+
+            // If there are no specific trust settings, the default is to trust
+            // the certificate as a root cert. The docs say:
+            //
+            // "Note that an empty Trust Settings array means 'always trust this
+            //  cert, with a resulting kSecTrustSettingsResult of
+            //  kSecTrustSettingsResultTrustRoot'."
+            let trusted = match ts.tls_trust_settings_for_certificate(&cert) {
+                Ok(trusted) => trusted.unwrap_or(TrustSettingsForCertificate::TrustRoot),
+                Err(err) => {
+                    result.os_error(err.into(), "certificate not trusted");
+                    continue;
+                }
+            };
+
+            all_certs.entry(der).or_insert(trusted);
+        }
+    }
+
+    // Now we have all the certificates and an idea of whether to use them.
+    for (der, trusted) in all_certs.drain() {
+        if let TrustSettingsForCertificate::TrustRoot | TrustSettingsForCertificate::TrustAsRoot =
+            trusted
+        {
+            result.certs.push(CertificateDer::from(der));
+        }
+    }
+
+    result
+}

--- a/rama-crypto/src/native_certs/mod.rs
+++ b/rama-crypto/src/native_certs/mod.rs
@@ -1,0 +1,436 @@
+//! Load the platform's native certificate store (system trust chain) in a
+//! tls-implementation agnostic way, as [`pki_types`] certificates.
+//!
+//! The certificates returned here can be fed into any tls backend (e.g.
+//! `rustls` or `boring`), which is why this lives in `rama-crypto` rather than
+//! in one of the tls backend crates.
+//!
+//! The main entry points are:
+//!
+//! - [`shared_native_trust_anchors`]: the cached, process-wide default trust
+//!   anchors used by rama tls clients. Loads the native store once; if nothing
+//!   is found it warns and falls back to the bundled webpki roots.
+//! - [`load_native_certs`]: a one-shot (uncached) read of the platform store,
+//!   for callers that want to manage caching/merging themselves.
+//! - [`bundled_root_certs`]: the bundled Mozilla (CCADB) root certificates used
+//!   as the fallback.
+//!
+//! # Attribution
+//!
+//! The platform readers and `SSL_CERT_FILE`/`SSL_CERT_DIR` handling are an
+//! adapted fork of [`rustls-native-certs`] (Apache-2.0 OR ISC OR MIT), with the
+//! pending [permission-skip fix][pr228] folded in and the public surface
+//! reshaped around rama's [`pki_types`] re-export, error and tracing
+//! conventions.
+//!
+//! [`pki_types`]: crate::pki_types
+//! [`rustls-native-certs`]: https://github.com/rustls/rustls-native-certs
+//! [pr228]: https://github.com/rustls/rustls-native-certs/pull/228
+
+use std::error::Error as StdError;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::{env, fmt, fs, io};
+
+use rama_core::telemetry::tracing::{debug, warn};
+
+use crate::pki_types::CertificateDer;
+use crate::pki_types::pem::{self, PemObject};
+
+#[cfg(all(unix, not(target_os = "macos")))]
+mod unix;
+#[cfg(all(unix, not(target_os = "macos")))]
+use unix as platform;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows as platform;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "macos")]
+use macos as platform;
+
+/// Returns the cached, process-wide default trust anchors used by rama tls
+/// clients (both the `rustls` and `boring` backends consume these).
+///
+/// On first call this loads the platform's native certificate store via
+/// [`load_native_certs`] (honoring `SSL_CERT_FILE`/`SSL_CERT_DIR`). If the
+/// native store yields no certificates, a warning is logged and the bundled
+/// webpki roots ([`bundled_root_certs`]) are used instead so that clients on
+/// minimal systems (e.g. distroless containers) still have a sane default.
+///
+/// The result is cached for the lifetime of the process: the (potentially
+/// expensive) native read happens at most once.
+pub fn shared_native_trust_anchors() -> Arc<[CertificateDer<'static>]> {
+    static ANCHORS: OnceLock<Arc<[CertificateDer<'static>]>> = OnceLock::new();
+    ANCHORS
+        .get_or_init(|| {
+            let paths = CertPaths::from_env();
+            let env_override = paths.has_overrides();
+            let result = load_native_certs_with_paths(paths);
+            for err in &result.errors {
+                debug!("rama native-certs: error while loading native root certificate: {err}");
+            }
+
+            if result.certs.is_empty() && !env_override {
+                warn!(
+                    native_cert_errors = result.errors.len(),
+                    "rama native-certs: no native system root certificates found; \
+                     falling back to the bundled webpki (Mozilla CCADB) root certificates"
+                );
+                bundled_root_certs().to_vec().into()
+            } else {
+                debug!(
+                    native_cert_count = result.certs.len(),
+                    "rama native-certs: loaded native system root certificates"
+                );
+                result.certs.into()
+            }
+        })
+        .clone()
+}
+
+/// The bundled Mozilla (CCADB) root certificates, used as the fallback by
+/// [`shared_native_trust_anchors`] and available for explicit use.
+///
+/// This is a re-export of the data shipped by the [`webpki-root-certs`] crate.
+///
+/// [`webpki-root-certs`]: https://docs.rs/webpki-root-certs
+pub fn bundled_root_certs() -> &'static [CertificateDer<'static>] {
+    webpki_root_certs::TLS_SERVER_ROOT_CERTS
+}
+
+/// Load root certificates found in the platform's native certificate store.
+///
+/// ## Environment Variables
+///
+/// | Env. Var.     | Description                                                       |
+/// |---------------|-------------------------------------------------------------------|
+/// | SSL_CERT_FILE | File containing an arbitrary number of certificates in PEM format.|
+/// | SSL_CERT_DIR  | `:`/`;` separated list of directories containing certificate files.|
+///
+/// If **either** (or **both**) are set, certificates are only loaded from the
+/// locations specified via environment variables and not the platform-native
+/// certificate store.
+///
+/// ## Caveats
+///
+/// This function can be expensive: on some platforms it involves loading and
+/// parsing a ~300KB disk file, or querying the OS keychain. Prefer
+/// [`shared_native_trust_anchors`] which caches the result.
+pub fn load_native_certs() -> CertificateResult {
+    load_native_certs_with_paths(CertPaths::from_env())
+}
+
+fn load_native_certs_with_paths(paths: CertPaths) -> CertificateResult {
+    match paths.has_overrides() {
+        true => paths.load(),
+        _ => platform::load_native_certs(),
+    }
+}
+
+/// Results from trying to load certificates from the platform's native store.
+#[non_exhaustive]
+#[derive(Debug, Default)]
+pub struct CertificateResult {
+    /// Any certificates that were successfully loaded.
+    pub certs: Vec<CertificateDer<'static>>,
+    /// Any errors encountered while loading certificates.
+    pub errors: Vec<Error>,
+}
+
+impl CertificateResult {
+    fn pem_error(&mut self, err: pem::Error, path: &Path) {
+        self.errors.push(Error {
+            context: "failed to read PEM from file",
+            kind: match err {
+                pem::Error::Io(err) => ErrorKind::Io {
+                    inner: err,
+                    path: path.to_owned(),
+                },
+                _ => ErrorKind::Pem(err),
+            },
+        });
+    }
+
+    fn io_error(&mut self, err: io::Error, path: &Path, context: &'static str) {
+        self.errors.push(Error {
+            context,
+            kind: ErrorKind::Io {
+                inner: err,
+                path: path.to_owned(),
+            },
+        });
+    }
+
+    #[cfg(any(windows, target_os = "macos"))]
+    fn os_error(&mut self, err: Box<dyn StdError + Send + Sync + 'static>, context: &'static str) {
+        self.errors.push(Error {
+            context,
+            kind: ErrorKind::Os(err),
+        });
+    }
+}
+
+/// Certificate paths from `SSL_CERT_FILE` and/or `SSL_CERT_DIR`.
+struct CertPaths {
+    file: Option<PathBuf>,
+    dirs: Vec<PathBuf>,
+}
+
+impl CertPaths {
+    fn from_env() -> Self {
+        Self {
+            file: env::var_os(ENV_CERT_FILE).map(PathBuf::from),
+            // Read `SSL_CERT_DIR`, split it on the platform delimiter (`:` on
+            // unix, `;` on windows), ignoring empty entries.
+            //
+            // See <https://docs.openssl.org/3.5/man1/openssl-rehash/#options>
+            dirs: match env::var_os(ENV_CERT_DIR) {
+                Some(dirs) => env::split_paths(&dirs)
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .collect(),
+                None => Vec::new(),
+            },
+        }
+    }
+
+    fn load(&self) -> CertificateResult {
+        load_certs_from_paths_internal(self.file.as_deref(), &self.dirs)
+    }
+
+    fn has_overrides(&self) -> bool {
+        self.file.is_some() || !self.dirs.is_empty()
+    }
+}
+
+/// Load certificates from the given paths.
+///
+/// If both are `None`, returns an empty [`CertificateResult`].
+///
+/// If `file` is `Some`, it must be a path to an existing, accessible file from
+/// which certificates can be loaded. The PEM parser ignores parts of the file
+/// which are not considered part of a certificate; malformed certificates may
+/// be silently skipped.
+///
+/// If `dir` is defined, a directory must exist at this path. The directory is
+/// not scanned recursively and may be empty; entries that are not readable
+/// (e.g. root-only files) are skipped.
+pub fn load_certs_from_paths(file: Option<&Path>, dir: Option<&Path>) -> CertificateResult {
+    let dir = match dir {
+        Some(d) => vec![d],
+        None => Vec::new(),
+    };
+
+    load_certs_from_paths_internal(file, dir.as_ref())
+}
+
+fn load_certs_from_paths_internal(
+    file: Option<&Path>,
+    dir: &[impl AsRef<Path>],
+) -> CertificateResult {
+    let mut out = CertificateResult::default();
+    if file.is_none() && dir.is_empty() {
+        return out;
+    }
+
+    if let Some(cert_file) = file {
+        // An explicit file is expected to exist and be readable: surface errors.
+        load_pem_certs(cert_file, &mut out, false);
+    }
+
+    for cert_dir in dir.iter() {
+        load_pem_certs_from_dir(cert_dir.as_ref(), &mut out);
+    }
+
+    out.certs.sort_unstable_by(|a, b| a.cmp(b));
+    out.certs.dedup();
+    out
+}
+
+/// Load certificates from a certificate directory (what OpenSSL calls CAdir).
+fn load_pem_certs_from_dir(dir: &Path, out: &mut CertificateResult) {
+    let dir_reader = match fs::read_dir(dir) {
+        Ok(reader) => reader,
+        Err(err) => {
+            out.io_error(err, dir, "opening directory");
+            return;
+        }
+    };
+
+    for entry in dir_reader {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                out.io_error(err, dir, "reading directory entries");
+                continue;
+            }
+        };
+
+        let path = entry.path();
+
+        // `openssl rehash` used to create this directory uses symlinks, so
+        // resolve them.
+        let metadata = match fs::metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                // Dangling symlink
+                continue;
+            }
+            Err(e) => {
+                out.io_error(e, &path, "failed to open file");
+                continue;
+            }
+        };
+
+        if metadata.is_file() {
+            // When scanning a directory, skip over files that are not readable
+            // (usually `chown root` or `chmod -r`), rather than failing the
+            // whole load. See <https://github.com/rustls/rustls-native-certs/pull/228>.
+            load_pem_certs(&path, out, true);
+        }
+    }
+}
+
+fn load_pem_certs(path: &Path, out: &mut CertificateResult, skip_eperm: bool) {
+    let iter = match CertificateDer::pem_file_iter(path) {
+        Ok(iter) => iter,
+        Err(err) => {
+            if skip_eperm
+                && let pem::Error::Io(io_error) = &err
+                && io_error.kind() == io::ErrorKind::PermissionDenied
+            {
+                return;
+            }
+            out.pem_error(err, path);
+            return;
+        }
+    };
+
+    for result in iter {
+        match result {
+            Ok(cert) => out.certs.push(cert),
+            Err(err) => out.pem_error(err, path),
+        }
+    }
+}
+
+/// An error encountered while loading certificates from the platform store.
+#[derive(Debug)]
+pub struct Error {
+    /// Human-readable context describing what was being attempted.
+    pub context: &'static str,
+    /// The underlying error kind.
+    pub kind: ErrorKind,
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(match &self.kind {
+            ErrorKind::Io { inner, .. } => inner,
+            ErrorKind::Os(err) => &**err,
+            ErrorKind::Pem(err) => err,
+        })
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.context)?;
+        f.write_str(": ")?;
+        match &self.kind {
+            ErrorKind::Io { inner, path } => write!(f, "{inner} at '{}'", path.display()),
+            ErrorKind::Os(err) => err.fmt(f),
+            ErrorKind::Pem(err) => err.fmt(f),
+        }
+    }
+}
+
+/// The kinds of errors that can occur while loading native certificates.
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// An I/O error while reading a certificate file or directory.
+    Io {
+        /// The underlying I/O error.
+        inner: io::Error,
+        /// The path being read.
+        path: PathBuf,
+    },
+    /// A platform (OS keychain / cert store) error.
+    Os(Box<dyn StdError + Send + Sync + 'static>),
+    /// A PEM parsing error.
+    Pem(pem::Error),
+}
+
+const ENV_CERT_FILE: &str = "SSL_CERT_FILE";
+const ENV_CERT_DIR: &str = "SSL_CERT_DIR";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_root_certs_non_empty() {
+        assert!(
+            !bundled_root_certs().is_empty(),
+            "bundled webpki root certificates should not be empty"
+        );
+    }
+
+    #[test]
+    fn from_env_missing_file() {
+        let mut result = CertificateResult::default();
+        load_pem_certs(Path::new("no/such/file"), &mut result, false);
+        match &result.errors.first().unwrap().kind {
+            ErrorKind::Io { inner, .. } => assert_eq!(inner.kind(), io::ErrorKind::NotFound),
+            other => panic!("unexpected error {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_env_missing_dir() {
+        let mut result = CertificateResult::default();
+        load_pem_certs_from_dir(Path::new("no/such/directory"), &mut result);
+        match &result.errors.first().unwrap().kind {
+            ErrorKind::Io { inner, .. } => assert_eq!(inner.kind(), io::ErrorKind::NotFound),
+            other => panic!("unexpected error {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cert_paths_detects_env_overrides() {
+        assert!(
+            !CertPaths {
+                file: None,
+                dirs: Vec::new()
+            }
+            .has_overrides()
+        );
+        assert!(
+            CertPaths {
+                file: Some(PathBuf::from("ca.pem")),
+                dirs: Vec::new()
+            }
+            .has_overrides()
+        );
+        assert!(
+            CertPaths {
+                file: None,
+                dirs: vec![PathBuf::from("certs")]
+            }
+            .has_overrides()
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn from_env_with_non_regular_and_empty_file() {
+        let mut result = CertificateResult::default();
+        load_pem_certs(Path::new("/dev/null"), &mut result, false);
+        assert_eq!(result.certs.len(), 0);
+        assert!(result.errors.is_empty());
+    }
+}

--- a/rama-crypto/src/native_certs/mod.rs
+++ b/rama-crypto/src/native_certs/mod.rs
@@ -29,7 +29,7 @@
 
 use std::error::Error as StdError;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 use std::{env, fmt, fs, io};
 
 use rama_core::telemetry::tracing::{debug, warn};
@@ -64,31 +64,29 @@ use macos as platform;
 /// The result is cached for the lifetime of the process: the (potentially
 /// expensive) native read happens at most once.
 pub fn shared_native_trust_anchors() -> Arc<[CertificateDer<'static>]> {
-    static ANCHORS: OnceLock<Arc<[CertificateDer<'static>]>> = OnceLock::new();
-    ANCHORS
-        .get_or_init(|| {
-            let paths = CertPaths::from_env();
-            let result = load_native_certs_with_paths(&paths);
-            for err in &result.errors {
-                debug!("rama native-certs: error while loading native root certificate: {err}");
-            }
+    static ANCHORS: LazyLock<Arc<[CertificateDer<'static>]>> = LazyLock::new(|| {
+        let paths = CertPaths::from_env();
+        let result = load_native_certs_with_paths(&paths);
+        for err in &result.errors {
+            debug!(%err, "rama native-certs: error while loading native root certificate");
+        }
 
-            if result.certs.is_empty() && !paths.has_overrides() {
-                warn!(
-                    native_cert_errors = result.errors.len(),
-                    "rama native-certs: no native system root certificates found; \
-                     falling back to the bundled webpki (Mozilla CCADB) root certificates"
-                );
-                bundled_root_certs().to_vec().into()
-            } else {
-                debug!(
-                    native_cert_count = result.certs.len(),
-                    "rama native-certs: loaded native system root certificates"
-                );
-                result.certs.into()
-            }
-        })
-        .clone()
+        if result.certs.is_empty() && !paths.has_overrides() {
+            warn!(
+                native_cert_errors = result.errors.len(),
+                "rama native-certs: no native system root certificates found; \
+                 falling back to the bundled webpki (Mozilla CCADB) root certificates"
+            );
+            bundled_root_certs().to_vec().into()
+        } else {
+            debug!(
+                native_cert_count = result.certs.len(),
+                "rama native-certs: loaded native system root certificates"
+            );
+            result.certs.into()
+        }
+    });
+    ANCHORS.clone()
 }
 
 /// The bundled Mozilla (CCADB) root certificates, used as the fallback by

--- a/rama-crypto/src/native_certs/mod.rs
+++ b/rama-crypto/src/native_certs/mod.rs
@@ -68,13 +68,12 @@ pub fn shared_native_trust_anchors() -> Arc<[CertificateDer<'static>]> {
     ANCHORS
         .get_or_init(|| {
             let paths = CertPaths::from_env();
-            let env_override = paths.has_overrides();
-            let result = load_native_certs_with_paths(paths);
+            let result = load_native_certs_with_paths(&paths);
             for err in &result.errors {
                 debug!("rama native-certs: error while loading native root certificate: {err}");
             }
 
-            if result.certs.is_empty() && !env_override {
+            if result.certs.is_empty() && !paths.has_overrides() {
                 warn!(
                     native_cert_errors = result.errors.len(),
                     "rama native-certs: no native system root certificates found; \
@@ -121,10 +120,10 @@ pub fn bundled_root_certs() -> &'static [CertificateDer<'static>] {
 /// parsing a ~300KB disk file, or querying the OS keychain. Prefer
 /// [`shared_native_trust_anchors`] which caches the result.
 pub fn load_native_certs() -> CertificateResult {
-    load_native_certs_with_paths(CertPaths::from_env())
+    load_native_certs_with_paths(&CertPaths::from_env())
 }
 
-fn load_native_certs_with_paths(paths: CertPaths) -> CertificateResult {
+fn load_native_certs_with_paths(paths: &CertPaths) -> CertificateResult {
     match paths.has_overrides() {
         true => paths.load(),
         _ => platform::load_native_certs(),

--- a/rama-crypto/src/native_certs/unix.rs
+++ b/rama-crypto/src/native_certs/unix.rs
@@ -1,0 +1,10 @@
+use super::{CertPaths, CertificateResult};
+
+pub(super) fn load_native_certs() -> CertificateResult {
+    let likely_locations = openssl_probe::probe();
+    CertPaths {
+        file: likely_locations.cert_file,
+        dirs: likely_locations.cert_dir,
+    }
+    .load()
+}

--- a/rama-crypto/src/native_certs/windows.rs
+++ b/rama-crypto/src/native_certs/windows.rs
@@ -1,0 +1,56 @@
+use schannel::cert_context::ValidUses;
+use schannel::cert_store::CertStore;
+
+use super::CertificateResult;
+use crate::pki_types::CertificateDer;
+
+static PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";
+
+type OpenStoreFn = for<'a> fn(&'a str) -> std::io::Result<CertStore>;
+
+pub(super) fn load_native_certs() -> CertificateResult {
+    let mut result = CertificateResult::default();
+
+    // Read both the per-user and the local-machine ROOT stores. Reading
+    // LOCAL_MACHINE in addition to CURRENT_USER matters:
+    // enterprise/admin-installed roots typically live under LOCAL_MACHINE\ROOT,
+    // which a per-user-only read would miss.
+    const OPENERS: &[OpenStoreFn] = &[CertStore::open_current_user, CertStore::open_local_machine];
+    // Omit CA: that Windows store contains intermediates, not trust anchors.
+    const STORE_NAMES: &[&str] = &["ROOT"];
+
+    for &open in OPENERS {
+        for &store_name in STORE_NAMES {
+            let store = match open(store_name) {
+                Ok(store) => store,
+                Err(err) => {
+                    result.os_error(err.into(), "failed to open windows certificate store");
+                    continue;
+                }
+            };
+
+            for cert in store.certs() {
+                let time_valid = cert.is_time_valid().unwrap_or_default();
+                let tls_usable = cert.valid_uses().map(usable_for_tls).unwrap_or_default();
+                if time_valid && tls_usable {
+                    result
+                        .certs
+                        .push(CertificateDer::from(cert.to_der().to_vec()));
+                }
+            }
+        }
+    }
+
+    // Dedup certs that appear in more than one store (e.g. user and machine).
+    result.certs.sort_unstable_by(|a, b| a.cmp(b));
+    result.certs.dedup();
+
+    result
+}
+
+fn usable_for_tls(uses: ValidUses) -> bool {
+    match uses {
+        ValidUses::All => true,
+        ValidUses::Oids(strs) => strs.iter().any(|x| x == PKIX_SERVER_AUTH),
+    }
+}

--- a/rama-tls-boring/Cargo.toml
+++ b/rama-tls-boring/Cargo.toml
@@ -46,15 +46,13 @@ pin-project-lite = { workspace = true }
 rama-boring = { workspace = true }
 rama-boring-tokio = { workspace = true }
 rama-core = { workspace = true }
+rama-crypto = { workspace = true, features = ["native-certs"] }
 rama-http-types = { workspace = true, optional = true }
 rama-net = { workspace = true, features = ["tls", "http"] }
 rama-ua = { workspace = true, optional = true, features = ["tls"] }
 rama-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "io-std"] }
 zstd = { workspace = true, optional = true }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-schannel = { workspace = true }
 
 [dev-dependencies]
 tracing-test = { workspace = true }

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -744,8 +744,8 @@ fn shared_default_verify_store() -> Result<&'static X509Store, BoxError> {
 fn build_os_default_verify_store() -> Result<X509Store, BoxError> {
     let anchors = rama_crypto::native_certs::shared_native_trust_anchors();
     trace!(
-        "boring connector: building shared verify store from {} native trust anchor(s)",
-        anchors.len()
+        anchor_count = anchors.len(),
+        "boring connector: building shared verify store from native trust anchors"
     );
 
     let mut builder =
@@ -759,17 +759,17 @@ fn build_os_default_verify_store() -> Result<X509Store, BoxError> {
                 Ok(()) => added += 1,
                 Err(err) => {
                     failed += 1;
-                    debug!("boring connector: failed to add native trust anchor to store: {err}");
+                    debug!(%err, "boring connector: failed to add native trust anchor to store");
                 }
             },
             Err(err) => {
                 failed += 1;
-                debug!("boring connector: failed to parse native trust anchor as x509: {err}");
+                debug!(%err, "boring connector: failed to parse native trust anchor as x509");
             }
         }
     }
 
-    trace!("boring connector: shared verify store built: added {added} anchor(s), {failed} failed");
+    trace!(added, failed, "boring connector: shared verify store built");
 
     if added == 0 {
         return Err(OpaqueError::from_static_str(

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -714,16 +714,14 @@ impl TlsConnectorDataBuilder {
     }
 }
 
-/// Process-wide OS default trust store, parsed once and shared by every
-/// connector that needs server verification.
+/// Process-wide trust store, built once and shared by every connector that
+/// needs server verification.
 ///
-/// `SslConnector::builder` calls `set_default_verify_paths` internally,
-/// which parses the entire system CA bundle into a *fresh* store on every
-/// call; left as-is that keeps a full copy of the bundle resident for the
-/// lifetime of each in-flight connection. Swapping in this single shared
-/// store via `set_cert_store_ref` collapses that to one parsed copy. (The
-/// redundant parse inside `builder` still happens per call — eliminating it
-/// would require a no-default-verify builder in `rama-boring`.)
+/// The store is populated from the platform's native trust anchors (the system
+/// root certificates), loaded once via
+/// [`rama_crypto::native_certs::shared_native_trust_anchors`] and shared across
+/// both the `rustls` and `boring` backends. Every connector references this one
+/// store via `set_cert_store_ref` instead of re-parsing a bundle per build.
 fn shared_default_verify_store() -> Result<&'static X509Store, BoxError> {
     static STORE: std::sync::LazyLock<Result<X509Store, BoxError>> =
         std::sync::LazyLock::new(build_os_default_verify_store);
@@ -736,106 +734,46 @@ fn shared_default_verify_store() -> Result<&'static X509Store, BoxError> {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+/// Build a boring [`X509Store`] from the shared, process-wide native trust
+/// anchors (the system root certificates).
+///
+/// The anchors are loaded once in a tls-implementation agnostic way by
+/// [`rama_crypto::native_certs::shared_native_trust_anchors`] (which itself
+/// warns and falls back to the bundled webpki roots if the platform store is
+/// empty), so this is identical to the trust used by the `rustls` backend.
 fn build_os_default_verify_store() -> Result<X509Store, BoxError> {
-    trace!("boring connector: loading OS default verify paths into shared store");
+    let anchors = rama_crypto::native_certs::shared_native_trust_anchors();
+    trace!(
+        "boring connector: building shared verify store from {} native trust anchor(s)",
+        anchors.len()
+    );
+
     let mut builder =
-        X509StoreBuilder::new().context("create x509 store builder for default verify paths")?;
-    builder
-        .set_default_paths()
-        .context("load OS default verify paths into shared x509 store")?;
-    Ok(builder.build())
-}
+        X509StoreBuilder::new().context("create x509 store builder for native trust anchors")?;
 
-#[cfg(target_os = "windows")]
-fn build_os_default_verify_store() -> Result<X509Store, BoxError> {
-    // on windows it seems to have no root CA by default when using boringssl
-    // this code path is there to set it anyway
-    trace!("boring connector: windows: load system certs");
-
-    let mut builder = X509StoreBuilder::new().context("build x509 store builder")?;
-
-    let mut total_cert_count = 0;
-    let mut total_added_cert_count = 0;
-
-    const PKIX_SERVER_AUTH: &str = "1.3.6.1.5.5.7.3.1";
-    const WINDOWS_STORE_NAMES: &[&str] = &["ROOT", "CA"];
-
-    type CertStoreOpenFn =
-        for<'a> fn(&'a str) -> Result<schannel::cert_store::CertStore, std::io::Error>;
-    const CERTIFICATE_OPENERS: &[(CertStoreOpenFn, &str)] = &[
-        (
-            schannel::cert_store::CertStore::open_current_user,
-            "open_current_user",
-        ),
-        (
-            schannel::cert_store::CertStore::open_local_machine,
-            "open_local_machine",
-        ),
-    ];
-
-    for (open_fn, open_fn_name) in CERTIFICATE_OPENERS {
-        for windows_store_name in WINDOWS_STORE_NAMES {
-            match open_fn(windows_store_name) {
-                Ok(cstore) => {
-                    let mut current_cert_count = 0;
-                    let mut current_invalid_cert_count = 0;
-                    let mut current_added_cert_count = 0;
-
-                    for cert in cstore.certs() {
-                        current_cert_count += 1;
-                        total_cert_count += 1;
-
-                        if !cert.is_time_valid().unwrap_or_default()
-                            || !cert
-                                .valid_uses()
-                                .map(|use_case| match use_case {
-                                    schannel::cert_context::ValidUses::All => true,
-                                    schannel::cert_context::ValidUses::Oids(strs) => {
-                                        strs.iter().any(|x| x == PKIX_SERVER_AUTH)
-                                    }
-                                })
-                                .unwrap_or_default()
-                        {
-                            current_invalid_cert_count += 1;
-                            continue;
-                        }
-
-                        // Convert the Windows cert to DER, then to BoringSSL X509
-                        match X509::from_der(cert.to_der()) {
-                            Ok(x509) => {
-                                if let Err(err) = builder.add_cert(x509) {
-                                    debug!("failed to add x509 cert to windows: {err}");
-                                } else {
-                                    current_added_cert_count += 1;
-                                    total_added_cert_count += 1;
-                                }
-                            }
-                            Err(err) => {
-                                debug!("failed to convert DER cert to x509: {err}");
-                            }
-                        }
-                    }
-                    trace!(
-                        "boring connector: windows: {open_fn_name}::{windows_store_name}: added {current_added_cert_count} certs of {current_cert_count} certs (invalid schannel certs: {current_invalid_cert_count})"
-                    );
-                }
+    let mut added = 0_usize;
+    let mut failed = 0_usize;
+    for der in anchors.iter() {
+        match X509::from_der(der.as_ref()) {
+            Ok(cert) => match builder.add_cert(cert) {
+                Ok(()) => added += 1,
                 Err(err) => {
-                    debug!(
-                        "failed to open {windows_store_name} cert store using schannel::cert_store::CertStore::{open_fn_name}; err = {err:?}",
-                    );
+                    failed += 1;
+                    debug!("boring connector: failed to add native trust anchor to store: {err}");
                 }
+            },
+            Err(err) => {
+                failed += 1;
+                debug!("boring connector: failed to parse native trust anchor as x509: {err}");
             }
         }
     }
 
-    trace!(
-        "boring connector: windows: final result: added {total_added_cert_count} certs of {total_cert_count} certs"
-    );
+    trace!("boring connector: shared verify store built: added {added} anchor(s), {failed} failed");
 
-    if total_added_cert_count == 0 {
+    if added == 0 {
         return Err(OpaqueError::from_static_str(
-            "failed to add windows certs from system (user/machine x Root/CA)",
+            "no native trust anchors could be added to the boring x509 verify store",
         )
         .into_box_error());
     }

--- a/rama-tls-rustls/Cargo.toml
+++ b/rama-tls-rustls/Cargo.toml
@@ -47,13 +47,12 @@ dial9-tokio-telemetry = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rama-core = { workspace = true }
-rama-crypto = { workspace = true }
+rama-crypto = { workspace = true, features = ["native-certs"] }
 rama-http-types = { workspace = true, optional = true }
 rama-net = { workspace = true, features = ["tls", "http"] }
 rama-utils = { workspace = true }
 rcgen = { workspace = true, optional = true }
 rustls = { workspace = true }
-rustls-native-certs = { workspace = true }
 tokio = { workspace = true, features = ["macros", "io-std"] }
 tokio-rustls = { workspace = true }
 webpki-roots = { workspace = true }

--- a/rama-tls-rustls/src/client/connector_data.rs
+++ b/rama-tls-rustls/src/client/connector_data.rs
@@ -11,7 +11,7 @@ use rama_net::address::Host;
 use rama_net::tls::DataEncoding;
 use rama_net::tls::client::{ClientAuth, ServerVerifyMode};
 use rama_net::tls::keylog::open_intent_sink;
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, LazyLock};
 
 #[cfg(any(feature = "aws-lc", feature = "ring"))]
 use rama_crypto::pki_types::PrivatePkcs8KeyDer;
@@ -137,20 +137,18 @@ fn rustls_client_auth(
 /// no native roots are found, that loader warns and falls back to the bundled
 /// webpki (Mozilla CCADB) roots.
 pub fn client_root_certs() -> Arc<RootCertStore> {
-    static ROOT_CERTS: OnceLock<Arc<RootCertStore>> = OnceLock::new();
-    ROOT_CERTS
-        .get_or_init(|| {
-            let mut root_storage = RootCertStore::empty();
-            let anchors = rama_crypto::native_certs::shared_native_trust_anchors();
-            let (added, ignored) = root_storage.add_parsable_certificates(anchors.iter().cloned());
-            rama_core::telemetry::tracing::trace!(
-                added,
-                ignored,
-                "rama-tls-rustls: initialised client root cert store from shared native trust anchors"
-            );
-            Arc::new(root_storage)
-        })
-        .clone()
+    static ROOT_CERTS: LazyLock<Arc<RootCertStore>> = LazyLock::new(|| {
+        let mut root_storage = RootCertStore::empty();
+        let anchors = rama_crypto::native_certs::shared_native_trust_anchors();
+        let (added, ignored) = root_storage.add_parsable_certificates(anchors.iter().cloned());
+        rama_core::telemetry::tracing::trace!(
+            added,
+            ignored,
+            "rama-tls-rustls: initialised client root cert store from shared native trust anchors"
+        );
+        Arc::new(root_storage)
+    });
+    ROOT_CERTS.clone()
 }
 
 #[cfg(not(any(feature = "aws-lc", feature = "ring")))]

--- a/rama-tls-rustls/src/client/connector_data.rs
+++ b/rama-tls-rustls/src/client/connector_data.rs
@@ -129,12 +129,25 @@ fn rustls_client_auth(
     Ok((cert_chain, private_key))
 }
 
+/// The default client root certificate store used to verify servers.
+///
+/// By default this is built from the platform's native trust store (the system
+/// root certificates), loaded once and shared process-wide via
+/// [`rama_crypto::native_certs::shared_native_trust_anchors`]. On systems where
+/// no native roots are found, that loader warns and falls back to the bundled
+/// webpki (Mozilla CCADB) roots.
 pub fn client_root_certs() -> Arc<RootCertStore> {
     static ROOT_CERTS: OnceLock<Arc<RootCertStore>> = OnceLock::new();
     ROOT_CERTS
         .get_or_init(|| {
             let mut root_storage = RootCertStore::empty();
-            root_storage.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            let anchors = rama_crypto::native_certs::shared_native_trust_anchors();
+            let (added, ignored) = root_storage.add_parsable_certificates(anchors.iter().cloned());
+            rama_core::telemetry::tracing::trace!(
+                added,
+                ignored,
+                "rama-tls-rustls: initialised client root cert store from shared native trust anchors"
+            );
             Arc::new(root_storage)
         })
         .clone()

--- a/rama-tls-rustls/src/lib.rs
+++ b/rama-tls-rustls/src/lib.rs
@@ -67,17 +67,6 @@ pub mod dep {
     //!
     //! Exported for your convenience.
 
-    pub mod native_certs {
-        //! Re-export of the [`rustls-native-certs`] crate.
-        //!
-        //! rustls-native-certs allows rustls to use the platform's native certificate
-        //! store when operating as a TLS client.
-        //!
-        //! [`rustls-native-certs`]: https://docs.rs/rustls-native-certs
-        #[doc(inline)]
-        pub use rustls_native_certs::*;
-    }
-
     pub mod rustls {
         //! Re-export of the [`rustls`] and  [`tokio-rustls`] crates.
         //!

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -299,6 +299,10 @@ criteria = "safe-to-deploy"
 version = "1.19.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.openssl-probe]]
+version = "0.2.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.opentelemetry]]
 version = "0.22.0"
 criteria = "safe-to-deploy"
@@ -413,10 +417,6 @@ criteria = "safe-to-run"
 
 [[exemptions.rustls]]
 version = "0.23.5"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-native-certs]]
-version = "0.7.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pki-types]]
@@ -601,6 +601,10 @@ criteria = "safe-to-deploy"
 
 [[exemptions.wasm-bindgen-shared]]
 version = "0.2.92"
+criteria = "safe-to-deploy"
+
+[[exemptions.webpki-root-certs]]
+version = "1.0.7"
 criteria = "safe-to-deploy"
 
 [[exemptions.winapi]]


### PR DESCRIPTION
New feature-gated rama-crypto native_certs module
(forked rustls-native-certs) loads the platform trust store once into shared pki_types anchors; rustls and boring both verify against it by default, falling back to bundled webpki roots (with a warning) when no native roots are found.

Note that this work is unrelated to a platform verifier, where we make use of the platform sdk (windows/linux/macos/...) to verify certificates. Advantage of the latter isd that it also works in contained environments (e.g. system extensions on MacOS) and always have the latest view of certificates. In contrast these certificates are static and require a cold start (to load them).

Regardless, it's a good default. And works for majority of use cases just fine.
That said I do think one of these weeks either I or you @soundofspace need to look into integrating code similar to 'platform-verifier' as an opt-in feature (just not sure where) and when enabled have that be the default for rustls/boring tls (client) connectors.