### PR TITLE
fix(tls-boring): correct MITM leaf cert mirroring

### DIFF
--- a/rama-net-apple-networkextension/tests/promote_ffi_e2e.rs
+++ b/rama-net-apple-networkextension/tests/promote_ffi_e2e.rs
@@ -423,7 +423,19 @@ fn run_round_trip(ack: (RamaPromoteConfirmStatus, Option<String>)) -> (ServiceRe
         len: single.len(),
     };
     let status = unsafe { rama_transparent_proxy_tcp_session_on_client_bytes(session, bytes_view) };
-    assert_eq!(status, RamaTcpDeliverStatus::Accepted);
+    // This races the promote resolution running on the service task: the
+    // service awaits `into_passthrough()` as soon as it starts, so on the
+    // failed-promote acks it can `cancel()` (clearing `client_tx`) before this
+    // byte lands, which legitimately yields `Closed`. The OK ack keeps the
+    // session open, so `Accepted` is the norm. Either is valid here; the
+    // meaningful propagation assertions live in each test below.
+    assert!(
+        matches!(
+            status,
+            RamaTcpDeliverStatus::Accepted | RamaTcpDeliverStatus::Closed
+        ),
+        "unexpected client-byte status: {status:?}"
+    );
 
     // Wait for the service's into_passthrough to resolve.
     let result = result_rx

--- a/rama-net/src/tls/server/config.rs
+++ b/rama-net/src/tls/server/config.rs
@@ -134,6 +134,27 @@ pub struct SelfSignedData {
     /// Subject Alternative Names (SAN) can be defined
     /// to create a cert which allows multiple hostnames or domains to be secured under one certificate.
     pub subject_alternative_names: Option<Vec<String>>,
+    /// Key algorithm used for the generated key pair (defaults to RSA-4096).
+    #[serde(default)]
+    pub key_kind: SelfSignedKeyKind,
+}
+
+/// Key algorithm to use when generating a self-signed key pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+pub enum SelfSignedKeyKind {
+    /// 2048-bit RSA.
+    Rsa2048,
+    /// 4096-bit RSA (default).
+    #[default]
+    Rsa4096,
+    /// ECDSA over NIST P-256 (secp256r1).
+    EcP256,
+    /// ECDSA over NIST P-384 (secp384r1).
+    EcP384,
+    /// ECDSA over NIST P-521 (secp521r1).
+    EcP521,
+    /// Ed25519 (EdDSA).
+    Ed25519,
 }
 
 #[derive(Debug, Clone)]

--- a/rama-net/src/tls/server/config.rs
+++ b/rama-net/src/tls/server/config.rs
@@ -134,20 +134,26 @@ pub struct SelfSignedData {
     /// Subject Alternative Names (SAN) can be defined
     /// to create a cert which allows multiple hostnames or domains to be secured under one certificate.
     pub subject_alternative_names: Option<Vec<String>>,
-    /// Key algorithm used for the generated key pair (defaults to RSA-4096).
+    /// Key algorithm used for the generated key pair (defaults to EC P-256).
     #[serde(default)]
     pub key_kind: SelfSignedKeyKind,
 }
 
 /// Key algorithm to use when generating a self-signed key pair.
+///
+/// The default is [`SelfSignedKeyKind::EcP256`]: it is universally supported by
+/// TLS clients, generates and signs far faster than any RSA variant, and offers
+/// stronger security (128-bit) than RSA-2048 with much smaller certificates.
+/// Pick [`SelfSignedKeyKind::EcP384`] for a higher security margin (e.g. a
+/// long-lived CA) while staying faster than RSA-4096.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub enum SelfSignedKeyKind {
     /// 2048-bit RSA.
     Rsa2048,
-    /// 4096-bit RSA (default).
-    #[default]
+    /// 4096-bit RSA.
     Rsa4096,
-    /// ECDSA over NIST P-256 (secp256r1).
+    /// ECDSA over NIST P-256 (secp256r1). Default.
+    #[default]
     EcP256,
     /// ECDSA over NIST P-384 (secp384r1).
     EcP384,

--- a/rama-net/src/tls/server/mod.rs
+++ b/rama-net/src/tls/server/mod.rs
@@ -3,8 +3,9 @@
 mod config;
 #[doc(inline)]
 pub use config::{
-    CacheKind, ClientVerifyMode, DynamicCertIssuer, DynamicIssuer, SelfSignedData, ServerAuth,
-    ServerAuthData, ServerCertIssuerData, ServerCertIssuerKind, ServerConfig,
+    CacheKind, ClientVerifyMode, DynamicCertIssuer, DynamicIssuer, SelfSignedData,
+    SelfSignedKeyKind, ServerAuth, ServerAuthData, ServerCertIssuerData, ServerCertIssuerKind,
+    ServerConfig,
 };
 
 mod peek;

--- a/rama-tls-boring/src/server/acceptor_data.rs
+++ b/rama-tls-boring/src/server/acceptor_data.rs
@@ -449,7 +449,6 @@ fn issue_cert_for_ca(
                     .unwrap_or_else(|| "Anonymous".to_owned()),
             ),
             common_name: domain.cloned(),
-            subject_alternative_names: None,
             ..Default::default()
         },
         ca_cert,

--- a/rama-tls-boring/src/server/acceptor_data.rs
+++ b/rama-tls-boring/src/server/acceptor_data.rs
@@ -450,6 +450,7 @@ fn issue_cert_for_ca(
             ),
             common_name: domain.cloned(),
             subject_alternative_names: None,
+            ..Default::default()
         },
         ca_cert,
         ca_key,

