### PR TITLE
BoxErrorExt trait to create BoxError from_static_str

### DIFF
--- a/examples/gateway/fastcgi-php/migration/main.rs
+++ b/examples/gateway/fastcgi-php/migration/main.rs
@@ -191,8 +191,10 @@ mod unix_impl {
 use unix_impl::run;
 
 #[cfg(not(target_family = "unix"))]
-async fn run() -> Result<(), rama::error::extra::OpaqueError> {
-    Err(rama::error::extra::OpaqueError::from_static_str(
+async fn run() -> Result<(), rama::error::BoxError> {
+    use rama::error::BoxErrorExt;
+
+    Err(rama::error::BoxError::from_static_str(
         "fastcgi_php_migration: this example uses Unix sockets and requires a \
          Unix-family target (Linux, macOS, BSD).",
     ))

--- a/examples/http_anti_bot_infinite_resource.rs
+++ b/examples/http_anti_bot_infinite_resource.rs
@@ -36,7 +36,7 @@
 use rama::{
     Layer, Service,
     conversion::FromRef,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt},
     extensions::{Extensions, ExtensionsRef},
     http::{
         InfiniteReader,
@@ -230,10 +230,8 @@ where
             .ip_addr;
         let block_list = self.block_list.lock().await;
         if block_list.contains(&ip_addr) {
-            return Err(
-                OpaqueError::from_static_str("drop connection for blocked ip")
-                    .context_field("ip_addr", ip_addr),
-            );
+            return Err(BoxError::from_static_str("drop connection for blocked ip")
+                .context_field("ip_addr", ip_addr));
         }
         std::mem::drop(block_list);
         self.inner.serve(stream).await.into_box_error()

--- a/examples/http_pooled_client.rs
+++ b/examples/http_pooled_client.rs
@@ -22,7 +22,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt},
     http::{
         BodyExtractExt,
         client::EasyHttpWebClient,
@@ -142,9 +142,9 @@ where
     async fn check(&self, request: Request) -> PolicyResult<Request, Self::Guard, Self::Error> {
         let output = match !self.0.swap(true, Ordering::AcqRel) {
             true => PolicyOutput::Ready(()),
-            false => PolicyOutput::Abort(
-                OpaqueError::from_static_str("only first connection is allowed").into_box_error(),
-            ),
+            false => PolicyOutput::Abort(BoxError::from_static_str(
+                "only first connection is allowed",
+            )),
         };
         PolicyResult {
             input: request,

--- a/examples/http_pooled_client.rs
+++ b/examples/http_pooled_client.rs
@@ -22,7 +22,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorExt, extra::OpaqueError},
+    error::{BoxError, extra::OpaqueError},
     http::{
         BodyExtractExt,
         client::EasyHttpWebClient,

--- a/examples/http_rama_tower.rs
+++ b/examples/http_rama_tower.rs
@@ -25,7 +25,7 @@
 
 use rama::{
     Layer as _,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, extra::OpaqueError},
     http::{
         HeaderValue, Request,
         layer::trace::TraceLayer,

--- a/examples/http_rama_tower.rs
+++ b/examples/http_rama_tower.rs
@@ -25,7 +25,7 @@
 
 use rama::{
     Layer as _,
-    error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt as _, ErrorContext as _},
     http::{
         HeaderValue, Request,
         layer::trace::TraceLayer,
@@ -211,10 +211,9 @@ where
         // Now check the sleep
         match this.sleep.poll(cx) {
             std::task::Poll::Pending => std::task::Poll::Pending,
-            std::task::Poll::Ready(_) => std::task::Poll::Ready(Err(OpaqueError::from_static_str(
-                "Elapses",
-            )
-            .into_box_error())),
+            std::task::Poll::Ready(_) => {
+                std::task::Poll::Ready(Err(BoxError::from_static_str("Elapses")))
+            }
         }
     }
 }

--- a/examples/linux_tproxy_tcp.rs
+++ b/examples/linux_tproxy_tcp.rs
@@ -112,8 +112,8 @@
 //! increase on both the `output` and `prerouting` rules.
 
 #[cfg(not(target_os = "linux"))]
-fn main() -> Result<(), rama::error::extra::OpaqueError> {
-    Err(rama::error::extra::OpaqueError::from_static_str(
+fn main() -> Result<(), BoxError> {
+    Err(BoxError::from_static_str(
         "the linux_tproxy_tcp example only supports Linux",
     ))
 }
@@ -143,6 +143,9 @@ use ::{
     },
     std::time::Duration,
 };
+
+#[cfg(not(target_os = "linux"))]
+use rama::error::{BoxError, BoxErrorExt};
 
 #[cfg(target_os = "linux")]
 const LISTEN_ADDR: SocketAddress = SocketAddress::default_ipv4(62052);

--- a/examples/tls_rustls_dynamic_config.rs
+++ b/examples/tls_rustls_dynamic_config.rs
@@ -58,7 +58,7 @@
 use rama::{
     Layer,
     crypto::pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject as _},
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt},
     graceful::Shutdown,
     http::{Request, Response, server::HttpServer, service::web::response::IntoResponse},
     layer::ConsumeErrLayer,
@@ -128,13 +128,12 @@ impl DynamicConfigProvider for DynamicConfig {
             Some(name) => match name {
                 "example" => load_example_certificate().await,
                 "second.example" => load_second_example_certificate().await,
-                name => Err(OpaqueError::from_static_str("server name not recognised")
+                name => Err(BoxError::from_static_str("server name not recognised")
                     .context_str_field("name", name)),
             },
-            _ => Err(
-                OpaqueError::from_static_str("server name required for this server to work")
-                    .into_box_error(),
-            ),
+            _ => Err(BoxError::from_static_str(
+                "server name required for this server to work",
+            )),
         }?;
 
         let config = TlsAcceptorDataBuilder::new(cert_chain, key_der)

--- a/examples/tls_sni_router.rs
+++ b/examples/tls_sni_router.rs
@@ -49,7 +49,7 @@
 
 use rama::{
     Layer, Service,
-    error::{BoxError, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt},
     extensions::ExtensionsRef,
     graceful::{Shutdown, ShutdownGuard},
     http::{
@@ -158,9 +158,7 @@ where
                         server.address = %sni,
                         "block connection for unknown destination",
                     );
-                    return Err(
-                        OpaqueError::from_static_str("unknown destination").into_box_error()
-                    );
+                    return Err(BoxError::from_static_str("unknown destination"));
                 }
             }
         };

--- a/examples/tls_sni_router.rs
+++ b/examples/tls_sni_router.rs
@@ -49,7 +49,7 @@
 
 use rama::{
     Layer, Service,
-    error::{BoxError, ErrorExt, extra::OpaqueError},
+    error::{BoxError, extra::OpaqueError},
     extensions::ExtensionsRef,
     graceful::{Shutdown, ShutdownGuard},
     http::{

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_xpc_server.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_xpc_server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use base64::Engine as _;
 use rama::{
     bytes::Bytes,
-    error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext},
     net::apple::xpc::{
         PeerSecurityRequirement, XpcListener, XpcListenerConfig, XpcMessageRouter, XpcServer,
     },
@@ -162,10 +162,9 @@ pub(crate) fn spawn_xpc_server(
                  config; refusing to bind XPC listener (fail-closed). Set it from the container \
                  app's `Bundle.main.bundleIdentifier`.",
             );
-            OpaqueError::from_static_str(
+            BoxError::from_static_str(
                 "xpc demo server: missing container_signing_identifier (fail-closed)",
             )
-            .into_box_error()
         })?;
 
     tracing::info!(

--- a/rama-cli/src/cmd/probe/tls/mod.rs
+++ b/rama-cli/src/cmd/probe/tls/mod.rs
@@ -2,7 +2,7 @@
 
 use rama::{
     Layer, Service,
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext},
     extensions::ExtensionsRef,
     net::{
         Protocol,
@@ -83,10 +83,9 @@ pub async fn run(cfg: CliCommandTls) -> Result<(), BoxError> {
             }
             DataEncoding::DerStack(raw_data_slice) => {
                 if raw_data_slice.is_empty() {
-                    return Err(OpaqueError::from_static_str(
+                    return Err(BoxError::from_static_str(
                         "DER-encoded stack byte slice for TLS cert is empty",
-                    )
-                    .into_box_error());
+                    ));
                 } else {
                     vec![
                         X509::from_der(raw_data_slice[0].as_slice())
@@ -108,9 +107,7 @@ pub async fn run(cfg: CliCommandTls) -> Result<(), BoxError> {
             println!();
         }
     } else {
-        return Err(
-            OpaqueError::from_static_str("no peer cert information found").into_box_error(),
-        );
+        return Err(BoxError::from_static_str("no peer cert information found"));
     }
 
     Ok(())

--- a/rama-cli/src/cmd/probe/tls/mod.rs
+++ b/rama-cli/src/cmd/probe/tls/mod.rs
@@ -2,7 +2,7 @@
 
 use rama::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     extensions::ExtensionsRef,
     net::{
         Protocol,

--- a/rama-cli/src/cmd/resolve.rs
+++ b/rama-cli/src/cmd/resolve.rs
@@ -25,7 +25,7 @@ use rama::{
             HappyEyeballAddressResolverExt,
         },
     },
-    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt as _},
     extensions::Extensions,
     futures::StreamExt,
     net::{
@@ -65,10 +65,9 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "failed to resolve domain into any A record",
-                )
-                .into_box_error());
+                ));
             }
         }
         Some(RecordType::AAAA) => {
@@ -85,10 +84,9 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "failed to resolve domain into any AAAA record",
-                )
-                .into_box_error());
+                ));
             }
         }
         Some(RecordType::TXT) => {
@@ -108,15 +106,14 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if records_found == 0 {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "failed to resolve domain into any TXT record",
-                )
-                .into_box_error());
+                ));
             }
         }
         Some(RecordType::Unknown(variant)) => {
             return Err(
-                OpaqueError::from_static_str("unknown record type").context_field("value", variant)
+                BoxError::from_static_str("unknown record type").context_field("value", variant)
             );
         }
         None => {
@@ -153,10 +150,9 @@ pub async fn run(cfg: ResolveCommand) -> Result<(), BoxError> {
                 }
             }
             if addresses_found == 0 {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "failed to resolve domain into any IP address",
-                )
-                .into_box_error());
+                ));
             }
         }
     }
@@ -223,9 +219,9 @@ fn build_dns_config_and_options(
 fn apply_options(
     cfg: &ResolveCommand,
     dns_options: &mut hickory::resolver::config::ResolverOpts,
-) -> Result<(), OpaqueError> {
+) -> Result<(), BoxError> {
     if cfg.ipv4_only && cfg.ipv6_only {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "IPv4-only and IPv6-only transport cannot be requested at the same time",
         ));
     }
@@ -334,7 +330,7 @@ impl FromStr for NameServerArg {
             return Ok(Self { ip, port: None });
         }
 
-        Err(OpaqueError::from_static_str("invalid nameserver address")
+        Err(BoxError::from_static_str("invalid nameserver address")
             .context_field("value", s.to_owned()))
     }
 }
@@ -408,23 +404,23 @@ pub struct ResolveCommand {
 }
 
 impl ResolveCommand {
-    fn domain(&self) -> Result<Domain, OpaqueError> {
+    fn domain(&self) -> Result<Domain, BoxError> {
         match (&self.domain, &self.query_name) {
             (Some(domain), None) | (None, Some(domain)) => Ok(domain.clone()),
-            (Some(_), Some(_)) => Err(OpaqueError::from_static_str(
+            (Some(_), Some(_)) => Err(BoxError::from_static_str(
                 "domain cannot be provided both positionally and via --name",
             )),
-            (None, None) => Err(OpaqueError::from_static_str(
+            (None, None) => Err(BoxError::from_static_str(
                 "domain is required either positionally or via --name",
             )),
         }
     }
 
-    fn record_type(&self) -> Result<Option<RecordType>, OpaqueError> {
+    fn record_type(&self) -> Result<Option<RecordType>, BoxError> {
         match (&self.record_type, &self.query_type) {
             (Some(record_type), None) | (None, Some(record_type)) => Ok(Some(record_type.clone())),
             (None, None) => Ok(None),
-            (Some(_), Some(_)) => Err(OpaqueError::from_static_str(
+            (Some(_), Some(_)) => Err(BoxError::from_static_str(
                 "record type cannot be provided both positionally and via --type",
             )),
         }

--- a/rama-cli/src/cmd/send/arg.rs
+++ b/rama-cli/src/cmd/send/arg.rs
@@ -1,6 +1,6 @@
 use clap::ValueEnum;
 use rama::{
-    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt as _},
     net::address::Domain,
 };
 use std::{fmt, net::IpAddr, str::FromStr};
@@ -62,7 +62,7 @@ impl FromStr for ResolveArg {
                 .map(|suffix| suffix.chars().all(|c| c.is_alphabetic() || c == '.'))
                 .unwrap_or_default()
             {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "invalid domain (suffix not found or invalid)",
                 )
                 .context_field("host", host));
@@ -81,10 +81,9 @@ impl FromStr for ResolveArg {
         }
 
         if arg.addresses.is_empty() {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "no addresses found while at least one is required",
-            )
-            .into_box_error());
+            ));
         }
 
         Ok(arg)

--- a/rama-cli/src/cmd/send/file.rs
+++ b/rama-cli/src/cmd/send/file.rs
@@ -2,7 +2,7 @@
 //! file at the URI's path and stream its bytes to stdout.
 
 use rama::{
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     net::uri::Uri,
 };
 use std::path::{Path, PathBuf};

--- a/rama-cli/src/cmd/send/file.rs
+++ b/rama-cli/src/cmd/send/file.rs
@@ -2,7 +2,7 @@
 //! file at the URI's path and stream its bytes to stdout.
 
 use rama::{
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext},
     net::uri::Uri,
 };
 use std::path::{Path, PathBuf};
@@ -35,7 +35,7 @@ fn extract_path(uri: &Uri) -> Result<PathBuf, BoxError> {
     let raw = uri.path().context("file:// URI has no path")?.as_raw_str();
 
     if raw.is_empty() {
-        return Err(OpaqueError::from_static_str("file:// URI has an empty path").into_box_error());
+        return Err(BoxError::from_static_str("file:// URI has an empty path"));
     }
 
     // On Windows, `file:///C:/x` parses with path `/C:/x` — curl

--- a/rama-cli/src/cmd/send/http/client/mod.rs
+++ b/rama-cli/src/cmd/send/http/client/mod.rs
@@ -1,6 +1,6 @@
 use rama::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::Extension,
     http::{
         Request, Response, StreamingBody,
@@ -146,7 +146,7 @@ fn new_inner_client(
         (false, false, true, false) => Some(SslVersion::TLS1_2),
         (false, false, false, true) => Some(SslVersion::TLS1_3),
         (false, false, false, false) => None,
-        _ => Err(OpaqueError::from_static_str(
+        _ => Err(BoxError::from_static_str(
             "--tlsv1.0, --tlsv1.1, --tlsv1.2, --tlsv1.3 are mutually exclusive",
         ))?,
     } {

--- a/rama-cli/src/cmd/send/http/mod.rs
+++ b/rama-cli/src/cmd/send/http/mod.rs
@@ -1,6 +1,6 @@
 use rama::{
     Service,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt},
     utils::collections::NonEmptySmallVec,
 };
 
@@ -65,7 +65,7 @@ pub async fn run_inner(cfg: &SendCommand, is_ws: bool) -> Result<(), BoxError> {
             let code = resp.status();
             if code.is_client_error() || code.is_server_error() {
                 return Err(Box::new(ErrorWithExitCode {
-                    error: OpaqueError::from_static_str("http failure status code")
+                    error: BoxError::from_static_str("http failure status code")
                         .context_field("code", code),
                     code: 22,
                 }));

--- a/rama-cli/src/cmd/send/http/request.rs
+++ b/rama-cli/src/cmd/send/http/request.rs
@@ -1,6 +1,6 @@
 use rama::{
     bytes::Bytes,
-    error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _},
     extensions::ExtensionsRef,
     futures::{StreamExt, stream},
     http::{
@@ -23,7 +23,7 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
 
     let input = build_data_input(cfg).await?;
     if input.is_some() && is_ws {
-        return Err(OpaqueError::from_static_str("input not allowed in WS mode").into_box_error());
+        return Err(BoxError::from_static_str("input not allowed in WS mode"));
     }
 
     let uri: Uri = expand_url(&cfg.uri)
@@ -44,7 +44,7 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
         (false, false, false, true, false) => Some(Version::HTTP_2),
         (false, false, false, false, true) => Some(Version::HTTP_3),
         (false, false, false, false, false) => None,
-        _ => Err(OpaqueError::from_static_str(
+        _ => Err(BoxError::from_static_str(
             "--http0.9, --http1.0, --http1.1, --http2, --http3 are mutually exclusive",
         ))?,
     } {
@@ -80,7 +80,7 @@ pub(super) async fn build(cfg: &SendCommand, is_ws: bool) -> Result<Request, Box
     }
 
     match (cfg.ipv4, cfg.ipv6) {
-        (true, true) => Err(OpaqueError::from_static_str(
+        (true, true) => Err(BoxError::from_static_str(
             "--ipv4, --ipv6 are mutually exclusive",
         ))?,
         (true, false) => {
@@ -153,10 +153,9 @@ enum DataInput {
 async fn build_data_input(cfg: &SendCommand) -> Result<Option<DataInput>, BoxError> {
     if let Some(specs) = cfg.form_data.as_deref().filter(|v| !v.is_empty()) {
         if cfg.data.is_some() || cfg.json || cfg.binary {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "--form-data is mutually exclusive with --data, --json, --binary",
-            )
-            .into_box_error());
+            ));
         }
         let mut form = multipart::Form::new();
         for spec in specs {
@@ -178,7 +177,7 @@ async fn build_data_input(cfg: &SendCommand) -> Result<Option<DataInput>, BoxErr
         (true, false) => (ContentType::octet_stream(), None),
         (false, true) => (ContentType::json(), Some(NATIVE_NEWLINE)),
         (false, false) => (ContentType::form_url_encoded(), Some("&")),
-        _ => Err(OpaqueError::from_static_str(
+        _ => Err(BoxError::from_static_str(
             "--binary, --json are mutually exclusive",
         ))?,
     };

--- a/rama-cli/src/cmd/send/http/request.rs
+++ b/rama-cli/src/cmd/send/http/request.rs
@@ -1,6 +1,6 @@
 use rama::{
     bytes::Bytes,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, extra::OpaqueError},
     extensions::ExtensionsRef,
     futures::{StreamExt, stream},
     http::{

--- a/rama-cli/src/cmd/send/http/ws/tui.rs
+++ b/rama-cli/src/cmd/send/http/ws/tui.rs
@@ -1,6 +1,6 @@
 use rama::{
     Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt, extra::OpaqueError},
     futures::{FutureExt, StreamExt},
     graceful::ShutdownGuard,
     http::{
@@ -236,7 +236,7 @@ impl App {
                     self.history.push_server_message(text);
                 }
                 Ok(Message::Close(close)) => {
-                    return Err(OpaqueError::from_static_str("recv close msg")
+                    return Err(BoxError::from_static_str("recv close msg")
                         .context_debug_field("frame", close));
                 }
                 Ok(message) => {

--- a/rama-cli/src/cmd/send/mod.rs
+++ b/rama-cli/src/cmd/send/mod.rs
@@ -1,5 +1,5 @@
 use rama::{
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt},
     net::{Protocol, address::ProxyAddress, uri::Uri, user::Basic},
     utils::str::NonEmptyStr,
 };
@@ -15,7 +15,7 @@ mod layer;
 
 pub async fn run(cfg: SendCommand) -> Result<(), BoxError> {
     if cfg.uri.is_empty() {
-        return Err(OpaqueError::from_static_str("empty URI is not valid").into_box_error());
+        return Err(BoxError::from_static_str("empty URI is not valid"));
     }
 
     // Canonical URI parse — relies on rama's RFC 3986 parser instead
@@ -37,7 +37,7 @@ pub async fn run(cfg: SendCommand) -> Result<(), BoxError> {
     if scheme.is_http() || is_ws {
         return http::run(cfg, is_ws).await;
     }
-    Err(OpaqueError::from_static_str("scheme is not supported")
+    Err(BoxError::from_static_str("scheme is not supported")
         .context_str_field("scheme", scheme.as_str()))
 }
 

--- a/rama-cli/src/cmd/serve/echo/mod.rs
+++ b/rama-cli/src/cmd/serve/echo/mod.rs
@@ -6,7 +6,7 @@ use rama::{
     Layer as _,
     cli::{ForwardKind, service::echo::EchoServiceBuilder},
     combinators::Either,
-    error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt as _},
     graceful::ShutdownGuard,
     layer::{
         ConsumeErrLayer, LimitLayer, TimeoutLayer,
@@ -210,16 +210,14 @@ async fn bind_echo_tcp_service(
 ) -> Result<(), BoxError> {
     let exec = Executor::graceful(graceful);
     if cfg.ws {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "websocket support is only possible in http(s) mode",
-        )
-        .into_box_error());
+        ));
     }
     if cfg.http_version != HttpVersion::Auto {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "http version selection is only possible in http(s) mode",
-        )
-        .into_box_error());
+        ));
     }
 
     let with_ha_proxy = match cfg.forward {
@@ -232,10 +230,9 @@ async fn bind_echo_tcp_service(
             | ForwardKind::CFConnectingIp
             | ForwardKind::TrueClientIp,
         ) => {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "forward http headers are only possible in http(s) mode",
-            )
-            .into_box_error());
+            ));
         }
         Some(ForwardKind::HaProxy) => true,
         None => false,
@@ -300,33 +297,29 @@ async fn bind_echo_udp_service(
     etx: tokio::sync::mpsc::Sender<BoxError>,
 ) -> Result<(), BoxError> {
     if cfg.ws {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "websocket support is only possible in http(s) mode",
-        )
-        .into_box_error());
+        ));
     }
     if cfg.http_version != HttpVersion::Auto {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "http version selection is only possible in http(s) mode",
-        )
-        .into_box_error());
+        ));
     }
     if maybe_tls_config.is_some() {
-        return Err(
-            OpaqueError::from_static_str("TLS is not supported for UDP mode").into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "TLS is not supported for UDP mode",
+        ));
     }
     if cfg.forward.is_some() {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "Forward info capabilities is not supported for UDP mode",
-        )
-        .into_box_error());
+        ));
     }
     if cfg.timeout.is_some() {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "connection timeout is not supported for UDP mode",
-        )
-        .into_box_error());
+        ));
     }
 
     tracing::info!("starting UDP echo service: bind interface = {:?}", cfg.bind);

