### PR TITLE
fix(tls-boring): drop OS trust-store parse on acceptors

### DIFF
--- a/rama-tls-boring/src/proxy/mitm/mod.rs
+++ b/rama-tls-boring/src/proxy/mitm/mod.rs
@@ -636,10 +636,14 @@ where
                     .context("tls mitm relay: create boring ssl acceptor")
                     .map_err(TlsMitmRelayError::config)?;
             acceptor_builder.set_grease_enabled(self.grease_enabled);
-            acceptor_builder
-                .set_default_verify_paths()
-                .context("tls mitm relay: set default verify paths")
-                .map_err(TlsMitmRelayError::config)?;
+            // Deliberately NOT calling `set_default_verify_paths()`: this
+            // acceptor never enables client-certificate verification
+            // (`SSL_VERIFY_PEER`), so the OS trust store it would parse is never
+            // consulted. Loading it parsed the whole bundle into this
+            // per-handshake `SSL_CTX` and kept it resident for the entire
+            // connection lifetime — pure waste, and an effective leak when flows
+            // are retained. The egress connector installs only the store it
+            // needs (see `connector_data`).
             for (i, crt) in mirrored_leaf_cert_chain.into_iter().enumerate() {
                 if i == 0 {
                     acceptor_builder

--- a/rama-tls-boring/src/server/service.rs
+++ b/rama-tls-boring/src/server/service.rs
@@ -70,9 +70,14 @@ where
             .context("create boring ssl acceptor")?;
 
         acceptor_builder.set_grease_enabled(true);
-        acceptor_builder
-            .set_default_verify_paths()
-            .context("build boring ssl acceptor: set default verify paths")?;
+        // Deliberately NOT calling `set_default_verify_paths()`: this acceptor
+        // never enables client-certificate verification (`SSL_VERIFY_PEER` is
+        // never set; `add_client_ca` below only advertises CA names and is inert
+        // without it), so the OS trust store it would parse is never consulted.
+        // Loading it parsed the whole bundle per handshake and kept it resident
+        // for the connection's lifetime. If client-cert auth is wired up later,
+        // install an explicit client-CA store + verify mode instead of the OS
+        // bundle (which is the wrong trust anchor set for client auth anyway).
 
         let server_domain = stream
             .extensions()


### PR DESCRIPTION
mitm + server acceptors never set SSL_VERIFY_PEER, so the set_default_verify_paths() store was never consulted yet parsed the whole OS bundle per handshake and stayed resident for the connection lifetime (effective leak with retained flows)