--- a/rama-tls-boring/src/server/utils/certs.rs
+++ b/rama-tls-boring/src/server/utils/certs.rs
@@ -5,7 +5,7 @@ use crate::core::{
     ec::{EcGroup, EcKey},
     hash::MessageDigest,
     nid::Nid,
-    pkey::{Id, PKey, Private},
+    pkey::{Id, PKey, PKeyRef, Private},
     rand::rand_bytes,
     rsa::Rsa,
     x509::{
@@ -41,6 +41,24 @@ fn aki_from_ca_pubkey_keyid(ca_cert: &X509Ref) -> Result<X509Extension, BoxError
         Asn1Object::from_str("2.5.29.35").context("construct AuthorityKeyIdentifier OID object")?;
     X509Extension::from_der_payload(aki_oid.as_ref(), false, &payload)
         .context("build AuthorityKeyIdentifier extension from raw DER payload")
+}
+
+/// Message digest to use when signing a certificate with `key`.
+///
+/// EdDSA (Ed25519 / Ed448) is a "pure" signature scheme: `X509_sign` must be
+/// invoked with a NULL digest because the algorithm signs the message directly
+/// instead of a prehash. Passing a real digest makes BoringSSL's
+/// `EVP_DigestSignInit` fail. Every other supported CA key type (RSA, RSA-PSS,
+/// EC, DSA) signs over a SHA-256 digest, matching prior behaviour.
+fn signing_digest_for(key: &PKeyRef<Private>) -> MessageDigest {
+    match key.id() {
+        Id::ED25519 | Id::ED448 => {
+            // SAFETY: a null `EVP_MD` is precisely what `X509_sign` expects for
+            // EdDSA keys; BoringSSL reads it as "no prehash".
+            unsafe { MessageDigest::from_ptr(std::ptr::null()) }
+        }
+        _ => MessageDigest::sha256(),
+    }
 }
 
 /// OID of the RFC 7633 TLS Feature extension (OCSP "must-staple").
@@ -224,7 +242,7 @@ pub fn self_signed_server_auth_gen_cert(
     }
 
     cert_builder
-        .sign(ca_privkey, MessageDigest::sha256())
+        .sign(ca_privkey, signing_digest_for(ca_privkey))
         .context("x509 cert builder: sign cert")?;
 
     let cert = cert_builder.build();
@@ -390,7 +408,7 @@ pub fn self_signed_server_auth_mirror_cert(
     }
 
     cert_builder
-        .sign(ca_privkey, MessageDigest::sha256())
+        .sign(ca_privkey, signing_digest_for(ca_privkey))
         .context("x509 cert builder: sign mirrored cert")?;
 
     Ok((cert_builder.build(), privkey))
@@ -492,7 +510,7 @@ pub fn self_signed_server_auth_gen_ca(
         .context("x509 cert builder: add subject key id x509 extension")?;
 
     ca_cert_builder
-        .sign(&privkey, MessageDigest::sha256())
+        .sign(&privkey, signing_digest_for(&privkey))
         .context("x509 cert builder: sign cert")?;
 
     let cert = ca_cert_builder.build();

--- a/rama-tls-boring/src/server/utils/certs.rs
+++ b/rama-tls-boring/src/server/utils/certs.rs
@@ -1,7 +1,6 @@
 use crate::core::{
     asn1::{Asn1Object, Asn1ObjectRef, Asn1Time},
     bn::{BigNum, MsbOption},
-    dsa::Dsa,
     ec::{EcGroup, EcKey},
     hash::MessageDigest,
     nid::Nid,
@@ -16,7 +15,10 @@ use crate::core::{
 use rama_boring::x509::extension::{AuthorityKeyIdentifier, SubjectAlternativeName};
 use rama_core::error::{BoxError, ErrorContext};
 use rama_core::telemetry::tracing;
-use rama_net::{address::Domain, tls::server::SelfSignedData};
+use rama_net::{
+    address::Domain,
+    tls::server::{SelfSignedData, SelfSignedKeyKind},
+};
 
 /// Build an `AuthorityKeyIdentifier` extension whose `keyIdentifier` is derived from
 /// the CA's public key per RFC 5280 §4.2.1.2 method (1): SHA-1 of the SubjectPublicKey
@@ -45,11 +47,14 @@ fn aki_from_ca_pubkey_keyid(ca_cert: &X509Ref) -> Result<X509Extension, BoxError
 
 /// Message digest to use when signing a certificate with `key`.
 ///
-/// EdDSA (Ed25519 / Ed448) is a "pure" signature scheme: `X509_sign` must be
-/// invoked with a NULL digest because the algorithm signs the message directly
-/// instead of a prehash. Passing a real digest makes BoringSSL's
-/// `EVP_DigestSignInit` fail. Every other supported CA key type (RSA, RSA-PSS,
-/// EC, DSA) signs over a SHA-256 digest, matching prior behaviour.
+/// - EdDSA (Ed25519 / Ed448) is a "pure" signature scheme: `X509_sign` must be
+///   invoked with a NULL digest because the algorithm signs the message
+///   directly instead of a prehash. Passing a real digest makes BoringSSL's
+///   `EVP_DigestSignInit` fail.
+/// - ECDSA pairs the digest to the curve strength (P-384 → SHA-384,
+///   P-521 → SHA-512), per common practice / CA-Browser-Forum guidance; an
+///   unnamed (explicit-parameter) curve falls back to SHA-256.
+/// - Everything else (RSA, RSA-PSS, DSA) signs over SHA-256, as before.
 fn signing_digest_for(key: &PKeyRef<Private>) -> MessageDigest {
     match key.id() {
         Id::ED25519 | Id::ED448 => {
@@ -57,7 +62,42 @@ fn signing_digest_for(key: &PKeyRef<Private>) -> MessageDigest {
             // EdDSA keys; BoringSSL reads it as "no prehash".
             unsafe { MessageDigest::from_ptr(std::ptr::null()) }
         }
+        Id::EC => match key.ec_key().ok().and_then(|ec| ec.group().curve_name()) {
+            Some(Nid::SECP521R1) => MessageDigest::sha512(),
+            Some(Nid::SECP384R1) => MessageDigest::sha384(),
+            _ => MessageDigest::sha256(),
+        },
         _ => MessageDigest::sha256(),
+    }
+}
+
+/// Generate a fresh private key of the requested [`SelfSignedKeyKind`].
+fn generate_self_signed_key(kind: SelfSignedKeyKind) -> Result<PKey<Private>, BoxError> {
+    fn ec(curve: Nid) -> Result<PKey<Private>, BoxError> {
+        let group =
+            EcGroup::from_curve_name(curve).context("create EC group for self-signed key")?;
+        let ec_key = EcKey::generate(&group).context("generate EC key for self-signed key")?;
+        PKey::from_ec_key(ec_key).context("create private key from generated EC key")
+    }
+
+    match kind {
+        SelfSignedKeyKind::Rsa2048 => {
+            let rsa = Rsa::generate(2048).context("generate 2048-bit RSA key")?;
+            PKey::from_rsa(rsa).context("create private key from 2048-bit RSA key")
+        }
+        SelfSignedKeyKind::Rsa4096 => {
+            let rsa = Rsa::generate(4096).context("generate 4096-bit RSA key")?;
+            PKey::from_rsa(rsa).context("create private key from 4096-bit RSA key")
+        }
+        SelfSignedKeyKind::EcP256 => ec(Nid::X9_62_PRIME256V1),
+        SelfSignedKeyKind::EcP384 => ec(Nid::SECP384R1),
+        SelfSignedKeyKind::EcP521 => ec(Nid::SECP521R1),
+        SelfSignedKeyKind::Ed25519 => {
+            let mut seed = [0_u8; 32];
+            rand_bytes(&mut seed).context("generate Ed25519 private key bytes")?;
+            PKey::from_ed25519_private_key(&seed)
+                .context("create private key from Ed25519 key bytes")
+        }
     }
 }
 
@@ -123,8 +163,7 @@ pub fn self_signed_server_auth_gen_cert(
     ca_cert: &X509,
     ca_privkey: &PKey<Private>,
 ) -> Result<(X509, PKey<Private>), BoxError> {
-    let rsa = Rsa::generate(4096).context("generate 4096 RSA key")?;
-    let privkey = PKey::from_rsa(rsa).context("create private key from 4096 RSA key")?;
+    let privkey = generate_self_signed_key(data.key_kind)?;
 
     let common_name = data
         .common_name
@@ -263,6 +302,10 @@ pub fn self_signed_server_auth_mirror_cert(
         .public_key()
         .context("x509 cert builder: read source public key")?;
     let privkey = match source_pubkey.id() {
+        // RSA-PSS leaves are mirrored as plain RSA (`rsaEncryption`) keys: the
+        // leaf still works for the TLS handshake, but its SPKI algorithm OID is
+        // not preserved, as rama-boring exposes no safe `id-RSASSA-PSS` key
+        // constructor. This is a fidelity-only gap, not a functional one.
         Id::RSA | Id::RSAPSS => {
             let bits = source_pubkey.bits().max(2048);
             let rsa =
@@ -274,23 +317,13 @@ pub fn self_signed_server_auth_mirror_cert(
             let source_ec_key = source_pubkey
                 .ec_key()
                 .context("x509 cert builder: read source EC key")?;
-            let source_curve = source_ec_key
-                .group()
-                .curve_name()
-                .context("x509 cert builder: source EC key has unnamed curve")?;
-            let group = EcGroup::from_curve_name(source_curve)
-                .context("x509 cert builder: create mirrored EC group")?;
-            let ec_key =
-                EcKey::generate(&group).context("x509 cert builder: generate mirrored EC key")?;
+            // Generate on the source key's own group rather than going through
+            // `curve_name()`, so explicit-parameter curves are mirrored too
+            // instead of hard-failing the whole interception.
+            let ec_key = EcKey::generate(source_ec_key.group())
+                .context("x509 cert builder: generate mirrored EC key")?;
             PKey::from_ec_key(ec_key)
                 .context("x509 cert builder: create private key from EC key")?
-        }
-        Id::DSA => {
-            let bits = source_pubkey.bits().max(2048);
-            let dsa =
-                Dsa::generate(bits).with_context(|| format!("generate {bits}-bit DSA key"))?;
-            PKey::from_dsa(dsa)
-                .with_context(|| format!("create private key from {bits}-bit DSA key"))?
         }
         Id::ED25519 => {
             let mut key = [0_u8; 32];
@@ -298,16 +331,15 @@ pub fn self_signed_server_auth_mirror_cert(
             PKey::from_ed25519_private_key(&key)
                 .context("create private key from Ed25519 key bytes")?
         }
-        Id::X25519 => {
-            let mut key = [0_u8; 32];
-            rand_bytes(&mut key).context("generate X25519 private key bytes")?;
-            PKey::from_x25519_private_key(&key)
-                .context("create private key from X25519 key bytes")?
-        }
+        // Everything else — DSA, X25519/X448, Ed448, or anything exotic — cannot
+        // serve as a TLS server-auth leaf key (key-agreement-only, disabled in
+        // modern TLS, or not constructible here). Mirroring such a key would
+        // yield a leaf the MITM server can never complete a handshake with, so
+        // fall back to a universally functional RSA-2048 key instead.
         other => {
             tracing::debug!(
                 key_type = ?other,
-                "source certificate key type not mirror-supported yet; falling back to RSA-2048"
+                "source cert key type cannot serve as a TLS leaf key; using RSA-2048 for the mirrored leaf"
             );
             let rsa = Rsa::generate(2048).context("generate fallback 2048 RSA key")?;
             PKey::from_rsa(rsa).context("create private key from fallback 2048 RSA key")?
@@ -420,8 +452,7 @@ pub fn self_signed_server_auth_mirror_cert(
 pub fn self_signed_server_auth_gen_ca(
     data: &SelfSignedData,
 ) -> Result<(X509, PKey<Private>), BoxError> {
-    let rsa = Rsa::generate(4096).context("generate 4096 RSA key")?;
-    let privkey = PKey::from_rsa(rsa).context("create private key from 4096 RSA key")?;
+    let privkey = generate_self_signed_key(data.key_kind)?;
 
     let mut x509_name = X509NameBuilder::new().context("create x509 name builder")?;
     x509_name

--- a/rama-tls-boring/src/server/utils/certs.rs
+++ b/rama-tls-boring/src/server/utils/certs.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    asn1::{Asn1Object, Asn1Time},
+    asn1::{Asn1Object, Asn1ObjectRef, Asn1Time},
     bn::{BigNum, MsbOption},
     dsa::Dsa,
     ec::{EcGroup, EcKey},
@@ -41,6 +41,59 @@ fn aki_from_ca_pubkey_keyid(ca_cert: &X509Ref) -> Result<X509Extension, BoxError
         Asn1Object::from_str("2.5.29.35").context("construct AuthorityKeyIdentifier OID object")?;
     X509Extension::from_der_payload(aki_oid.as_ref(), false, &payload)
         .context("build AuthorityKeyIdentifier extension from raw DER payload")
+}
+
+/// OID of the RFC 7633 TLS Feature extension (OCSP "must-staple").
+const OID_TLS_FEATURE: &str = "1.3.6.1.5.5.7.1.24";
+/// OID of the RFC 6962 embedded Signed Certificate Timestamp (SCT) list.
+const OID_SCT_LIST: &str = "1.3.6.1.4.1.11129.2.4.2";
+
+/// Canonical OID renderings of the extensions we strip by OID rather than by
+/// [`Nid`] (rama-boring exposes no stable constant for these). Resolving them
+/// once keeps the per-extension membership check cheap.
+fn mirror_strip_oid_texts() -> Vec<String> {
+    [OID_TLS_FEATURE, OID_SCT_LIST]
+        .into_iter()
+        .filter_map(|oid| Asn1Object::from_str(oid).ok().map(|obj| obj.to_string()))
+        .collect()
+}
+
+/// Returns `true` when a source-certificate extension must NOT be mirrored onto
+/// a leaf that we re-sign with our own MITM CA.
+///
+/// Two classes are stripped (see [`self_signed_server_auth_mirror_cert`]):
+///
+/// 1. Revocation / authority-info pointers bound to the *real* issuer — CRL
+///    Distribution Points, Authority Information Access (OCSP responder +
+///    caIssuers) and Freshest CRL (delta CRL). A leaf re-signed by our CA can
+///    never be covered by those responders, so a client that follows them
+///    (notably Windows schannel via `lsass.exe`) hits an issuer mismatch and
+///    aborts the handshake with `CRYPT_E_REVOCATION_OFFLINE`. Both are OPTIONAL
+///    and non-critical (RFC 5280 §4.2): with no pointer present, conformant
+///    clients simply skip the revocation check, which is the correct behaviour
+///    for a locally-trusted MITM CA.
+///
+/// 2. Assertions we cannot honour after re-signing — the RFC 7633 TLS Feature
+///    extension ("must-staple") would force the client to *require* a stapled
+///    OCSP response we never produce (handshake abort), and RFC 6962 embedded
+///    SCTs are signed over the original `TBSCertificate` and become invalid the
+///    instant we re-sign. These have no stable `Nid` constant, so they are
+///    matched by canonical OID text, which is robust whether or not BoringSSL
+///    knows the OID by name.
+fn should_strip_mirrored_extension(
+    ext_nid: Nid,
+    ext_obj: &Asn1ObjectRef,
+    strip_oid_texts: &[String],
+) -> bool {
+    if ext_nid == Nid::CRL_DISTRIBUTION_POINTS
+        || ext_nid == Nid::INFO_ACCESS
+        || ext_nid == Nid::FRESHEST_CRL
+    {
+        return true;
+    }
+
+    let ext_text = ext_obj.to_string();
+    strip_oid_texts.contains(&ext_text)
 }
 
 /// Generate a server cert for the [`SelfSignedData`] using the given CA Cert + Key.
@@ -279,12 +332,23 @@ pub fn self_signed_server_auth_mirror_cert(
     let source_had_ski = source_cert.subject_key_id().is_some();
     let source_had_aki = source_cert.authority_key_id().is_some();
 
+    let strip_oid_texts = mirror_strip_oid_texts();
+
     for source_ext in source_cert.extensions() {
         let ext_nid = source_ext.object().nid();
         if ext_nid == Nid::SUBJECT_KEY_IDENTIFIER || ext_nid == Nid::AUTHORITY_KEY_IDENTIFIER {
             tracing::trace!(
                 ?ext_nid,
                 "skip source key identifier extension (will regenerate if applicable)"
+            );
+            continue;
+        }
+
+        if should_strip_mirrored_extension(ext_nid, source_ext.object(), &strip_oid_texts) {
+            tracing::trace!(
+                ?ext_nid,
+                "skip source extension invalid for a re-signed MITM leaf \
+                 (issuer-bound revocation/authority pointer, or assertion we cannot honour)"
             );
             continue;
         }

--- a/rama-tls-boring/src/server/utils/certs_tests.rs
+++ b/rama-tls-boring/src/server/utils/certs_tests.rs
@@ -798,3 +798,143 @@ fn gen_and_mirror_with_ed25519_ca_produce_valid_signatures() {
         "mirrored leaf signed by Ed25519 CA must verify"
     );
 }
+
+#[test]
+fn signing_digest_pairs_to_ec_curve() {
+    let ec = |nid| {
+        let group = EcGroup::from_curve_name(nid).expect("ec group");
+        PKey::from_ec_key(EcKey::generate(&group).expect("ec key")).expect("ec pkey")
+    };
+
+    assert_eq!(
+        signing_digest_for(&ec(Nid::X9_62_PRIME256V1)).as_ptr(),
+        MessageDigest::sha256().as_ptr(),
+        "P-256 must sign over SHA-256"
+    );
+    assert_eq!(
+        signing_digest_for(&ec(Nid::SECP384R1)).as_ptr(),
+        MessageDigest::sha384().as_ptr(),
+        "P-384 must sign over SHA-384"
+    );
+    assert_eq!(
+        signing_digest_for(&ec(Nid::SECP521R1)).as_ptr(),
+        MessageDigest::sha512().as_ptr(),
+        "P-521 must sign over SHA-512"
+    );
+}
+
+#[test]
+fn gen_ca_honors_key_kind() {
+    for (kind, want) in [
+        (SelfSignedKeyKind::Rsa2048, Id::RSA),
+        (SelfSignedKeyKind::EcP256, Id::EC),
+        (SelfSignedKeyKind::EcP384, Id::EC),
+        (SelfSignedKeyKind::EcP521, Id::EC),
+        (SelfSignedKeyKind::Ed25519, Id::ED25519),
+    ] {
+        let data = SelfSignedData {
+            key_kind: kind,
+            ..sample_data("ca.rama.test")
+        };
+        let (ca_cert, ca_key) = self_signed_server_auth_gen_ca(&data).expect("gen ca");
+        assert_eq!(ca_key.id(), want, "kind={kind:?}");
+        assert!(
+            ca_cert.verify(&ca_key).expect("verify self-signed ca"),
+            "self-signed CA of kind={kind:?} must verify"
+        );
+    }
+}
+
+#[test]
+fn gen_cert_with_ec_ca_and_ec_leaf_verifies() {
+    let ca_data = SelfSignedData {
+        key_kind: SelfSignedKeyKind::EcP384,
+        ..sample_data("ec-ca.rama.test")
+    };
+    let (ca_cert, ca_key) = self_signed_server_auth_gen_ca(&ca_data).expect("ec ca");
+    assert_eq!(ca_key.id(), Id::EC);
+
+    let leaf_data = SelfSignedData {
+        key_kind: SelfSignedKeyKind::EcP256,
+        ..sample_data("leaf.rama.test")
+    };
+    let (leaf, leaf_key) =
+        self_signed_server_auth_gen_cert(&leaf_data, &ca_cert, &ca_key).expect("ec leaf");
+    assert_eq!(leaf_key.id(), Id::EC);
+    assert_eq!(ca_cert.issued(&leaf), Ok(()));
+    assert!(
+        leaf.verify(&ca_key).expect("verify leaf"),
+        "leaf signed by P-384 CA must verify"
+    );
+}
+
+/// Build a source cert whose *subject* public key is `subject_pub`, signed by a
+/// separate issuer. Needed for source keys (e.g. X25519) that cannot self-sign.
+fn build_source_cert_with_pubkey(
+    subject_pub: &PKey<Private>,
+    issuer_cert: &X509,
+    issuer_key: &PKey<Private>,
+    common_name: &str,
+) -> Result<X509, BoxError> {
+    let mut name = X509NameBuilder::new().context("name builder")?;
+    name.append_entry_by_nid(Nid::COMMONNAME, common_name)
+        .context("cn")?;
+    let name = name.build();
+
+    let mut b = X509::builder().context("builder")?;
+    b.set_version(2).context("version")?;
+    let serial = {
+        let mut s = BigNum::new().context("serial bn")?;
+        s.rand(159, MsbOption::MAYBE_ZERO, false)
+            .context("serial rand")?;
+        s.to_asn1_integer().context("serial asn1")?
+    };
+    b.set_serial_number(&serial).context("serial")?;
+    b.set_subject_name(&name).context("subject")?;
+    b.set_issuer_name(issuer_cert.subject_name())
+        .context("issuer")?;
+    b.set_pubkey(subject_pub).context("pubkey")?;
+    let nb = Asn1Time::days_from_now(0).context("nb")?;
+    b.set_not_before(&nb).context("set nb")?;
+    let na = Asn1Time::days_from_now(30).context("na")?;
+    b.set_not_after(&na).context("set na")?;
+    b.sign(issuer_key, signing_digest_for(issuer_key))
+        .context("sign source")?;
+    Ok(b.build())
+}
+
+#[test]
+fn mirror_falls_back_to_rsa_for_non_signing_source_key() {
+    let (ca_cert, ca_key) =
+        self_signed_server_auth_gen_ca(&sample_data("ca.rama.test")).expect("ca");
+
+    // Source cert whose SUBJECT key is X25519 — a key-agreement-only key that
+    // cannot serve as a TLS leaf signing key. Signed by a separate RSA issuer.
+    let mut seed = [0_u8; 32];
+    crate::core::rand::rand_bytes(&mut seed).expect("seed");
+    let x25519 = PKey::from_x25519_private_key(&seed).expect("x25519 key");
+    let (issuer_cert, issuer_key) =
+        self_signed_server_auth_gen_ca(&sample_data("issuer.rama.test")).expect("issuer");
+    let source = build_source_cert_with_pubkey(
+        &x25519,
+        &issuer_cert,
+        &issuer_key,
+        "x25519-source.rama.test",
+    )
+    .expect("source cert");
+    assert_eq!(source.public_key().expect("source pubkey").id(), Id::X25519);
+
+    let (mirrored, mirrored_key) =
+        self_signed_server_auth_mirror_cert(source.as_ref(), &ca_cert, &ca_key).expect("mirror");
+
+    assert_eq!(
+        mirrored_key.id(),
+        Id::RSA,
+        "a non-signing source key must fall back to a functional RSA leaf key"
+    );
+    assert_eq!(ca_cert.issued(&mirrored), Ok(()));
+    assert!(
+        mirrored.verify(&ca_key).expect("verify mirrored"),
+        "fallback mirrored leaf must verify against the CA"
+    );
+}

--- a/rama-tls-boring/src/server/utils/certs_tests.rs
+++ b/rama-tls-boring/src/server/utils/certs_tests.rs
@@ -686,3 +686,115 @@ fn mirror_uses_ec_key_for_ec_source() {
 
     assert_eq!(mirrored_key.id(), Id::EC);
 }
+
+/// Build a self-signed Ed25519 CA, signed via the NULL-digest EdDSA path.
+fn build_ed25519_ca(common_name: &str) -> Result<(X509, PKey<Private>), BoxError> {
+    let mut seed = [0_u8; 32];
+    crate::core::rand::rand_bytes(&mut seed).context("ed25519 ca key bytes")?;
+    let privkey = PKey::from_ed25519_private_key(&seed).context("ed25519 ca pkey")?;
+
+    let mut x509_name = X509NameBuilder::new().context("ca name builder")?;
+    x509_name
+        .append_entry_by_nid(Nid::COMMONNAME, common_name)
+        .context("ca cn")?;
+    let x509_name = x509_name.build();
+
+    let mut b = X509::builder().context("ca builder")?;
+    b.set_version(2).context("ca version")?;
+    let serial = {
+        let mut serial = BigNum::new().context("ca serial bn")?;
+        serial
+            .rand(159, MsbOption::MAYBE_ZERO, false)
+            .context("ca serial rand")?;
+        serial.to_asn1_integer().context("ca serial asn1")?
+    };
+    b.set_serial_number(&serial).context("ca serial")?;
+    b.set_subject_name(&x509_name).context("ca subject")?;
+    b.set_issuer_name(&x509_name).context("ca issuer")?;
+    b.set_pubkey(&privkey).context("ca pubkey")?;
+    let not_before = Asn1Time::days_from_now(0).context("ca nb")?;
+    b.set_not_before(&not_before).context("ca set nb")?;
+    let not_after = Asn1Time::days_from_now(365).context("ca na")?;
+    b.set_not_after(&not_after).context("ca set na")?;
+    b.append_extension(
+        BasicConstraints::new()
+            .critical()
+            .ca()
+            .build()
+            .context("ca bc")?
+            .as_ref(),
+    )
+    .context("append ca bc")?;
+    b.append_extension(
+        KeyUsage::new()
+            .critical()
+            .key_cert_sign()
+            .crl_sign()
+            .build()
+            .context("ca ku")?
+            .as_ref(),
+    )
+    .context("append ca ku")?;
+    let ski = SubjectKeyIdentifier::new()
+        .build(&b.x509v3_context(None, None))
+        .context("ca ski")?;
+    b.append_extension(ski.as_ref()).context("append ca ski")?;
+
+    b.sign(&privkey, signing_digest_for(&privkey))
+        .context("sign ed25519 ca")?;
+
+    Ok((b.build(), privkey))
+}
+
+#[test]
+fn signing_digest_is_null_for_eddsa_and_sha256_otherwise() {
+    let mut seed = [0_u8; 32];
+    crate::core::rand::rand_bytes(&mut seed).expect("seed");
+    let ed = PKey::from_ed25519_private_key(&seed).expect("ed25519 key");
+    assert!(
+        signing_digest_for(&ed).as_ptr().is_null(),
+        "EdDSA must sign with a NULL digest"
+    );
+
+    let rsa = PKey::from_rsa(Rsa::generate(2048).expect("rsa")).expect("rsa pkey");
+    assert_eq!(
+        signing_digest_for(&rsa).as_ptr(),
+        MessageDigest::sha256().as_ptr(),
+        "non-EdDSA keys sign over SHA-256"
+    );
+}
+
+#[test]
+fn gen_and_mirror_with_ed25519_ca_produce_valid_signatures() {
+    let (ca_cert, ca_key) = build_ed25519_ca("ed25519-ca.rama.test").expect("ed25519 ca");
+    assert_eq!(ca_key.id(), Id::ED25519);
+    assert!(
+        ca_cert
+            .verify(&ca_key)
+            .expect("verify self-signed ed25519 ca"),
+        "self-signed Ed25519 CA signature must verify"
+    );
+
+    // gen_cert signs a fresh leaf with the Ed25519 CA
+    let leaf_data = sample_data("leaf.rama.test");
+    let (leaf, _) = self_signed_server_auth_gen_cert(&leaf_data, &ca_cert, &ca_key)
+        .expect("gen leaf with ed25519 ca");
+    assert_eq!(ca_cert.issued(&leaf), Ok(()));
+    assert!(
+        leaf.verify(&ca_key).expect("verify leaf sig"),
+        "leaf signed by Ed25519 CA must verify"
+    );
+
+    // the mirror path must likewise sign correctly with the Ed25519 CA
+    let source_pkey =
+        PKey::from_rsa(Rsa::generate(2048).expect("source rsa")).expect("source pkey");
+    let source =
+        build_self_signed_source_with_pkey(&source_pkey, "source.rama.test").expect("source cert");
+    let (mirrored, _) = self_signed_server_auth_mirror_cert(source.as_ref(), &ca_cert, &ca_key)
+        .expect("mirror with ed25519 ca");
+    assert_eq!(ca_cert.issued(&mirrored), Ok(()));
+    assert!(
+        mirrored.verify(&ca_key).expect("verify mirrored sig"),
+        "mirrored leaf signed by Ed25519 CA must verify"
+    );
+}

--- a/rama-tls-boring/src/server/utils/certs_tests.rs
+++ b/rama-tls-boring/src/server/utils/certs_tests.rs
@@ -89,7 +89,7 @@ fn gen_ca_basics() {
     let data = sample_data("ca.rama.test");
     let (ca_cert, ca_key) = self_signed_server_auth_gen_ca(&data).expect("generate CA");
 
-    assert_eq!(ca_key.id(), Id::RSA);
+    assert_eq!(ca_key.id(), Id::EC); // default key kind is EC P-256
     assert!(ca_cert.verify(&ca_key).expect("verify self-signed ca cert"));
     assert_eq!(
         ca_cert.subject_name().to_der().expect("ca subject der"),
@@ -113,7 +113,7 @@ fn gen_leaf_signed_by_ca_and_has_common_name_san() {
     let (leaf_cert, leaf_key) =
         self_signed_server_auth_gen_cert(&leaf_data, &ca_cert, &ca_key).expect("generate leaf");
 
-    assert_eq!(leaf_key.id(), Id::RSA);
+    assert_eq!(leaf_key.id(), Id::EC); // default key kind is EC P-256
     assert_eq!(ca_cert.issued(&leaf_cert), Ok(()));
     assert_eq!(
         leaf_cert.issuer_name().to_der().expect("leaf issuer der"),
@@ -172,7 +172,9 @@ fn mirror_preserves_subject_validity_and_issuer() {
             .expect("mirrored issuer der"),
         ca_cert.subject_name().to_der().expect("ca subject der")
     );
-    assert_eq!(mirrored_key.id(), Id::RSA);
+    // source was gen'd with the default key kind (EC P-256), so the mirror
+    // matches it.
+    assert_eq!(mirrored_key.id(), Id::EC);
 }
 
 #[test]

--- a/rama-tls-boring/src/server/utils/certs_tests.rs
+++ b/rama-tls-boring/src/server/utils/certs_tests.rs
@@ -501,6 +501,174 @@ fn gen_cert_derives_aki_keyid_when_ca_has_no_ski() {
     assert_eq!(ca_cert.issued(&leaf_cert), Ok(()));
 }
 
+/// Append a raw extension (OID + DER payload) to a cert builder. The mirror
+/// logic keys off the extension OID, not the payload, so dummy payloads are
+/// sufficient to exercise the strip behaviour.
+fn append_raw_ext(
+    cert_builder: &mut crate::core::x509::X509Builder,
+    oid: &str,
+    critical: bool,
+    payload: &[u8],
+) -> Result<(), BoxError> {
+    let obj = Asn1Object::from_str(oid).context("strippable ext oid")?;
+    let ext = X509Extension::from_der_payload(obj.as_ref(), critical, payload)
+        .context("build strippable ext")?;
+    cert_builder
+        .append_extension(ext.as_ref())
+        .context("append strippable ext")?;
+    Ok(())
+}
+
+fn has_ext_oid(cert: &X509Ref, oid: &str) -> bool {
+    let want = Asn1Object::from_str(oid).expect("resolve oid").to_string();
+    cert.extensions()
+        .any(|ext| ext.object().to_string() == want)
+}
+
+/// Build a self-signed source cert carrying SAN + KeyUsage (which must survive
+/// mirroring) plus every extension class that must be stripped from a re-signed
+/// MITM leaf: CRL Distribution Points, Authority Information Access, Freshest
+/// CRL, RFC 7633 must-staple, and an RFC 6962 embedded SCT list.
+fn build_source_with_strippable_exts(common_name: &str) -> Result<X509, BoxError> {
+    let rsa = Rsa::generate(2048).context("source rsa")?;
+    let pkey = PKey::from_rsa(rsa).context("source pkey")?;
+
+    let mut x509_name = X509NameBuilder::new().context("source name builder")?;
+    x509_name
+        .append_entry_by_nid(Nid::COMMONNAME, common_name)
+        .context("source cn")?;
+    let x509_name = x509_name.build();
+
+    let mut cert_builder = X509::builder().context("source builder")?;
+    cert_builder.set_version(2).context("source version")?;
+    let serial = {
+        let mut serial = BigNum::new().context("source serial bn")?;
+        serial
+            .rand(159, MsbOption::MAYBE_ZERO, false)
+            .context("source serial rand")?;
+        serial.to_asn1_integer().context("source serial asn1")?
+    };
+    cert_builder
+        .set_serial_number(&serial)
+        .context("source serial")?;
+    cert_builder
+        .set_subject_name(&x509_name)
+        .context("source subject")?;
+    cert_builder
+        .set_issuer_name(&x509_name)
+        .context("source issuer")?;
+    cert_builder.set_pubkey(&pkey).context("source pubkey")?;
+    let not_before = Asn1Time::days_from_now(0).context("source nb")?;
+    cert_builder
+        .set_not_before(&not_before)
+        .context("source set nb")?;
+    let not_after = Asn1Time::days_from_now(30).context("source na")?;
+    cert_builder
+        .set_not_after(&not_after)
+        .context("source set na")?;
+
+    // survivors
+    let san = SubjectAlternativeName::new()
+        .dns(common_name)
+        .build(&cert_builder.x509v3_context(None, None))
+        .context("source san")?;
+    cert_builder
+        .append_extension(san.as_ref())
+        .context("append source san")?;
+    cert_builder
+        .append_extension(
+            KeyUsage::new()
+                .critical()
+                .digital_signature()
+                .key_encipherment()
+                .build()
+                .context("source ku")?
+                .as_ref(),
+        )
+        .context("append source ku")?;
+
+    // strippable: issuer-bound revocation / authority pointers
+    append_raw_ext(&mut cert_builder, "2.5.29.31", false, &[0x30, 0x00])?; // CRL DP
+    append_raw_ext(&mut cert_builder, "1.3.6.1.5.5.7.1.1", false, &[0x30, 0x00])?; // AIA
+    append_raw_ext(&mut cert_builder, "2.5.29.46", false, &[0x30, 0x00])?; // Freshest CRL
+    // strippable: assertions we cannot honour after re-signing
+    append_raw_ext(
+        &mut cert_builder,
+        "1.3.6.1.5.5.7.1.24",
+        true,
+        &[0x30, 0x03, 0x02, 0x01, 0x05],
+    )?; // must-staple
+    append_raw_ext(
+        &mut cert_builder,
+        "1.3.6.1.4.1.11129.2.4.2",
+        false,
+        &[0x04, 0x02, 0x00, 0x00],
+    )?; // SCT list
+
+    cert_builder
+        .sign(&pkey, MessageDigest::sha256())
+        .context("sign source")?;
+
+    Ok(cert_builder.build())
+}
+
+#[test]
+fn mirror_strips_issuer_bound_and_unsatisfiable_extensions() {
+    let ca_data = sample_data("ca.rama.test");
+    let (ca_cert, ca_key) = self_signed_server_auth_gen_ca(&ca_data).expect("generate CA");
+
+    let source_cert =
+        build_source_with_strippable_exts("strip.rama.test").expect("build source cert");
+
+    // sanity: the source really does carry all of them
+    assert!(!ext_by_nid(source_cert.as_ref(), Nid::CRL_DISTRIBUTION_POINTS).is_empty());
+    assert!(!ext_by_nid(source_cert.as_ref(), Nid::INFO_ACCESS).is_empty());
+    assert!(!ext_by_nid(source_cert.as_ref(), Nid::FRESHEST_CRL).is_empty());
+    assert!(has_ext_oid(source_cert.as_ref(), "1.3.6.1.5.5.7.1.24"));
+    assert!(has_ext_oid(source_cert.as_ref(), "1.3.6.1.4.1.11129.2.4.2"));
+
+    let (mirrored_cert, _) =
+        self_signed_server_auth_mirror_cert(source_cert.as_ref(), &ca_cert, &ca_key)
+            .expect("mirror cert");
+
+    // stripped
+    assert!(
+        ext_by_nid(mirrored_cert.as_ref(), Nid::CRL_DISTRIBUTION_POINTS).is_empty(),
+        "CRL Distribution Points must be stripped"
+    );
+    assert!(
+        ext_by_nid(mirrored_cert.as_ref(), Nid::INFO_ACCESS).is_empty(),
+        "Authority Information Access must be stripped"
+    );
+    assert!(
+        ext_by_nid(mirrored_cert.as_ref(), Nid::FRESHEST_CRL).is_empty(),
+        "Freshest CRL must be stripped"
+    );
+    assert!(
+        !has_ext_oid(mirrored_cert.as_ref(), "1.3.6.1.5.5.7.1.24"),
+        "must-staple (TLS Feature) must be stripped"
+    );
+    assert!(
+        !has_ext_oid(mirrored_cert.as_ref(), "1.3.6.1.4.1.11129.2.4.2"),
+        "embedded SCT list must be stripped"
+    );
+
+    // survivors: identity-bearing extensions are still mirrored
+    assert!(
+        !ext_by_nid(mirrored_cert.as_ref(), Nid::KEY_USAGE).is_empty(),
+        "Key Usage must survive mirroring"
+    );
+    let san = mirrored_cert.subject_alt_names().expect("mirrored SAN");
+    assert!(
+        san.iter()
+            .any(|name| name.dnsname() == Some("strip.rama.test")),
+        "SAN must survive mirroring"
+    );
+
+    // and the leaf is still validly issued by our CA
+    assert_eq!(ca_cert.issued(&mirrored_cert), Ok(()));
+}
+
 #[test]
 fn mirror_uses_ec_key_for_ec_source() {
     let ca_data = sample_data("ca.rama.test");

--- a/tests/integration/cli/cli_tests/serve_echo.rs
+++ b/tests/integration/cli/cli_tests/serve_echo.rs
@@ -535,6 +535,7 @@ async fn test_https_with_remote_tls_cert_issuer() {
                 organisation_name: Some(DOMAIN_TLS_ECHO_CERTS.to_string()),
                 common_name: Some(DOMAIN_TLS_ECHO_CERTS),
                 subject_alternative_names: Some(vec![DOMAIN_TLS_ECHO_CERTS.to_string()]),
+                ..Default::default()
             },
             &ca_issuer_cert,
             &ca_issuer_key,
@@ -598,6 +599,7 @@ async fn test_https_with_remote_tls_cert_issuer() {
                             organisation_name: Some(domain.to_string()),
                             common_name: Some(domain.clone()),
                             subject_alternative_names: Some(vec![domain.to_string()]),
+                            ..Default::default()
                         },
                         &ca_crt,
                         &ca_key,


### PR DESCRIPTION
MITM leaves no longer copy issuer-bound/unsatisfiable extensions (CRL DP, AIA/OCSP, must-staple, SCTs) — fixes schannel `CRYPT_E_REVOCATION_OFFLINE`. Plus: sign per CA key type (Ed25519 ok), key-kind knob, and non-signing source keys (X25519/DSA) fall back so the handshake always completes. Default key is now EC P-256.