--- a/rama-cli/src/cmd/serve/stunnel/mod.rs
+++ b/rama-cli/src/cmd/serve/stunnel/mod.rs
@@ -27,7 +27,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, extra::OpaqueError},
     graceful::ShutdownGuard,
     net::{
         address::{HostWithPort, SocketAddress},

--- a/rama-cli/src/cmd/serve/stunnel/mod.rs
+++ b/rama-cli/src/cmd/serve/stunnel/mod.rs
@@ -27,7 +27,7 @@
 
 use rama::{
     Layer,
-    error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorContext as _},
     graceful::ShutdownGuard,
     net::{
         address::{HostWithPort, SocketAddress},
@@ -272,10 +272,9 @@ fn load_server_config(
             })))
         }
         (None, None) => Ok(try_new_server_config(None, exec)?),
-        _ => Err(OpaqueError::from_static_str(
+        _ => Err(BoxError::from_static_str(
             "Both certificate and key must be provided together, or neither",
-        )
-        .into_box_error()),
+        )),
     }
 }
 

--- a/rama-cli/src/utils/http.rs
+++ b/rama-cli/src/utils/http.rs
@@ -1,5 +1,5 @@
 use rama::{
-    error::{BoxError, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorExt as _},
     http,
     utils::str::smol_str::StrExt,
 };
@@ -31,7 +31,7 @@ impl FromStr for HttpVersion {
             "h1" | "http1" | "http/1" | "http/1.0" | "http/1.1" => Self::H1,
             "h2" | "http2" | "http/2" | "http/2.0" => Self::H2,
             version => {
-                return Err(OpaqueError::from_static_str("unsupported http version")
+                return Err(BoxError::from_static_str("unsupported http version")
                     .context_str_field("version", version));
             }
         })

--- a/rama-core/src/stream/json/io/read.rs
+++ b/rama-core/src/stream/json/io/read.rs
@@ -91,7 +91,8 @@ mod tests {
 
     use crate::futures::StreamExt;
     use crate::futures::stream;
-    use rama_error::extra::OpaqueError;
+    use rama_error::BoxErrorExt;
+
     use tokio_test::assert_pending;
     use tokio_test::task;
 
@@ -249,10 +250,10 @@ mod tests {
     #[test]
     fn fallible_stream_operates_correctly_with_interspersed_errors() {
         let data_vec = vec![
-            Err(OpaqueError::from_static_str("test message 1")),
+            Err(BoxError::from_static_str("test message 1")),
             Ok("invalid json\n{\"key\":11,\"val"),
             Ok("ue\":22}\n{\"key\":33,\"value\":44}\ninvalid json\n"),
-            Err(OpaqueError::from_static_str("test message 2")),
+            Err(BoxError::from_static_str("test message 2")),
             Ok("{\"key\":55,\"value\":66}\n"),
         ];
         let data_stream = stream::iter(data_vec);

--- a/rama-core/src/username/parse.rs
+++ b/rama-core/src/username/parse.rs
@@ -1,7 +1,7 @@
 use super::DEFAULT_USERNAME_LABEL_SEPARATOR;
 use crate::error::BoxError;
+use crate::error::BoxErrorExt as _;
 use crate::extensions::{Extension, Extensions};
-use rama_error::extra::OpaqueError;
 use rama_error::{ErrorContext as _, ErrorExt};
 use rama_utils::macros::all_the_tuples_no_last_special_case;
 use std::convert::Infallible;
@@ -88,12 +88,12 @@ where
     let username = match label_it.next() {
         Some(username) => {
             if username.is_empty() {
-                return Err(OpaqueError::from_static_str("empty username").into_box_error());
+                return Err(BoxError::from_static_str("empty username"));
             } else {
                 username
             }
         }
-        None => return Err(OpaqueError::from_static_str("missing username").into_box_error()),
+        None => return Err(BoxError::from_static_str("missing username")),
     };
 
     for (index, label) in label_it.enumerate() {
@@ -103,13 +103,13 @@ where
                 if lossy {
                     tracing::debug!(index, label, "parse_username: skipping ignored label");
                 } else {
-                    return Err(OpaqueError::from_static_str("ignored username label")
+                    return Err(BoxError::from_static_str("ignored username label")
                         .context_field("index", index)
                         .context_str_field("label", label));
                 }
             }
             UsernameLabelState::Abort => {
-                return Err(OpaqueError::from_static_str("invalid username label")
+                return Err(BoxError::from_static_str("invalid username label")
                     .context_field("index", index)
                     .context_str_field("label", label));
             }

--- a/rama-crypto/src/jose/jwa.rs
+++ b/rama-crypto/src/jose/jwa.rs
@@ -1,3 +1,4 @@
+use rama_core::error::BoxErrorExt as _;
 use std::ops::Deref;
 
 use aws_lc_rs::{
@@ -12,7 +13,7 @@ use aws_lc_rs::{
         RSA_PSS_SHA512, RsaEncoding, VerificationAlgorithm,
     },
 };
-use rama_core::error::{BoxError, extra::OpaqueError};
+use rama_core::error::BoxError;
 use serde::{Deserialize, Serialize};
 
 use crate::jose::JWKEllipticCurves;
@@ -63,36 +64,36 @@ impl From<JWKEllipticCurves> for JWA {
 }
 
 impl TryFrom<JWA> for JWKEllipticCurves {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::ES256 => Ok(Self::P256),
             JWA::ES384 => Ok(Self::P384),
             JWA::ES512 => Ok(Self::P521),
-            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(OpaqueError::from_static_str(
+            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(BoxError::from_static_str(
                 "Hmac cannot be converted to elliptic curve",
             )),
             JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => Err(
-                OpaqueError::from_static_str("RSA cannot be converted to elliptic curve"),
+                BoxError::from_static_str("RSA cannot be converted to elliptic curve"),
             ),
         }
     }
 }
 
 impl TryFrom<JWA> for &'static EcdsaSigningAlgorithm {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::ES256 => Ok(&ECDSA_P256_SHA256_FIXED_SIGNING),
             JWA::ES384 => Ok(&ECDSA_P384_SHA384_FIXED_SIGNING),
             JWA::ES512 => Ok(&ECDSA_P521_SHA512_FIXED_SIGNING),
-            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(OpaqueError::from_static_str(
+            JWA::HS256 | JWA::HS384 | JWA::HS512 => Err(BoxError::from_static_str(
                 "Hmac cannot be converted to elliptic curve",
             )),
             JWA::RS256 | JWA::RS384 | JWA::RS512 | JWA::PS256 | JWA::PS384 | JWA::PS512 => Err(
-                OpaqueError::from_static_str("RSA cannot be converted to elliptic curve"),
+                BoxError::from_static_str("RSA cannot be converted to elliptic curve"),
             ),
         }
     }
@@ -108,27 +109,27 @@ impl TryFrom<JWA> for &'static EcdsaVerificationAlgorithm {
 }
 
 impl TryFrom<&'static EcdsaSigningAlgorithm> for JWA {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: &'static EcdsaSigningAlgorithm) -> Result<Self, Self::Error> {
         match value {
             alg if *alg == ECDSA_P256_SHA256_FIXED_SIGNING => Ok(Self::ES256),
             alg if *alg == ECDSA_P384_SHA384_FIXED_SIGNING => Ok(Self::ES384),
             alg if *alg == ECDSA_P521_SHA512_FIXED_SIGNING => Ok(Self::ES512),
-            _ => Err(OpaqueError::from_static_str("cannot convert to jwa")),
+            _ => Err(BoxError::from_static_str("cannot convert to jwa")),
         }
     }
 }
 
 impl TryFrom<JWA> for &'static hmac::Algorithm {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
             JWA::HS256 => Ok(&HMAC_SHA256),
             JWA::HS384 => Ok(&HMAC_SHA384),
             JWA::HS512 => Ok(&HMAC_SHA512),
-            _ => Err(OpaqueError::from_static_str(
+            _ => Err(BoxError::from_static_str(
                 "Non-Hmac algorithm cannot be converted to hmac types",
             )),
         }
@@ -136,7 +137,7 @@ impl TryFrom<JWA> for &'static hmac::Algorithm {
 }
 
 impl TryFrom<JWA> for &'static dyn RsaEncoding {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
@@ -146,7 +147,7 @@ impl TryFrom<JWA> for &'static dyn RsaEncoding {
             JWA::PS256 => Ok(&RSA_PSS_SHA256),
             JWA::PS384 => Ok(&RSA_PSS_SHA384),
             JWA::PS512 => Ok(&RSA_PSS_SHA512),
-            _ => Err(OpaqueError::from_static_str(
+            _ => Err(BoxError::from_static_str(
                 "Non-RSA algorithm cannot be converted to rsa types",
             )),
         }
@@ -154,7 +155,7 @@ impl TryFrom<JWA> for &'static dyn RsaEncoding {
 }
 
 impl TryFrom<JWA> for &'static dyn VerificationAlgorithm {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: JWA) -> Result<Self, Self::Error> {
         match value {
@@ -168,7 +169,7 @@ impl TryFrom<JWA> for &'static dyn VerificationAlgorithm {
                 let signing_algo: &'static EcdsaSigningAlgorithm = value.try_into()?;
                 Ok(signing_algo.deref())
             }
-            _ => Err(OpaqueError::from_static_str(
+            _ => Err(BoxError::from_static_str(
                 "Verification algorithm is not supported",
             )),
         }

--- a/rama-crypto/src/jose/jwk.rs
+++ b/rama-crypto/src/jose/jwk.rs
@@ -10,7 +10,8 @@ use aws_lc_rs::{
     },
 };
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 
 use crate::jose::{JWA, Signer, jwk_utils::create_subject_public_key_info};
@@ -173,10 +174,9 @@ impl JWK {
                     rsa_public_key_sequence,
                 ))
             }
-            JWKType::OCT { .. } => Err(OpaqueError::from_static_str(
+            JWKType::OCT { .. } => Err(BoxError::from_static_str(
                 "Symmetric key cannot be converted to public key",
-            )
-            .into_box_error()),
+            )),
             JWKType::EC { crv, x, y } => {
                 let alg: &'static EcdsaVerificationAlgorithm =
                     JWA::from(crv.to_owned()).try_into()?;

--- a/rama-crypto/src/jose/jwk.rs
+++ b/rama-crypto/src/jose/jwk.rs
@@ -10,7 +10,7 @@ use aws_lc_rs::{
     },
 };
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
 
 use crate::jose::{JWA, Signer, jwk_utils::create_subject_public_key_info};

--- a/rama-crypto/src/jose/jws.rs
+++ b/rama-crypto/src/jose/jws.rs
@@ -1,5 +1,5 @@
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
 use rama_utils::macros::generate_set_and_with;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};

--- a/rama-crypto/src/jose/jws.rs
+++ b/rama-crypto/src/jose/jws.rs
@@ -1,5 +1,6 @@
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
-use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext as _};
 use rama_utils::macros::generate_set_and_with;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
@@ -63,7 +64,7 @@ impl Headers {
 
             let mut headers = match headers {
                 Value::Object(map) => map,
-                _ => Err(OpaqueError::from_static_str(
+                _ => Err(BoxError::from_static_str(
                     "Can only set multiple headers if input is key value object",
                 ))?,
             };
@@ -104,10 +105,9 @@ impl Headers {
     {
         match &self.0 {
             Some(headers) => Ok(T::deserialize(headers).context("deserialize headers into T")?),
-            None => Err(OpaqueError::from_static_str(
+            None => Err(BoxError::from_static_str(
                 "headers are None, deserialize not supported",
-            )
-            .into_box_error()),
+            )),
         }
     }
 }
@@ -212,10 +212,9 @@ impl JWSBuilder {
     /// This only available if there is no unprotected header set
     pub fn build_compact(mut self, signer: &impl Signer) -> Result<JWSCompact, BoxError> {
         if self.unprotected_headers.is_some() {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "Compact jws does not support unprotected headers",
-            )
-            .into_box_error());
+            ));
         }
 
         signer
@@ -583,10 +582,9 @@ impl JWSFlattened {
     /// Create a [`JWSCompact`] from this [`JWSFlattened`]
     pub fn as_compact(&self) -> Result<String, BoxError> {
         if self.signature.unprotected.is_some() {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "JWSCompact does not support unprotected headers",
-            )
-            .into_box_error());
+            ));
         };
 
         Ok(format!(
@@ -802,7 +800,7 @@ pub trait Verifier {
 
 #[cfg(test)]
 mod tests {
-    use rama_core::error::extra::OpaqueError;
+
     use tokio_test::assert_err;
 
     use super::*;
@@ -841,29 +839,27 @@ mod tests {
     }
 
     impl Verifier for DummyKey {
-        type Error = OpaqueError;
+        type Error = BoxError;
         type Output = ();
 
         fn verify(
             &self,
             _payload: &[u8],
             to_verify_sigs: &[ToVerifySignature],
-        ) -> Result<(), OpaqueError> {
+        ) -> Result<(), BoxError> {
             let to_verify = &to_verify_sigs[0];
             let original = to_verify.signed_data.as_bytes();
 
             let signature = to_verify.decoded_signature.signature();
 
             if original.len() + 1 != signature.len() {
-                Err(OpaqueError::from_static_str(
+                Err(BoxError::from_static_str(
                     "signature should add single u8 to original slice",
                 ))
             } else if original[..] != signature[..original.len()] {
-                Err(OpaqueError::from_static_str(
-                    "original data should be equal",
-                ))
+                Err(BoxError::from_static_str("original data should be equal"))
             } else if signature[signature.len() - 1] != 33 {
-                Err(OpaqueError::from_static_str(
+                Err(BoxError::from_static_str(
                     "last element in signature should be 33",
                 ))
             } else {
@@ -1097,10 +1093,9 @@ mod tests {
                 if protected_header.data.as_str() == "very protected" {
                     Ok(())
                 } else {
-                    Err(
-                        OpaqueError::from_static_str("received unexpected second protected header")
-                            .into_box_error(),
-                    )
+                    Err(BoxError::from_static_str(
+                        "received unexpected second protected header",
+                    ))
                 }
             }
         }

--- a/rama-dns/src/client/resolver/address/happy_eyeball.rs
+++ b/rama-dns/src/client/resolver/address/happy_eyeball.rs
@@ -1,3 +1,4 @@
+use rama_core::error::{BoxError, BoxErrorExt as _};
 use std::{
     net::IpAddr,
     pin::Pin,
@@ -88,11 +89,11 @@ impl<'a, R: crate::client::resolver::DnsAddressResolver> HappyEyeballAddressReso
             return HappyEyeballIpStream::Once {
                 stream: rama_core::stream::once(match (ip, ip_mode) {
                     (IpAddr::V4(_), ConnectIpMode::Ipv6) => {
-                        Err(OpaqueError::from_static_str("IPv4 address is not allowed")
+                        Err(BoxError::from_static_str("IPv4 address is not allowed")
                             .into_opaque_error())
                     }
                     (IpAddr::V6(_), ConnectIpMode::Ipv4) => {
-                        Err(OpaqueError::from_static_str("IPv6 address is not allowed")
+                        Err(BoxError::from_static_str("IPv6 address is not allowed")
                             .into_opaque_error())
                     }
                     _ => Ok(ip),
@@ -101,7 +102,7 @@ impl<'a, R: crate::client::resolver::DnsAddressResolver> HappyEyeballAddressReso
         }
         let Ok(domain) = self.host.try_into_domain() else {
             return HappyEyeballIpStream::Once {
-                stream: rama_core::stream::once(Err(OpaqueError::from_static_str(
+                stream: rama_core::stream::once(Err(BoxError::from_static_str(
                     "host is not resolvable as a domain",
                 )
                 .into_opaque_error())),

--- a/rama-error/src/ext/context.rs
+++ b/rama-error/src/ext/context.rs
@@ -277,7 +277,7 @@ impl crate::StdError for ErrorWithContext {
 mod tests {
     use super::*;
 
-    use crate::{ErrorExt, StdError, extra::OpaqueError};
+    use crate::{BoxErrorExt, ErrorExt, StdError};
 
     #[derive(Debug, Clone)]
     struct BoomError;
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn empty_keys_are_seen_as_simple_values_and_keys_are_trimmed() {
-        let err = OpaqueError::from_static_str("test error")
+        let err = BoxError::from_static_str("test error")
             .context_field("foo  ", "bar")
             .context_field("  ", "baz")
             .context_field("", 42);

--- a/rama-error/src/ext/mod.rs
+++ b/rama-error/src/ext/mod.rs
@@ -713,8 +713,24 @@ impl<Error: Into<BoxError>> ErrorExt for Error {
         Box::new(self::backtrace::ErrorWithBacktrace::new(source))
     }
 }
+pub trait BoxErrorExt: private::SealedBoxErrorExt {
+    /// Create a [`BoxError`] from a static str.
+    ///
+    /// Use this instead of `"msg".context()` or
+    /// some other method that turns it into a BoxError...
+    /// Because the std rust library turns this into a `String` otherwise...
+    fn from_static_str(e: &'static str) -> Self;
+}
+
+impl BoxErrorExt for BoxError {
+    fn from_static_str(e: &'static str) -> Self {
+        OpaqueError::from_static_str(e).into_box_error()
+    }
+}
 
 mod private {
+    use crate::BoxError;
+
     // These sealed traits document intent rather than enforce hard closure:
     // because the blanket impls cover every type that satisfies the public
     // trait bounds, any downstream type that meets those bounds will satisfy
@@ -728,6 +744,9 @@ mod private {
     pub trait SealedErrorExt {}
 
     impl<Error: Into<crate::BoxError>> SealedErrorExt for Error {}
+
+    pub trait SealedBoxErrorExt {}
+    impl SealedBoxErrorExt for BoxError {}
 }
 
 #[cfg(test)]

--- a/rama-error/src/ext/mod.rs
+++ b/rama-error/src/ext/mod.rs
@@ -259,7 +259,7 @@ impl<T> ErrorContext for Option<T> {
     fn into_box_error(self) -> Self::Context {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())),
         }
     }
@@ -275,7 +275,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context(value)),
         }
@@ -287,7 +287,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_hex(value)),
         }
@@ -299,7 +299,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_debug(value)),
         }
@@ -311,7 +311,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_field(key, value)),
         }
@@ -323,7 +323,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_str_field(key, value)),
         }
@@ -335,7 +335,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_hex_field(key, value)),
         }
@@ -347,7 +347,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .context_debug_field(key, value)),
         }
@@ -360,7 +360,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context(cb)),
         }
@@ -373,7 +373,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_hex(cb)),
         }
@@ -386,7 +386,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_debug(cb)),
         }
@@ -399,7 +399,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_field(key, cb)),
         }
@@ -412,7 +412,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_str_field(key, cb)),
         }
@@ -425,7 +425,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_hex_field(key, cb)),
         }
@@ -438,7 +438,7 @@ impl<T> ErrorContext for Option<T> {
     {
         match self {
             Some(value) => Ok(value),
-            None => Err(OpaqueError::from_static_str("Option is None")
+            None => Err(BoxError::from_static_str("Option is None")
                 .context_debug_field("type", core::any::type_name::<Self>())
                 .with_context_debug_field(key, cb)),
         }

--- a/rama-error/src/ext/opaque.rs
+++ b/rama-error/src/ext/opaque.rs
@@ -25,6 +25,15 @@ impl OpaqueError {
     pub fn from_static_str(e: &'static str) -> Self {
         Self(Box::new(StaticStrError(e)))
     }
+
+    #[inline(always)]
+    /// Unwrap into the inner [`BoxError`].
+    ///
+    /// [`OpaqueError`] is a transparent [`BoxError`] wrapper, so this is free.
+    /// This shadows the generic `into_box_error` added by `ErrorExt` trait.
+    pub fn into_box_error(self) -> BoxError {
+        self.0
+    }
 }
 
 impl fmt::Debug for OpaqueError {

--- a/rama-error/src/lib.rs
+++ b/rama-error/src/lib.rs
@@ -170,7 +170,7 @@ use core::error::Error as StdError;
 pub type BoxError = self::std::Box<dyn StdError + Send + Sync + 'static>;
 
 mod ext;
-pub use ext::{ErrorContext, ErrorExt};
+pub use ext::{BoxErrorExt, ErrorContext, ErrorExt};
 
 pub mod extra {
     //! extra types for edge cases

--- a/rama-fastcgi/src/client/proto.rs
+++ b/rama-fastcgi/src/client/proto.rs
@@ -1,12 +1,12 @@
 //! FastCGI wire protocol: sending requests and reading responses.
 
+use rama_core::error::{BoxError, BoxErrorExt as _};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use rama_core::bytes::{Bytes, BytesMut};
 
 use crate::body::FastCgiBody;
 use rama_core::error::ErrorExt;
-use rama_core::error::extra::OpaqueError;
 use rama_core::io::discard;
 
 use crate::proto::{
@@ -206,7 +206,7 @@ where
                         return Err(ClientError {
                             kind: ClientErrorKind::Protocol,
                             source: Some(
-                                OpaqueError::from_static_str(
+                                BoxError::from_static_str(
                                     "fastcgi client: stdout exceeded max_stdout_bytes",
                                 )
                                 .context_field("cap", options.max_stdout_bytes),

--- a/rama-fastcgi/src/http/convert.rs
+++ b/rama-fastcgi/src/http/convert.rs
@@ -8,7 +8,8 @@
 //! [`ClientOptions::max_stdout_bytes`][crate::client::ClientOptions::max_stdout_bytes]).
 
 use rama_core::bytes::{Bytes, BytesMut};
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::extensions::ExtensionsRef;
 use rama_core::futures::TryStreamExt;
 use rama_core::telemetry::tracing;
@@ -69,7 +70,7 @@ fn version_to_protocol(v: Version) -> Result<&'static str, BoxError> {
         Version::HTTP_11 => Ok("HTTP/1.1"),
         Version::HTTP_2 => Ok("HTTP/2"),
         Version::HTTP_3 => Ok("HTTP/3"),
-        other => Err(OpaqueError::from_static_str(
+        other => Err(BoxError::from_static_str(
             "fastcgi: unsupported HTTP version (cannot map to SERVER_PROTOCOL)",
         )
         .context_debug_field("version", other)),
@@ -357,10 +358,10 @@ fn parse_server_protocol(value: Option<&str>) -> Result<Version, BoxError> {
         Some("HTTP/1.1") => Ok(Version::HTTP_11),
         Some("HTTP/2" | "HTTP/2.0") => Ok(Version::HTTP_2),
         Some("HTTP/3" | "HTTP/3.0") => Ok(Version::HTTP_3),
-        Some(other) => Err(OpaqueError::from_static_str(
-            "fastcgi: unsupported SERVER_PROTOCOL value",
-        )
-        .context_str_field("value", other)),
+        Some(other) => Err(
+            BoxError::from_static_str("fastcgi: unsupported SERVER_PROTOCOL value")
+                .context_str_field("value", other),
+        ),
         None => {
             tracing::debug!("fastcgi: SERVER_PROTOCOL missing, defaulting to HTTP/1.1");
             Ok(Version::HTTP_11)

--- a/rama-haproxy/src/client/layer.rs
+++ b/rama-haproxy/src/client/layer.rs
@@ -1,10 +1,11 @@
+use rama_core::error::BoxErrorExt as _;
 use std::{fmt, marker::PhantomData, net::IpAddr};
 
 use crate::protocol::{v1, v2};
 use rama_core::{
     Layer, Service,
     bytes::Bytes,
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     extensions::ExtensionsRef,
     io::Io,
 };
@@ -294,7 +295,7 @@ where
                     .map(|info| info.peer_addr())
             })
             .ok_or_else(|| {
-                OpaqueError::from_static_str("PROXY client (v1): missing src socket address")
+                BoxError::from_static_str("PROXY client (v1): missing src socket address")
             })?;
 
         let peer_addr = conn.peer_addr()?;
@@ -306,10 +307,9 @@ where
                 v1::Addresses::new_tcp6(src_ip, dst_ip, src.port, peer_addr.port)
             }
             (_, _) => {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "PROXY client (v1): IP version mismatch between src and dest",
-                )
-                .into_box_error());
+                ));
             }
         };
 
@@ -346,7 +346,7 @@ where
                         .map(|info| info.peer_addr())
                 })
                 .ok_or_else(|| {
-                    OpaqueError::from_static_str("PROXY client (v2): missing src socket address")
+                    BoxError::from_static_str("PROXY client (v2): missing src socket address")
                 })?
         };
 
@@ -363,10 +363,9 @@ where
                 v2::IPv6::new(src_ip, dst_ip, src.port, peer_addr.port),
             ),
             (_, _) => {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "PROXY client (v2): IP version mismatch between src and dest",
-                )
-                .into_box_error());
+                ));
             }
         };
 
@@ -375,11 +374,10 @@ where
             // — receivers parse the entire post-address area as TLVs, so the
             // payload would be mis-interpreted (or rejected) and the CRC
             // would be computed over a header the peer can't validate.
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "PROXY client (v2): `payload` and `crc32c` cannot be combined; \
                  use typed TLVs instead",
-            )
-            .into_box_error());
+            ));
         }
 
         // A CRC32C TLV value is never something a sender should compute by
@@ -393,11 +391,10 @@ where
             .iter()
             .any(|(kind, _)| *kind == v2::Type::CRC32C)
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "PROXY client (v2): manual `with_tlv(Type::CRC32C, ...)` is not supported; \
                  use `with_crc32c(true)` instead",
-            )
-            .into_box_error());
+            ));
         }
 
         let mut builder = builder;

--- a/rama-haproxy/src/client/layer.rs
+++ b/rama-haproxy/src/client/layer.rs
@@ -4,7 +4,7 @@ use crate::protocol::{v1, v2};
 use rama_core::{
     Layer, Service,
     bytes::Bytes,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::Io,
 };

--- a/rama-haproxy/src/server/layer.rs
+++ b/rama-haproxy/src/server/layer.rs
@@ -1,8 +1,9 @@
 use crate::protocol::{HeaderResult, PartialResult, v1, v2};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
     bytes::Bytes,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, ErrorExt},
     extensions::{Extension, ExtensionsRef},
     io::{HeapReader, Io, PrefixedIo},
     telemetry::tracing,
@@ -495,10 +496,9 @@ impl<S> HaProxyService<S> {
         if self.strictness.reject_unknown_address_family
             && matches!(header.addresses, v1::Addresses::Unknown)
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "haproxy v1: UNKNOWN address family rejected by strictness configuration",
-            )
-            .into_box_error());
+            ));
         }
 
         match header.addresses {
@@ -524,17 +524,15 @@ impl<S> HaProxyService<S> {
         if self.strictness.reject_unknown_address_family
             && matches!(header.addresses, v2::Addresses::Unspecified)
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "haproxy v2: AF_UNSPEC rejected by strictness configuration",
-            )
-            .into_box_error());
+            ));
         }
 
         if self.strictness.reject_local_command && header.command == v2::Command::Local {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "haproxy v2: LOCAL command rejected by strictness configuration",
-            )
-            .into_box_error());
+            ));
         }
 
         // CRC32C verification — section 2.2.5 of the spec mandates that a
@@ -546,10 +544,9 @@ impl<S> HaProxyService<S> {
         // the two concerns orthogonal.
         let crc_status = header.verify_crc32c();
         if self.strictness.verify_crc32c_when_present && crc_status == v2::Crc32cStatus::Invalid {
-            return Err(
-                OpaqueError::from_static_str("haproxy v2: CRC32C TLV present but invalid")
-                    .into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "haproxy v2: CRC32C TLV present but invalid",
+            ));
         }
         if self.strictness.require_crc32c
             && !matches!(
@@ -557,10 +554,9 @@ impl<S> HaProxyService<S> {
                 v2::Crc32cStatus::Valid | v2::Crc32cStatus::Invalid
             )
         {
-            return Err(
-                OpaqueError::from_static_str("haproxy v2: required CRC32C TLV missing")
-                    .into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "haproxy v2: required CRC32C TLV missing",
+            ));
         }
 
         // Collect TLVs into an extension before consuming them.
@@ -582,10 +578,9 @@ impl<S> HaProxyService<S> {
         }
 
         if self.strictness.fail_on_malformed_tlv && tlv_malformed {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "haproxy v2: malformed TLV area rejected by strictness configuration",
-            )
-            .into_box_error());
+            ));
         }
 
         // Spec section 2.2: the receiver MUST ignore any address information

--- a/rama-http-backend/src/client/conn.rs
+++ b/rama-http-backend/src/client/conn.rs
@@ -1,4 +1,5 @@
 use super::{HttpClientService, svc::SendRequest};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
     error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError},
@@ -271,7 +272,7 @@ where
                 conn: svc,
             })
         }
-        version => Err(OpaqueError::from_static_str("unsupported Http version")
+        version => Err(BoxError::from_static_str("unsupported Http version")
             .context_debug_field("version", version)
             .into_opaque_error()),
     }

--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/service.rs
@@ -1,10 +1,11 @@
 use crate::client::proxy::layer::HttpProxyError;
+use rama_core::error::BoxErrorExt as _;
 
 use super::InnerHttpProxyConnector;
 use pin_project_lite::pin_project;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt},
     extensions::{Extension, Extensions, ExtensionsRef},
     io::Io,
     telemetry::tracing,
@@ -120,10 +121,9 @@ where
             .map(|p| p.is_http())
             .unwrap_or(true)
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "http proxy connector can only serve http protocol",
-            )
-            .into_box_error());
+            ));
         }
 
         let transport_ctx = input

--- a/rama-http-backend/src/client/svc.rs
+++ b/rama-http-backend/src/client/svc.rs
@@ -1,6 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, ErrorExt},
     extensions::{Extensions, ExtensionsRef},
     telemetry::tracing,
 };
@@ -48,11 +49,11 @@ where
         match (&self.sender, req.version()) {
             (SendRequest::Http1(_), Version::HTTP_10 | Version::HTTP_11)
             | (SendRequest::Http2(_), Version::HTTP_2) => (),
-            (SendRequest::Http1(_), version) => Err(OpaqueError::from_static_str(
+            (SendRequest::Http1(_), version) => Err(BoxError::from_static_str(
                 "Http1 connector cannot send request with version",
             )
             .context_debug_field("version", version))?,
-            (SendRequest::Http2(_), version) => Err(OpaqueError::from_static_str(
+            (SendRequest::Http2(_), version) => Err(BoxError::from_static_str(
                 "Http2 connector cannot send request with version",
             )
             .context_debug_field("version", version))?,
@@ -136,9 +137,7 @@ impl<B> ExtensionsRef for HttpClientService<B> {
 fn sanitize_client_req_header<B>(req: Request<B>) -> Result<Request<B>, BoxError> {
     // logic specific to this method
     if req.method() == Method::CONNECT && req.uri().host().is_none() {
-        return Err(
-            OpaqueError::from_static_str("missing host in CONNECT request").into_box_error(),
-        );
+        return Err(BoxError::from_static_str("missing host in CONNECT request"));
     }
 
     let uses_http_proxy = req

--- a/rama-http-backend/src/proxy/mitm.rs
+++ b/rama-http-backend/src/proxy/mitm.rs
@@ -1,10 +1,11 @@
+use rama_core::error::BoxErrorExt as _;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt as _},
     extensions::ExtensionsRef,
     graceful::ShutdownGuard,
     io::{BridgeIo, GracefulIo, Io},
@@ -339,10 +340,10 @@ impl TryFrom<Version> for RelayMode {
         match version {
             Version::HTTP_2 => Ok(Self::Http2),
             Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11 => Ok(Self::Http1),
-            version => Err(OpaqueError::from_static_str(
-                "unsupported request version for MITM relay",
-            )
-            .context_debug_field("version", version)),
+            version => Err(
+                BoxError::from_static_str("unsupported request version for MITM relay")
+                    .context_debug_field("version", version),
+            ),
         }
     }
 }

--- a/rama-http-core/src/client/conn/http1.rs
+++ b/rama-http-core/src/client/conn/http1.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll, ready};
 
 use httparse::ParserConfig;
 use rama_core::bytes::Bytes;
-use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, extra::OpaqueError};
 use rama_core::extensions::ExtensionsRef;
 use rama_core::telemetry::tracing::{debug, trace};
 use rama_http::StreamingBody;

--- a/rama-http-core/src/client/conn/http1.rs
+++ b/rama-http-core/src/client/conn/http1.rs
@@ -1,12 +1,13 @@
 //! HTTP/1 client connections.
 
+use rama_core::error::BoxErrorExt as _;
 use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 
 use httparse::ParserConfig;
 use rama_core::bytes::Bytes;
-use rama_core::error::{BoxError, extra::OpaqueError};
+use rama_core::error::BoxError;
 use rama_core::extensions::ExtensionsRef;
 use rama_core::telemetry::tracing::{debug, trace};
 use rama_http::StreamingBody;
@@ -505,9 +506,9 @@ impl Builder {
         /// The minimum value allowed is 8192. This method errors if the passed `max` is less than the minimum.
         pub fn max_buf_size(mut self, max: usize) -> Result<Self, BoxError> {
             if max < proto::h1::MINIMUM_MAX_BUFFER_SIZE {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "the max_buf_size cannot be smaller than the minimum that h1 specifies."
-                ).into_box_error());
+                ));
             }
 
             self.h1_max_buf_size = Some(max);

--- a/rama-http-core/src/error.rs
+++ b/rama-http-core/src/error.rs
@@ -1,10 +1,11 @@
 //! Error and Result module.
 
+use rama_core::error::BoxErrorExt as _;
 use std::error::Error as StdError;
 use std::fmt;
 
 use crate::h2;
-use rama_core::error::{BoxError, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorExt as _};
 use rama_http_types as http;
 
 /// Result type often returned from methods that can have hyper `Error`s.
@@ -269,7 +270,7 @@ impl Error {
         mut self,
         msg: impl std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
     ) -> Self {
-        self.inner.cause = Some(OpaqueError::from_static_str("http error cause").context(msg));
+        self.inner.cause = Some(BoxError::from_static_str("http error cause").context(msg));
         self
     }
 

--- a/rama-http-core/src/h2/client.rs
+++ b/rama-http-core/src/h2/client.rs
@@ -140,9 +140,8 @@
 use crate::h2::codec::{Codec, SendError, UserError};
 use crate::h2::proto::{self, Error};
 use crate::h2::{FlowControl, PingPong, RecvStream, SendStream};
-
 use rama_core::bytes::{Buf, Bytes};
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, BoxErrorExt};
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing::{self, Instrument, debug, warn};
 use rama_http::proto::HeaderByteLength;
@@ -1330,10 +1329,10 @@ impl Builder {
 
     rama_utils::macros::generate_set_and_with! {
         /// Sets the first stream ID to something other than 1.
-        pub fn initial_stream_id(mut self, stream_id: u32) -> Result<Self, OpaqueError> {
+        pub fn initial_stream_id(mut self, stream_id: u32) -> Result<Self, BoxError> {
             self.stream_id = stream_id.into();
             if !self.stream_id.is_client_initiated() {
-                return Err(OpaqueError::from_static_str("stream id must be odd"));
+                return Err(BoxError::from_static_str("stream id must be odd"));
             }
             Ok(self)
         }

--- a/rama-http-core/src/server/conn/auto.rs
+++ b/rama-http-core/src/server/conn/auto.rs
@@ -1,5 +1,6 @@
 //! Http1 or Http2 connection.
 
+use rama_core::error::BoxErrorExt as _;
 use std::convert::Infallible;
 use std::io;
 use std::marker::PhantomPinned;
@@ -10,7 +11,6 @@ use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use rama_core::Service;
-use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::ExtensionsRef;
 use rama_http::{Request, Response};
 use tokio::io::AsyncRead;
@@ -224,7 +224,7 @@ where
         // We start as H2 and switch to H1 as soon as we don't have the preface.
         while buf.filled().len() < H2_PREFACE.len() {
             let Some(io) = this.io.as_mut() else {
-                return Poll::Ready(Err(std::io::Error::other(OpaqueError::from_static_str(
+                return Poll::Ready(Err(std::io::Error::other(BoxError::from_static_str(
                     "unexpected error: ReadVersion(..., >IO<) already taken in earlier Poll::ready, cannot read from it, report bug in rama repo",
                 ))));
             };
@@ -243,7 +243,7 @@ where
         }
 
         let Some(io) = this.io.take() else {
-            return Poll::Ready(Err(std::io::Error::other(OpaqueError::from_static_str(
+            return Poll::Ready(Err(std::io::Error::other(BoxError::from_static_str(
                 "unexpected error: ReadVersion(..., >IO<) already taken in earlier Poll::ready, cannot take it again, report bug in rama repo",
             ))));
         };
@@ -378,9 +378,9 @@ where
                 } => {
                     let (version, io) = ready!(read_version.poll(cx))?;
                     let Some(service) = service.take() else {
-                        return Poll::Ready(Err(OpaqueError::from_static_str(
+                        return Poll::Ready(Err(BoxError::from_static_str(
                             "unexpected error: auto http svc in connection already taken, report bug in rama repo",
-                        ).into_box_error()));
+                        )));
                     };
                     match version {
                         Version::H1 => {
@@ -508,9 +508,9 @@ where
                 } => {
                     let (version, io) = ready!(read_version.poll(cx))?;
                     let Some(service) = service.take() else {
-                        return Poll::Ready(Err(OpaqueError::from_static_str(
+                        return Poll::Ready(Err(BoxError::from_static_str(
                             "unexpected error: auto http svc in upgradeable connection already taken, report bug in rama repo",
-                        ).into_box_error()));
+                        )));
                     };
                     match version {
                         Version::H1 => {

--- a/rama-http-core/src/server/conn/auto.rs
+++ b/rama-http-core/src/server/conn/auto.rs
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 use rama_core::Service;
-use rama_core::error::{ErrorExt as _, extra::OpaqueError};
+use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::ExtensionsRef;
 use rama_http::{Request, Response};
 use tokio::io::AsyncRead;

--- a/rama-http-core/src/server/conn/http1.rs
+++ b/rama-http-core/src/server/conn/http1.rs
@@ -1,5 +1,6 @@
 //! HTTP/1 Server Connections.
 
+use rama_core::error::{BoxError, BoxErrorExt};
 use std::convert::Infallible;
 use std::fmt;
 use std::pin::Pin;
@@ -9,7 +10,6 @@ use std::time::Duration;
 use httparse::ParserConfig;
 use rama_core::Service;
 use rama_core::bytes::Bytes;
-use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::ExtensionsRef;
 use rama_http::io::upgrade::Upgraded;
 use rama_http::{Body, Request, Response};
@@ -376,9 +376,9 @@ impl Builder {
         /// # Error
         ///
         /// The minimum value allowed is 8192. This method errors if the passed `max` is less than the minimum.
-        pub fn max_buf_size(mut self, max: Option<usize>) -> Result<Self, OpaqueError> {
+        pub fn max_buf_size(mut self, max: Option<usize>) -> Result<Self, BoxError> {
             if max.map(|max| max < proto::h1::MINIMUM_MAX_BUFFER_SIZE).unwrap_or_default() {
-                return Err(OpaqueError::from_static_str("the max_buf_size cannot be smaller than the minimum that h1 specifies"));
+                return Err(BoxError::from_static_str("the max_buf_size cannot be smaller than the minimum that h1 specifies"));
             }
             self.max_buf_size = max;
             Ok(self)

--- a/rama-http-headers/src/common/sec_websocket_extensions.rs
+++ b/rama-http-headers/src/common/sec_websocket_extensions.rs
@@ -3,9 +3,9 @@
 //! More information:
 //! <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-WebSocket-Extensions>
 
+use rama_core::error::BoxErrorExt as _;
 use std::{fmt, str::FromStr};
 
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension as ExtensionTrait;
 use rama_core::telemetry::tracing;
@@ -226,31 +226,27 @@ impl FromStr for Extension {
             for part in parts {
                 if part.eq_ignore_ascii_case("server_no_context_takeover") {
                     if std::mem::replace(&mut config.server_no_context_takeover, true) {
-                        return Err(OpaqueError::from_static_str(
+                        return Err(BoxError::from_static_str(
                             "duplicate extension param: server_no_context_takeover",
-                        )
-                        .into_box_error());
+                        ));
                     }
                 } else if part.eq_ignore_ascii_case("client_no_context_takeover") {
                     if std::mem::replace(&mut config.client_no_context_takeover, true) {
-                        return Err(OpaqueError::from_static_str(
+                        return Err(BoxError::from_static_str(
                             "duplicate extension param: client_no_context_takeover",
-                        )
-                        .into_box_error());
+                        ));
                     }
                 } else if part.eq_ignore_ascii_case("server_max_window_bits") {
                     if config.server_max_window_bits.replace(0).is_some() {
-                        return Err(OpaqueError::from_static_str(
+                        return Err(BoxError::from_static_str(
                             "duplicate extension param: server_max_window_bits",
-                        )
-                        .into_box_error());
+                        ));
                     }
                 } else if part.eq_ignore_ascii_case("client_max_window_bits") {
                     if config.client_max_window_bits.replace(0).is_some() {
-                        return Err(OpaqueError::from_static_str(
+                        return Err(BoxError::from_static_str(
                             "duplicate extension param: client_max_window_bits",
-                        )
-                        .into_box_error());
+                        ));
                     }
                 } else if let Some((k, v)) = part.split_once('=') {
                     let k = k.trim();
@@ -270,16 +266,15 @@ impl FromStr for Extension {
                                     tracing::debug!(
                                         "fail per-message-deflate config value for server max windows bits: {v} not in [8,15] range"
                                     );
-                                    return Err(OpaqueError::from_static_str(
+                                    return Err(BoxError::from_static_str(
                                         "invalid server max windows bits (OOB)",
                                     )
                                     .context_field("value", v));
                                 }
                                 if config.server_max_window_bits.replace(v).is_some() {
-                                    return Err(OpaqueError::from_static_str(
+                                    return Err(BoxError::from_static_str(
                                         "duplicate extension param: server_max_window_bits",
-                                    )
-                                    .into_box_error());
+                                    ));
                                 }
                             }
                             Err(err) => {
@@ -296,16 +291,15 @@ impl FromStr for Extension {
                                     tracing::debug!(
                                         "fail per-message-deflate config value for client max windows bits: {v} not in [8,15] range"
                                     );
-                                    return Err(OpaqueError::from_static_str(
+                                    return Err(BoxError::from_static_str(
                                         "invalid client max windows bits (OOB)",
                                     )
                                     .context_field("value", v));
                                 }
                                 if config.client_max_window_bits.replace(v).is_some() {
-                                    return Err(OpaqueError::from_static_str(
+                                    return Err(BoxError::from_static_str(
                                         "duplicate extension param: client_max_window_bits",
-                                    )
-                                    .into_box_error());
+                                    ));
                                 }
                             }
                             Err(err) => {
@@ -319,17 +313,17 @@ impl FromStr for Extension {
                         tracing::debug!(
                             "fail per-message-deflate config with unknown permessage-deflate config parameter: {k} = {v}"
                         );
-                        return Err(OpaqueError::from_static_str(
-                            "value not expected for given key",
-                        )
-                        .context_str_field("key", k)
-                        .context_str_field("value", v));
+                        return Err(
+                            BoxError::from_static_str("value not expected for given key")
+                                .context_str_field("key", k)
+                                .context_str_field("value", v),
+                        );
                     }
                 } else {
                     tracing::debug!(
                         "received unknown permessage-deflate config parameter part: {part}"
                     );
-                    return Err(OpaqueError::from_static_str(
+                    return Err(BoxError::from_static_str(
                         "key not expected for permessage-deflate config",
                     )
                     .context_str_field("key", part));

--- a/rama-http-headers/src/forwarded/exotic_forward_ip.rs
+++ b/rama-http-headers/src/forwarded/exotic_forward_ip.rs
@@ -1,5 +1,5 @@
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::ErrorExt;
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_http_types::header::{
     CF_CONNECTING_IP, CLIENT_IP, TRUE_CLIENT_IP, X_CLIENT_IP, X_REAL_IP,
@@ -43,7 +43,7 @@ impl std::str::FromStr for ClientAddr {
 
         match ip {
             IpAddr::V6(_) if port.is_some() && !s.starts_with('[') => Err(
-                OpaqueError::from_static_str("missing brackets for IPv6 address with port")
+                BoxError::from_static_str("missing brackets for IPv6 address with port")
                     .context_field("ip", ip)
                     .context_debug_field("port", port),
             ),

--- a/rama-http-headers/src/forwarded/via.rs
+++ b/rama-http-headers/src/forwarded/via.rs
@@ -1,6 +1,6 @@
 use crate::{HeaderDecode, HeaderEncode, TypedHeader, util};
 use rama_core::{
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     telemetry::tracing,
 };
 use rama_http_types::{HeaderName, HeaderValue, header};

--- a/rama-http-headers/src/forwarded/via.rs
+++ b/rama-http-headers/src/forwarded/via.rs
@@ -1,6 +1,7 @@
 use crate::{HeaderDecode, HeaderEncode, TypedHeader, util};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     telemetry::tracing,
 };
 use rama_http_types::{HeaderName, HeaderValue, header};
@@ -167,9 +168,7 @@ impl std::str::FromStr for ViaElement {
                         .context("parse via utf-8 protocol as protocol")?;
                     bytes = &bytes[index + 1..];
                     let index = bytes.iter().position(|b| *b == b' ').ok_or_else(|| {
-                        OpaqueError::from_static_str(
-                            "via str: missing space after protocol separator",
-                        )
+                        BoxError::from_static_str("via str: missing space after protocol separator")
                     })?;
                     let version =
                         ForwardedVersion::try_from(&bytes[..index]).context("parse via version")?;
@@ -185,9 +184,7 @@ impl std::str::FromStr for ViaElement {
                 _ => unreachable!(),
             },
             None => {
-                return Err(
-                    OpaqueError::from_static_str("via str: missing version").into_box_error()
-                );
+                return Err(BoxError::from_static_str("via str: missing version"));
             }
         };
 

--- a/rama-http-headers/src/x_robots_tag/components/date_time.rs
+++ b/rama-http-headers/src/x_robots_tag/components/date_time.rs
@@ -4,7 +4,8 @@ use jiff::{
     fmt::{StdFmtWrite, rfc2822, temporal::DateTimePrinter},
     tz::{Offset, TimeZone},
 };
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -119,7 +120,7 @@ impl AsRef<Timestamp> for DirectiveDateTime {
 }
 
 impl FromStr for DirectiveDateTime {
-    type Err = OpaqueError;
+    type Err = BoxError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(dt) = datetime_from_rfc3339(s) {
@@ -141,7 +142,7 @@ impl FromStr for DirectiveDateTime {
             });
         }
         tracing::debug!("failed to parse datetime value: {s}");
-        Err(OpaqueError::from_static_str("invalid datetime value"))
+        Err(BoxError::from_static_str("invalid datetime value"))
     }
 }
 
@@ -201,7 +202,7 @@ fn parse_rfc3339_timestamp(s: &str) -> Result<Timestamp, BoxError> {
 
 fn parse_iso8601_date_only(s: &str) -> Result<Timestamp, BoxError> {
     if s.contains('T') || s.contains(' ') {
-        return Err(OpaqueError::from_static_str("invalid ISO 8601 date").into_box_error());
+        return Err(BoxError::from_static_str("invalid ISO 8601 date"));
     }
     let date = s
         .parse::<civil::Date>()
@@ -234,13 +235,11 @@ fn validate_rfc3339_offset(s: &str) -> Result<(), BoxError> {
             if hour < 24 && minute < 60 {
                 Ok(())
             } else {
-                Err(OpaqueError::from_static_str("invalid RFC 3339 offset").into_box_error())
+                Err(BoxError::from_static_str("invalid RFC 3339 offset"))
             }
         }
-        _ if s.contains('T') => {
-            Err(OpaqueError::from_static_str("invalid RFC 3339 offset").into_box_error())
-        }
-        _ => Err(OpaqueError::from_static_str("invalid RFC 3339 datetime").into_box_error()),
+        _ if s.contains('T') => Err(BoxError::from_static_str("invalid RFC 3339 offset")),
+        _ => Err(BoxError::from_static_str("invalid RFC 3339 datetime")),
     }
 }
 
@@ -262,12 +261,10 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
         Some(b'+') => 1,
         Some(b'-') => -1,
         Some(_) => {
-            return Err(
-                OpaqueError::from_static_str("invalid timezone offset sign").into_box_error()
-            );
+            return Err(BoxError::from_static_str("invalid timezone offset sign"));
         }
         None => {
-            return Err(OpaqueError::from_static_str("missing timezone offset").into_box_error());
+            return Err(BoxError::from_static_str("missing timezone offset"));
         }
     };
 
@@ -285,9 +282,7 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
             let hours = i32::from((h1 - b'0') * 10 + (h2 - b'0'));
             let minutes = i32::from((m1 - b'0') * 10 + (m2 - b'0'));
             if hours >= 24 || minutes >= 60 {
-                return Err(
-                    OpaqueError::from_static_str("invalid timezone offset").into_box_error()
-                );
+                return Err(BoxError::from_static_str("invalid timezone offset"));
             }
 
             let seconds = sign * (hours * 60 * 60 + minutes * 60);
@@ -295,7 +290,7 @@ fn parse_offset(offset: &str) -> Result<Offset, BoxError> {
                 .context("timezone offset outside supported range")
                 .context_str_field("offset", offset)
         }
-        _ => Err(OpaqueError::from_static_str("invalid timezone offset digits").into_box_error()),
+        _ => Err(BoxError::from_static_str("invalid timezone offset digits")),
     }
 }
 

--- a/rama-http-headers/src/x_robots_tag/components/date_time.rs
+++ b/rama-http-headers/src/x_robots_tag/components/date_time.rs
@@ -4,7 +4,7 @@ use jiff::{
     fmt::{StdFmtWrite, rfc2822, temporal::DateTimePrinter},
     tz::{Offset, TimeZone},
 };
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use rama_core::telemetry::tracing;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;

--- a/rama-http-headers/src/x_robots_tag/tag.rs
+++ b/rama-http-headers/src/x_robots_tag/tag.rs
@@ -1,6 +1,6 @@
 use crate::util::HeaderValueString;
 use crate::x_robots_tag::{CustomRule, DirectiveDateTime, MaxImagePreviewSetting};
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::telemetry::tracing;
 use rama_utils::macros::generate_set_and_with;
@@ -669,9 +669,9 @@ impl Iterator for Parser<'_> {
 
                         if tag.bot_name.is_some() {
                             self.buffer = &self.buffer[self.buffer.len()..];
-                            return Some(Err(OpaqueError::from_static_str(
+                            return Some(Err(BoxError::from_static_str(
                                 "unexpected bot name: one is already defined without any directives",
-                            ).into_box_error()));
+                            )));
                         } else {
                             let s = match std::str::from_utf8(key_buffer) {
                                 Ok(value) => value,
@@ -740,7 +740,7 @@ impl Iterator for Parser<'_> {
                 if directive_count == 0 {
                     if let Some(bot_name) = tag.bot_name {
                         self.buffer = &self.buffer[self.buffer.len()..];
-                        return Some(Err(OpaqueError::from_static_str(
+                        return Some(Err(BoxError::from_static_str(
                             "tag with only a bot name is not allowed",
                         )
                         .context_field("bot_name", bot_name)));
@@ -753,10 +753,7 @@ impl Iterator for Parser<'_> {
         }
 
         self.buffer = &self.buffer[self.buffer.len()..];
-        Some(Err(OpaqueError::from_static_str(
-            "delimiter search overflow",
-        )
-        .into_box_error()))
+        Some(Err(BoxError::from_static_str("delimiter search overflow")))
     }
 }
 

--- a/rama-http-types/src/body/sse/datastar/patch_elements.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_elements.rs
@@ -4,7 +4,7 @@ use crate::sse::{
     datastar::EventType, parser::is_lf,
 };
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
 

--- a/rama-http-types/src/body/sse/datastar/patch_elements.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_elements.rs
@@ -3,7 +3,7 @@ use crate::sse::{
     Event, EventBuildError, EventDataLineReader, EventDataRead, EventDataWrite,
     datastar::EventType, parser::is_lf,
 };
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
@@ -238,10 +238,9 @@ impl EventDataLineReader for PatchElementsReader {
             })
             .unwrap_or_default()
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "PatchElementsReader: unexpected event type: expected: datastar-patch-elements",
-            )
-            .into_box_error());
+            ));
         }
 
         Ok(Some(PatchElements {

--- a/rama-http-types/src/body/sse/datastar/patch_signals.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_signals.rs
@@ -2,7 +2,7 @@ use crate::sse::{
     Event, EventBuildError, EventDataLineReader, EventDataRead, EventDataWrite, datastar::EventType,
 };
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 
 /// [`PatchSignals`] patches signals into the signal store

--- a/rama-http-types/src/body/sse/datastar/patch_signals.rs
+++ b/rama-http-types/src/body/sse/datastar/patch_signals.rs
@@ -1,7 +1,7 @@
 use crate::sse::{
     Event, EventBuildError, EventDataLineReader, EventDataRead, EventDataWrite, datastar::EventType,
 };
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 
@@ -171,10 +171,9 @@ impl<R: EventDataLineReader> EventDataLineReader for PatchSignalsReader<R> {
             })
             .unwrap_or_default()
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "PatchSignalsReader: unexpected event type: expected: datastar-patch-signals",
-            )
-            .into_box_error());
+            ));
         }
 
         let only_if_missing = std::mem::take(&mut self.only_if_missing);

--- a/rama-http-types/src/body/sse/event_stream.rs
+++ b/rama-http-types/src/body/sse/event_stream.rs
@@ -1,11 +1,11 @@
 use crate::sse::event_data::EventDataLineReader;
+use rama_core::error::BoxErrorExt as _;
 
 use super::parser::{RawEventLine, is_bom, line};
 use super::utf8_stream::Utf8Stream;
 use super::{Event, EventBuildError, EventDataRead};
 
 use pin_project_lite::pin_project;
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::futures::stream::Stream;
 use rama_core::futures::task::{Context, Poll};
@@ -230,7 +230,7 @@ fn parse_event<T: EventDataRead>(
                 return Ok(None);
             }
             Err(nom::Err::Error(err) | nom::Err::Failure(err)) => {
-                return Err(OpaqueError::from_static_str("SSE parse error")
+                return Err(BoxError::from_static_str("SSE parse error")
                     .context_debug_field("code", err.code)
                     .context_str_field("input", err.input));
             }

--- a/rama-http-types/src/uri.rs
+++ b/rama-http-types/src/uri.rs
@@ -1,4 +1,4 @@
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
 use rama_utils::str::{smol_str::format_smolstr, starts_with_ignore_ascii_case};
 
 pub use crate::dep::hyperium::http::uri::*;

--- a/rama-http-types/src/uri.rs
+++ b/rama-http-types/src/uri.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext as _};
 use rama_utils::str::{smol_str::format_smolstr, starts_with_ignore_ascii_case};
 
 pub use crate::dep::hyperium::http::uri::*;
@@ -11,9 +12,9 @@ pub fn try_to_strip_path_prefix_from_uri(
     let og_path = uri.path().trim_start_matches('/');
 
     if !starts_with_ignore_ascii_case(og_path, prefix) {
-        return Err(
-            OpaqueError::from_static_str("URI's path does NOT contain prefix").into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "URI's path does NOT contain prefix",
+        ));
     }
 
     // Bounds: the `starts_with_ignore_ascii_case` check above guarantees

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -32,6 +32,7 @@
 //! upgrade, you call `on()` with the `Request`, and then can spawn a task
 //! awaiting it.
 
+use rama_core::error::BoxErrorExt as _;
 use std::any::TypeId;
 use std::fmt;
 use std::io;
@@ -40,7 +41,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use parking_lot::Mutex;
-use rama_core::error::extra::OpaqueError;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::oneshot;
 
@@ -116,15 +116,14 @@ pub fn handle_upgrade<T: ExtensionsRef>(
         Some(on_upgrade) => {
             trace!("upgrading this: {:?}", on_upgrade);
             if on_upgrade.has_handled_upgrade() {
-                Err(
-                    OpaqueError::from_static_str("upgraded has already been handled")
-                        .into_box_error(),
-                )
+                Err(BoxError::from_static_str(
+                    "upgraded has already been handled",
+                ))
             } else {
                 Ok(on_upgrade)
             }
         }
-        None => Err(OpaqueError::from_static_str("no pending update found").into_box_error()),
+        None => Err(BoxError::from_static_str("no pending update found")),
     };
 
     async move {
@@ -311,10 +310,9 @@ impl Future for OnUpgrade {
             .map(|res| match res {
                 Ok(Ok(upgraded)) => Ok(upgraded),
                 Ok(Err(err)) => Err(err),
-                Err(_oneshot_canceled) => Err(OpaqueError::from_static_str(
+                Err(_oneshot_canceled) => Err(BoxError::from_static_str(
                     "OnUpgrade: cancelled while expecting upgrade",
-                )
-                .into_box_error()),
+                )),
             })
     }
 }
@@ -338,10 +336,9 @@ impl Pending {
     /// upgrades are handled manually.
     pub fn manual(self) {
         trace!("pending upgrade handled manually");
-        _ = self.tx.send(Err(OpaqueError::from_static_str(
+        _ = self.tx.send(Err(BoxError::from_static_str(
             "OnUpgrade: manual upgrade failed",
-        )
-        .into_box_error()));
+        )));
     }
 }
 

--- a/rama-http/src/io/upgrade.rs
+++ b/rama-http/src/io/upgrade.rs
@@ -40,7 +40,6 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use parking_lot::Mutex;
-use rama_core::error::ErrorExt as _;
 use rama_core::error::extra::OpaqueError;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::oneshot;

--- a/rama-http/src/layer/cors/mod.rs
+++ b/rama-http/src/layer/cors/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     HeaderMap, HeaderValue, Method, Request, Response,
     header::{self},
 };
-use rama_core::error::{BoxError, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::{BoxError, extra::OpaqueError};
 use rama_core::{Layer, Service};
 use rama_http_headers::{
     AccessControlAllowHeaders, AccessControlAllowMethods, AccessControlExposeHeaders,

--- a/rama-http/src/layer/cors/mod.rs
+++ b/rama-http/src/layer/cors/mod.rs
@@ -6,7 +6,8 @@ use crate::{
     HeaderMap, HeaderValue, Method, Request, Response,
     header::{self},
 };
-use rama_core::error::{BoxError, extra::OpaqueError};
+use rama_core::error::BoxError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{Layer, Service};
 use rama_http_headers::{
     AccessControlAllowHeaders, AccessControlAllowMethods, AccessControlExposeHeaders,
@@ -126,7 +127,7 @@ impl CorsLayer {
                 || self.allow_methods.as_ref().map(|v| v.is_any()).unwrap_or_default()
                 || self.allow_origin.as_ref().map(|v| v.is_any()).unwrap_or_default()
                 || self.expose_headers.as_ref().map(|v| v.is_any()).unwrap_or_default() {
-                return Err(OpaqueError::from_static_str("CORS combo error: allow credentials is not allowed if some of the wildcard-abled headers are set to use the wildcard value").into_box_error());
+                return Err(BoxError::from_static_str("CORS combo error: allow credentials is not allowed if some of the wildcard-abled headers are set to use the wildcard value"));
             }
             self.allow_credentials = Some(AllowCredentials::Const);
             Ok(self)
@@ -157,7 +158,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
         pub fn allow_headers(mut self, headers: AccessControlAllowHeaders) -> Result<Self, BoxError> {
             if headers.is_any() && self.is_allow_credentials_any() {
-                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`").into_box_error())
+                return Err(BoxError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`"))
             }
             self.allow_headers = Some(AllowHeaders::Const(headers));
             Ok(self)
@@ -226,7 +227,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
         pub fn allow_methods(mut self, methods: AccessControlAllowMethods) -> Result<Self, BoxError> {
             if methods.is_any() && self.is_allow_credentials_any() {
-                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`").into_box_error())
+                return Err(BoxError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`"))
             }
             self.allow_methods = Some(AllowMethods::Const(methods));
             Ok(self)
@@ -258,7 +259,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
         pub fn allow_origin_any(mut self) -> Result<Self, BoxError> {
             if self.is_allow_credentials_any() {
-                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`").into_box_error())
+                return Err(BoxError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`"))
             }
             self.allow_origin = Some(AllowOrigin::Any);
             Ok(self)
@@ -322,7 +323,7 @@ impl CorsLayer {
         /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
         pub fn expose_headers(mut self, headers: AccessControlExposeHeaders) -> Result<Self, BoxError> {
             if headers.is_any() && self.is_allow_credentials_any() {
-                return Err(OpaqueError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Expose-Headers: *`").into_box_error())
+                return Err(BoxError::from_static_str("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Expose-Headers: *`"))
             }
             self.expose_headers = Some(headers);
             Ok(self)

--- a/rama-http/src/layer/dns/dns_resolve/mod.rs
+++ b/rama-http/src/layer/dns/dns_resolve/mod.rs
@@ -6,7 +6,7 @@
 //! by IP address instead of domain name.
 
 use crate::HeaderValue;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_core::username::{ComposeError, Composer, UsernameLabelWriter};
@@ -74,7 +74,7 @@ impl DnsResolveMode {
 }
 
 impl std::str::FromStr for DnsResolveMode {
-    type Err = OpaqueError;
+    type Err = BoxError;
 
     #[inline(always)]
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -83,14 +83,14 @@ impl std::str::FromStr for DnsResolveMode {
 }
 
 impl TryFrom<&str> for DnsResolveMode {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match_ignore_ascii_case_str! {
             match (value) {
                 "eager" => Ok(Self::eager()),
                 "lazy" => Ok(Self::lazy()),
-                _ => Err(OpaqueError::from_static_str("Invalid DNS resolve mode: unknown str")),
+                _ => Err(BoxError::from_static_str("Invalid DNS resolve mode: unknown str")),
             }
         }
     }

--- a/rama-http/src/layer/dns/dns_resolve/username_parser.rs
+++ b/rama-http/src/layer/dns/dns_resolve/username_parser.rs
@@ -1,5 +1,5 @@
 use super::DnsResolveMode;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::username::{UsernameLabelParser, UsernameLabelState};
 use rama_core::{
     error::{BoxError, ErrorContext},
@@ -54,10 +54,9 @@ impl UsernameLabelParser for DnsResolveModeUsernameParser {
 
     fn build(self, ext: &Extensions) -> Result<(), Self::Error> {
         if self.key_found {
-            return Err(
-                OpaqueError::from_static_str("unused dns resolve mode username key: dns")
-                    .into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "unused dns resolve mode username key: dns",
+            ));
         }
         ext.insert(self.mode);
         Ok(())

--- a/rama-http/src/layer/dns/dns_resolve/username_parser.rs
+++ b/rama-http/src/layer/dns/dns_resolve/username_parser.rs
@@ -1,5 +1,4 @@
 use super::DnsResolveMode;
-use rama_core::error::ErrorExt;
 use rama_core::error::extra::OpaqueError;
 use rama_core::username::{UsernameLabelParser, UsernameLabelState};
 use rama_core::{

--- a/rama-http/src/layer/header_option_value.rs
+++ b/rama-http/src/layer/header_option_value.rs
@@ -4,9 +4,10 @@
 //! and has a bool-like value.
 
 use crate::{HeaderName, Request, utils::HeaderValueGetter};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt},
     extensions::{Extension, ExtensionsRef},
     telemetry::tracing,
 };
@@ -99,7 +100,7 @@ where
                 if str_value == "1" || str_value.eq_ignore_ascii_case("true") {
                     request.extensions().insert(T::default());
                 } else if str_value != "0" && !str_value.eq_ignore_ascii_case("false") {
-                    return Err(OpaqueError::from_static_str("invalid header option")
+                    return Err(BoxError::from_static_str("invalid header option")
                         .context_field("header_name", self.header_name.clone())
                         .context_str_field("header_value", str_value));
                 }

--- a/rama-http/src/layer/retry/mod.rs
+++ b/rama-http/src/layer/retry/mod.rs
@@ -145,7 +145,7 @@ mod test {
     };
     use rama_core::{
         Layer,
-        error::extra::OpaqueError,
+        error::BoxErrorExt,
         extensions::{Extension, Extensions, ExtensionsRef},
         service::service_fn,
     };
@@ -203,7 +203,7 @@ mod test {
                 let txt = req.try_into_string().await.unwrap();
                 match txt.as_str() {
                     "internal" => Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-                    "error" => Err(OpaqueError::from_static_str("custom error")),
+                    "error" => Err(BoxError::from_static_str("custom error")),
                     _ => Ok(txt.into_response()),
                 }
             },

--- a/rama-http/src/layer/retry/tests.rs
+++ b/rama-http/src/layer/retry/tests.rs
@@ -9,7 +9,7 @@ use crate::service::web::response::IntoResponse;
 use crate::{Request, Response};
 use parking_lot::Mutex;
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorExt};
+use rama_core::error::{BoxError};
 use rama_core::{Layer, Service};
 use std::sync::{
     Arc,

--- a/rama-http/src/layer/retry/tests.rs
+++ b/rama-http/src/layer/retry/tests.rs
@@ -8,8 +8,8 @@ use crate::BodyExtractExt;
 use crate::service::web::response::IntoResponse;
 use crate::{Request, Response};
 use parking_lot::Mutex;
-use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError};
+use rama_core::error::BoxError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{Layer, Service};
 use std::sync::{
     Arc,
@@ -35,7 +35,7 @@ async fn retry_errors() {
                 Ok("world".into_response())
             } else {
                 self.error_counter.fetch_add(1, Ordering::AcqRel);
-                Err(OpaqueError::from_static_str("retry me").into_box_error())
+                Err(BoxError::from_static_str("retry me"))
             }
         }
     }
@@ -68,7 +68,7 @@ async fn retry_limit() {
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
             self.error_counter.fetch_add(1, Ordering::AcqRel);
-            Err(OpaqueError::from_static_str("error forever").into_box_error())
+            Err(BoxError::from_static_str("error forever"))
         }
     }
 
@@ -96,9 +96,9 @@ async fn retry_error_inspection() {
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
             if self.errored.swap(true, Ordering::AcqRel) {
-                Err(OpaqueError::from_static_str("reject").into_box_error())
+                Err(BoxError::from_static_str("reject"))
             } else {
-                Err(OpaqueError::from_static_str("retry me").into_box_error())
+                Err(BoxError::from_static_str("retry me"))
             }
         }
     }
@@ -121,7 +121,7 @@ async fn retry_cannot_clone_request() {
 
         async fn serve(&self, req: Request<RetryBody>) -> Result<Self::Output, Self::Error> {
             assert_eq!(req.try_into_string().await.unwrap(), "hello");
-            Err(OpaqueError::from_static_str("failed").into_box_error())
+            Err(BoxError::from_static_str("failed"))
         }
     }
 
@@ -308,9 +308,7 @@ where
     ) -> PolicyResult<Response, Error> {
         let mut remaining = self.remaining.lock();
         if *remaining == 0 {
-            PolicyResult::Abort(Err(
-                OpaqueError::from_static_str("out of retries").into_box_error()
-            ))
+            PolicyResult::Abort(Err(BoxError::from_static_str("out of retries")))
         } else {
             *remaining -= 1;
             PolicyResult::Retry {

--- a/rama-http/src/service/client/ext.rs
+++ b/rama-http/src/service/client/ext.rs
@@ -1,4 +1,5 @@
 use crate::{Method, Request, Response, Uri};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Service,
     error::{BoxError, ErrorExt},
@@ -234,7 +235,7 @@ impl IntoHeaderValue for &String {}
 impl IntoHeaderValue for &[u8] {}
 
 mod private {
-    use rama_core::error::extra::OpaqueError;
+
     use rama_http_types::HeaderName;
     use rama_net::Protocol;
 
@@ -252,11 +253,11 @@ mod private {
                     if protocol.is_http() || protocol.is_ws() {
                         Ok(self)
                     } else {
-                        Err(OpaqueError::from_static_str("unsupported protocol")
+                        Err(BoxError::from_static_str("unsupported protocol")
                             .context_field("protocol", protocol))
                     }
                 }
-                None => Err(OpaqueError::from_static_str("Missing scheme in URI").into_box_error()),
+                None => Err(BoxError::from_static_str("Missing scheme in URI")),
             }
         }
     }
@@ -266,8 +267,7 @@ mod private {
             match self.parse::<Uri>() {
                 Ok(uri) => uri.into_url(),
                 Err(_) => {
-                    Err(OpaqueError::from_static_str("invalid url")
-                        .context_str_field("raw_str", self))
+                    Err(BoxError::from_static_str("invalid url").context_str_field("raw_str", self))
                 }
             }
         }
@@ -301,9 +301,7 @@ mod private {
         fn into_header_name(self) -> Result<crate::HeaderName, BoxError> {
             match self {
                 Some(name) => Ok(name),
-                None => {
-                    Err(OpaqueError::from_static_str("Header name is required").into_box_error())
-                }
+                None => Err(BoxError::from_static_str("Header name is required")),
             }
         }
     }

--- a/rama-http/src/service/fs/serve_dir/mod.rs
+++ b/rama-http/src/service/fs/serve_dir/mod.rs
@@ -6,7 +6,7 @@ use crate::{Body, Method, Request, Response, StatusCode, StreamingBody, header};
 use rama_core::Service;
 use rama_core::bytes::Bytes;
 use rama_core::error::BoxError;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::telemetry::tracing;
 use rama_net::uri::util::percent_encoding::percent_decode;
 use rama_utils::include_dir::Dir;
@@ -405,7 +405,7 @@ impl fmt::Display for DirectoryServeMode {
 }
 
 impl FromStr for DirectoryServeMode {
-    type Err = OpaqueError;
+    type Err = BoxError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         rama_utils::macros::match_ignore_ascii_case_str! {
@@ -413,28 +413,28 @@ impl FromStr for DirectoryServeMode {
                 "append-index" | "append_index" => Ok(Self::AppendIndexHtml),
                 "not-found" | "not_found" => Ok(Self::NotFound),
                 "html-file-list" | "html_file_list" => html_file_list_from_str(),
-                _ => Err(OpaqueError::from_static_str("invalid DirectoryServeMode str")),
+                _ => Err(BoxError::from_static_str("invalid DirectoryServeMode str")),
             }
         }
     }
 }
 
 #[inline(always)]
-fn html_file_list_from_str() -> Result<DirectoryServeMode, OpaqueError> {
+fn html_file_list_from_str() -> Result<DirectoryServeMode, BoxError> {
     #[cfg(feature = "html")]
     {
         Ok(DirectoryServeMode::HtmlFileList)
     }
     #[cfg(not(feature = "html"))]
     {
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "invalid DirectoryServeMode str: html file list requires html feature",
         ))
     }
 }
 
 impl TryFrom<&str> for DirectoryServeMode {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     #[inline]
     fn try_from(value: &str) -> Result<Self, Self::Error> {

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -1,8 +1,9 @@
+use rama_core::error::BoxErrorExt as _;
 use std::sync::Arc;
 use std::time::Duration;
 
 use rama_core::{
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     rt::Executor,
 };
 
@@ -291,19 +292,19 @@ where
         // a misconfigured capacity is more useful as a build-time error than
         // as a footgun. `None` continues to mean "use the default".
         if matches!(tcp_flow_buffer_size, Some(0)) {
-            return Err(
-                OpaqueError::from_static_str("tcp_flow_buffer_size must be > 0").into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "tcp_flow_buffer_size must be > 0",
+            ));
         }
         if matches!(tcp_channel_capacity, Some(0)) {
-            return Err(
-                OpaqueError::from_static_str("tcp_channel_capacity must be > 0").into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "tcp_channel_capacity must be > 0",
+            ));
         }
         if matches!(udp_channel_capacity, Some(0)) {
-            return Err(
-                OpaqueError::from_static_str("udp_channel_capacity must be > 0").into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "udp_channel_capacity must be > 0",
+            ));
         }
 
         let rt = runtime_factory

--- a/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rama_core::{
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     rt::Executor,
 };
 

--- a/rama-net-apple-xpc/src/router/mod.rs
+++ b/rama-net-apple-xpc/src/router/mod.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use ahash::{HashMap, HashMapExt as _};
 use rama_core::{
     Service,
-    error::{BoxError, ErrorExt, extra::OpaqueError},
+    error::{BoxError, extra::OpaqueError},
 };
 use rama_utils::str::arcstr::arcstr;
 use serde::{Serialize, de::DeserializeOwned};

--- a/rama-net-apple-xpc/src/router/mod.rs
+++ b/rama-net-apple-xpc/src/router/mod.rs
@@ -1,10 +1,8 @@
+use rama_core::error::BoxErrorExt as _;
 use std::borrow::Cow;
 
 use ahash::{HashMap, HashMapExt as _};
-use rama_core::{
-    Service,
-    error::{BoxError, extra::OpaqueError},
-};
+use rama_core::{Service, error::BoxError};
 use rama_utils::str::arcstr::arcstr;
 use serde::{Serialize, de::DeserializeOwned};
 
@@ -202,10 +200,9 @@ impl Service<XpcMessage> for XpcMessageRouter {
             return fallback.serve(input).await;
         }
 
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "XpcMessageRouter: no matching router found and no fallback defined",
-        )
-        .into_box_error())
+        ))
     }
 }
 

--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -2,7 +2,7 @@ use crate::address::{HostRef, HostWithOptPort, HostWithPort, OptPort, UserInfo, 
 
 use super::{Domain, DomainAddress, Host, SocketAddress};
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -1,7 +1,7 @@
 use crate::address::{HostRef, HostWithOptPort, HostWithPort, OptPort, UserInfo, UserInfoRef};
+use rama_core::error::BoxErrorExt as _;
 
 use super::{Domain, DomainAddress, Host, SocketAddress};
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
@@ -530,9 +530,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
     let mut s = maybe_borrowed.as_ref();
 
     if s.is_empty() {
-        return Err(
-            OpaqueError::from_static_str("empty string is invalid authority").into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "empty string is invalid authority",
+        ));
     }
 
     // Split on the *last* `@`. See [`super::parse_utils::find_userinfo_split`]
@@ -550,10 +550,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
         // mirroring the URI parser's authority handler.
         let ui_bytes = &s.as_bytes()[..idx];
         if ui_bytes.iter().any(|&b| b < 0x20 || b == 0x7F) {
-            return Err(
-                OpaqueError::from_static_str("userinfo contains control character")
-                    .into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "userinfo contains control character",
+            ));
         }
         user_info = Some(UserInfo::from_bytes_unchecked(
             rama_core::bytes::Bytes::copy_from_slice(ui_bytes),
@@ -570,7 +569,7 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
     if s.starts_with('[') && s.ends_with(']') {
         let inside = &s[1..s.len() - 1];
         if inside.is_empty() {
-            return Err(OpaqueError::from_static_str("empty bracketed IP-literal").into_box_error());
+            return Err(BoxError::from_static_str("empty bracketed IP-literal"));
         }
         // IPvFuture: `[v1.xxx]` — stored as `Uninterpreted(bracketed=true)`
         // verbatim, matching the URI authority parser's shape.
@@ -590,10 +589,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
             });
         }
         if crate::address::parse_utils::ipv6_bracket_has_zone(inside.as_bytes()) {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "ipv6 zone identifiers (RFC 6874) are not supported",
-            )
-            .into_box_error());
+            ));
         }
         let addr = inside
             .parse::<Ipv6Addr>()
@@ -621,10 +619,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<Authority
             // parser rejects the same shape — keep the eager paths
             // symmetric.
             if first_part.is_empty() {
-                return Err(
-                    OpaqueError::from_static_str("empty host before ':port' is invalid")
-                        .into_box_error(),
-                );
+                return Err(BoxError::from_static_str(
+                    "empty host before ':port' is invalid",
+                ));
             }
             let port_bytes = &s.as_bytes()[last_colon + 1..];
             port = if port_bytes.is_empty() {

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -3,7 +3,8 @@ use super::{Domain, UninterpretedHost, UninterpretedHostRef, parse_utils};
 use crate::address::ip::{
     IPV4_BROADCAST, IPV4_LOCALHOST, IPV4_UNSPECIFIED, IPV6_LOCALHOST, IPV6_UNSPECIFIED,
 };
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
@@ -92,10 +93,7 @@ impl Host {
     pub fn try_as_domain(&self) -> Result<std::borrow::Cow<'_, Domain>, BoxError> {
         match self {
             Self::Name(d) => Ok(std::borrow::Cow::Borrowed(d)),
-            Self::Address(_) => Err(rama_core::error::extra::OpaqueError::from_static_str(
-                "Host::Address is not a Domain",
-            )
-            .into_box_error()),
+            Self::Address(_) => Err(BoxError::from_static_str("Host::Address is not a Domain")),
             Self::Uninterpreted(host) => Domain::try_from(host)
                 .map(std::borrow::Cow::Owned)
                 .map_err(Into::into),
@@ -106,10 +104,7 @@ impl Host {
     pub fn try_into_domain(self) -> Result<Domain, BoxError> {
         match self {
             Self::Name(d) => Ok(d),
-            Self::Address(_) => Err(rama_core::error::extra::OpaqueError::from_static_str(
-                "Host::Address is not a Domain",
-            )
-            .into_box_error()),
+            Self::Address(_) => Err(BoxError::from_static_str("Host::Address is not a Domain")),
             Self::Uninterpreted(ref host) => Domain::try_from(host).map_err(Into::into),
         }
     }
@@ -121,10 +116,7 @@ impl Host {
     pub fn try_as_ip(&self) -> Result<IpAddr, BoxError> {
         match self {
             Self::Address(ip) => Ok(*ip),
-            Self::Name(_) => Err(rama_core::error::extra::OpaqueError::from_static_str(
-                "Host::Name is not an IpAddr",
-            )
-            .into_box_error()),
+            Self::Name(_) => Err(BoxError::from_static_str("Host::Name is not an IpAddr")),
             Self::Uninterpreted(host) => IpAddr::try_from(host).map_err(Into::into),
         }
     }
@@ -313,10 +305,9 @@ impl<'a> HostRef<'a> {
     pub fn try_as_domain(self) -> Result<Domain, BoxError> {
         match self {
             Self::Name(d) => Ok(d.into_owned()),
-            Self::Address(_) => Err(rama_core::error::extra::OpaqueError::from_static_str(
+            Self::Address(_) => Err(BoxError::from_static_str(
                 "HostRef::Address is not a Domain",
-            )
-            .into_box_error()),
+            )),
             Self::Uninterpreted(host) => Domain::try_from(host).map_err(Into::into),
         }
     }
@@ -325,10 +316,7 @@ impl<'a> HostRef<'a> {
     pub fn try_as_ip(self) -> Result<IpAddr, BoxError> {
         match self {
             Self::Address(ip) => Ok(ip),
-            Self::Name(_) => Err(rama_core::error::extra::OpaqueError::from_static_str(
-                "HostRef::Name is not an IpAddr",
-            )
-            .into_box_error()),
+            Self::Name(_) => Err(BoxError::from_static_str("HostRef::Name is not an IpAddr")),
             Self::Uninterpreted(host) => IpAddr::try_from(host).map_err(Into::into),
         }
     }
@@ -815,14 +803,14 @@ impl TryFrom<&str> for Host {
 /// `Display`-round-trips through this entry point.
 fn try_from_host_str(s: &str) -> Result<Host, BoxError> {
     if s.is_empty() {
-        return Err(OpaqueError::from_static_str("empty host string").into_box_error());
+        return Err(BoxError::from_static_str("empty host string"));
     }
     // Bracketed IP-literal fast path — without it, the colon-in-IPv6
     // body confuses bare parses and `[v1.X]` IPvFuture has no shot.
     if s.starts_with('[') && s.ends_with(']') {
         let inside = &s[1..s.len() - 1];
         if inside.is_empty() {
-            return Err(OpaqueError::from_static_str("empty bracketed IP-literal").into_box_error());
+            return Err(BoxError::from_static_str("empty bracketed IP-literal"));
         }
         // IPvFuture: surface as `Uninterpreted(bracketed=true)`.
         if matches!(inside.as_bytes().first(), Some(b'v' | b'V')) {
@@ -837,10 +825,9 @@ fn try_from_host_str(s: &str) -> Result<Host, BoxError> {
             ));
         }
         if super::parse_utils::ipv6_bracket_has_zone(inside.as_bytes()) {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "ipv6 zone identifiers (RFC 6874) are not supported",
-            )
-            .into_box_error());
+            ));
         }
         let addr = inside
             .parse::<std::net::Ipv6Addr>()
@@ -906,7 +893,7 @@ impl TryFrom<&[u8]> for Host {
         if let Ok(arr) = <&[u8; 16]>::try_from(name) {
             return Ok(Self::Address(IpAddr::from(*arr)));
         }
-        Err(OpaqueError::from_static_str("parse host from bytes failed").into_box_error())
+        Err(BoxError::from_static_str("parse host from bytes failed"))
     }
 }
 

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -3,7 +3,7 @@ use super::{Domain, UninterpretedHost, UninterpretedHostRef, parse_utils};
 use crate::address::ip::{
     IPV4_BROADCAST, IPV4_LOCALHOST, IPV4_UNSPECIFIED, IPV6_LOCALHOST, IPV6_UNSPECIFIED,
 };
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use std::{
     fmt,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -1,8 +1,8 @@
 use crate::Protocol;
 use crate::address::HostWithPort;
+use rama_core::error::BoxErrorExt as _;
 
 use super::{Domain, DomainAddress, Host, OptPort, SocketAddress, parse_utils};
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
@@ -481,10 +481,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<HostWithO
     let s = maybe_borrowed.as_ref();
 
     if s.is_empty() {
-        return Err(
-            OpaqueError::from_static_str("empty string is invalid host (with opt port)")
-                .into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "empty string is invalid host (with opt port)",
+        ));
     }
 
     let host;
@@ -496,7 +495,7 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<HostWithO
     if s.starts_with('[') && s.ends_with(']') {
         let inside = &s[1..s.len() - 1];
         if inside.is_empty() {
-            return Err(OpaqueError::from_static_str("empty bracketed IP-literal").into_box_error());
+            return Err(BoxError::from_static_str("empty bracketed IP-literal"));
         }
         // IPvFuture: `[v1.xxx]` — stored as `Uninterpreted(bracketed=true)`
         // verbatim, matching the URI authority parser's shape.
@@ -513,10 +512,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<HostWithO
             });
         }
         if parse_utils::ipv6_bracket_has_zone(inside.as_bytes()) {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "ipv6 zone identifiers (RFC 6874) are not supported",
-            )
-            .into_box_error());
+            ));
         }
         let addr = inside
             .parse::<Ipv6Addr>()
@@ -540,10 +538,9 @@ fn try_from_maybe_borrowed_str(maybe_borrowed: Cow<'_, str>) -> Result<HostWithO
             // parser rejects the same shape — keep the eager paths
             // symmetric.
             if first_part.is_empty() {
-                return Err(
-                    OpaqueError::from_static_str("empty host before ':port' is invalid")
-                        .into_box_error(),
-                );
+                return Err(BoxError::from_static_str(
+                    "empty host before ':port' is invalid",
+                ));
             }
             let port_str = &s[last_colon + 1..];
             port = if port_str.is_empty() {

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -3,7 +3,7 @@ use crate::address::HostWithPort;
 
 use super::{Domain, DomainAddress, Host, OptPort, SocketAddress, parse_utils};
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::borrow::Cow;
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -2,7 +2,7 @@ use crate::Protocol;
 
 use super::{Domain, DomainAddress, Host, SocketAddress, parse_utils};
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::{

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -1,7 +1,7 @@
 use crate::Protocol;
+use rama_core::error::BoxErrorExt as _;
 
 use super::{Domain, DomainAddress, Host, SocketAddress, parse_utils};
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -327,12 +327,9 @@ impl TryFrom<&str> for HostWithPort {
         let (host, port) = parse_utils::split_port_from_str(s)?;
         let host = Host::try_from(host).context("parse host from host-with-port")?;
         match host {
-            Host::Address(IpAddr::V6(_)) if !s.starts_with('[') => {
-                Err(OpaqueError::from_static_str(
-                    "missing brackets for IPv6 address with port (in host-with-port)",
-                )
-                .into_box_error())
-            }
+            Host::Address(IpAddr::V6(_)) if !s.starts_with('[') => Err(BoxError::from_static_str(
+                "missing brackets for IPv6 address with port (in host-with-port)",
+            )),
             _ => Ok(Self { host, port }),
         }
     }

--- a/rama-net/src/address/parse_utils.rs
+++ b/rama-net/src/address/parse_utils.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use std::net::{IpAddr, Ipv6Addr};
 
 pub(crate) fn split_port_from_str(s: &str) -> Result<(&str, u16), BoxError> {
@@ -8,7 +9,7 @@ pub(crate) fn split_port_from_str(s: &str) -> Result<(&str, u16), BoxError> {
             Err(err) => Err(err.context("parse port as u16")),
         }
     } else {
-        Err(OpaqueError::from_static_str("missing port").into_box_error())
+        Err(BoxError::from_static_str("missing port"))
     }
 }
 
@@ -107,10 +108,9 @@ pub(crate) fn parse_bracketed_ipv6_with_port(
         // we haven't built. Reject with a clear message rather than
         // letting `Ipv6Addr::parse` fail opaquely on the `%`.
         if ipv6_bracket_has_zone(value.as_bytes()) {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "ipv6 zone identifiers (RFC 6874) are not supported",
-            )
-            .into_box_error());
+            ));
         }
         let addr = value
             .parse::<Ipv6Addr>()

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV
 use std::str::FromStr;
 
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 
 use crate::address::ip::{

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -1,8 +1,8 @@
+use rama_core::error::BoxErrorExt as _;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::str::FromStr;
 
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::macros::generate_set_and_with;
 
@@ -343,10 +343,9 @@ impl TryFrom<&str> for SocketAddress {
         let ip_addr =
             try_to_parse_str_to_ip(ip_addr).context("parse ip address from socket address")?;
         match ip_addr {
-            IpAddr::V6(_) if !s.starts_with('[') => Err(OpaqueError::from_static_str(
+            IpAddr::V6(_) if !s.starts_with('[') => Err(BoxError::from_static_str(
                 "missing brackets for IPv6 address with port",
-            )
-            .into_box_error()),
+            )),
             _ => Ok(Self { ip_addr, port }),
         }
     }

--- a/rama-net/src/address/user_info.rs
+++ b/rama-net/src/address/user_info.rs
@@ -11,7 +11,7 @@
 use rama_core::bytes::Bytes;
 
 use crate::user::Basic;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 
 /// Raw RFC 3986 userinfo bytes. Cheap to clone.
 ///

--- a/rama-net/src/address/user_info.rs
+++ b/rama-net/src/address/user_info.rs
@@ -9,9 +9,10 @@
 //! [`UserInfo::to_basic`] for HTTP Basic-Auth interop.
 
 use rama_core::bytes::Bytes;
+use rama_core::error::BoxErrorExt as _;
 
 use crate::user::Basic;
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext};
 
 /// Raw RFC 3986 userinfo bytes. Cheap to clone.
 ///
@@ -216,7 +217,7 @@ fn validate_userinfo_runtime(bytes: &[u8]) -> Result<(), BoxError> {
                 }
                 UserInfoFault::DisallowedByte => "userinfo contains disallowed character",
             };
-            Err(OpaqueError::from_static_str(msg).into_box_error())
+            Err(BoxError::from_static_str(msg))
         }
     }
 }

--- a/rama-net/src/client/pool/mod.rs
+++ b/rama-net/src/client/pool/mod.rs
@@ -3,7 +3,7 @@ use crate::address::SocketAddress;
 use crate::conn::{ConnectionHealth, ConnectionHealthWatcher};
 use crate::stream::Socket;
 use parking_lot::Mutex;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_core::extensions::{Extension, Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing::trace;
@@ -223,14 +223,14 @@ impl<C, ID> Clone for LruDropPool<C, ID> {
 impl<C, ID> LruDropPool<C, ID> {
     pub fn try_new(max_active: usize, max_total: usize) -> Result<Self, BoxError> {
         if max_active == 0 || max_total == 0 {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "max_active or max_total of 0 will make this pool unusable",
             )
             .context_field("max_active", max_active)
             .context_field("max_total", max_total));
         }
         if max_active > max_total {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "max_active should be smaller or equal to max_total",
             )
             .context_field("max_active", max_active)
@@ -1075,7 +1075,7 @@ mod tests {
 
     impl Service<bool> for InnerService {
         type Output = ();
-        type Error = OpaqueError;
+        type Error = BoxError;
 
         async fn serve(&self, should_error: bool) -> Result<Self::Output, Self::Error> {
             // Once this service is broken it will stay in this state, similar to a closed tcp connection
@@ -1088,7 +1088,7 @@ mod tests {
             }
 
             if self.should_error.load(Ordering::Relaxed) {
-                Err(OpaqueError::from_static_str("service is in broken state"))
+                Err(BoxError::from_static_str("service is in broken state"))
             } else {
                 Ok(())
             }

--- a/rama-net/src/forwarded/element/parser.rs
+++ b/rama-net/src/forwarded/element/parser.rs
@@ -1,7 +1,7 @@
 use super::ExtensionValue;
 use super::{ForwardedElement, NodeId};
 use crate::forwarded::ForwardedProtocol;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_utils::macros::match_ignore_ascii_case_str;
 
@@ -9,7 +9,7 @@ pub(crate) fn parse_single_forwarded_element(bytes: &[u8]) -> Result<ForwardedEl
     if bytes.len() > 512 {
         // custom max length, to keep things sane here...
         return Err(
-            OpaqueError::from_static_str("forwarded element bytes length is too big")
+            BoxError::from_static_str("forwarded element bytes length is too big")
                 .context_field("length", bytes.len()),
         );
     }
@@ -18,10 +18,10 @@ pub(crate) fn parse_single_forwarded_element(bytes: &[u8]) -> Result<ForwardedEl
     if bytes.is_empty() {
         Ok(element)
     } else {
-        Err(OpaqueError::from_static_str(
-            "trailing characters found following the forwarded element",
+        Err(
+            BoxError::from_static_str("trailing characters found following the forwarded element")
+                .context_field("count", bytes.len()),
         )
-        .context_field("count", bytes.len()))
     }
 }
 
@@ -30,10 +30,10 @@ pub(crate) fn parse_one_plus_forwarded_elements(
 ) -> Result<(ForwardedElement, Vec<ForwardedElement>), BoxError> {
     if bytes.len() > 8096 {
         // custom max length, to keep things sane here...
-        return Err(OpaqueError::from_static_str(
-            "forwarded elements list bytes length is too big",
-        )
-        .context_field("length", bytes.len()));
+        return Err(
+            BoxError::from_static_str("forwarded elements list bytes length is too big")
+                .context_field("length", bytes.len()),
+        );
     }
 
     let mut others = Vec::new();
@@ -47,7 +47,7 @@ pub(crate) fn parse_one_plus_forwarded_elements(
     loop {
         // skip comma first
         if bytes[0] != b',' {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "unexpected char in forward element list: expected comma",
             )
             .context_field("char", bytes[0]));
@@ -68,10 +68,9 @@ pub(crate) fn parse_one_plus_forwarded_elements(
 
 fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &[u8]), BoxError> {
     if bytes.is_empty() {
-        return Err(
-            OpaqueError::from_static_str("empty str is not a valid Forwarded Element")
-                .into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "empty str is not a valid Forwarded Element",
+        ));
     }
 
     let mut el = ForwardedElement {
@@ -110,7 +109,7 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
             match bytes[index] {
                 b'"' => {
                     if index != 0 {
-                        return Err(OpaqueError::from_static_str("dangling quote string quote")
+                        return Err(BoxError::from_static_str("dangling quote string quote")
                             .context_field("quote_pos", index));
                     }
                     bytes = &bytes[1..];
@@ -157,7 +156,7 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
         // >
         // > remark: we do not apply any validation here
         if !quoted && value.contains(['[', ']', ':']) {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "Forwarded Element pair's value was expected to be a quoted string due to the chars it contains"
             ).context_str_field("value", value));
         }
@@ -165,22 +164,22 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
         match_ignore_ascii_case_str! {
             match(key) {
                 "for" => if el.for_node.is_some() {
-                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'for' property").into_box_error());
+                    return Err(BoxError::from_static_str("Forwarded Element can only contain one 'for' property"));
                 } else {
                     el.for_node = Some(NodeId::try_from(value).context("parse Forwarded Element 'for' node")?);
                 },
                 "host" => if el.authority.is_some() {
-                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'host' property").into_box_error());
+                    return Err(BoxError::from_static_str("Forwarded Element can only contain one 'host' property"));
                 } else {
                     el.authority = Some(value.parse().context("parse Forwarded Element 'host' authority")?);
                 },
                 "by" => if el.by_node.is_some() {
-                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'by' property").into_box_error());
+                    return Err(BoxError::from_static_str("Forwarded Element can only contain one 'by' property"));
                 } else {
                     el.by_node = Some(NodeId::try_from(value).context("parse Forwarded Element 'by' node")?);
                 },
                 "proto" => if el.proto.is_some() {
-                    return Err(OpaqueError::from_static_str("Forwarded Element can only contain one 'proto' property").into_box_error());
+                    return Err(BoxError::from_static_str("Forwarded Element can only contain one 'proto' property"));
                 } else {
                     el.proto = Some(ForwardedProtocol::try_from(value).context("parse Forwarded Element 'proto' protocol")?);
                 },
@@ -207,10 +206,9 @@ fn parse_next_forwarded_element(mut bytes: &[u8]) -> Result<(ForwardedElement, &
 
     if el.for_node.is_none() && el.by_node.is_none() && el.authority.is_none() && el.proto.is_none()
     {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "invalid forwarded element: none of required properties are set",
-        )
-        .into_box_error());
+        ));
     }
 
     bytes = trim_left(bytes);
@@ -265,7 +263,9 @@ fn scan_quoted_string(bytes: &[u8]) -> Result<QuotedScan, BoxError> {
             }
         }
     }
-    Err(OpaqueError::from_static_str("quote string missing trailer quote").into_box_error())
+    Err(BoxError::from_static_str(
+        "quote string missing trailer quote",
+    ))
 }
 
 fn trim_left(b: &[u8]) -> &[u8] {
@@ -295,9 +295,9 @@ fn trim(b: &[u8]) -> &[u8] {
 /// Parse a `token`-form value: visible ASCII (`0x21..=0x7E`) only, no `"`.
 fn parse_value(slice: &[u8]) -> Result<&str, BoxError> {
     if slice.iter().any(|b| !(32..127).contains(b) || *b == b'"') {
-        return Err(
-            OpaqueError::from_static_str("value contains invalid characters").into_box_error(),
-        );
+        return Err(BoxError::from_static_str(
+            "value contains invalid characters",
+        ));
     }
     std::str::from_utf8(slice).context("parse value as utf-8")
 }
@@ -331,7 +331,7 @@ fn parse_quoted_value(slice: &[u8]) -> Result<&str, BoxError> {
         .position(|b| matches!(*b, 0..=0x08 | 0x0a..=0x1f | 0x7f))
     {
         return Err(
-            OpaqueError::from_static_str("quoted value contains invalid control byte")
+            BoxError::from_static_str("quoted value contains invalid control byte")
                 .context_field("byte_index", idx),
         );
     }

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -1,6 +1,7 @@
 use super::{ObfNode, ObfPort};
 use crate::address::{Domain, Host, HostWithOptPort, HostWithPort, SocketAddress};
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::str::smol_str::SmolStr;
 use std::{
     fmt,
@@ -340,8 +341,7 @@ impl TryFrom<&str> for NodeId {
 
         match name {
             NodeName::Ip(IpAddr::V6(_)) if port.is_some() && !s.starts_with('[') => Err(
-                OpaqueError::from_static_str("missing brackets for node IPv6 address with port")
-                    .into_box_error(),
+                BoxError::from_static_str("missing brackets for node IPv6 address with port"),
             ),
             _ => Ok(Self { name, port }),
         }

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -1,6 +1,6 @@
 use super::{ObfNode, ObfPort};
 use crate::address::{Domain, Host, HostWithOptPort, HostWithPort, SocketAddress};
-use rama_core::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use rama_utils::str::smol_str::SmolStr;
 use std::{
     fmt,

--- a/rama-net/src/forwarded/obfuscated.rs
+++ b/rama-net/src/forwarded/obfuscated.rs
@@ -3,7 +3,7 @@
     reason = "macro-emitted `#[allow(dead_code)]` whose underlying lint fires only for some macro instantiations"
 )]
 
-use rama_core::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use rama_utils::str::smol_str::SmolStr;
 use std::fmt;
 

--- a/rama-net/src/forwarded/obfuscated.rs
+++ b/rama-net/src/forwarded/obfuscated.rs
@@ -3,7 +3,8 @@
     reason = "macro-emitted `#[allow(dead_code)]` whose underlying lint fires only for some macro instantiations"
 )]
 
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use rama_utils::str::smol_str::SmolStr;
 use std::fmt;
 
@@ -103,7 +104,7 @@ macro_rules! create_obf_type {
                 if $val_fn(s.as_bytes()) {
                     Ok(Self(SmolStr::new(s)))
                 } else {
-                    Err(OpaqueError::from_static_str(concat!("invalid ", stringify!($name))).into_box_error())
+                    Err(BoxError::from_static_str(concat!("invalid ", stringify!($name))))
                 }
             }
         }
@@ -117,7 +118,7 @@ macro_rules! create_obf_type {
                         String::from_utf8(s).context(concat!("convert ", stringify!($name), "bytes to utf-8 string"))?,
                     )))
                 } else {
-                    Err(OpaqueError::from_static_str(concat!("invalid ", stringify!($name))).into_box_error())
+                    Err(BoxError::from_static_str(concat!("invalid ", stringify!($name))))
                 }
             }
         }

--- a/rama-net/src/http/request_context.rs
+++ b/rama-net/src/http/request_context.rs
@@ -7,7 +7,7 @@ use crate::{
     address::{Domain, Host},
 };
 use rama_core::error::BoxError;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::extensions::{Extension, Extensions};
 use rama_core::telemetry::tracing;
 use rama_http_types::request::Parts;
@@ -150,7 +150,7 @@ pub fn try_request_ctx_from_http_parts(
                 })
         })
         .ok_or_else(|| {
-            OpaqueError::from_static_str("RequestContext: no authourity found in http::Request")
+            BoxError::from_static_str("RequestContext: no authourity found in http::Request")
         })?;
 
     tracing::trace!(url.full = %uri, "request context: detected authority: {authority}");

--- a/rama-net/src/http/uri/match_replace/fmt.rs
+++ b/rama-net/src/http/uri/match_replace/fmt.rs
@@ -1,6 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use std::{borrow::Cow, fmt};
 
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_http_types::Uri;
 
 #[derive(Clone)]
@@ -77,7 +78,7 @@ impl UriFormatter {
                         offset = index + 1;
                     } else if byte == b'?' {
                         if include_query {
-                            return Err(OpaqueError::from_static_str(
+                            return Err(BoxError::from_static_str(
                                 "uri can only contain a single '?': multiple found",
                             )
                             .context_field("index", index));
@@ -114,10 +115,9 @@ impl UriFormatter {
         let literal_len =
             template.len() - captures.iter().map(|capture| capture.length).sum::<usize>();
         if literal_len + captures.len() >= MAX_URI_LEN {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "Uri Formatter potential length exceeds max URI length",
-            )
-            .into_box_error());
+            ));
         }
 
         Ok(Self {
@@ -155,10 +155,10 @@ fn try_rule_capture_from_byte_range(
     bytes: &[u8],
     offset: usize,
     index: usize,
-) -> Result<RuleCapture, OpaqueError> {
+) -> Result<RuleCapture, BoxError> {
     let length = index.saturating_sub(offset);
     if length == 0 || length > 2 {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "invalid capture raw byte length (OOR)",
         ));
     }
@@ -173,7 +173,7 @@ fn try_rule_capture_from_byte_range(
         .sum();
 
     if capture_index == 0 || capture_index > 16 {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "uri formatter is invalid: capture index has to be within inclusive range [1, 16]",
         ));
     }

--- a/rama-net/src/https.rs
+++ b/rama-net/src/https.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorExt};
 use rama_http_types::Version;
 
 use crate::tls::ApplicationProtocol;
@@ -13,7 +14,7 @@ impl TryFrom<Version> for ApplicationProtocol {
             Version::HTTP_11 => Self::HTTP_11,
             Version::HTTP_2 => Self::HTTP_2,
             Version::HTTP_3 => Self::HTTP_3,
-            _ => Err(OpaqueError::from_static_str(
+            _ => Err(BoxError::from_static_str(
                 "received unexpected http version",
             ))?,
         };
@@ -39,7 +40,7 @@ impl TryFrom<&ApplicationProtocol> for Version {
             ApplicationProtocol::HTTP_11 => Self::HTTP_11,
             ApplicationProtocol::HTTP_2 => Self::HTTP_2,
             ApplicationProtocol::HTTP_3 => Self::HTTP_3,
-            alpn => Err(OpaqueError::from_static_str(
+            alpn => Err(BoxError::from_static_str(
                 "cannot convert given alpn {alpn} to http version",
             )
             .context_field("alpn", alpn.clone()))?,

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -1,7 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use std::cmp::min;
 use std::str::FromStr;
 
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::extensions::Extension;
 use rama_utils::macros::str::eq_ignore_ascii_case;
@@ -404,7 +404,7 @@ pub(crate) fn try_to_extract_protocol_from_uri_scheme(
     s: &[u8],
 ) -> Result<(Option<Protocol>, usize), BoxError> {
     if s.is_empty() {
-        return Err(OpaqueError::from_static_str("empty uri contains no scheme").into_box_error());
+        return Err(BoxError::from_static_str("empty uri contains no scheme"));
     }
 
     for i in 0..min(s.len(), 512) {

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 use std::str::FromStr;
 
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::extensions::Extension;
 use rama_utils::macros::str::eq_ignore_ascii_case;
 use rama_utils::str::smol_str::SmolStr;

--- a/rama-net/src/socket/device_name.rs
+++ b/rama-net/src/socket/device_name.rs
@@ -1,6 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use std::{fmt, str::FromStr};
 
-use rama_core::error::{BoxError, ErrorContext as _, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext as _};
 use rama_utils::str::smol_str::SmolStr;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -77,10 +78,8 @@ impl TryFrom<&str> for DeviceName {
             return Ok(Self(SmolStr::from(s)));
         }
 
-        Err(
-            OpaqueError::from_static_str("invalid (interface) device name")
-                .context_str_field("str", s),
-        )
+        Err(BoxError::from_static_str("invalid (interface) device name")
+            .context_str_field("str", s))
     }
 }
 

--- a/rama-net/src/tls/client/parser.rs
+++ b/rama-net/src/tls/client/parser.rs
@@ -17,7 +17,7 @@ use nom::{
     multi::{length_data, many0},
     number::streaming::{be_u8, be_u16},
 };
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorExt as _};
 use rama_core::telemetry::tracing;
 use std::str;
@@ -29,7 +29,7 @@ use std::str;
 pub fn parse_client_hello(i: &[u8]) -> Result<ClientHello, BoxError> {
     match parse_client_hello_inner(i) {
         Err(err) => Err(
-            OpaqueError::from_static_str("parse client hello handshake message")
+            BoxError::from_static_str("parse client hello handshake message")
                 .context_debug_field("err", err.to_owned()),
         ),
         Ok((i, hello)) => {
@@ -51,7 +51,7 @@ pub fn parse_client_hello(i: &[u8]) -> Result<ClientHello, BoxError> {
 pub fn parse_client_hello_handshake(i: &[u8]) -> Result<ClientHello, BoxError> {
     match parse_client_hello_handshake_inner(i) {
         Err(err) => Err(
-            OpaqueError::from_static_str("parse client hello handshake message")
+            BoxError::from_static_str("parse client hello handshake message")
                 .context_debug_field("err", err.to_owned()),
         ),
         Ok((i, hello)) => {
@@ -91,7 +91,7 @@ pub fn extract_sni_from_client_hello_handshake(i: &[u8]) -> Result<Option<Domain
     parse_client_hello_handshake_sni_inner(i)
         .map(|(_, domain)| domain)
         .map_err(|err| {
-            OpaqueError::from_static_str("parse client hello handshake message to find SNI")
+            BoxError::from_static_str("parse client hello handshake message to find SNI")
                 .context_debug_field("err", err.to_owned())
         })
 }
@@ -109,7 +109,7 @@ pub fn extract_sni_from_client_hello_record(i: &[u8]) -> Result<Option<Domain>, 
     parse_client_hello_record_sni_inner(i)
         .map(|(_, domain)| domain)
         .map_err(|err| {
-            OpaqueError::from_static_str("parse client hello record message to find SNI")
+            BoxError::from_static_str("parse client hello record message to find SNI")
                 .context_debug_field("err", err.to_owned())
         })
 }

--- a/rama-net/src/tls/enums.rs
+++ b/rama-net/src/tls/enums.rs
@@ -1,10 +1,8 @@
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 
-use rama_core::{
-    bytes::{BufMut, Bytes, BytesMut},
-    error::extra::OpaqueError,
-};
+use rama_core::bytes::{BufMut, Bytes, BytesMut};
+use rama_core::error::{BoxError, BoxErrorExt as _};
 use rama_utils::macros::enums::enum_builder;
 
 macro_rules! impl_u16_is_grease {
@@ -810,7 +808,7 @@ impl ApplicationProtocol {
         if b.len() > 255 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                OpaqueError::from_static_str("application protocol is too large"),
+                BoxError::from_static_str("application protocol is too large"),
             ));
         }
 

--- a/rama-net/src/tls/keylog/rotating.rs
+++ b/rama-net/src/tls/keylog/rotating.rs
@@ -24,7 +24,7 @@ use std::{
 };
 
 use jiff::{Timestamp, tz::TimeZone};
-use rama_core::error::{BoxError, ErrorContext, ErrorExt as _, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use rama_core::telemetry::tracing;
 
 use super::sink::KeyLogSink;

--- a/rama-net/src/tls/keylog/rotating.rs
+++ b/rama-net/src/tls/keylog/rotating.rs
@@ -12,6 +12,7 @@
 //! parsed bucket is older than `now - retention` on each rotation.
 //! The actively-open file is never swept.
 
+use rama_core::error::BoxErrorExt as _;
 use std::{
     fs::{File, OpenOptions},
     io::Write,
@@ -24,7 +25,7 @@ use std::{
 };
 
 use jiff::{Timestamp, tz::TimeZone};
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
 
 use super::sink::KeyLogSink;
@@ -63,9 +64,7 @@ impl RotationPeriod {
             Self::Minutes(n) | Self::Hours(n) => n,
         };
         if n == 0 {
-            return Err(
-                OpaqueError::from_static_str("RotationPeriod must be non-zero").into_box_error(),
-            );
+            return Err(BoxError::from_static_str("RotationPeriod must be non-zero"));
         }
         Ok(self)
     }

--- a/rama-net/src/tls/server/sni.rs
+++ b/rama-net/src/tls/server/sni.rs
@@ -1,3 +1,4 @@
+use rama_core::error::BoxErrorExt as _;
 use std::{
     fmt,
     io::{IoSlice, Read, Write},
@@ -8,7 +9,7 @@ use std::{
 use pin_project_lite::pin_project;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     extensions::{Extensions, ExtensionsRef},
     io::{HeapReader, PrefixedIo, StackReader},
     service::RejectService,
@@ -111,10 +112,9 @@ where
                 read_size,
                 "unexpected read size for client hello handshake data"
             );
-            return Err(
-                OpaqueError::from_static_str("missing client hello tls handshake data")
-                    .into_box_error(),
-            );
+            return Err(BoxError::from_static_str(
+                "missing client hello tls handshake data",
+            ));
         }
         let sni = extract_sni_from_client_hello_handshake(&v)
             .context("parse client hello handshake bytes and extract SNI")?;

--- a/rama-net/src/tls/server/sni.rs
+++ b/rama-net/src/tls/server/sni.rs
@@ -8,7 +8,7 @@ use std::{
 use pin_project_lite::pin_project;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     extensions::{Extensions, ExtensionsRef},
     io::{HeapReader, PrefixedIo, StackReader},
     service::RejectService,

--- a/rama-net/src/user/credentials/basic.rs
+++ b/rama-net/src/user/credentials/basic.rs
@@ -1,6 +1,6 @@
+use rama_core::error::BoxErrorExt as _;
 use std::{fmt, str::FromStr};
 
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::str::NonEmptyStr;
@@ -178,12 +178,11 @@ fn validate_basic_field(field: &str, value: &str) -> Result<(), BoxError> {
         .iter()
         .position(|b| matches!(*b, b'\r' | b'\n' | 0))
     {
-        return Err(OpaqueError::from_static_str(
-            "basic credential contains forbidden control byte",
-        )
-        .context_str_field("field", field)
-        .context_field("byte_index", idx)
-        .into_box_error());
+        return Err(
+            BoxError::from_static_str("basic credential contains forbidden control byte")
+                .context_str_field("field", field)
+                .context_field("byte_index", idx),
+        );
     }
     Ok(())
 }
@@ -194,10 +193,9 @@ impl TryFrom<&str> for Basic {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         validate_basic_field("credential blob", value)?;
         match value.find(':') {
-            Some(0) => Err(
-                OpaqueError::from_static_str("missing username in basic credential")
-                    .into_box_error(),
-            ),
+            Some(0) => Err(BoxError::from_static_str(
+                "missing username in basic credential",
+            )),
             Some(n) => Ok(Self {
                 username: NonEmptyStr::try_from(&value[..n])
                     .context("create username for secure basic credentials")?,

--- a/rama-net/src/user/credentials/bearer.rs
+++ b/rama-net/src/user/credentials/bearer.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
 use std::{fmt, str::FromStr};
 
@@ -101,9 +102,8 @@ impl Bearer {
             .position(|b| *b <= 32 || *b >= 127 || *b == b',')
         {
             return Err(
-                OpaqueError::from_static_str("Bearer token contains forbidden byte")
-                    .context_field("byte_index", idx)
-                    .into_box_error(),
+                BoxError::from_static_str("Bearer token contains forbidden byte")
+                    .context_field("byte_index", idx),
             );
         }
 

--- a/rama-net/src/user/credentials/raw.rs
+++ b/rama-net/src/user/credentials/raw.rs
@@ -1,4 +1,5 @@
-use rama_core::error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_utils::bytes::ct::ct_eq_bytes;
 use rama_utils::str::{NonEmptyStr, arcstr::ArcStr};
 use std::{fmt, str::FromStr};
@@ -109,9 +110,8 @@ impl RawToken {
             .position(|b| !(*b == b'\t' || (b' '..=b'~').contains(b)))
         {
             return Err(
-                OpaqueError::from_static_str("RawToken contains forbidden byte")
-                    .context_field("byte_index", idx)
-                    .into_box_error(),
+                BoxError::from_static_str("RawToken contains forbidden byte")
+                    .context_field("byte_index", idx),
             );
         }
 

--- a/rama-proxy/src/proxydb/layer.rs
+++ b/rama-proxy/src/proxydb/layer.rs
@@ -1,7 +1,8 @@
 use super::{Proxy, ProxyContext, ProxyDB, ProxyFilter, ProxyQueryPredicate};
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, ErrorExt},
     extensions::{Extensions, ExtensionsRef},
 };
 use rama_net::{
@@ -236,9 +237,9 @@ where
                         } else if proxy.socks5h {
                             Some(Protocol::SOCKS5H)
                         } else {
-                            return Err(OpaqueError::from_static_str(
+                            return Err(BoxError::from_static_str(
                                 "selected udp proxy does not have a valid protocol available (db bug?!)",
-                            ).into_box_error());
+                            ));
                         }
                     }
                     TransportProtocol::Tcp => match proxy_address.address.port {
@@ -257,9 +258,9 @@ where
                             } else if proxy.https {
                                 Some(Protocol::HTTPS)
                             } else {
-                                return Err(OpaqueError::from_static_str(
+                                return Err(BoxError::from_static_str(
                                     "selected tcp proxy does not have a valid protocol available (db bug?!)",
-                                ).into_box_error());
+                                ));
                             }
                         }
                     },

--- a/rama-proxy/src/proxydb/mod.rs
+++ b/rama-proxy/src/proxydb/mod.rs
@@ -1,5 +1,5 @@
 use rama_core::error::extra::OpaqueError;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt};
+use rama_core::error::{BoxError, ErrorContext};
 use rama_core::extensions::Extension;
 use rama_net::asn::Asn;
 use rama_utils::str::NonEmptyStr;

--- a/rama-proxy/src/proxydb/mod.rs
+++ b/rama-proxy/src/proxydb/mod.rs
@@ -1,4 +1,4 @@
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::extensions::Extension;
 use rama_net::asn::Asn;
@@ -155,7 +155,7 @@ pub trait ProxyDB: Send + Sync + 'static {
 }
 
 impl ProxyDB for () {
-    type Error = OpaqueError;
+    type Error = BoxError;
 
     #[inline]
     async fn get_proxy_if(
@@ -164,7 +164,7 @@ impl ProxyDB for () {
         _filter: ProxyFilter,
         _predicate: impl ProxyQueryPredicate,
     ) -> Result<Proxy, Self::Error> {
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "()::get_proxy_if: no ProxyDB defined",
         ))
     }
@@ -175,7 +175,7 @@ impl ProxyDB for () {
         _ctx: ProxyContext,
         _filter: ProxyFilter,
     ) -> Result<Proxy, Self::Error> {
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "()::get_proxy: no ProxyDB defined",
         ))
     }
@@ -199,10 +199,9 @@ where
                 .get_proxy_if(ctx, filter, predicate)
                 .await
                 .context("Some::get_proxy_if"),
-            None => Err(
-                OpaqueError::from_static_str("None::get_proxy_if: no ProxyDB defined")
-                    .into_box_error(),
-            ),
+            None => Err(BoxError::from_static_str(
+                "None::get_proxy_if: no ProxyDB defined",
+            )),
         }
     }
 
@@ -214,10 +213,9 @@ where
     ) -> Result<Proxy, Self::Error> {
         match self {
             Some(db) => db.get_proxy(ctx, filter).await.context("Some::get_proxy"),
-            None => Err(
-                OpaqueError::from_static_str("None::get_proxy: no ProxyDB defined")
-                    .into_box_error(),
-            ),
+            None => Err(BoxError::from_static_str(
+                "None::get_proxy: no ProxyDB defined",
+            )),
         }
     }
 }

--- a/rama-proxy/src/proxydb/update.rs
+++ b/rama-proxy/src/proxydb/update.rs
@@ -1,6 +1,7 @@
 use super::ProxyDB;
 use arc_swap::ArcSwap;
-use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
+use rama_core::error::BoxErrorExt as _;
+use rama_core::error::{BoxError, ErrorContext};
 use std::{fmt, ops::Deref, sync::Arc};
 
 /// Create a new [`ProxyDB`] updater which allows you to have a (typically in-memory) [`ProxyDB`]
@@ -70,10 +71,9 @@ where
                 .get_proxy_if(ctx, filter, predicate)
                 .await
                 .into_box_error(),
-            None => Err(OpaqueError::from_static_str(
+            None => Err(BoxError::from_static_str(
                 "live proxy db: proxy db is None: get_proxy_if unable to proceed",
-            )
-            .into_box_error()),
+            )),
         }
     }
 
@@ -84,10 +84,9 @@ where
     ) -> Result<super::Proxy, Self::Error> {
         match self.0.load().deref().deref() {
             Some(db) => db.get_proxy(ctx, filter).await.into_box_error(),
-            None => Err(OpaqueError::from_static_str(
+            None => Err(BoxError::from_static_str(
                 "live proxy db: proxy db is None: get_proxy unable to proceed",
-            )
-            .into_box_error()),
+            )),
         }
     }
 }

--- a/rama-proxy/src/proxydb/update.rs
+++ b/rama-proxy/src/proxydb/update.rs
@@ -1,6 +1,6 @@
 use super::ProxyDB;
 use arc_swap::ArcSwap;
-use rama_core::error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, ErrorContext, extra::OpaqueError};
 use std::{fmt, ops::Deref, sync::Arc};
 
 /// Create a new [`ProxyDB`] updater which allows you to have a (typically in-memory) [`ProxyDB`]

--- a/rama-proxy/src/username.rs
+++ b/rama-proxy/src/username.rs
@@ -1,6 +1,7 @@
 use super::ProxyFilter;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
-    error::{BoxError, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorExt},
     extensions::Extensions,
     telemetry::tracing,
     username::{UsernameLabelParser, UsernameLabelState, UsernameLabelWriter},
@@ -165,7 +166,7 @@ impl UsernameLabelParser for ProxyFilterUsernameParser {
     fn build(self, ext: &Extensions) -> Result<(), Self::Error> {
         if let Some(key) = self.key {
             return Err(
-                OpaqueError::from_static_str("unused proxy filter username key")
+                BoxError::from_static_str("unused proxy filter username key")
                     .context_debug_field("key", key),
             );
         }

--- a/rama-socks5/src/client/proxy_connector.rs
+++ b/rama-socks5/src/client/proxy_connector.rs
@@ -2,9 +2,10 @@ use crate::{
     Socks5Client,
     client::{core::HandshakeError, proxy_error::Socks5ProxyError},
 };
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt},
     extensions::ExtensionsRef,
     io::Io,
     telemetry::tracing,
@@ -342,10 +343,9 @@ where
             .map(|p| p.is_socks5())
             .unwrap_or(true)
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "socks5 proxy connector can only serve socks5 protocol",
-            )
-            .into_box_error());
+            ));
         }
 
         let address = match address {
@@ -417,10 +417,9 @@ where
                 client.set_auth(basic.clone());
             }
             Some(ProxyCredential::Bearer(_)) => {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "socks5proxy does not support auth with bearer credential",
-                )
-                .into_box_error());
+                ));
             }
             None => {
                 tracing::trace!(
@@ -435,7 +434,7 @@ where
 
         let Some(connect_authority) = transport_ctx.host_with_port() else {
             return Err(Box::new(Socks5ProxyError::Handshake(
-                HandshakeError::other(OpaqueError::from_static_str(
+                HandshakeError::other(BoxError::from_static_str(
                     "failed to get port from transport context",
                 )),
             )));

--- a/rama-socks5/src/client/udp.rs
+++ b/rama-socks5/src/client/udp.rs
@@ -1,5 +1,5 @@
 use rama_core::bytes::{BufMut, BytesMut};
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt as _};
 use rama_core::futures::Sink;
 use rama_core::futures::Stream;
@@ -247,7 +247,7 @@ impl<S: rama_core::io::Io + Unpin> UdpSocketRelay<S> {
 
 fn validate_udp_header(header: UdpHeader) -> Result<(usize, SocketAddress), BoxError> {
     if header.fragment_number != 0 {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "UdpSocketRelay: fragment number != 0 is not supported",
         )
         .context_field("fragment_number", header.fragment_number));
@@ -259,7 +259,7 @@ fn validate_udp_header(header: UdpHeader) -> Result<(usize, SocketAddress), BoxE
     let from: SocketAddress = match host.try_as_ip() {
         Ok(ip) => (ip, port).into(),
         Err(_) => {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "server responded with non-IP host: incompatible for udp bind",
             )
             .context_field("host", host.to_string()));

--- a/rama-tcp/src/client/connect.rs
+++ b/rama-tcp/src/client/connect.rs
@@ -1,6 +1,6 @@
 use rama_core::combinators::Either;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::ErrorExt as _;
-use rama_core::error::extra::OpaqueError;
 use rama_core::extensions::Extensions;
 use rama_core::stream::StreamExt;
 use rama_core::stream::wrappers::ReceiverStream;
@@ -351,13 +351,13 @@ where
 
     if resolved_count > 0 {
         Err(
-            OpaqueError::from_static_str("failed to (tcp) connect to any resolved IP address")
+            BoxError::from_static_str("failed to (tcp) connect to any resolved IP address")
                 .context_field("host", host)
                 .context_field("port", port)
                 .context_field("resolved_addr_count", resolved_count),
         )
     } else {
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "failed to resolve into any IP address (as part of tcp connect)",
         )
         .context_field("host", host)

--- a/rama-tcp/src/client/service/connector.rs
+++ b/rama-tcp/src/client/service/connector.rs
@@ -1,6 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     extensions::ExtensionsRef,
     rt::Executor,
     telemetry::tracing,
@@ -171,10 +172,9 @@ where
             TransportProtocol::Tcp => (), // a-ok :)
             TransportProtocol::Udp => {
                 // sanity check, shouldn't happen, but in case someone makes a weird stack, it can
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "Tcp Connector Service cannot establish a UDP transport",
-                )
-                .into_box_error());
+                ));
             }
         }
 

--- a/rama-tcp/src/client/service/connector.rs
+++ b/rama-tcp/src/client/service/connector.rs
@@ -1,6 +1,6 @@
 use rama_core::{
     Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     extensions::ExtensionsRef,
     rt::Executor,
     telemetry::tracing,

--- a/rama-tcp/src/pool/mod.rs
+++ b/rama-tcp/src/pool/mod.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-use rama_core::error::{BoxError, ErrorExt, extra::OpaqueError};
+use rama_core::error::{BoxError, extra::OpaqueError};
 use rand::Rng as _;
 
 use crate::{TcpStream, client::TcpStreamConnector};

--- a/rama-tcp/src/pool/mod.rs
+++ b/rama-tcp/src/pool/mod.rs
@@ -1,9 +1,10 @@
+use rama_core::error::BoxErrorExt as _;
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},
 };
 
-use rama_core::error::{BoxError, extra::OpaqueError};
+use rama_core::error::BoxError;
 use rand::Rng as _;
 
 use crate::{TcpStream, client::TcpStreamConnector};
@@ -73,8 +74,7 @@ where
 
     async fn connect(&self, addr: std::net::SocketAddr) -> Result<TcpStream, Self::Error> {
         let connector = self.selector.next(&self.connectors).ok_or_else(|| {
-            OpaqueError::from_static_str("TcpStreamConnectorPool has empty connectors collection")
-                .into_box_error()
+            BoxError::from_static_str("TcpStreamConnectorPool has empty connectors collection")
         })?;
         connector.connect(addr).await
     }

--- a/rama-tcp/src/proxy/io_to_bridge_io.rs
+++ b/rama-tcp/src/proxy/io_to_bridge_io.rs
@@ -1,6 +1,7 @@
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _},
     extensions::ExtensionsRef,
     io::{BridgeIo, Io},
     rt::Executor,
@@ -192,9 +193,9 @@ where
                 if let Some(ProxyTarget(host_with_port)) = ingress.extensions().get_ref().cloned() {
                     host_with_port
                 } else {
-                    return Err(OpaqueError::from_static_str(
+                    return Err(BoxError::from_static_str(
                         "missing ProxyTarget in IoToProxyBridgeIo: proxy target assumed to exist in ingress extensions",
-                    ).into_box_error());
+                    ));
                 }
             }
         };

--- a/rama-tcp/src/proxy/io_to_bridge_io.rs
+++ b/rama-tcp/src/proxy/io_to_bridge_io.rs
@@ -1,6 +1,6 @@
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext as _, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, extra::OpaqueError},
     extensions::ExtensionsRef,
     io::{BridgeIo, Io},
     rt::Executor,

--- a/rama-tls-acme/src/client.rs
+++ b/rama-tls-acme/src/client.rs
@@ -1,4 +1,5 @@
 use crate::proto::common::{ProtectedHeaderAcme, ProtectedHeaderCrypto, ProtectedHeaderKey};
+use rama_core::error::BoxErrorExt as _;
 
 use super::proto::{
     client::FinalizePayload,
@@ -180,7 +181,7 @@ impl AcmeClient {
                 .context("create account request")?;
 
             if mode == CreateAccountMode::Create && response.status() == 200 {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "Tried creating new account, but account already exists",
                 )
                 .into());
@@ -562,7 +563,7 @@ impl<'a> Order<'a> {
                 server::ChallengeStatus::Valid => return Ok(()),
                 server::ChallengeStatus::Invalid => {
                     return Err(
-                        OpaqueError::from_static_str("challenge is detected as invalid").into(),
+                        BoxError::from_static_str("challenge is detected as invalid").into(),
                     );
                 }
             }
@@ -679,7 +680,7 @@ impl<'a> Order<'a> {
                 return Ok::<_, ClientError>(&self.inner);
             }
             if self.inner.status == server::OrderStatus::Invalid {
-                return Err(OpaqueError::from_static_str("Order is invalid state").into());
+                return Err(BoxError::from_static_str("Order is invalid state").into());
             }
 
             sleep(retry_wait.unwrap_or(self.account.client.default_retry_duration)).await;
@@ -759,7 +760,7 @@ async fn bytes_into_error(response_parts: Parts, bytes: Bytes) -> ClientError {
         problem.into()
     } else {
         match bytes.try_into_string().await {
-            Ok(body_str) => OpaqueError::from_static_str("unexpected problem response")
+            Ok(body_str) => BoxError::from_static_str("unexpected problem response")
                 .context_field("status", response_parts.status)
                 .context_str_field("body", body_str),
             Err(err) => err

--- a/rama-tls-boring/src/client/connector.rs
+++ b/rama-tls-boring/src/client/connector.rs
@@ -1,6 +1,6 @@
 use rama_boring_tokio::{HandshakeError, SslStream};
 use rama_core::conversion::RamaTryInto;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext as _, ErrorExt};
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::io::Io;
@@ -382,7 +382,7 @@ fn set_target_http_version(
         if let Some(target_version) = request_extensions.get_ref::<TargetHttpVersion>()
             && target_version.0 != neg_version
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "target http version not compatible with negotiated tls alpn version",
             )
             .context_debug_field("target_version", *target_version)
@@ -559,7 +559,7 @@ where
                             .context_debug_field("sni", server_name)
                             .context_debug_field("code", maybe_ssl_code)
                     } else {
-                        OpaqueError::from_static_str(
+                        BoxError::from_static_str(
                             "boring ssl connector (connect): without error info",
                         )
                         .context_debug_field("sni", server_name)
@@ -576,7 +576,7 @@ where
                 .protocol_version()
                 .rama_try_into()
                 .map_err(|v| {
-                    OpaqueError::from_static_str("boring ssl connector: cast min proto version")
+                    BoxError::from_static_str("boring ssl connector: cast min proto version")
                         .context_field("protocol_version", v)
                 })?;
             let application_layer_protocol = stream
@@ -602,10 +602,9 @@ where
             }
         }
         None => {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "boring ssl connector: failed to establish session...",
-            )
-            .into_box_error());
+            ));
         }
     };
 

--- a/rama-tls-boring/src/client/connector_data.rs
+++ b/rama-tls-boring/src/client/connector_data.rs
@@ -12,15 +12,13 @@ use rama_boring::{
         store::{X509Store, X509StoreBuilder},
     },
 };
+use rama_core::error::BoxErrorExt as _;
+use rama_core::telemetry::tracing::{debug, trace};
 use rama_core::{
     bytes::Bytes,
     conversion::RamaTryInto,
     error::{BoxError, ErrorContext, ErrorExt},
     extensions::Extension,
-};
-use rama_core::{
-    error::extra::OpaqueError,
-    telemetry::tracing::{debug, trace},
 };
 use rama_net::tls::{
     ApplicationProtocol, CertificateCompressionAlgorithm, ExtensionId, KeyLogIntent,
@@ -646,10 +644,9 @@ impl TlsConnectorDataBuilder {
                 .set_private_key(auth.private_key.as_ref())
                 .context("build (boring) ssl connector: set private key")?;
             if auth.cert_chain.is_empty() {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "build (boring) ssl connector: cert chain is empty",
-                )
-                .into_box_error());
+                ));
             }
             trace!("boring connector: client mTls: set cert chain root");
             cfg_builder
@@ -772,10 +769,9 @@ fn build_os_default_verify_store() -> Result<X509Store, BoxError> {
     trace!(added, failed, "boring connector: shared verify store built");
 
     if added == 0 {
-        return Err(OpaqueError::from_static_str(
+        return Err(BoxError::from_static_str(
             "no native trust anchors could be added to the boring x509 verify store",
-        )
-        .into_box_error());
+        ));
     }
 
     Ok(builder.build())
@@ -976,7 +972,7 @@ impl TlsConnectorDataBuilder {
                                 min_ver
                             );
                             min_ssl_version = Some((*min_ver).rama_try_into().map_err(|v| {
-                                OpaqueError::from_static_str(
+                                BoxError::from_static_str(
                                     "build boring ssl connector: cast min proto version",
                                 )
                                 .context_field("protocol_version", v)
@@ -1000,7 +996,7 @@ impl TlsConnectorDataBuilder {
                                 max_ver
                             );
                             max_ssl_version = Some((*max_ver).rama_try_into().map_err(|v| {
-                                OpaqueError::from_static_str(
+                                BoxError::from_static_str(
                                     "build boring ssl connector: cast max proto version",
                                 )
                                 .context_field("protocol_version", v)
@@ -1223,7 +1219,7 @@ impl TryFrom<ClientHello> for TlsConnectorDataBuilder {
         if !has_supported_versions_extension {
             let max_ssl_version =
                 legacy_protocol_version.rama_try_into().map_err(|v| {
-                    OpaqueError::from_static_str(
+                    BoxError::from_static_str(
                         "build boring ssl connector: cast max proto version from legacy ClientHello version",
                     )
                     .context_field("protocol_version", v)

--- a/rama-tls-boring/src/proxy/mitm/mod.rs
+++ b/rama-tls-boring/src/proxy/mitm/mod.rs
@@ -4,10 +4,11 @@ use rama_boring::{
     x509::X509,
 };
 use rama_boring_tokio::SslErrorStack;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Layer,
     conversion::RamaTryInto as _,
-    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt as _},
     extensions::{self, ExtensionsRef as _},
     io::{BridgeIo, Io},
     telemetry::tracing,
@@ -527,7 +528,7 @@ where
                         } else {
                             TlsMitmRelayError::handshake(
                                 TlsMitmRelayErrorDirection::Egress,
-                                OpaqueError::from_static_str(
+                                BoxError::from_static_str(
                                     "tls mitm relay: egress tls accept failed",
                                 )
                                 .context_debug_field("code", maybe_ssl_code)
@@ -590,7 +591,7 @@ where
                 let source_cert = egress_ssl_ref
                     .peer_certificate()
                     .ok_or_else(|| {
-                        OpaqueError::from_static_str(
+                        BoxError::from_static_str(
                             "tls mitm relay: egress tls stream has no peer cert",
                         )
                     })
@@ -677,7 +678,7 @@ where
                     let protocol_version = protocol_version
                         .rama_try_into()
                         .map_err(|v| {
-                            OpaqueError::from_static_str(
+                            BoxError::from_static_str(
                                 "boring ssl connector: cast min proto version",
                             )
                             .context_field("protocol_version", v)
@@ -783,7 +784,7 @@ where
                 } else {
                     TlsMitmRelayError::handshake(
                         TlsMitmRelayErrorDirection::Ingress,
-                        OpaqueError::from_static_str("tls mitm relay: ingress tls accept failed")
+                        BoxError::from_static_str("tls mitm relay: ingress tls accept failed")
                             .context_debug_field("code", maybe_ssl_code),
                         maybe_ssl_code,
                     )

--- a/rama-tls-boring/src/server/service.rs
+++ b/rama-tls-boring/src/server/service.rs
@@ -5,10 +5,11 @@ use crate::{
     types::SecureTransport,
 };
 use parking_lot::Mutex;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::{
     Service,
     conversion::RamaTryInto,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, ErrorExt},
     extensions::ExtensionsRef,
     io::Io,
     telemetry::tracing::{debug, trace},
@@ -100,10 +101,8 @@ where
         if let Some(min_ver) = tls_config.protocol_versions.iter().flatten().min() {
             acceptor_builder
                 .set_min_proto_version(Some((*min_ver).rama_try_into().map_err(|v| {
-                    OpaqueError::from_static_str(
-                        "build boring ssl acceptor: cast min proto version",
-                    )
-                    .context_field("protocol_version", v)
+                    BoxError::from_static_str("build boring ssl acceptor: cast min proto version")
+                        .context_field("protocol_version", v)
                 })?))
                 .context("build boring ssl acceptor: set min proto version")?;
         }
@@ -111,10 +110,8 @@ where
         if let Some(max_ver) = tls_config.protocol_versions.iter().flatten().max() {
             acceptor_builder
                 .set_max_proto_version(Some((*max_ver).rama_try_into().map_err(|v| {
-                    OpaqueError::from_static_str(
-                        "build boring ssl acceptor: cast max proto version",
-                    )
-                    .context_field("protocol_version", v)
+                    BoxError::from_static_str("build boring ssl acceptor: cast max proto version")
+                        .context_field("protocol_version", v)
                 })?))
                 .context("build boring ssl acceptor: set max proto version")?;
         }
@@ -184,7 +181,7 @@ where
                         .context_debug_field("domain", server_domain)
                         .context_debug_field("code", maybe_ssl_code)
                 } else {
-                    OpaqueError::from_static_str("boring ssl acceptor (accept): without error info")
+                    BoxError::from_static_str("boring ssl acceptor (accept): without error info")
                         .context_debug_field("domain", server_domain)
                         .context_debug_field("code", maybe_ssl_code)
                 }
@@ -197,10 +194,8 @@ where
                         .protocol_version()
                         .rama_try_into()
                         .map_err(|v| {
-                            OpaqueError::from_static_str(
-                                "boring ssl acceptor: cast min proto version",
-                            )
-                            .context_field("protocol_version", v)
+                            BoxError::from_static_str("boring ssl acceptor: cast min proto version")
+                                .context_field("protocol_version", v)
                         })?;
                 let application_layer_protocol = stream
                     .ssl()
@@ -239,10 +234,9 @@ where
                 }
             }
             None => {
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "boring ssl acceptor: failed to establish session",
-                )
-                .into_box_error());
+                ));
             }
         };
 

--- a/rama-tls-rustls/src/client/connector.rs
+++ b/rama-tls-rustls/src/client/connector.rs
@@ -3,11 +3,7 @@ use crate::client::config::RustlsTlsConnectorConfig;
 use crate::dep::tokio_rustls::TlsConnector as RustlsConnector;
 use crate::types::TlsTunnel;
 use rama_core::conversion::{RamaInto, RamaTryFrom};
-#[cfg(feature = "http")]
-use rama_core::error::extra::OpaqueError;
 use rama_core::error::{BoxError, ErrorContext};
-#[cfg(feature = "http")]
-use rama_core::extensions::Extensions;
 use rama_core::extensions::ExtensionsRef;
 use rama_core::io::Io;
 use rama_core::telemetry::tracing;
@@ -16,15 +12,17 @@ use rama_net::address::Host;
 use rama_net::client::{ConnectorService, EstablishedClientConnection};
 use rama_net::extensions::StreamTransformed;
 use rama_net::tls::ApplicationProtocol;
-#[cfg(feature = "http")]
-use rama_net::tls::client::TlsAlpn;
 use rama_net::tls::client::{NegotiatedTlsParameters, TlsClientConfig};
 use rama_net::transport::TryRefIntoTransportContext;
 
 #[cfg(feature = "http")]
 use ::{
-    rama_core::error::ErrorExt,
+    rama_core::{
+        error::{BoxErrorExt, ErrorExt},
+        extensions::Extensions,
+    },
     rama_http_types::{Version, conn::TargetHttpVersion},
+    rama_net::tls::client::TlsAlpn,
 };
 
 /// A [`Layer`] which wraps the given service with a [`TlsConnector`].
@@ -468,7 +466,7 @@ fn set_target_http_version(
         if let Some(target_version) = request_extensions.get_ref::<TargetHttpVersion>()
             && target_version.0 != neg_version
         {
-            return Err(OpaqueError::from_static_str(
+            return Err(BoxError::from_static_str(
                 "TargetHTTPVersion incompatible with tls ALPN negotiated version",
             )
             .context_debug_field("target_version", *target_version)

--- a/rama-tls-rustls/src/server/acceptor_data.rs
+++ b/rama-tls-rustls/src/server/acceptor_data.rs
@@ -204,12 +204,11 @@ impl TlsAcceptorDataBuilder {
 pub fn self_signed_server_auth(
     _: SelfSignedData,
 ) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>), BoxError> {
-    use rama_core::error::{ErrorExt, extra::OpaqueError};
+    use rama_core::error::BoxErrorExt;
 
-    Err(OpaqueError::from_static_str(
+    Err(BoxError::from_static_str(
         "enable aws-lc or ring feature to use fn self_signed_server_auth",
-    )
-    .into_box_error())
+    ))
 }
 
 #[cfg(any(feature = "aws-lc", feature = "ring"))]

--- a/rama-tls-rustls/src/type_conversion.rs
+++ b/rama-tls-rustls/src/type_conversion.rs
@@ -1,6 +1,6 @@
 use crate::RamaTlsRustlsCrateMarker;
 use rama_core::conversion::{RamaFrom, RamaTryFrom};
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorContext, ErrorExt};
 use rama_net::{
     address::{Domain, Host},
@@ -56,7 +56,7 @@ impl<'a> RamaTryFrom<rustls::pki_types::ServerName<'a>, RamaTlsRustlsCrateMarker
             }
             rustls::pki_types::ServerName::IpAddress(ip) => Ok(Self::from(IpAddr::from(ip))),
             _ => Err(
-                OpaqueError::from_static_str("unrecognised rustls (PKI) server name")
+                BoxError::from_static_str("unrecognised rustls (PKI) server name")
                     .with_context_debug_field("server_name", || value.to_owned()),
             ),
         }
@@ -93,7 +93,7 @@ impl<'a> RamaTryFrom<&rustls::pki_types::ServerName<'a>, RamaTlsRustlsCrateMarke
             }
             rustls::pki_types::ServerName::IpAddress(ip) => Ok(Self::from(IpAddr::from(*ip))),
             _ => Err(
-                OpaqueError::from_static_str("urecognised rustls (PKI) server name")
+                BoxError::from_static_str("urecognised rustls (PKI) server name")
                     .with_context_debug_field("value", || value.to_owned()),
             ),
         }

--- a/rama-ua/src/layer/emulate/service.rs
+++ b/rama-ua/src/layer/emulate/service.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext, ErrorExt, extra::OpaqueError},
+    error::{BoxError, ErrorContext, extra::OpaqueError},
     extensions::ExtensionsRef,
     telemetry::tracing,
 };

--- a/rama-ua/src/layer/emulate/service.rs
+++ b/rama-ua/src/layer/emulate/service.rs
@@ -1,8 +1,9 @@
+use rama_core::error::BoxErrorExt as _;
 use std::borrow::Cow;
 
 use rama_core::{
     Layer, Service,
-    error::{BoxError, ErrorContext, extra::OpaqueError},
+    error::{BoxError, ErrorContext},
     extensions::ExtensionsRef,
     telemetry::tracing,
 };
@@ -163,10 +164,9 @@ where
             return if self.optional {
                 Ok(self.inner.serve(req).await.into_box_error()?)
             } else {
-                Err(OpaqueError::from_static_str(
+                Err(BoxError::from_static_str(
                     "requirement not fulfilled: user agent profile could not be selected",
-                )
-                .into_box_error())
+                ))
             };
         };
 

--- a/rama-ua/src/profile/runtime_hints.rs
+++ b/rama-ua/src/profile/runtime_hints.rs
@@ -1,4 +1,4 @@
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorExt as _};
 use rama_core::extensions::Extension;
 use rama_http::headers::ClientHint;
@@ -128,7 +128,7 @@ impl FromStr for RequestInitiator {
                 "form" => Ok(Self::Form),
                 "xhr" => Ok(Self::Xhr),
                 "fetch" => Ok(Self::Fetch),
-                _ => Err(OpaqueError::from_static_str("invalid request initiator").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid request initiator").context_str_field("str", s)),
             }
         }
     }

--- a/rama-ua/src/ua/info.rs
+++ b/rama-ua/src/ua/info.rs
@@ -1,5 +1,5 @@
 use super::parse_http_user_agent_header;
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::{macros::match_ignore_ascii_case_str, str::arcstr::ArcStr};
@@ -242,7 +242,7 @@ impl FromStr for UserAgentKind {
                 "chromium" => Ok(Self::Chromium),
                 "firefox" => Ok(Self::Firefox),
                 "safari" => Ok(Self::Safari),
-                _ => Err(OpaqueError::from_static_str("invalid user agent kind").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid user agent kind").context_str_field("str", s)),
             }
         }
     }
@@ -294,7 +294,7 @@ impl FromStr for DeviceKind {
             match (s) {
                 "desktop" => Ok(Self::Desktop),
                 "mobile" => Ok(Self::Mobile),
-                _ => Err(OpaqueError::from_static_str("invalid device").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid device").context_str_field("str", s)),
             }
         }
     }
@@ -372,7 +372,7 @@ impl FromStr for PlatformKind {
                 "linux" => Ok(Self::Linux),
                 "android" => Ok(Self::Android),
                 "ios" => Ok(Self::IOS),
-                _ => Err(OpaqueError::from_static_str("invalid platform").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid platform").context_str_field("str", s)),
             }
         }
     }
@@ -466,7 +466,7 @@ impl FromStr for HttpAgent {
                 "Firefox" => Ok(Self::Firefox),
                 "Safari" => Ok(Self::Safari),
                 "preserve" => Ok(Self::Preserve),
-                _ => Err(OpaqueError::from_static_str("invalid http agent").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid http agent").context_str_field("str", s)),
             }
         }
     }
@@ -537,7 +537,7 @@ impl FromStr for TlsAgent {
                 "boring" | "boringssl" => Ok(Self::Boringssl),
                 "nss" => Ok(Self::Nss),
                 "preserve" => Ok(Self::Preserve),
-                _ => Err(OpaqueError::from_static_str("invalid tls agent").context_str_field("str", s)),
+                _ => Err(BoxError::from_static_str("invalid tls agent").context_str_field("str", s)),
             }
         }
     }

--- a/rama-udp/src/socket.rs
+++ b/rama-udp/src/socket.rs
@@ -1,7 +1,8 @@
+use rama_core::error::BoxErrorExt as _;
 use std::net::SocketAddr;
 
 use rama_core::{
-    error::{BoxError, ErrorContext as _, ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, ErrorContext as _, ErrorExt as _},
     extensions::Extensions,
     futures::StreamExt,
     telemetry::tracing,
@@ -152,13 +153,13 @@ where
 
     if resolved_count > 0 {
         Err(
-            OpaqueError::from_static_str("failed to (udp) connect to any resolved IP address")
+            BoxError::from_static_str("failed to (udp) connect to any resolved IP address")
                 .context_field("host", host)
                 .context_field("port", port)
                 .context_field("resolved_addr_count", resolved_count),
         )
     } else {
-        Err(OpaqueError::from_static_str(
+        Err(BoxError::from_static_str(
             "failed to resolve into any IP address (as part of udp connect)",
         )
         .context_field("host", host)

--- a/rama-ws/src/handshake/server.rs
+++ b/rama-ws/src/handshake/server.rs
@@ -849,11 +849,11 @@ impl Service<upgrade::Upgraded> for WebSocketEchoService {
         #[cfg(not(feature = "compression"))]
         let maybe_ws_config = {
             if let Some(Extension::PerMessageDeflate(_)) = io.extensions().get_ref() {
-                use rama_core::error::{ErrorExt, extra::OpaqueError};
+                use rama_core::error::BoxErrorExt;
 
-                return Err(OpaqueError::from_static_str(
+                return Err(BoxError::from_static_str(
                     "per-message-deflate is used but compression feature is disabled. Enable it if you wish to use this extension.",
-                ).into_box_error());
+                ));
             }
             None
         };

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -5,7 +5,7 @@
     reason = "vendored from upstream `tungstenite-rs`: arms gated on caller-validated WebSocket protocol state that the type system can't enforce"
 )]
 
-use rama_core::error::extra::OpaqueError;
+use rama_core::error::{BoxError, BoxErrorExt as _};
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing;
 use rama_core::telemetry::tracing::{debug, trace};
@@ -690,7 +690,7 @@ impl WebSocketContext {
                 self.state = WebSocketState::Terminated;
                 return Err(ProtocolError::Io(io::Error::new(
                     io::ErrorKind::ConnectionAborted,
-                    OpaqueError::from_static_str("Connection closed normally by me-the-server"),
+                    BoxError::from_static_str("Connection closed normally by me-the-server"),
                 )));
             }
 
@@ -850,7 +850,7 @@ impl WebSocketContext {
             self.state = WebSocketState::Terminated;
             Err(ProtocolError::Io(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                OpaqueError::from_static_str("Connection closed normally by me-the-server (EOF)"),
+                BoxError::from_static_str("Connection closed normally by me-the-server (EOF)"),
             )))
         } else {
             Ok(should_flush)
@@ -895,7 +895,7 @@ impl WebSocketContext {
                 WebSocketState::ClosedByPeer | WebSocketState::CloseAcknowledged => {
                     Err(ProtocolError::Io(io::Error::new(
                         io::ErrorKind::ConnectionAborted,
-                        OpaqueError::from_static_str("Connection closed normally by peer"),
+                        BoxError::from_static_str("Connection closed normally by peer"),
                     )))
                 }
                 WebSocketState::Active
@@ -1246,7 +1246,7 @@ impl WebSocketState {
         match self {
             Self::Terminated => Err(ProtocolError::Io(io::Error::new(
                 io::ErrorKind::NotConnected,
-                OpaqueError::from_static_str("Trying to work with closed connection"),
+                BoxError::from_static_str("Trying to work with closed connection"),
             ))),
             Self::Active | Self::CloseAcknowledged | Self::ClosedByPeer | Self::ClosedByUs => {
                 Ok(())

--- a/rama-ws/src/runtime/stream.rs
+++ b/rama-ws/src/runtime/stream.rs
@@ -1,10 +1,11 @@
+use rama_core::error::{BoxError, BoxErrorExt as _};
 use std::{
     io::{self, Read, Write},
     pin::Pin,
     task::{Context, Poll, ready},
 };
 
-use rama_core::{error::extra::OpaqueError, io::Io};
+use rama_core::io::Io;
 use rama_core::{
     extensions::{Extensions, ExtensionsRef},
     futures::{self, SinkExt, StreamExt},
@@ -147,7 +148,7 @@ impl<S: Io + Unpin> AsyncWebSocket<S> {
         self.next().await.ok_or_else(|| {
             ProtocolError::Io(io::Error::new(
                 io::ErrorKind::ConnectionAborted,
-                OpaqueError::from_static_str(
+                BoxError::from_static_str(
                     "Connection closed: no messages to be received any longer",
                 ),
             ))

--- a/src/cli/forward.rs
+++ b/src/cli/forward.rs
@@ -1,5 +1,5 @@
-use crate::error::BoxError;
-use rama_core::error::{ErrorExt as _, extra::OpaqueError};
+use crate::error::{BoxError, BoxErrorExt};
+use rama_core::error::ErrorExt as _;
 use rama_utils::macros::match_ignore_ascii_case_str;
 use std::str::FromStr;
 
@@ -55,7 +55,7 @@ impl<'a> TryFrom<&'a str> for ForwardKind {
                 "cf-connecting-ip" => Ok(Self::CFConnectingIp),
                 "true-client-ip" => Ok(Self::TrueClientIp),
                 "haproxy" => Ok(Self::HaProxy),
-                _ => Err(OpaqueError::from_static_str("unknown forward kind").context_str_field("str", value)),
+                _ => Err(BoxError::from_static_str("unknown forward kind").context_str_field("str", value)),
             }
         }
     }

--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -9,7 +9,7 @@ use crate::{
     Layer, Service,
     cli::ForwardKind,
     combinators::{Either, Either3, Either7},
-    error::{BoxError, ErrorContext},
+    error::{BoxError, BoxErrorExt, ErrorContext},
     extensions::ExtensionsRef,
     http::{
         Request, Response, Version,
@@ -46,7 +46,7 @@ use crate::{
     ua::{UserAgent, layer::classifier::UserAgentClassifierLayer, profile::UserAgentDatabase},
 };
 
-use rama_core::error::{ErrorExt as _, extra::OpaqueError};
+use rama_core::error::ErrorExt as _;
 use rama_http::layer::upgrade::UpgradeLayer;
 use serde::Serialize;
 use serde_json::json;
@@ -293,7 +293,7 @@ where
                 Either3::B(HttpServer::new_http1(exec).service(http_service))
             }
             Some(version) => {
-                return Err(OpaqueError::from_static_str("unsupported http version")
+                return Err(BoxError::from_static_str("unsupported http version")
                     .context_debug_field("version", version));
             }
             None => Either3::C({

--- a/src/cli/service/fs.rs
+++ b/src/cli/service/fs.rs
@@ -1,13 +1,11 @@
 //! [`Service`] that serves a file or directory using [`ServeFile`] or [`ServeDir`], or a placeholder page.
 
-use rama_core::error::{ErrorExt as _, extra::OpaqueError};
-
 use crate::{
     Layer, Service,
     cli::ForwardKind,
     combinators::Either,
     combinators::{Either3, Either7},
-    error::BoxError,
+    error::{BoxError, BoxErrorExt, ErrorExt},
     http::{
         Request, Response, Version,
         headers::exotic::XClacksOverhead,
@@ -293,7 +291,7 @@ where
                 Either3::B(HttpServer::new_http1(executor).service(http_service))
             }
             Some(version) => {
-                return Err(OpaqueError::from_static_str("unsupported http version")
+                return Err(BoxError::from_static_str("unsupported http version")
                     .context_debug_field("version", version));
             }
             None => Either3::C(HttpServer::auto(executor).service(http_service)),
@@ -341,10 +339,10 @@ where
                     .with_html_as_default_extension(self.html_as_default_extension),
             ),
             Some(path) => {
-                return Err(OpaqueError::from_static_str(
-                    "invalid path: no such file or directory",
-                )
-                .with_context_debug_field("path", || path.clone()));
+                return Err(
+                    BoxError::from_static_str("invalid path: no such file or directory")
+                        .with_context_debug_field("path", || path.clone()),
+                );
             }
         };
 

--- a/src/cli/service/ip.rs
+++ b/src/cli/service/ip.rs
@@ -12,8 +12,7 @@ use crate::{
     cli::ForwardKind,
     combinators::Either,
     combinators::Either7,
-    error::BoxError,
-    error::{ErrorExt as _, extra::OpaqueError},
+    error::{BoxError, BoxErrorExt, ErrorExt as _},
     extensions::ExtensionsRef,
     http::{
         Request, Response, StatusCode,
@@ -343,10 +342,10 @@ impl<M> IpServiceBuilder<M> {
             None => None,
             Some(ForwardKind::HaProxy) => Some(HaProxyLayer::default()),
             Some(other) => {
-                return Err(OpaqueError::from_static_str(
-                    "invalid forward kind for Transport mode",
-                )
-                .with_context_debug_field("kind", || other.clone()));
+                return Err(
+                    BoxError::from_static_str("invalid forward kind for Transport mode")
+                        .with_context_debug_field("kind", || other.clone()),
+                );
             }
         };
 

--- a/src/http/client/proxy_connector.rs
+++ b/src/http/client/proxy_connector.rs
@@ -1,6 +1,6 @@
 use crate::{
     Layer, Service,
-    error::BoxError,
+    error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt as _},
     extensions::{Extensions, ExtensionsRef},
     http::client::proxy::layer::{
         HttpProxyConnector, HttpProxyConnectorLayer, MaybeHttpProxiedConnection,
@@ -16,7 +16,6 @@ use crate::{
     telemetry::tracing,
 };
 use pin_project_lite::pin_project;
-use rama_core::error::{ErrorContext as _, ErrorExt as _, extra::OpaqueError};
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -94,10 +93,9 @@ where
         match proxy {
             None => {
                 if self.required {
-                    return Err(
-                        OpaqueError::from_static_str("proxy required but none is defined")
-                            .into_box_error(),
-                    );
+                    return Err(BoxError::from_static_str(
+                        "proxy required but none is defined",
+                    ));
                 }
                 tracing::trace!("no proxy detected in ctx, using inner connector");
                 let EstablishedClientConnection { input, conn } =
@@ -131,7 +129,7 @@ where
                     Ok(EstablishedClientConnection { input, conn })
                 } else {
                     Err(
-                        OpaqueError::from_static_str("received unsupport proxy protocol")
+                        BoxError::from_static_str("received unsupport proxy protocol")
                             .with_context_debug_field("protocol", || protocol.clone()),
                     )
                 }

--- a/src/http/tls.rs
+++ b/src/http/tls.rs
@@ -1,6 +1,6 @@
 //! tls features provided from the http layer.
 
-use crate::error::{BoxError, ErrorContext as _, ErrorExt as _};
+use crate::error::{BoxError, BoxErrorExt, ErrorContext as _, ErrorExt as _};
 use crate::http::{
     BodyExtractExt as _, Request, Response, StatusCode, Uri, client::EasyHttpWebClient,
     service::client::HttpClientExt as _,
@@ -201,7 +201,7 @@ impl CertIssuerHttpClient {
         let status = response.status();
         if status != StatusCode::OK {
             return Err(
-                OpaqueError::from_static_str("unexpected dinocert order response")
+                BoxError::from_static_str("unexpected dinocert order response")
                     .context_field("status", status),
             );
         }
@@ -247,7 +247,7 @@ impl DynamicCertIssuer for CertIssuerHttpClient {
                 if let Some(ref allow_list) = self.allow_list {
                     match allow_list.get(domain) {
                         None => {
-                            return Err(OpaqueError::from_static_str(
+                            return Err(BoxError::from_static_str(
                                 "sni found: unexpected unknown domain",
                             )
                             .with_context_field("domain", || domain.clone()));
@@ -264,7 +264,7 @@ impl DynamicCertIssuer for CertIssuerHttpClient {
                 }
             }
             None => {
-                return Err(OpaqueError::from_static_str("no SNI found").into_box_error());
+                return Err(BoxError::from_static_str("no SNI found"));
             }
         };
 


### PR DESCRIPTION
- shadow into_box_error with a dedicated one for opaqueError to prevent to double boxing
- BoxErrorExt trait which we can use to easily created special boxedErrors: for now only from_static_str, but could be extended