### PR TITLE
MITM OCSP stapling for re-signed leaf certs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -164,6 +164,19 @@ jobs:
       - name: Run ignored tests
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-15'
         run: cargo nextest run --all-features --workspace --run-ignored=only
+      # MITM OCSP-stapling gate. Linux: hermetic curl --cert-status matrix
+      # (incl. the no-staple negative) + a real-crates.io curl/cargo leg.
+      # Windows: cargo through the CONNECT proxy to real crates.io, where
+      # schannel enforces revocation (the customer scenario).
+      - name: MITM OCSP stapling gate (curl + cargo)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          OCSP_GATE_REQUIRE: "1"
+        run: bash scripts/ocsp-relay-gate.sh
+      - name: MITM OCSP stapling gate (cargo / schannel)
+        if: matrix.os == 'windows-2025'
+        shell: pwsh
+        run: ./scripts/ocsp-relay-gate.ps1
 
   test-ffi-apple-example-transparent-proxy-e2e:
     runs-on: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bb8"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +678,12 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -931,6 +943,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,6 +967,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1074,7 +1110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1315,6 +1351,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -2919,6 +2961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3560,9 +3611,11 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "time",
  "tokio-test",
  "webpki-root-certs",
  "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -4026,6 +4079,8 @@ dependencies = [
  "rama-utils",
  "tokio",
  "tracing-test",
+ "x509-cert",
+ "x509-ocsp",
  "zstd",
 ]
 
@@ -4794,6 +4849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "spmc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,6 +5239,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "tokio"
@@ -6257,6 +6343,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
+name = "x509-ocsp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e54e695a31f0fecb826cf59ae2093c941d7ef932a1f8508185dd23b29ce2e2e"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,6 +6464,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -696,6 +696,10 @@ name = "http_mitm_relay_proxy_boring"
 required-features = ["http-full", "boring"]
 
 [[example]]
+name = "mitm_ocsp_relay_gate"
+required-features = ["http-full", "boring"]
+
+[[example]]
 name = "http_mitm_proxy_rustls"
 # ensure to also enable at least one of following features: aws-lc, ring
 # in order to test this example we cannot add this to required features, sorry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -259,7 +259,10 @@ webpki-root-certs = "1.0"
 webpki-roots = "1.0"
 wildcard = "0.3"
 windows-sys = "0.61"
+x509-cert = "0.2"
+x509-ocsp = "0.2"
 x509-parser = { version = "0.18", default-features = false }
+yasna = { version = "0.6", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["alloc"] }
 zstd = "0.13"
 

--- a/docs/book/src/proxies/mitm.md
+++ b/docs/book/src/proxies/mitm.md
@@ -23,6 +23,12 @@
   and usually the kind of approach more desired for MITM proxies,
   especially transparent proxies.
 
+- [/examples/mitm_ocsp_relay_gate.rs](https://github.com/plabayo/rama/tree/main/examples/mitm_ocsp_relay_gate.rs):
+  Test harness behind the MITM OCSP-stapling gate: a local upstream TLS server
+  plus the boring relay proxy, exercising the mirror → issue → staple flow so an
+  external client (`curl --cert-status` / `openssl s_client -status`) can validate
+  the stapled leaf. Driven by `scripts/ocsp-relay-gate.sh` (`just test-ocsp-gate`).
+
 - [/examples/http_mitm_proxy_rustls.rs](https://github.com/plabayo/rama/tree/main/examples/http_mitm_proxy_rustls.rs):
   A minimal HTTP proxy that accepts both HTTP/1.1 and HTTP/2 connections,
   proxying them to the target host using Rustls for TLS.

--- a/examples/README.md
+++ b/examples/README.md
@@ -100,6 +100,7 @@ The following examples show how you can integrate ACME into you webservices (ACM
 - [`http_mitm_proxy_rustls.rs`](./http_mitm_proxy_rustls.rs) - MITM proxy using Rustls
 - [`http_mitm_proxy_boring.rs`](./http_mitm_proxy_boring.rs) - MITM proxy using BoringSSL
 - [`http_mitm_relay_proxy_boring.rs`](./http_mitm_relay_proxy_boring.rs) - MITM proxy using BoringSSL with a more advanced relay approach
+- [`mitm_ocsp_relay_gate.rs`](./mitm_ocsp_relay_gate.rs) - harness for the MITM OCSP-stapling gate (curl/openssl validate stapled leaves through the relay)
 
 ### Http within TLS Proxies
 

--- a/examples/mitm_ocsp_relay_gate.rs
+++ b/examples/mitm_ocsp_relay_gate.rs
@@ -1,0 +1,357 @@
+//! Self-contained harness for the MITM OCSP-stapling gate: a local upstream
+//! TLS+HTTP server plus the boring [`TlsMitmRelay`] proxy in front of it. It
+//! runs the real mirror → issue → staple flow so an external client
+//! (`curl --cert-status` / `openssl s_client -status`) can validate the stapled
+//! response. Driven by `scripts/ocsp-relay-gate.sh`.
+//!
+//! The upstream cert advertises the revocation source picked by
+//! `--upstream-revocation` (`ocsp`, `crl`, or `none`); the relay staples iff the
+//! upstream advertised one, mirroring the origin's posture.
+//!
+//! ```sh
+//! cargo run --example mitm_ocsp_relay_gate --features=http-full,boring -- \
+//!   --upstream-revocation ocsp --ca-out /tmp/ca.pem
+//! ```
+//!
+//! Prints `READY proxy=<addr> ca=<path>` once both listeners are up, then serves
+//! until killed.
+
+#![expect(
+    clippy::expect_used,
+    clippy::print_stdout,
+    clippy::let_underscore_must_use,
+    reason = "harness: panic-on-setup-error, the READY line on stdout, and best-effort upstream I/O are intended"
+)]
+
+use std::{fs, sync::Arc};
+
+use rama::{
+    ServiceInput,
+    error::{BoxError, ErrorContext},
+    io::BridgeIo,
+    net::{
+        address::Domain,
+        tls::{client::ServerVerifyMode, server::SelfSignedData},
+    },
+    tls::boring::{
+        client::TlsConnectorDataBuilder,
+        core::{
+            asn1::{Asn1Object, Asn1Time},
+            bn::{BigNum, MsbOption},
+            hash::MessageDigest,
+            pkey::{PKey, Private},
+            rsa::Rsa,
+            ssl::{SslAcceptor, SslMethod},
+            tokio::accept,
+            x509::{
+                X509, X509Builder, X509Extension, X509NameBuilder,
+                extension::SubjectAlternativeName,
+            },
+        },
+        proxy::TlsMitmRelay,
+        server::utils::self_signed_server_auth_gen_ca,
+    },
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt, copy_bidirectional},
+    net::{TcpListener, TcpStream},
+};
+
+/// Hostname mirrored onto the leaf; clients connect with this SNI.
+const SNI: &str = "upstream.example";
+
+#[derive(Clone, Copy)]
+enum Revocation {
+    Ocsp,
+    Crl,
+    None,
+}
+
+impl Revocation {
+    fn parse(s: &str) -> Result<Self, BoxError> {
+        match s {
+            "ocsp" => Ok(Self::Ocsp),
+            "crl" => Ok(Self::Crl),
+            "none" => Ok(Self::None),
+            other => Err(format!("invalid --upstream-revocation: {other}").into()),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let mut revocation = Revocation::Ocsp;
+    let mut ca_out = "/tmp/rama-mitm-ocsp-ca.pem".to_owned();
+    let mut connect = false;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--upstream-revocation" => {
+                revocation = Revocation::parse(&args.next().context("missing revocation value")?)?;
+            }
+            "--ca-out" => ca_out = args.next().context("missing --ca-out value")?,
+            // CONNECT-proxy mode: MITM clients through to the real host they ask
+            // for (e.g. crates.io) instead of the built-in local upstream.
+            "--connect" => connect = true,
+            other => return Err(format!("unknown arg: {other}").into()),
+        }
+    }
+
+    // MITM relay with a fresh in-memory CA; export the CA cert for the client.
+    let (ca_crt, ca_key) = self_signed_server_auth_gen_ca(&SelfSignedData {
+        organisation_name: Some("Rama MITM OCSP Gate".to_owned()),
+        ..Default::default()
+    })
+    .context("gen MITM CA")?;
+    fs::write(&ca_out, ca_crt.to_pem().context("CA to PEM")?).context("write CA PEM")?;
+    let relay = Arc::new(TlsMitmRelay::new_in_memory(ca_crt, ca_key));
+
+    let proxy = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind proxy")?;
+    let proxy_addr = proxy.local_addr().context("proxy addr")?;
+
+    if connect {
+        // CONNECT-proxy mode: MITM each client through to the real host it asks
+        // for (e.g. crates.io), mirroring that origin's real cert. No local
+        // upstream; `--upstream-revocation` is ignored.
+        announce_ready(proxy_addr, &ca_out)?;
+        loop {
+            let (client, _) = proxy.accept().await.context("accept client")?;
+            let relay = relay.clone();
+            tokio::spawn(async move {
+                if let Err(err) = connect_one(&relay, client).await {
+                    eprintln!("connect: {err}");
+                }
+            });
+        }
+    }
+
+    // Local hermetic mode: a built-in upstream advertising `revocation`.
+    let (up_key, up_crt) = upstream_identity(revocation);
+    let mut up = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server())
+        .context("build upstream acceptor")?;
+    up.set_certificate(&up_crt).context("upstream cert")?;
+    up.set_private_key(&up_key).context("upstream key")?;
+    let up_acceptor = Arc::new(up.build());
+    let up_listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("bind upstream")?;
+    let up_addr = up_listener.local_addr().context("upstream addr")?;
+    tokio::spawn(serve_upstream(up_listener, up_acceptor));
+
+    announce_ready(proxy_addr, &ca_out)?;
+    loop {
+        let (client, _) = proxy.accept().await.context("accept client")?;
+        let relay = relay.clone();
+        tokio::spawn(async move {
+            if let Err(err) = relay_one(&relay, client, up_addr).await {
+                eprintln!("relay: {err}");
+            }
+        });
+    }
+}
+
+fn announce_ready(proxy_addr: std::net::SocketAddr, ca_out: &str) -> Result<(), BoxError> {
+    use std::io::Write as _;
+    println!("READY proxy={proxy_addr} ca={ca_out}");
+    std::io::stdout().flush().context("flush stdout")?;
+    Ok(())
+}
+
+/// CONNECT-proxy one client: read its `CONNECT host:port`, reply `200`, dial the
+/// real host, run the relay handshake (egress verifies the real cert via native
+/// roots and sends SNI), then bridge plaintext both ways.
+async fn connect_one(
+    relay: &TlsMitmRelay<
+        impl rama::tls::boring::proxy::cert_issuer::BoringMitmCertIssuer<Error: Into<BoxError>>,
+    >,
+    mut client: TcpStream,
+) -> Result<(), BoxError> {
+    let target = read_connect_target(&mut client).await?;
+    client
+        .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        .await
+        .context("write CONNECT 200")?;
+    let upstream = TcpStream::connect(&target)
+        .await
+        .with_context(|| format!("dial upstream {target}"))?;
+    let host = target.rsplit_once(':').map_or(target.as_str(), |(h, _)| h);
+    let mut builder = TlsConnectorDataBuilder::new();
+    if let Ok(domain) = Domain::try_from(host) {
+        builder = builder.with_server_name(domain); // SNI for the egress handshake
+    }
+    let egress = builder.build().ok();
+    let BridgeIo(mut ingress, mut egress_stream) = relay
+        .handshake(
+            BridgeIo(ServiceInput::new(client), ServiceInput::new(upstream)),
+            egress,
+        )
+        .await
+        .map_err(BoxError::from)?;
+    copy_bidirectional(&mut ingress, &mut egress_stream)
+        .await
+        .context("bridge")?;
+    Ok(())
+}
+
+/// Read an HTTP `CONNECT host:port` request line (up to the blank line) and
+/// return the `host:port` authority. Byte-at-a-time so we never over-read into
+/// the client's following TLS bytes.
+async fn read_connect_target(stream: &mut TcpStream) -> Result<String, BoxError> {
+    let mut buf = Vec::with_capacity(128);
+    let mut byte = [0u8; 1];
+    loop {
+        if stream.read(&mut byte).await.context("read CONNECT")? == 0 {
+            return Err("eof before CONNECT terminator".into());
+        }
+        buf.push(byte[0]);
+        if buf.ends_with(b"\r\n\r\n") {
+            break;
+        }
+        if buf.len() > 8192 {
+            return Err("CONNECT header too large".into());
+        }
+    }
+    let first_line = buf.split(|&b| b == b'\r').next().unwrap_or_default();
+    std::str::from_utf8(first_line)
+        .context("CONNECT line utf8")?
+        .strip_prefix("CONNECT ")
+        .and_then(|rest| rest.split_whitespace().next())
+        .map(str::to_owned)
+        .ok_or_else(|| BoxError::from("malformed CONNECT request"))
+}
+
+/// MITM a single client connection: connect upstream, run the real relay
+/// handshake (mirror → issue → staple), then bridge plaintext both ways.
+async fn relay_one(
+    relay: &TlsMitmRelay<
+        impl rama::tls::boring::proxy::cert_issuer::BoringMitmCertIssuer<Error: Into<BoxError>>,
+    >,
+    client: TcpStream,
+    up_addr: std::net::SocketAddr,
+) -> Result<(), BoxError> {
+    let upstream = TcpStream::connect(up_addr)
+        .await
+        .context("connect upstream")?;
+    let egress = TlsConnectorDataBuilder::new()
+        .with_server_verify_mode(ServerVerifyMode::Disable)
+        .build()
+        .ok();
+    let BridgeIo(mut ingress, mut egress_stream) = relay
+        .handshake(
+            BridgeIo(ServiceInput::new(client), ServiceInput::new(upstream)),
+            egress,
+        )
+        .await
+        .map_err(BoxError::from)?;
+    copy_bidirectional(&mut ingress, &mut egress_stream)
+        .await
+        .context("bridge")?;
+    Ok(())
+}
+
+/// Accept loop for the upstream: TLS handshake, then a fixed `200 OK`.
+async fn serve_upstream(listener: TcpListener, acceptor: Arc<SslAcceptor>) {
+    while let Ok((sock, _)) = listener.accept().await {
+        let acceptor = acceptor.clone();
+        tokio::spawn(async move {
+            let Ok(mut tls) = accept(&acceptor, sock).await else {
+                return;
+            };
+            let mut buf = [0u8; 1024];
+            let _ = tls.read(&mut buf).await;
+            let _ = tls
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 3\r\nConnection: close\r\n\r\nok\n")
+                .await;
+            let _ = tls.shutdown().await;
+        });
+    }
+}
+
+/// Self-signed upstream identity (key + cert) with a SAN and the given
+/// revocation advertisement.
+fn upstream_identity(revocation: Revocation) -> (PKey<Private>, X509) {
+    let key = PKey::from_rsa(Rsa::generate(2048).expect("rsa")).expect("pkey");
+    let mut name = X509NameBuilder::new().expect("name builder");
+    name.append_entry_by_text("CN", SNI).expect("cn");
+    let name = name.build();
+
+    let mut b = X509Builder::new().expect("x509 builder");
+    b.set_version(2).expect("version");
+    let serial = {
+        let mut bn = BigNum::new().expect("bn");
+        bn.rand(159, MsbOption::MAYBE_ZERO, false).expect("rand");
+        bn.to_asn1_integer().expect("serial")
+    };
+    b.set_serial_number(&serial).expect("serial");
+    b.set_subject_name(&name).expect("subject");
+    b.set_issuer_name(&name).expect("issuer");
+    b.set_pubkey(&key).expect("pubkey");
+    b.set_not_before(&Asn1Time::days_from_now(0).expect("nb"))
+        .expect("set nb");
+    b.set_not_after(&Asn1Time::days_from_now(365).expect("na"))
+        .expect("set na");
+
+    // SAN so a strict client (curl) accepts the mirrored hostname.
+    let san = SubjectAlternativeName::new()
+        .dns(SNI)
+        .build(&b.x509v3_context(None, None))
+        .expect("san");
+    b.append_extension(&san).expect("append san");
+
+    match revocation {
+        Revocation::None => {}
+        Revocation::Ocsp => {
+            let oid = Asn1Object::from_str("1.3.6.1.5.5.7.1.1").expect("aia oid");
+            let ext = X509Extension::from_der_payload(
+                oid.as_ref(),
+                false,
+                &aia_ocsp_payload(b"http://ocsp.test.example"),
+            )
+            .expect("aia ext");
+            b.append_extension(&ext).expect("append aia");
+        }
+        Revocation::Crl => {
+            let oid = Asn1Object::from_str("2.5.29.31").expect("crldp oid");
+            let ext = X509Extension::from_der_payload(
+                oid.as_ref(),
+                false,
+                &crldp_payload(b"http://crl.test.example/a.crl"),
+            )
+            .expect("crldp ext");
+            b.append_extension(&ext).expect("append crldp");
+        }
+    }
+    b.sign(&key, MessageDigest::sha256()).expect("sign");
+    (key, b.build())
+}
+
+/// DER of `AuthorityInfoAccessSyntax` with one `id-ad-ocsp` AccessDescription.
+fn aia_ocsp_payload(uri: &[u8]) -> Vec<u8> {
+    let mut loc = vec![0x86, uri.len() as u8];
+    loc.extend_from_slice(uri);
+    let oid = [0x06u8, 0x08, 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x30, 0x01];
+    let mut ad = oid.to_vec();
+    ad.extend_from_slice(&loc);
+    let mut ad_seq = vec![0x30, ad.len() as u8];
+    ad_seq.extend_from_slice(&ad);
+    let mut aia = vec![0x30, ad_seq.len() as u8];
+    aia.extend_from_slice(&ad_seq);
+    aia
+}
+
+/// DER of `CRLDistributionPoints` with one fullName URI DistributionPoint.
+fn crldp_payload(uri: &[u8]) -> Vec<u8> {
+    let mut gn = vec![0x86, uri.len() as u8];
+    gn.extend_from_slice(uri);
+    let mut full = vec![0xA0, gn.len() as u8];
+    full.extend_from_slice(&gn);
+    let mut dpn = vec![0xA0, full.len() as u8];
+    dpn.extend_from_slice(&full);
+    let mut dp = vec![0x30, dpn.len() as u8];
+    dp.extend_from_slice(&dpn);
+    let mut crldp = vec![0x30, dp.len() as u8];
+    crldp.extend_from_slice(&dp);
+    crldp
+}

--- a/examples/mitm_ocsp_relay_gate.rs
+++ b/examples/mitm_ocsp_relay_gate.rs
@@ -31,7 +31,10 @@ use rama::{
     io::BridgeIo,
     net::{
         address::Domain,
-        tls::{client::ServerVerifyMode, server::SelfSignedData},
+        tls::{
+            client::ServerVerifyMode,
+            server::{SelfSignedData, peek_client_hello_from_input},
+        },
     },
     tls::boring::{
         client::TlsConnectorDataBuilder,
@@ -160,8 +163,9 @@ fn announce_ready(proxy_addr: std::net::SocketAddr, ca_out: &str) -> Result<(), 
 }
 
 /// CONNECT-proxy one client: read its `CONNECT host:port`, reply `200`, dial the
-/// real host, run the relay handshake (egress verifies the real cert via native
-/// roots and sends SNI), then bridge plaintext both ways.
+/// real host, peek the client's ClientHello to mirror its TLS version/SNI onto
+/// the egress connector (which verifies the real cert via native roots), run the
+/// relay handshake, then bridge plaintext both ways.
 async fn connect_one(
     relay: &TlsMitmRelay<
         impl rama::tls::boring::proxy::cert_issuer::BoringMitmCertIssuer<Error: Into<BoxError>>,
@@ -177,16 +181,32 @@ async fn connect_one(
         .await
         .with_context(|| format!("dial upstream {target}"))?;
     let host = target.rsplit_once(':').map_or(target.as_str(), |(h, _)| h);
-    let mut builder = TlsConnectorDataBuilder::new();
+
+    // Peek the client's ClientHello off the ingress side and mirror its TLS
+    // capabilities onto the egress connector — the same thing the production
+    // `TlsMitmRelayService` does. The relay pins the ingress acceptor to the
+    // version it negotiated on egress; with a generic egress connector that
+    // version can be newer (e.g. TLS 1.3 with crates.io) than the real client
+    // offered — cargo's libcurl+schannel is TLS 1.2 only over a CONNECT tunnel
+    // — and the pinned ingress would then reject it with UNSUPPORTED_PROTOCOL.
+    // Mirroring caps egress to the client's own versions, keeping them aligned.
+    let bridge = BridgeIo(ServiceInput::new(client), ServiceInput::new(upstream));
+    let (bridge, client_hello) = peek_client_hello_from_input(bridge, None)
+        .await
+        .context("peek client hello")?;
+
+    let mut builder = match client_hello {
+        Some(hello) => TlsConnectorDataBuilder::try_from(hello)
+            .unwrap_or_else(|_| TlsConnectorDataBuilder::new()),
+        None => TlsConnectorDataBuilder::new(),
+    };
     if let Ok(domain) = Domain::try_from(host) {
-        builder = builder.with_server_name(domain); // SNI for the egress handshake
+        builder = builder.with_server_name(domain); // SNI + verify hostname for egress
     }
     let egress = builder.build().ok();
+
     let BridgeIo(mut ingress, mut egress_stream) = relay
-        .handshake(
-            BridgeIo(ServiceInput::new(client), ServiceInput::new(upstream)),
-            egress,
-        )
+        .handshake(bridge, egress)
         .await
         .map_err(BoxError::from)?;
     copy_bidirectional(&mut ingress, &mut egress_stream)

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "rama-ws",
  "rustversion",
  "serde",
+ "time",
  "tokio",
  "tokio-util",
  "tracing-subscriber",
@@ -2222,8 +2223,10 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "time",
  "webpki-root-certs",
  "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -3951,6 +3954,15 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
  "time",
 ]
 

--- a/justfile
+++ b/justfile
@@ -112,7 +112,19 @@ test-doc-crate CRATE *ARGS:
 test-spec-h2 *ARGS:
     bash rama-http-core/ci/h2spec.sh {{ARGS}}
 
-test-spec: test-spec-h2
+# MITM OCSP-stapling gate (Linux/macOS): hermetic curl --cert-status matrix
+# (incl. the no-staple negative) + a real-crates.io curl/cargo leg through the
+# CONNECT proxy. Skips the strict legs if no OpenSSL-backed curl is found (set
+# OCSP_GATE_REQUIRE=1 to make that a failure, as CI does).
+test-ocsp-gate *ARGS:
+    bash scripts/ocsp-relay-gate.sh {{ARGS}}
+
+# MITM OCSP-stapling gate (Windows): cargo through the CONNECT proxy to real
+# crates.io, where schannel enforces revocation (the customer scenario).
+test-ocsp-gate-windows:
+    pwsh scripts/ocsp-relay-gate.ps1
+
+test-spec: test-spec-h2 test-ocsp-gate
 
 test-ignored:
     @command -v cargo-nextest >/dev/null || cargo install cargo-nextest --locked

--- a/rama-crypto/Cargo.toml
+++ b/rama-crypto/Cargo.toml
@@ -36,18 +36,6 @@ native-certs = [
     "dep:ahash",
 ]
 
-[dependencies]
-aws-lc-rs = { workspace = true, optional = true }
-base64 = { workspace = true }
-rama-core = { workspace = true }
-rama-utils = { workspace = true }
-rcgen = { workspace = true, optional = true }
-rustls-pki-types = { workspace = true, features = ["std"] }
-serde = { workspace = true }
-serde_json = { workspace = true }
-webpki-root-certs = { workspace = true, optional = true }
-x509-parser = { workspace = true }
-
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
 openssl-probe = { workspace = true, optional = true }
 
@@ -57,6 +45,20 @@ security-framework = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
 schannel = { workspace = true, optional = true }
+
+[dependencies]
+aws-lc-rs = { workspace = true, optional = true }
+base64 = { workspace = true }
+rama-core = { workspace = true }
+rama-utils = { workspace = true }
+rcgen = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true, features = ["std"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+time.workspace = true
+webpki-root-certs = { workspace = true, optional = true }
+x509-parser = { workspace = true }
+yasna = { workspace = true, features = ["time"] }
 
 [dev-dependencies]
 tokio-test = { workspace = true }

--- a/rama-crypto/src/lib.rs
+++ b/rama-crypto/src/lib.rs
@@ -39,6 +39,8 @@ pub mod pki_types {
 #[cfg_attr(docsrs, doc(cfg(feature = "native-certs")))]
 pub mod native_certs;
 
+pub mod ocsp;
+
 pub mod dep {
     //! Dependencies for rama crypto modules.
     //!

--- a/rama-crypto/src/ocsp.rs
+++ b/rama-crypto/src/ocsp.rs
@@ -88,8 +88,8 @@ pub fn build_ocsp_response(
 ) -> Result<Vec<u8>, BoxError> {
     let OcspCertStatus::Good = status;
 
+    // producedAt and thisUpdate are the same instant — encode it once.
     let produced = generalized_time(produced_at)?;
-    let this_update = generalized_time(produced_at)?;
     let next_at = produced_at
         .checked_add(validity)
         .ok_or_else(|| BoxError::from("ocsp: nextUpdate overflow"))?;
@@ -122,8 +122,8 @@ pub fn build_ocsp_response(
                     // certStatus ::= good [0] IMPLICIT NULL
                     w.next()
                         .write_tagged_implicit(Tag::context(0), |w| w.write_null());
-                    // thisUpdate
-                    w.next().write_generalized_time(&this_update);
+                    // thisUpdate (same instant as producedAt)
+                    w.next().write_generalized_time(&produced);
                     // nextUpdate [0] EXPLICIT GeneralizedTime
                     w.next()
                         .write_tagged(Tag::context(0), |w| w.write_generalized_time(&next_update));

--- a/rama-crypto/src/ocsp.rs
+++ b/rama-crypto/src/ocsp.rs
@@ -1,0 +1,263 @@
+//! Generic OCSP response builder (TLS-backend agnostic).
+//!
+//! Builds and DER-encodes an OCSP response asserting a single certificate's
+//! status, signed by its issuer. Hashing and signing are supplied *by the
+//! caller* (the TLS backend), so this module pulls in no crypto backend — it is
+//! pure ASN.1 assembly on the `yasna` DER writer already in the dependency tree.
+//!
+//! BoringSSL (and others) can *staple* a pre-built OCSP response on the server
+//! side but cannot *build* one — there is no responder/builder API. This is
+//! that builder, kept generic so every TLS backend (`rama-tls-boring`,
+//! `rama-tls-rustls`, …) can share it; only the cert/key/hash/sign glue lives
+//! in the backend crate.
+//!
+//! Primary use: a MITM proxy stapling an issuer-signed `good` status onto a
+//! re-signed leaf, so revocation-strict clients (e.g. cargo / schannel on
+//! Windows) accept it inline without an external responder.
+
+use std::time::{Duration, SystemTime};
+
+use rama_core::error::{BoxError, ErrorContext};
+use yasna::{
+    Tag,
+    models::{GeneralizedTime, ObjectIdentifier},
+};
+
+fn oid_sha1() -> ObjectIdentifier {
+    ObjectIdentifier::from_slice(&[1, 3, 14, 3, 2, 26])
+}
+fn oid_ecdsa_sha256() -> ObjectIdentifier {
+    ObjectIdentifier::from_slice(&[1, 2, 840, 10045, 4, 3, 2])
+}
+fn oid_rsa_sha256() -> ObjectIdentifier {
+    ObjectIdentifier::from_slice(&[1, 2, 840, 113549, 1, 1, 11])
+}
+fn oid_ocsp_basic() -> ObjectIdentifier {
+    ObjectIdentifier::from_slice(&[1, 3, 6, 1, 5, 5, 7, 48, 1, 1])
+}
+
+/// Status to assert for the certificate. Only `Good` today; `Revoked` is the
+/// seam for a future mode that mirrors an upstream's real revocation status.
+#[derive(Debug, Clone, Copy)]
+pub enum OcspCertStatus {
+    /// The certificate is valid.
+    Good,
+}
+
+/// Signature algorithm the caller used to sign the `tbsResponseData`.
+#[derive(Debug, Clone, Copy)]
+pub enum OcspSignatureAlgorithm {
+    /// `ecdsa-with-SHA256` (1.2.840.10045.4.3.2) — parameters absent.
+    EcdsaSha256,
+    /// `sha256WithRSAEncryption` (1.2.840.113549.1.1.11) — NULL parameters.
+    RsaSha256,
+}
+
+/// Identifies the certificate whose status is attested (RFC 6960 `CertID`).
+///
+/// All fields are caller-computed so this crate needs no hash backend; the
+/// `*_sha1` hashes use the SHA-1 CertID algorithm clients expect.
+#[derive(Debug, Clone, Copy)]
+pub struct OcspCertId<'a> {
+    /// DER of the issuer's subject `Name` (the full `SEQUENCE` TLV), used for
+    /// the `responderID` byName field.
+    pub issuer_name_der: &'a [u8],
+    /// SHA-1 over the issuer `Name` (the `issuerNameHash`).
+    pub issuer_name_sha1: &'a [u8],
+    /// SHA-1 over the issuer's `subjectPublicKey` BIT STRING value
+    /// (the `issuerKeyHash`).
+    pub issuer_key_sha1: &'a [u8],
+    /// The leaf's serial number as a big-endian unsigned magnitude.
+    pub serial: &'a [u8],
+}
+
+/// Build a DER-encoded `OCSPResponse` attesting `cert`'s `status`.
+///
+/// `sign_tbs` signs the `tbsResponseData` DER with the issuer key and reports
+/// which algorithm it used. `produced_at` sets `producedAt`/`thisUpdate`;
+/// `nextUpdate` = `produced_at + validity`.
+///
+/// The public surface takes only `std` time types — `time::OffsetDateTime` is
+/// an internal detail of the DER `GeneralizedTime` encoding.
+pub fn build_ocsp_response(
+    cert: &OcspCertId<'_>,
+    status: OcspCertStatus,
+    produced_at: SystemTime,
+    validity: Duration,
+    sign_tbs: impl FnOnce(&[u8]) -> Result<(OcspSignatureAlgorithm, Vec<u8>), BoxError>,
+) -> Result<Vec<u8>, BoxError> {
+    let OcspCertStatus::Good = status;
+
+    let produced = generalized_time(produced_at)?;
+    let this_update = generalized_time(produced_at)?;
+    let next_at = produced_at
+        .checked_add(validity)
+        .ok_or_else(|| BoxError::from("ocsp: nextUpdate overflow"))?;
+    let next_update = generalized_time(next_at)?;
+
+    // tbsResponseData (ResponseData) — exactly the bytes that get signed.
+    // Borrow `cert`'s slices straight into the writer; no intermediate copies.
+    let tbs_der = yasna::construct_der(|w| {
+        w.write_sequence(|w| {
+            // version [0] DEFAULT v1 — omitted.
+            // responderID ::= byName [1] EXPLICIT Name
+            w.next()
+                .write_tagged(Tag::context(1), |w| w.write_der(cert.issuer_name_der));
+            // producedAt
+            w.next().write_generalized_time(&produced);
+            // responses ::= SEQUENCE OF SingleResponse (one entry)
+            w.next().write_sequence(|w| {
+                w.next().write_sequence(|w| {
+                    // certID
+                    w.next().write_sequence(|w| {
+                        // hashAlgorithm = sha1, NULL params
+                        w.next().write_sequence(|w| {
+                            w.next().write_oid(&oid_sha1());
+                            w.next().write_null();
+                        });
+                        w.next().write_bytes(cert.issuer_name_sha1);
+                        w.next().write_bytes(cert.issuer_key_sha1);
+                        w.next().write_bigint_bytes(cert.serial, true);
+                    });
+                    // certStatus ::= good [0] IMPLICIT NULL
+                    w.next()
+                        .write_tagged_implicit(Tag::context(0), |w| w.write_null());
+                    // thisUpdate
+                    w.next().write_generalized_time(&this_update);
+                    // nextUpdate [0] EXPLICIT GeneralizedTime
+                    w.next()
+                        .write_tagged(Tag::context(0), |w| w.write_generalized_time(&next_update));
+                });
+            });
+        });
+    });
+
+    let (alg, signature) = sign_tbs(&tbs_der)?;
+
+    // BasicOCSPResponse
+    let basic_der = yasna::construct_der(|w| {
+        w.write_sequence(|w| {
+            w.next().write_der(&tbs_der);
+            // signatureAlgorithm
+            w.next().write_sequence(|w| match alg {
+                OcspSignatureAlgorithm::EcdsaSha256 => {
+                    w.next().write_oid(&oid_ecdsa_sha256());
+                }
+                OcspSignatureAlgorithm::RsaSha256 => {
+                    w.next().write_oid(&oid_rsa_sha256());
+                    w.next().write_null();
+                }
+            });
+            // signature BIT STRING (0 unused bits)
+            w.next().write_bitvec_bytes(&signature, signature.len() * 8);
+        });
+    });
+
+    // OCSPResponse
+    let resp_der = yasna::construct_der(|w| {
+        w.write_sequence(|w| {
+            // responseStatus = successful (0)
+            w.next().write_enum(0);
+            // responseBytes [0] EXPLICIT ResponseBytes
+            w.next().write_tagged(Tag::context(0), |w| {
+                w.write_sequence(|w| {
+                    w.next().write_oid(&oid_ocsp_basic());
+                    w.next().write_bytes(&basic_der);
+                });
+            });
+        });
+    });
+
+    Ok(resp_der)
+}
+
+/// Convert a `SystemTime` to a DER `GeneralizedTime`. `time::OffsetDateTime` is
+/// used only here (internal); it never appears in the public API.
+fn generalized_time(t: SystemTime) -> Result<GeneralizedTime, BoxError> {
+    let secs = t
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .context("ocsp: timestamp before unix epoch")?
+        .as_secs();
+    let odt = time::OffsetDateTime::from_unix_timestamp(secs as i64)
+        .map_err(|e| BoxError::from(format!("ocsp: invalid timestamp: {e}")))?;
+    Ok(GeneralizedTime::from_datetime(odt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The builder emits a well-formed `OCSPResponse`: `successful` status,
+    /// `id-pkix-ocsp-basic` responseBytes wrapping a 3-element
+    /// BasicOCSPResponse, and it feeds the caller a non-empty `tbsResponseData`
+    /// to sign. Parsed back with yasna (no extra deps).
+    #[test]
+    fn builds_wellformed_ocsp_response() {
+        let cert = OcspCertId {
+            issuer_name_der: &yasna::construct_der(|w| {
+                // a minimal Name: SEQUENCE {} (empty RDNSequence) — enough for shape.
+                w.write_sequence(|_| {});
+            }),
+            issuer_name_sha1: &[0xAA; 20],
+            issuer_key_sha1: &[0xBB; 20],
+            serial: &[0x12, 0x34, 0x56],
+        };
+
+        let mut signed_tbs: Vec<u8> = Vec::new();
+        let der = build_ocsp_response(
+            &cert,
+            OcspCertStatus::Good,
+            SystemTime::UNIX_EPOCH + Duration::from_secs(1_800_000_000),
+            Duration::from_hours(24 * 7),
+            |tbs| {
+                signed_tbs = tbs.to_vec();
+                Ok((
+                    OcspSignatureAlgorithm::EcdsaSha256,
+                    vec![0xDE, 0xAD, 0xBE, 0xEF],
+                ))
+            },
+        )
+        .expect("build ocsp response");
+
+        assert!(
+            !signed_tbs.is_empty(),
+            "tbsResponseData was handed to the signer"
+        );
+
+        // Parse the outer OCSPResponse: SEQUENCE { ENUMERATED, [0] { OID, OCTET STRING } }.
+        let basic_der = yasna::parse_der(&der, |r| {
+            r.read_sequence(|r| {
+                let status = r.next().read_enum()?;
+                assert_eq!(status, 0, "responseStatus successful");
+                r.next().read_tagged(Tag::context(0), |r| {
+                    r.read_sequence(|r| {
+                        let oid = r.next().read_oid()?;
+                        assert_eq!(oid, oid_ocsp_basic(), "responseType id-pkix-ocsp-basic");
+                        r.next().read_bytes()
+                    })
+                })
+            })
+        })
+        .expect("parse OCSPResponse");
+
+        // Inner BasicOCSPResponse: SEQUENCE { tbs, sigAlg, signature }.
+        yasna::parse_der(&basic_der, |r| {
+            r.read_sequence(|r| {
+                // tbsResponseData round-trips byte-for-byte with what we signed.
+                let tbs = r.next().read_der()?;
+                assert_eq!(tbs, signed_tbs, "embedded tbs == signed tbs");
+                // signatureAlgorithm
+                r.next().read_sequence(|r| {
+                    let oid = r.next().read_oid()?;
+                    assert_eq!(oid, oid_ecdsa_sha256());
+                    Ok(())
+                })?;
+                // signature BIT STRING
+                let (sig, _bits) = r.next().read_bitvec_bytes()?;
+                assert_eq!(sig, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+                Ok(())
+            })
+        })
+        .expect("parse BasicOCSPResponse");
+    }
+}

--- a/rama-tls-boring/Cargo.toml
+++ b/rama-tls-boring/Cargo.toml
@@ -56,6 +56,8 @@ zstd = { workspace = true, optional = true }
 
 [dev-dependencies]
 tracing-test = { workspace = true }
+x509-cert = { workspace = true }
+x509-ocsp = { workspace = true }
 
 [lints]
 workspace = true

--- a/rama-tls-boring/src/proxy/mitm/issuer/cache.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/cache.rs
@@ -1,14 +1,10 @@
-use std::{fmt, num::NonZeroU64, sync::Arc, time::Duration};
+use std::{num::NonZeroU64, sync::Arc, time::Duration};
 
 use moka::sync::Cache;
-use rama_boring::{
-    pkey::{PKey, Private},
-    x509::X509,
-};
+use rama_boring::x509::X509;
 use rama_core::telemetry::tracing;
-use rama_utils::collections::NonEmptyVec;
 
-use super::BoringMitmCertIssuer;
+use super::{BoringMitmCertIssuer, MitmIssuedCert};
 
 #[derive(Debug, Clone)]
 /// A [`BoringMitmCertIssuer`] which adds an in-memory
@@ -16,7 +12,7 @@ use super::BoringMitmCertIssuer;
 /// allowing to reuse previously issued certs.
 pub struct CachedBoringMitmCertIssuer<T> {
     issuer: T,
-    cache: Cache<Arc<[u8]>, IssuedCert>,
+    cache: Cache<Arc<[u8]>, MitmIssuedCert>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -41,21 +37,6 @@ const CACHE_DEFAULT_TTL: Duration = Duration::from_hours(24 * 89); // 89 DAYS
 
 const CACHE_KIND_DEFAULT_MAX_SIZE: NonZeroU64 =
     NonZeroU64::new(32_000).expect("NonZeroU64: 32_000 != 0");
-
-#[derive(Clone)]
-struct IssuedCert {
-    crt_chain: NonEmptyVec<X509>,
-    key: PKey<Private>,
-}
-
-impl fmt::Debug for IssuedCert {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("IssuedCert")
-            .field("crt_chain", &self.crt_chain)
-            .field("key", &"PKey<Private>")
-            .finish()
-    }
-}
 
 impl<T> CachedBoringMitmCertIssuer<T> {
     #[inline(always)]
@@ -86,34 +67,25 @@ impl<T: BoringMitmCertIssuer> BoringMitmCertIssuer for CachedBoringMitmCertIssue
     type Error = T::Error;
 
     #[inline(always)]
-    async fn issue_mitm_x509_cert(
-        &self,
-        original: X509,
-    ) -> Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error> {
+    async fn issue_mitm_x509_cert(&self, original: X509) -> Result<MitmIssuedCert, Self::Error> {
         let signature = original.signature().as_slice();
 
-        if let Some(IssuedCert { crt_chain, key }) = self.cache.get(signature) {
+        if let Some(issued) = self.cache.get(signature) {
             tracing::debug!(
                 "reuse cached x509 cert pair for MITM boring crt issuer (signature: 0x{signature:x?}"
             );
-            return Ok((crt_chain, key));
+            return Ok(issued);
         }
 
         let signature = Arc::from(signature);
-        let (crt_chain, key) = self.issuer.issue_mitm_x509_cert(original).await?;
+        let issued = self.issuer.issue_mitm_x509_cert(original).await?;
 
         tracing::debug!(
             "cached newly issued x509 cert pair for MITM boring crt issuer (signature: 0x{signature:x?}; return copy"
         );
 
-        self.cache.insert(
-            signature,
-            IssuedCert {
-                crt_chain: crt_chain.clone(),
-                key: key.clone(),
-            },
-        );
+        self.cache.insert(signature, issued.clone());
 
-        Ok((crt_chain, key))
+        Ok(issued)
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/issuer/deny.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/deny.rs
@@ -1,10 +1,7 @@
-use rama_boring::{
-    pkey::{PKey, Private},
-    x509::X509,
-};
-use rama_utils::{collections::NonEmptyVec, macros::error::static_str_error};
+use rama_boring::x509::X509;
+use rama_utils::macros::error::static_str_error;
 
-use super::BoringMitmCertIssuer;
+use super::{BoringMitmCertIssuer, MitmIssuedCert};
 
 #[derive(Debug, Clone, Default)]
 #[non_exhaustive]
@@ -32,8 +29,7 @@ impl BoringMitmCertIssuer for DenyBoringMitmCertIssuer {
     fn issue_mitm_x509_cert(
         &self,
         _: X509,
-    ) -> impl Future<Output = Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error>> + Send + '_
-    {
+    ) -> impl Future<Output = Result<MitmIssuedCert, Self::Error>> + Send + '_ {
         std::future::ready(Err(CertIssueDeniedError))
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/issuer/either.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/either.rs
@@ -1,10 +1,6 @@
-use super::BoringMitmCertIssuer;
+use super::{BoringMitmCertIssuer, MitmIssuedCert};
 
-use rama_boring::{
-    pkey::{PKey, Private},
-    x509::X509,
-};
-use rama_utils::collections::NonEmptyVec;
+use rama_boring::x509::X509;
 
 macro_rules! impl_boring_cert_issuer_either {
     ($id:ident, $first:ident $(, $param:ident)* $(,)?) => {
@@ -20,7 +16,7 @@ macro_rules! impl_boring_cert_issuer_either {
             async fn issue_mitm_x509_cert(
                 &self,
                 original: X509,
-            ) -> Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error> {
+            ) -> Result<MitmIssuedCert, Self::Error> {
                 match self {
                     rama_core::combinators::$id::$first(issuer) => issuer.issue_mitm_x509_cert(original).await,
                     $(

--- a/rama-tls-boring/src/proxy/mitm/issuer/memory.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/memory.rs
@@ -1,6 +1,7 @@
 use std::{fmt, sync::Arc};
 
 use rama_boring::{
+    nid::Nid,
     pkey::{PKey, Private},
     x509::X509,
 };
@@ -56,12 +57,11 @@ impl BoringMitmCertIssuer for InMemoryBoringMitmCertIssuer {
             &self.ca_key,
         )?;
 
-        // OCSP staple: only when the upstream advertised OCSP (so we restore
-        // parity with what a direct client could have checked) — and signed by
-        // the MITM CA that just issued the leaf, i.e. the leaf's direct issuer,
-        // which is what a client validates against (works for a root *or*
-        // intermediate MITM CA). Best-effort: a failure must not block issuance.
-        let ocsp_staple = if upstream_advertised_ocsp(&original) {
+        // Staple a `good` only when the upstream advertised revocation info (the
+        // mirror strips it, so a strict client would otherwise have nothing to
+        // check). Signed by the issuing CA — root or intermediate, though an
+        // intermediate's own hop isn't covered. Best-effort: never block issuance.
+        let ocsp_staple = if upstream_advertised_revocation(&original) {
             match crate::server::utils::build_mitm_leaf_ocsp_response(
                 &crt,
                 &self.ca_crt,
@@ -86,14 +86,21 @@ impl BoringMitmCertIssuer for InMemoryBoringMitmCertIssuer {
     }
 }
 
-/// Whether the upstream certificate advertises an OCSP responder (AIA). We only
-/// staple when it did, mirroring the origin's revocation posture rather than
-/// fabricating status the origin never offered.
-fn upstream_advertised_ocsp(original: &X509) -> bool {
-    original
+/// Whether the upstream cert advertised any revocation source (OCSP responder,
+/// CRL distribution point, or freshest CRL) — the pointers the mirror strips.
+/// We staple only then, mirroring the origin's posture rather than fabricating.
+fn upstream_advertised_revocation(original: &X509) -> bool {
+    if original
         .ocsp_responders()
         .map(|responders| !responders.is_empty())
         .unwrap_or(false)
+    {
+        return true;
+    }
+    original.extensions().any(|ext| {
+        let nid = ext.object().nid();
+        nid == Nid::CRL_DISTRIBUTION_POINTS || nid == Nid::FRESHEST_CRL
+    })
 }
 
 #[cfg(test)]
@@ -168,7 +175,26 @@ mod tests {
             matches!(single.cert_status, CertStatus::Good(_)),
             "certStatus good"
         );
-        assert!(single.next_update.is_some(), "nextUpdate present");
+
+        // nextUpdate must track the leaf's notAfter, else a long-lived cache
+        // serves an expired staple for a still-valid leaf (the original bug).
+        let next_update_unix = single
+            .next_update
+            .as_ref()
+            .expect("nextUpdate present")
+            .0
+            .to_unix_duration()
+            .as_secs() as i64;
+        let not_after_diff = Asn1Time::from_unix(0)
+            .unwrap()
+            .diff(leaf.not_after())
+            .unwrap();
+        let not_after_unix =
+            i64::from(not_after_diff.days) * 86_400 + i64::from(not_after_diff.secs);
+        assert!(
+            (next_update_unix - not_after_unix).abs() <= 1,
+            "nextUpdate ({next_update_unix}) must track leaf notAfter ({not_after_unix})"
+        );
 
         // CertID == this leaf under this CA (independent boring computations).
         let name_der = ca_cert.subject_name().to_der().unwrap();
@@ -199,10 +225,43 @@ mod tests {
         );
     }
 
-    /// Build a self-signed "upstream" certificate, optionally advertising an
-    /// OCSP responder via Authority Information Access — the signal the staple
-    /// gate keys off.
-    fn upstream_cert(with_ocsp: bool) -> X509 {
+    /// Which revocation source an upstream test certificate advertises.
+    #[derive(Clone, Copy, Debug)]
+    enum Revocation {
+        /// No revocation pointers at all (a private-CA leaf looks like this).
+        None,
+        /// An OCSP responder via Authority Information Access.
+        Ocsp,
+        /// A CRL Distribution Point and no OCSP — e.g. every current Let's
+        /// Encrypt leaf, which dropped OCSP in 2025.
+        Crl,
+    }
+
+    /// DER of `CRLDistributionPoints` with a single DistributionPoint whose
+    /// fullName is `uri` (short-form lengths; uri < 120 bytes). Only the
+    /// extension's OID (→ NID) drives the staple gate, but a well-formed payload
+    /// keeps the test cert realistic.
+    fn crldp_payload(uri: &[u8]) -> Vec<u8> {
+        // GeneralName ::= uniformResourceIdentifier [6] IA5String
+        let mut gn = vec![0x86, uri.len() as u8];
+        gn.extend_from_slice(uri);
+        // fullName [0] IMPLICIT GeneralNames (SEQUENCE OF GeneralName)
+        let mut full_name = vec![0xA0, gn.len() as u8];
+        full_name.extend_from_slice(&gn);
+        // distributionPoint [0] EXPLICIT DistributionPointName
+        let mut dpn = vec![0xA0, full_name.len() as u8];
+        dpn.extend_from_slice(&full_name);
+        // DistributionPoint ::= SEQUENCE { distributionPoint ... }
+        let mut dp = vec![0x30, dpn.len() as u8];
+        dp.extend_from_slice(&dpn);
+        // CRLDistributionPoints ::= SEQUENCE SIZE (1..MAX) OF DistributionPoint
+        let mut crldp = vec![0x30, dp.len() as u8];
+        crldp.extend_from_slice(&dp);
+        crldp
+    }
+
+    /// A self-signed "upstream" identity (key + cert) advertising `revocation`.
+    fn upstream_identity(revocation: Revocation) -> (PKey<Private>, X509) {
         let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
         let mut name = X509NameBuilder::new().unwrap();
         name.append_entry_by_text("CN", "upstream.example").unwrap();
@@ -223,19 +282,38 @@ mod tests {
             .unwrap();
         b.set_not_after(&Asn1Time::days_from_now(365).unwrap())
             .unwrap();
-        if with_ocsp {
-            // authorityInfoAccess (1.3.6.1.5.5.7.1.1) advertising an OCSP responder.
-            let aia_oid = Asn1Object::from_str("1.3.6.1.5.5.7.1.1").unwrap();
-            let ext = X509Extension::from_der_payload(
-                aia_oid.as_ref(),
-                false,
-                &aia_ocsp_payload(b"http://ocsp.test.example"),
-            )
-            .unwrap();
-            b.append_extension(&ext).unwrap();
+        match revocation {
+            Revocation::None => {}
+            Revocation::Ocsp => {
+                // authorityInfoAccess (1.3.6.1.5.5.7.1.1) advertising an OCSP responder.
+                let oid = Asn1Object::from_str("1.3.6.1.5.5.7.1.1").unwrap();
+                let ext = X509Extension::from_der_payload(
+                    oid.as_ref(),
+                    false,
+                    &aia_ocsp_payload(b"http://ocsp.test.example"),
+                )
+                .unwrap();
+                b.append_extension(&ext).unwrap();
+            }
+            Revocation::Crl => {
+                // cRLDistributionPoints (2.5.29.31).
+                let oid = Asn1Object::from_str("2.5.29.31").unwrap();
+                let ext = X509Extension::from_der_payload(
+                    oid.as_ref(),
+                    false,
+                    &crldp_payload(b"http://crl.test.example/a.crl"),
+                )
+                .unwrap();
+                b.append_extension(&ext).unwrap();
+            }
         }
         b.sign(&key, MessageDigest::sha256()).unwrap();
-        b.build()
+        (key, b.build())
+    }
+
+    /// A self-signed "upstream" certificate advertising `revocation`.
+    fn upstream_cert(revocation: Revocation) -> X509 {
+        upstream_identity(revocation).1
     }
 
     /// Full mirror + issue flow, end to end, across CA key kinds and the
@@ -244,21 +322,24 @@ mod tests {
     /// CertID, CA signature) — so we know it'll be trusted.
     #[tokio::test]
     async fn e2e_mirror_ocsp_staple_matrix() {
-        // (CA key kind, upstream advertises OCSP, expect a valid staple)
+        // (CA key kind, revocation the upstream advertises, expect a valid staple)
         let scenarios = [
-            (SelfSignedKeyKind::EcP256, true, true),
-            (SelfSignedKeyKind::EcP384, true, true),
-            (SelfSignedKeyKind::Rsa2048, true, true),
-            // gate: upstream advertised no OCSP → no staple
-            (SelfSignedKeyKind::EcP256, false, false),
+            (SelfSignedKeyKind::EcP256, Revocation::Ocsp, true),
+            (SelfSignedKeyKind::EcP384, Revocation::Ocsp, true),
+            (SelfSignedKeyKind::Rsa2048, Revocation::Ocsp, true),
+            // CRL-only upstream (no OCSP) must staple too — the mirror strips the
+            // CRLDP, so a revocation-strict client needs the staple in its place.
+            (SelfSignedKeyKind::EcP256, Revocation::Crl, true),
+            // gate: upstream advertised no revocation source → no staple
+            (SelfSignedKeyKind::EcP256, Revocation::None, false),
             // unsupported OCSP signing key → graceful skip (no staple), issuance still ok
-            (SelfSignedKeyKind::Ed25519, true, false),
+            (SelfSignedKeyKind::Ed25519, Revocation::Ocsp, false),
         ];
 
-        for (key_kind, upstream_ocsp, expect_staple) in scenarios {
+        for (key_kind, revocation, expect_staple) in scenarios {
             let issuer = mitm_ca(key_kind);
             let issued = issuer
-                .issue_mitm_x509_cert(upstream_cert(upstream_ocsp))
+                .issue_mitm_x509_cert(upstream_cert(revocation))
                 .await
                 .unwrap_or_else(|err| panic!("issue failed for {key_kind:?}: {err}"));
 
@@ -273,14 +354,10 @@ mod tests {
                 }
                 (false, None) => {}
                 (true, None) => {
-                    panic!(
-                        "{key_kind:?} (upstream_ocsp={upstream_ocsp}): expected a staple, got none"
-                    )
+                    panic!("{key_kind:?} ({revocation:?}): expected a staple, got none")
                 }
                 (false, Some(_)) => {
-                    panic!(
-                        "{key_kind:?} (upstream_ocsp={upstream_ocsp}): expected no staple, got one"
-                    )
+                    panic!("{key_kind:?} ({revocation:?}): expected no staple, got one")
                 }
             }
         }
@@ -298,7 +375,7 @@ mod tests {
     async fn e2e_handshake_delivers_valid_staple() {
         let issuer = mitm_ca(SelfSignedKeyKind::EcP256);
         let issued = issuer
-            .issue_mitm_x509_cert(upstream_cert(true))
+            .issue_mitm_x509_cert(upstream_cert(Revocation::Ocsp))
             .await
             .expect("issue with upstream OCSP");
         let staple = issued.ocsp_staple.clone().expect("staple present");
@@ -357,5 +434,94 @@ mod tests {
         let leaf = chain.next().unwrap();
         let ca = chain.next().unwrap();
         validate_staple(&received, ca, leaf);
+    }
+
+    /// Drive the real [`TlsMitmRelay::handshake`] end to end: live upstream
+    /// (OCSP-advertising cert) → relay → OCSP-requesting client. Unlike
+    /// `e2e_handshake_delivers_valid_staple`, this exercises the actual
+    /// `set_status_callback` wiring, so a regression there fails the suite.
+    /// ([`ServiceInput`] wraps the duplex ends for the `ExtensionsRef` bound.)
+    #[tokio::test]
+    async fn e2e_relay_handshake_staples_mirrored_leaf() {
+        use crate::client::TlsConnectorDataBuilder;
+        use crate::proxy::mitm::TlsMitmRelay;
+        use rama_core::{ServiceInput, io::BridgeIo};
+        use rama_net::tls::client::ServerVerifyMode;
+
+        // Upstream TLS server presenting a cert that advertises OCSP.
+        let (upstream_key, upstream_x509) = upstream_identity(Revocation::Ocsp);
+        let mut up = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server()).unwrap();
+        up.set_certificate(&upstream_x509).unwrap();
+        up.set_private_key(&upstream_key).unwrap();
+        let up_acceptor = up.build();
+
+        // MITM relay with an in-memory self-signed CA (kept here for validation).
+        let (ca_crt, ca_key) = self_signed_server_auth_gen_ca(&SelfSignedData {
+            common_name: Some(Domain::from_static("rama-mitm-relay-ca.example")),
+            organisation_name: Some("Rama".to_owned()),
+            ..Default::default()
+        })
+        .expect("self-signed MITM CA");
+        let relay = TlsMitmRelay::new_in_memory(ca_crt.clone(), ca_key);
+
+        let (client_io, relay_ingress) = duplex(1 << 20);
+        let (relay_egress, upstream_io) = duplex(1 << 20);
+
+        // Upstream accepts the relay's egress handshake (stream held until teardown).
+        let upstream = tokio::spawn(async move {
+            rama_boring_tokio::accept(&up_acceptor, upstream_io)
+                .await
+                .map_err(|e| e.to_string())
+        });
+
+        // Egress connector: verification disabled (self-signed test upstream),
+        // exactly as the relay service configures it.
+        let egress_cd = TlsConnectorDataBuilder::default()
+            .with_server_verify_mode(ServerVerifyMode::Disable)
+            .build()
+            .expect("egress connector data");
+
+        // Relay drives both handshakes: egress connect → mirror → ingress accept.
+        let relay_task = tokio::spawn(async move {
+            relay
+                .handshake(
+                    BridgeIo(
+                        ServiceInput::new(relay_ingress),
+                        ServiceInput::new(relay_egress),
+                    ),
+                    Some(egress_cd),
+                )
+                .await
+                .map_err(|e| e.to_string())
+        });
+
+        // Ingress client requests OCSP stapling.
+        let mut conn = SslConnector::builder(SslMethod::tls_client()).unwrap();
+        conn.set_verify(SslVerifyMode::NONE);
+        conn.enable_ocsp_stapling();
+        let mut cfg = conn.build().configure().unwrap();
+        cfg.set_verify_hostname(false);
+        let client_stream = rama_boring_tokio::connect(cfg, Some("upstream.example"), client_io)
+            .await
+            .expect("client TLS handshake through relay");
+
+        // The client received a staple — produced by the real relay wiring.
+        let received = client_stream
+            .ssl()
+            .ocsp_status()
+            .map(|s| s.to_vec())
+            .expect("relay stapled an OCSP response on the wire");
+        assert!(!received.is_empty(), "non-empty staple via relay");
+
+        // Validate it against the MITM CA and the leaf the relay actually minted
+        // (the client's peer cert is that mirrored leaf).
+        let leaf = client_stream
+            .ssl()
+            .peer_certificate()
+            .expect("client received the mirrored leaf");
+        validate_staple(&received, &ca_crt, &leaf);
+
+        relay_task.await.unwrap().expect("relay handshake ok");
+        upstream.await.unwrap().expect("upstream server ok");
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/issuer/memory.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/memory.rs
@@ -1,16 +1,16 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use rama_boring::{
     pkey::{PKey, Private},
     x509::X509,
 };
-use rama_core::error::BoxError;
+use rama_core::{error::BoxError, telemetry::tracing};
 use rama_net::tls::server::SelfSignedData;
-use rama_utils::collections::{NonEmptyVec, non_empty_vec};
+use rama_utils::collections::non_empty_vec;
 
-use crate::server::utils::self_signed_server_auth_gen_ca;
+use crate::server::utils::{MitmLeafOcspStatus, self_signed_server_auth_gen_ca};
 
-use super::BoringMitmCertIssuer;
+use super::{BoringMitmCertIssuer, MitmIssuedCert};
 
 #[derive(Clone)]
 /// A [`BoringMitmCertIssuer`] which mirrors the original reference
@@ -49,15 +49,313 @@ impl BoringMitmCertIssuer for InMemoryBoringMitmCertIssuer {
     type Error = BoxError;
 
     #[inline(always)]
-    async fn issue_mitm_x509_cert(
-        &self,
-        original: X509,
-    ) -> Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error> {
+    async fn issue_mitm_x509_cert(&self, original: X509) -> Result<MitmIssuedCert, Self::Error> {
         let (crt, key) = crate::server::utils::self_signed_server_auth_mirror_cert(
             &original,
             &self.ca_crt,
             &self.ca_key,
         )?;
-        Ok((non_empty_vec![crt, self.ca_crt.clone()], key))
+
+        // OCSP staple: only when the upstream advertised OCSP (so we restore
+        // parity with what a direct client could have checked) — and signed by
+        // the MITM CA that just issued the leaf, i.e. the leaf's direct issuer,
+        // which is what a client validates against (works for a root *or*
+        // intermediate MITM CA). Best-effort: a failure must not block issuance.
+        let ocsp_staple = if upstream_advertised_ocsp(&original) {
+            match crate::server::utils::build_mitm_leaf_ocsp_response(
+                &crt,
+                &self.ca_crt,
+                &self.ca_key,
+                MitmLeafOcspStatus::Good,
+            ) {
+                Ok(der) => Some(Arc::from(der.into_boxed_slice())),
+                Err(err) => {
+                    tracing::debug!("mitm: OCSP staple generation skipped (build failed): {err}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        Ok(MitmIssuedCert {
+            crt_chain: non_empty_vec![crt, self.ca_crt.clone()],
+            key,
+            ocsp_staple,
+        })
+    }
+}
+
+/// Whether the upstream certificate advertises an OCSP responder (AIA). We only
+/// staple when it did, mirroring the origin's revocation posture rather than
+/// fabricating status the origin never offered.
+fn upstream_advertised_ocsp(original: &X509) -> bool {
+    original
+        .ocsp_responders()
+        .map(|responders| !responders.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama_boring::{
+        asn1::{Asn1Object, Asn1Time},
+        bn::{BigNum, MsbOption},
+        hash::{MessageDigest, hash},
+        rsa::Rsa,
+        sign::Verifier,
+        ssl::{SslAcceptor, SslConnector, SslMethod, SslVerifyMode},
+        x509::{X509, X509Builder, X509Extension, X509NameBuilder},
+    };
+    use rama_net::{
+        address::Domain,
+        tls::server::{SelfSignedData, SelfSignedKeyKind},
+    };
+    use tokio::io::duplex;
+    use x509_cert::der::{Decode, Encode};
+    use x509_ocsp::{BasicOcspResponse, CertStatus, OcspResponse, OcspResponseStatus};
+
+    /// DER of `AuthorityInfoAccessSyntax` with a single `id-ad-ocsp`
+    /// AccessDescription pointing at `uri` (short-form lengths; uri < 128 bytes).
+    fn aia_ocsp_payload(uri: &[u8]) -> Vec<u8> {
+        // accessLocation ::= GeneralName [6] IA5String (URI)
+        let mut loc = vec![0x86, uri.len() as u8];
+        loc.extend_from_slice(uri);
+        // accessMethod ::= id-ad-ocsp OID (1.3.6.1.5.5.7.48.1)
+        let oid = [0x06u8, 0x08, 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x30, 0x01];
+        // AccessDescription ::= SEQUENCE { accessMethod, accessLocation }
+        let mut ad = oid.to_vec();
+        ad.extend_from_slice(&loc);
+        let mut ad_seq = vec![0x30, ad.len() as u8];
+        ad_seq.extend_from_slice(&ad);
+        // AuthorityInfoAccessSyntax ::= SEQUENCE OF AccessDescription
+        let mut aia = vec![0x30, ad_seq.len() as u8];
+        aia.extend_from_slice(&ad_seq);
+        aia
+    }
+
+    fn mitm_ca(key_kind: SelfSignedKeyKind) -> InMemoryBoringMitmCertIssuer {
+        InMemoryBoringMitmCertIssuer::try_new_self_signed(&SelfSignedData {
+            common_name: Some(Domain::from_static("rama-mitm-ca.example")),
+            organisation_name: Some("Rama".to_owned()),
+            key_kind,
+            ..Default::default()
+        })
+        .expect("self-signed MITM CA")
+    }
+
+    /// Validate a stapled OCSP response the way a strict client does: parse it
+    /// with a vetted parser (x509-ocsp), check it is `successful` + `good` for
+    /// the right CertID (issuer name/key hashes + leaf serial), and verify the
+    /// signature against the issuing CA's key. Parsing with x509-ocsp +
+    /// re-encoding the tbs (which must still verify) also proves our yasna DER
+    /// is canonical — what a strict client's parser expects.
+    fn validate_staple(staple: &[u8], ca_cert: &X509, leaf: &X509) {
+        let resp = OcspResponse::from_der(staple).expect("parse OcspResponse");
+        assert_eq!(resp.response_status, OcspResponseStatus::Successful);
+        let bytes = resp.response_bytes.expect("response bytes present");
+        let basic = BasicOcspResponse::from_der(bytes.response.as_bytes())
+            .expect("parse BasicOcspResponse");
+
+        assert_eq!(
+            basic.tbs_response_data.responses.len(),
+            1,
+            "one SingleResponse"
+        );
+        let single = &basic.tbs_response_data.responses[0];
+        assert!(
+            matches!(single.cert_status, CertStatus::Good(_)),
+            "certStatus good"
+        );
+        assert!(single.next_update.is_some(), "nextUpdate present");
+
+        // CertID == this leaf under this CA (independent boring computations).
+        let name_der = ca_cert.subject_name().to_der().unwrap();
+        let name_hash = hash(MessageDigest::sha1(), &name_der).unwrap();
+        let key_hash = ca_cert.pubkey_digest(MessageDigest::sha1()).unwrap();
+        assert_eq!(
+            single.cert_id.issuer_name_hash.as_bytes(),
+            name_hash.as_ref(),
+            "issuerNameHash"
+        );
+        assert_eq!(
+            single.cert_id.issuer_key_hash.as_bytes(),
+            key_hash.as_ref(),
+            "issuerKeyHash"
+        );
+        let got = BigNum::from_slice(single.cert_id.serial_number.as_bytes()).unwrap();
+        let want = leaf.serial_number().to_bn().unwrap();
+        assert_eq!(got, want, "CertID serial == leaf serial");
+
+        // Signature over tbsResponseData verifies against the CA key.
+        let tbs = basic.tbs_response_data.to_der().unwrap();
+        let ca_pub = ca_cert.public_key().unwrap();
+        let mut verifier = Verifier::new(MessageDigest::sha256(), &ca_pub).unwrap();
+        verifier.update(&tbs).unwrap();
+        assert!(
+            verifier.verify(basic.signature.raw_bytes()).unwrap(),
+            "OCSP signature must verify against the issuing CA key"
+        );
+    }
+
+    /// Build a self-signed "upstream" certificate, optionally advertising an
+    /// OCSP responder via Authority Information Access — the signal the staple
+    /// gate keys off.
+    fn upstream_cert(with_ocsp: bool) -> X509 {
+        let key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let mut name = X509NameBuilder::new().unwrap();
+        name.append_entry_by_text("CN", "upstream.example").unwrap();
+        let name = name.build();
+
+        let mut b = X509Builder::new().unwrap();
+        b.set_version(2).unwrap();
+        let serial = {
+            let mut bn = BigNum::new().unwrap();
+            bn.rand(159, MsbOption::MAYBE_ZERO, false).unwrap();
+            bn.to_asn1_integer().unwrap()
+        };
+        b.set_serial_number(&serial).unwrap();
+        b.set_subject_name(&name).unwrap();
+        b.set_issuer_name(&name).unwrap();
+        b.set_pubkey(&key).unwrap();
+        b.set_not_before(&Asn1Time::days_from_now(0).unwrap())
+            .unwrap();
+        b.set_not_after(&Asn1Time::days_from_now(365).unwrap())
+            .unwrap();
+        if with_ocsp {
+            // authorityInfoAccess (1.3.6.1.5.5.7.1.1) advertising an OCSP responder.
+            let aia_oid = Asn1Object::from_str("1.3.6.1.5.5.7.1.1").unwrap();
+            let ext = X509Extension::from_der_payload(
+                aia_oid.as_ref(),
+                false,
+                &aia_ocsp_payload(b"http://ocsp.test.example"),
+            )
+            .unwrap();
+            b.append_extension(&ext).unwrap();
+        }
+        b.sign(&key, MessageDigest::sha256()).unwrap();
+        b.build()
+    }
+
+    /// Full mirror + issue flow, end to end, across CA key kinds and the
+    /// upstream-OCSP gate. For every case that should staple, the produced
+    /// response is parsed and validated the way a strict client would (status,
+    /// CertID, CA signature) — so we know it'll be trusted.
+    #[tokio::test]
+    async fn e2e_mirror_ocsp_staple_matrix() {
+        // (CA key kind, upstream advertises OCSP, expect a valid staple)
+        let scenarios = [
+            (SelfSignedKeyKind::EcP256, true, true),
+            (SelfSignedKeyKind::EcP384, true, true),
+            (SelfSignedKeyKind::Rsa2048, true, true),
+            // gate: upstream advertised no OCSP → no staple
+            (SelfSignedKeyKind::EcP256, false, false),
+            // unsupported OCSP signing key → graceful skip (no staple), issuance still ok
+            (SelfSignedKeyKind::Ed25519, true, false),
+        ];
+
+        for (key_kind, upstream_ocsp, expect_staple) in scenarios {
+            let issuer = mitm_ca(key_kind);
+            let issued = issuer
+                .issue_mitm_x509_cert(upstream_cert(upstream_ocsp))
+                .await
+                .unwrap_or_else(|err| panic!("issue failed for {key_kind:?}: {err}"));
+
+            let mut chain = issued.crt_chain.iter();
+            let leaf = chain.next().expect("leaf cert");
+            let ca = chain.next().expect("issuing CA in chain");
+
+            match (expect_staple, issued.ocsp_staple.as_deref()) {
+                (true, Some(staple)) => {
+                    assert!(!staple.is_empty(), "{key_kind:?}: empty staple");
+                    validate_staple(staple, ca, leaf);
+                }
+                (false, None) => {}
+                (true, None) => {
+                    panic!(
+                        "{key_kind:?} (upstream_ocsp={upstream_ocsp}): expected a staple, got none"
+                    )
+                }
+                (false, Some(_)) => {
+                    panic!(
+                        "{key_kind:?} (upstream_ocsp={upstream_ocsp}): expected no staple, got one"
+                    )
+                }
+            }
+        }
+    }
+
+    /// Real in-memory TLS handshake: a boring client that requested OCSP
+    /// stapling connects to a server acceptor configured like the mirror flow
+    /// (minted leaf chain + `set_status_callback` → `set_ocsp_status`). Proves
+    /// the staple is actually emitted on the wire and the client receives it,
+    /// then validates the received bytes the way a strict client would.
+    ///
+    /// (No pure-Rust client *enforces* OCSP — boring soft-fails — so this proves
+    /// delivery + validity; strict acceptance is the Windows curl/cargo gate.)
+    #[tokio::test]
+    async fn e2e_handshake_delivers_valid_staple() {
+        let issuer = mitm_ca(SelfSignedKeyKind::EcP256);
+        let issued = issuer
+            .issue_mitm_x509_cert(upstream_cert(true))
+            .await
+            .expect("issue with upstream OCSP");
+        let staple = issued.ocsp_staple.clone().expect("staple present");
+
+        // Server acceptor, configured like the mirror flow.
+        let mut acc = SslAcceptor::mozilla_intermediate_v5(SslMethod::tls_server()).unwrap();
+        for (i, crt) in issued.crt_chain.iter().enumerate() {
+            if i == 0 {
+                acc.set_certificate(crt).unwrap();
+            } else {
+                acc.add_extra_chain_cert(crt.clone()).unwrap();
+            }
+        }
+        acc.set_private_key(&issued.key).unwrap();
+        {
+            let staple = staple.clone();
+            acc.set_status_callback(move |ssl| ssl.set_ocsp_status(&staple).map(|()| true))
+                .unwrap();
+        }
+        let acceptor = acc.build();
+
+        // Client requesting OCSP stapling (verify disabled — self-signed test CA).
+        let mut conn = SslConnector::builder(SslMethod::tls_client()).unwrap();
+        conn.set_verify(SslVerifyMode::NONE);
+        conn.enable_ocsp_stapling();
+        let mut cfg = conn.build().configure().unwrap();
+        cfg.set_verify_hostname(false);
+
+        let (client_io, server_io) = duplex(1 << 20);
+        let server = tokio::spawn(async move {
+            rama_boring_tokio::accept(&acceptor, server_io)
+                .await
+                .map_err(|e| e.to_string())
+        });
+
+        let client_stream = rama_boring_tokio::connect(cfg, Some("example.com"), client_io)
+            .await
+            .expect("client TLS handshake");
+
+        // The client received the server's stapled OCSP on the wire.
+        let received = client_stream
+            .ssl()
+            .ocsp_status()
+            .map(|s| s.to_vec())
+            .expect("client received a stapled OCSP response");
+        assert_eq!(
+            received.as_slice(),
+            staple.as_ref(),
+            "received == server staple"
+        );
+
+        server.await.unwrap().expect("server handshake");
+
+        // …and it passes strict-client validation.
+        let mut chain = issued.crt_chain.iter();
+        let leaf = chain.next().unwrap();
+        let ca = chain.next().unwrap();
+        validate_staple(&received, ca, leaf);
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/issuer/mod.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/mod.rs
@@ -1,3 +1,5 @@
+use std::{fmt, sync::Arc};
+
 use rama_boring::{
     pkey::{PKey, Private},
     x509::X509,
@@ -10,13 +12,41 @@ mod either;
 mod memory;
 mod static_pair;
 
+/// A MITM leaf certificate minted by a [`BoringMitmCertIssuer`]: the cert chain
+/// (`leaf` first, then the signing CA chain), the leaf private key, and an
+/// optional pre-built OCSP `good` staple for the leaf.
+#[derive(Clone)]
+pub struct MitmIssuedCert {
+    /// Leaf certificate first, followed by the issuing CA chain.
+    pub crt_chain: NonEmptyVec<X509>,
+    /// Private key of the leaf certificate.
+    pub key: PKey<Private>,
+    /// DER-encoded OCSP response (`good`) for the leaf, signed by the MITM CA
+    /// that issued it, ready to staple via `SslRef::set_ocsp_status`.
+    ///
+    /// `None` when stapling does not apply — e.g. the upstream certificate
+    /// advertised no OCSP, or staple generation was skipped/failed (stapling is
+    /// best-effort and never blocks issuance).
+    pub ocsp_staple: Option<Arc<[u8]>>,
+}
+
+impl fmt::Debug for MitmIssuedCert {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MitmIssuedCert")
+            .field("crt_chain", &self.crt_chain)
+            .field("key", &"PKey<Private>")
+            .field("ocsp_staple", &self.ocsp_staple.as_ref().map(|s| s.len()))
+            .finish()
+    }
+}
+
 pub trait BoringMitmCertIssuer: Sized + Send + Sync + 'static {
     type Error: Send + 'static;
 
     fn issue_mitm_x509_cert(
         &self,
         original: X509,
-    ) -> impl Future<Output = Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error>> + Send + '_;
+    ) -> impl Future<Output = Result<MitmIssuedCert, Self::Error>> + Send + '_;
 }
 
 pub use self::{

--- a/rama-tls-boring/src/proxy/mitm/issuer/static_pair.rs
+++ b/rama-tls-boring/src/proxy/mitm/issuer/static_pair.rs
@@ -6,7 +6,7 @@ use rama_boring::{
 };
 use rama_utils::collections::NonEmptyVec;
 
-use super::BoringMitmCertIssuer;
+use super::{BoringMitmCertIssuer, MitmIssuedCert};
 
 #[derive(Clone)]
 /// A [`BoringMitmCertIssuer`] which clones its own pair data,
@@ -41,8 +41,11 @@ impl BoringMitmCertIssuer for StaticBoringMitmCertIssuer {
     fn issue_mitm_x509_cert(
         &self,
         _: X509,
-    ) -> impl Future<Output = Result<(NonEmptyVec<X509>, PKey<Private>), Self::Error>> + Send + '_
-    {
-        std::future::ready(Ok((self.crt_chain.clone(), self.key.clone())))
+    ) -> impl Future<Output = Result<MitmIssuedCert, Self::Error>> + Send + '_ {
+        std::future::ready(Ok(MitmIssuedCert {
+            crt_chain: self.crt_chain.clone(),
+            key: self.key.clone(),
+            ocsp_staple: None,
+        }))
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/mod.rs
+++ b/rama-tls-boring/src/proxy/mitm/mod.rs
@@ -624,7 +624,11 @@ where
             };
             // `egress_ssl_ref` borrow is released here.
 
-            let (mirrored_leaf_cert_chain, mirrored_leaf_key) = self
+            let self::issuer::MitmIssuedCert {
+                crt_chain: mirrored_leaf_cert_chain,
+                key: mirrored_leaf_key,
+                ocsp_staple: mirrored_ocsp_staple,
+            } = self
                 .issuer
                 .issue_mitm_x509_cert(snapshot.source_cert)
                 .await
@@ -665,6 +669,17 @@ where
                 .check_private_key()
                 .context("tls mitm relay: check mirrored private key")
                 .map_err(TlsMitmRelayError::config)?;
+
+            // Staple the issuer-signed OCSP `good` response (when one was built
+            // for this leaf) so revocation-strict clients accept the re-signed
+            // leaf inline. Boring only emits it if the client sent
+            // `status_request`, so this is a no-op for clients that don't ask.
+            if let Some(staple) = mirrored_ocsp_staple {
+                acceptor_builder
+                    .set_status_callback(move |ssl| ssl.set_ocsp_status(&staple).map(|()| true))
+                    .context("tls mitm relay: set OCSP status callback")
+                    .map_err(TlsMitmRelayError::config)?;
+            }
 
             let maybe_negotiated_params =
                 if let Some(protocol_version) = snapshot.session_protocol_version {

--- a/rama-tls-boring/src/server/utils/mod.rs
+++ b/rama-tls-boring/src/server/utils/mod.rs
@@ -5,3 +5,6 @@ pub use self::certs::{
     self_signed_server_auth_gen_ca, self_signed_server_auth_gen_cert,
     self_signed_server_auth_mirror_cert,
 };
+
+mod ocsp;
+pub use self::ocsp::{MitmLeafOcspStatus, build_mitm_leaf_ocsp_response};

--- a/rama-tls-boring/src/server/utils/ocsp.rs
+++ b/rama-tls-boring/src/server/utils/ocsp.rs
@@ -89,8 +89,13 @@ fn validity_until_not_after(leaf: &X509Ref, produced_at: SystemTime) -> Result<D
         .duration_since(UNIX_EPOCH)
         .context("ocsp: producedAt before unix epoch")?
         .as_secs();
+    // `from_unix` takes a `time_t` (i32 on 32-bit platforms, i64 elsewhere);
+    // infer the width via `try_into` so this builds on every target.
+    let produced_unix = produced_unix
+        .try_into()
+        .context("ocsp: producedAt out of range for ASN1 time")?;
     let produced_asn1 =
-        Asn1Time::from_unix(produced_unix as i64).context("ocsp: producedAt to ASN1 time")?;
+        Asn1Time::from_unix(produced_unix).context("ocsp: producedAt to ASN1 time")?;
     let diff = produced_asn1
         .diff(leaf.not_after())
         .context("ocsp: diff producedAt..notAfter")?;

--- a/rama-tls-boring/src/server/utils/ocsp.rs
+++ b/rama-tls-boring/src/server/utils/ocsp.rs
@@ -12,9 +12,10 @@
 //! issuer, an issuer-signed `good` status the client already trusts resolves it
 //! inline, without an external responder.
 
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rama_boring::{
+    asn1::Asn1Time,
     hash::{MessageDigest, hash},
     pkey::{Id, PKeyRef, Private},
     sign::Signer,
@@ -26,10 +27,11 @@ use rama_crypto::ocsp::{OcspCertId, OcspSignatureAlgorithm, build_ocsp_response}
 #[doc(inline)]
 pub use rama_crypto::ocsp::OcspCertStatus as MitmLeafOcspStatus;
 
-/// `nextUpdate` window for the produced status (7 days).
-const DEFAULT_VALIDITY: Duration = Duration::from_hours(24 * 7);
 /// Backdate `producedAt`/`thisUpdate` to tolerate client clock skew.
 const CLOCK_SKEW_BACKDATE: Duration = Duration::from_hours(1);
+/// Floor on the derived validity, for the degenerate case of a leaf `notAfter`
+/// at/before `producedAt` (shouldn't happen post egress handshake).
+const MIN_VALIDITY: Duration = Duration::from_hours(1);
 
 /// Build a DER-encoded OCSP response for `leaf`, signed by the MITM CA
 /// (`issuer` + `issuer_key`), ready for `SslRef::set_ocsp_status`.
@@ -70,8 +72,33 @@ pub fn build_mitm_leaf_ocsp_response(
         .checked_sub(CLOCK_SKEW_BACKDATE)
         .unwrap_or_else(SystemTime::now);
 
-    build_ocsp_response(&cert, status, produced_at, DEFAULT_VALIDITY, |tbs| {
+    // nextUpdate = the leaf's own notAfter, so the staple never goes stale
+    // before the cert it attests (independent of the issuer cache TTL).
+    let validity = validity_until_not_after(leaf, produced_at)?;
+
+    build_ocsp_response(&cert, status, produced_at, validity, |tbs| {
         sign_tbs(issuer_key, tbs)
+    })
+}
+
+/// Window from `produced_at` to the leaf's `notAfter`, so the OCSP `nextUpdate`
+/// lands on the cert's own expiry. Clamped to [`MIN_VALIDITY`] for the
+/// degenerate near-/post-expiry case.
+fn validity_until_not_after(leaf: &X509Ref, produced_at: SystemTime) -> Result<Duration, BoxError> {
+    let produced_unix = produced_at
+        .duration_since(UNIX_EPOCH)
+        .context("ocsp: producedAt before unix epoch")?
+        .as_secs();
+    let produced_asn1 =
+        Asn1Time::from_unix(produced_unix as i64).context("ocsp: producedAt to ASN1 time")?;
+    let diff = produced_asn1
+        .diff(leaf.not_after())
+        .context("ocsp: diff producedAt..notAfter")?;
+    let secs = i64::from(diff.days) * 86_400 + i64::from(diff.secs);
+    Ok(if secs <= MIN_VALIDITY.as_secs() as i64 {
+        MIN_VALIDITY
+    } else {
+        Duration::from_secs(secs as u64)
     })
 }
 

--- a/rama-tls-boring/src/server/utils/ocsp.rs
+++ b/rama-tls-boring/src/server/utils/ocsp.rs
@@ -1,0 +1,169 @@
+//! Boring glue for OCSP "good" stapling of MITM leaf certificates.
+//!
+//! The generic OCSP response assembly lives in [`rama_crypto::ocsp`]; this
+//! module only adapts boring types: it extracts the CertID inputs from the
+//! issuer/leaf `X509` (issuer Name DER + SHA-1 hashes + leaf serial) and signs
+//! the `tbsResponseData` with the boring CA key. The DER it returns is fed to
+//! `SslRef::set_ocsp_status` during the handshake.
+//!
+//! Why: a revocation-strict client (notably cargo / schannel on Windows with
+//! `http.check-revoke=true`) hard-fails with `CRYPT_E_NO_REVOCATION_CHECK` when
+//! a re-signed MITM leaf carries no revocation information. Because we are the
+//! issuer, an issuer-signed `good` status the client already trusts resolves it
+//! inline, without an external responder.
+
+use std::time::{Duration, SystemTime};
+
+use rama_boring::{
+    hash::{MessageDigest, hash},
+    pkey::{Id, PKeyRef, Private},
+    sign::Signer,
+    x509::X509Ref,
+};
+use rama_core::error::{BoxError, ErrorContext};
+use rama_crypto::ocsp::{OcspCertId, OcspSignatureAlgorithm, build_ocsp_response};
+
+#[doc(inline)]
+pub use rama_crypto::ocsp::OcspCertStatus as MitmLeafOcspStatus;
+
+/// `nextUpdate` window for the produced status (7 days).
+const DEFAULT_VALIDITY: Duration = Duration::from_hours(24 * 7);
+/// Backdate `producedAt`/`thisUpdate` to tolerate client clock skew.
+const CLOCK_SKEW_BACKDATE: Duration = Duration::from_hours(1);
+
+/// Build a DER-encoded OCSP response for `leaf`, signed by the MITM CA
+/// (`issuer` + `issuer_key`), ready for `SslRef::set_ocsp_status`.
+///
+/// CertID uses SHA-1 (the algorithm clients compute for CertID matching) and
+/// the response is signed directly by the issuer CA, so no delegated
+/// OCSP-signing certificate is needed.
+pub fn build_mitm_leaf_ocsp_response(
+    leaf: &X509Ref,
+    issuer: &X509Ref,
+    issuer_key: &PKeyRef<Private>,
+    status: MitmLeafOcspStatus,
+) -> Result<Vec<u8>, BoxError> {
+    // CertID inputs, all from boring.
+    let issuer_name_der = issuer
+        .subject_name()
+        .to_der()
+        .context("ocsp: issuer subject name to DER")?;
+    let issuer_name_sha1 =
+        hash(MessageDigest::sha1(), &issuer_name_der).context("ocsp: hash issuer name")?;
+    let issuer_key_sha1 = issuer
+        .pubkey_digest(MessageDigest::sha1())
+        .context("ocsp: hash issuer key")?;
+    let serial = leaf
+        .serial_number()
+        .to_bn()
+        .context("ocsp: leaf serial to bn")?
+        .to_vec();
+
+    let cert = OcspCertId {
+        issuer_name_der: &issuer_name_der,
+        issuer_name_sha1: issuer_name_sha1.as_ref(),
+        issuer_key_sha1: issuer_key_sha1.as_ref(),
+        serial: &serial,
+    };
+
+    let produced_at = SystemTime::now()
+        .checked_sub(CLOCK_SKEW_BACKDATE)
+        .unwrap_or_else(SystemTime::now);
+
+    build_ocsp_response(&cert, status, produced_at, DEFAULT_VALIDITY, |tbs| {
+        sign_tbs(issuer_key, tbs)
+    })
+}
+
+/// Sign `tbs` with the CA key; SHA-256 based, algorithm chosen by key type.
+fn sign_tbs(
+    issuer_key: &PKeyRef<Private>,
+    tbs: &[u8],
+) -> Result<(OcspSignatureAlgorithm, Vec<u8>), BoxError> {
+    let alg = match issuer_key.id() {
+        Id::EC => OcspSignatureAlgorithm::EcdsaSha256,
+        Id::RSA => OcspSignatureAlgorithm::RsaSha256,
+        other => {
+            return Err(format!("ocsp: unsupported CA key type for stapling: {other:?}").into());
+        }
+    };
+    let mut signer =
+        Signer::new(MessageDigest::sha256(), issuer_key).context("ocsp: new signer")?;
+    let signature = signer
+        .sign_oneshot_to_vec(tbs)
+        .context("ocsp: sign tbsResponseData")?;
+    Ok((alg, signature))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::utils::{self_signed_server_auth_gen_ca, self_signed_server_auth_gen_cert};
+    use rama_boring::sign::Verifier;
+    use rama_crypto::ocsp::OcspCertStatus;
+    use rama_net::{address::Domain, tls::server::SelfSignedData};
+
+    fn sample(common_name: &'static str) -> SelfSignedData {
+        SelfSignedData {
+            common_name: Some(Domain::from_static(common_name)),
+            organisation_name: Some("Rama OCSP Test".to_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// End-to-end through the boring glue: build a `good` response for a real
+    /// CA+leaf and prove the CA's signature over the `tbsResponseData`
+    /// verifies. The tbs + signature are captured via the sign closure (we
+    /// drive `build_ocsp_response` directly so we don't need an OCSP parser to
+    /// re-extract them).
+    #[test]
+    fn ocsp_tbs_signature_verifies_against_ca() {
+        let (ca_cert, ca_key) =
+            self_signed_server_auth_gen_ca(&sample("rama-mitm-test-ca.example")).expect("gen CA");
+        let (leaf, _leaf_key) =
+            self_signed_server_auth_gen_cert(&sample("example.com"), &ca_cert, &ca_key)
+                .expect("gen leaf");
+
+        let issuer_name_der = ca_cert.subject_name().to_der().expect("issuer name der");
+        let issuer_name_sha1 =
+            hash(MessageDigest::sha1(), &issuer_name_der).expect("hash issuer name");
+        let issuer_key_sha1 = ca_cert
+            .pubkey_digest(MessageDigest::sha1())
+            .expect("hash issuer key");
+        let serial = leaf.serial_number().to_bn().expect("serial bn").to_vec();
+        assert_eq!(issuer_key_sha1.as_ref().len(), 20, "SHA-1 issuerKeyHash");
+
+        let cert = OcspCertId {
+            issuer_name_der: &issuer_name_der,
+            issuer_name_sha1: issuer_name_sha1.as_ref(),
+            issuer_key_sha1: issuer_key_sha1.as_ref(),
+            serial: &serial,
+        };
+
+        let mut captured_tbs: Vec<u8> = Vec::new();
+        let mut captured_sig: Vec<u8> = Vec::new();
+        let der = build_ocsp_response(
+            &cert,
+            OcspCertStatus::Good,
+            SystemTime::now(),
+            Duration::from_hours(24 * 7),
+            |tbs| {
+                captured_tbs = tbs.to_vec();
+                let (alg, sig) = sign_tbs(&ca_key, tbs)?;
+                captured_sig = sig.clone();
+                Ok((alg, sig))
+            },
+        )
+        .expect("build ocsp response");
+
+        assert!(!der.is_empty(), "produced a non-empty OCSP response");
+
+        let ca_pub = ca_cert.public_key().expect("ca public key");
+        let mut verifier = Verifier::new(MessageDigest::sha256(), &ca_pub).expect("verifier");
+        verifier.update(&captured_tbs).expect("verifier update");
+        assert!(
+            verifier.verify(&captured_sig).expect("verify"),
+            "the CA signature over tbsResponseData must verify against the CA key"
+        );
+    }
+}

--- a/scripts/ocsp-relay-gate.ps1
+++ b/scripts/ocsp-relay-gate.ps1
@@ -13,6 +13,15 @@ Set-Location (Join-Path $PSScriptRoot "..")
 
 function Fail($msg) { Write-Error "FAIL: $msg"; exit 1 }
 
+# Trusting the CA requires writing the LocalMachine Root store, which needs
+# elevation (see the Import-Certificate note below). Fail fast and clearly when
+# not elevated rather than dying mid-run on an access-denied. CI runners are
+# already elevated; run this script from an elevated shell locally.
+$admin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltinRole]::Administrator)
+if (-not $admin) { Fail "must run elevated (administrator) to trust the MITM CA in LocalMachine\Root" }
+
 cargo build --example mitm_ocsp_relay_gate --features=http-full,boring
 if ($LASTEXITCODE -ne 0) { Fail "failed to build the harness" }
 $bin = "target\debug\examples\mitm_ocsp_relay_gate.exe"
@@ -41,9 +50,13 @@ try {
     if (-not $addr) { Get-Content $log -ErrorAction SilentlyContinue; Fail "harness never became READY" }
     Write-Host "[connect] proxy=$addr -> real crates.io"
 
-    # Trust the MITM CA in the current-user Root store; schannel reads it (no admin,
-    # no prompt for CurrentUser). Captured for cleanup.
-    $cert = Import-Certificate -FilePath $ca -CertStoreLocation Cert:\CurrentUser\Root
+    # Trust the MITM CA in the machine Root store; schannel reads it for chain
+    # building + revocation. Must be LocalMachine, not CurrentUser: adding to the
+    # CurrentUser Root store always raises an interactive "Security Warning"
+    # consent dialog (CryptUI) that nothing can click in CI, hanging the job.
+    # LocalMachine requires elevation and is therefore prompt-free. Captured for
+    # cleanup.
+    $cert = Import-Certificate -FilePath $ca -CertStoreLocation Cert:\LocalMachine\Root
     $thumb = $cert.Thumbprint
 
     # A real crate resolved through the MITM. Windows enforces revocation by
@@ -74,7 +87,7 @@ itoa = "1"
     Write-Host "OCSP RELAY GATE (WINDOWS/CARGO) PASSED"
 }
 finally {
-    if ($thumb) { Remove-Item -Path ("Cert:\CurrentUser\Root\" + $thumb) -ErrorAction SilentlyContinue }
+    if ($thumb) { Remove-Item -Path ("Cert:\LocalMachine\Root\" + $thumb) -ErrorAction SilentlyContinue }
     if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
     Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
 }

--- a/scripts/ocsp-relay-gate.ps1
+++ b/scripts/ocsp-relay-gate.ps1
@@ -1,0 +1,80 @@
+# Windows half of the MITM OCSP-stapling gate.
+#
+# Proves the actual customer scenario: cargo on Windows (libcurl + schannel, with
+# http.check-revoke on by default) accepts a re-signed leaf that the relay staples,
+# talking through the CONNECT proxy to the *real* crates.io. If the staple were
+# missing/invalid, schannel would fail with CRYPT_E_NO_REVOCATION_CHECK.
+#
+# The curl/Linux hermetic matrix + the no-staple negative control live in
+# ocsp-relay-gate.sh; this script is cargo-on-Windows only.
+
+$ErrorActionPreference = "Stop"
+Set-Location (Join-Path $PSScriptRoot "..")
+
+function Fail($msg) { Write-Error "FAIL: $msg"; exit 1 }
+
+cargo build --example mitm_ocsp_relay_gate --features=http-full,boring
+if ($LASTEXITCODE -ne 0) { Fail "failed to build the harness" }
+$bin = "target\debug\examples\mitm_ocsp_relay_gate.exe"
+
+$work = Join-Path $env:TEMP ("ocsp-gate-" + [System.Guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Force -Path $work | Out-Null
+$ca = Join-Path $work "ca.pem"
+$log = Join-Path $work "harness.log"
+
+$proc = $null
+$thumb = $null
+try {
+    $proc = Start-Process -FilePath $bin -ArgumentList @("--connect", "--ca-out", $ca) `
+        -RedirectStandardOutput $log -NoNewWindow -PassThru
+
+    # Wait for "READY proxy=127.0.0.1:PORT ...".
+    $addr = $null
+    for ($i = 0; $i -lt 100; $i++) {
+        if (Test-Path $log) {
+            $m = Select-String -Path $log -Pattern '^READY proxy=(\S+) ' | Select-Object -First 1
+            if ($m) { $addr = $m.Matches[0].Groups[1].Value; break }
+        }
+        if ($proc.HasExited) { Get-Content $log -ErrorAction SilentlyContinue; Fail "harness exited early" }
+        Start-Sleep -Milliseconds 100
+    }
+    if (-not $addr) { Get-Content $log -ErrorAction SilentlyContinue; Fail "harness never became READY" }
+    Write-Host "[connect] proxy=$addr -> real crates.io"
+
+    # Trust the MITM CA in the current-user Root store; schannel reads it (no admin,
+    # no prompt for CurrentUser). Captured for cleanup.
+    $cert = Import-Certificate -FilePath $ca -CertStoreLocation Cert:\CurrentUser\Root
+    $thumb = $cert.Thumbprint
+
+    # A real crate resolved through the MITM. Windows enforces revocation by
+    # default, so this only succeeds if our staple is good.
+    $proj = Join-Path $work "cargo-probe"
+    New-Item -ItemType Directory -Force -Path (Join-Path $proj "src") | Out-Null
+    Set-Content -Path (Join-Path $proj "src\lib.rs") -Value ""
+    @"
+[package]
+name = "gate-probe"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+itoa = "1"
+"@ | Set-Content -Path (Join-Path $proj "Cargo.toml")
+
+    $env:CARGO_HOME = Join-Path $work "cargo-home"
+    $env:CARGO_HTTP_PROXY = "http://$addr"
+    $env:CARGO_HTTP_CHECK_REVOKE = "true" # default on Windows; explicit for clarity
+    cargo generate-lockfile --manifest-path (Join-Path $proj "Cargo.toml")
+    if ($LASTEXITCODE -ne 0) { Fail "cargo rejected the stapled crates.io mirror (revocation/trust)" }
+    if (-not (Select-String -Path (Join-Path $proj "Cargo.lock") -Pattern 'name = "itoa"' -Quiet)) {
+        Fail "cargo did not resolve itoa through the MITM"
+    }
+
+    Write-Host "[connect] OK - cargo (schannel + check-revoke) trusts the stapled crates.io mirror"
+    Write-Host "OCSP RELAY GATE (WINDOWS/CARGO) PASSED"
+}
+finally {
+    if ($thumb) { Remove-Item -Path ("Cert:\CurrentUser\Root\" + $thumb) -ErrorAction SilentlyContinue }
+    if ($proc -and -not $proc.HasExited) { Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue }
+    Remove-Item -Recurse -Force $work -ErrorAction SilentlyContinue
+}

--- a/scripts/ocsp-relay-gate.sh
+++ b/scripts/ocsp-relay-gate.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+#
+# MITM OCSP-stapling gate.
+#
+# Stands up the `mitm_ocsp_relay_gate` example (a local upstream TLS+HTTP server
+# behind the boring TlsMitmRelay proxy) across three upstream revocation
+# profiles and asserts, with real external clients, that:
+#
+#   upstream advertises | curl (plain) | curl --cert-status | openssl -status
+#   --------------------+--------------+--------------------+-----------------
+#   OCSP responder      | trusts       | trusts             | successful/good
+#   CRL distribution pt | trusts       | trusts             | successful/good
+#   nothing             | trusts       | FAILS (no staple)  | (no response)
+#
+# The `none` row is the negative control: a genuinely revocation-less upstream
+# where a strict client must NOT see a staple — proving the gate isn't a
+# rubber stamp. Chain trust holds in all three.
+#
+# `curl --cert-status` needs an OpenSSL/GnuTLS-backed curl (not SecureTransport).
+# On macOS that means a brew curl; the system one is skipped automatically.
+# Set OCSP_GATE_REQUIRE=1 (CI) to turn "no suitable curl" into a hard failure.
+# Overrides: OCSP_GATE_CURL, OCSP_GATE_OPENSSL.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REQUIRE="${OCSP_GATE_REQUIRE:-0}"
+OPENSSL="${OCSP_GATE_OPENSSL:-openssl}"
+
+# Pick a curl that actually enforces --cert-status (OpenSSL/GnuTLS/wolfSSL
+# backends). SecureTransport/LibreSSL builds list the flag but don't verify.
+find_curl() {
+    local c ver
+    for c in "${OCSP_GATE_CURL:-}" curl \
+        /opt/homebrew/opt/curl/bin/curl /usr/local/opt/curl/bin/curl; do
+        [ -n "$c" ] || continue
+        ver="$(command -v "$c" >/dev/null 2>&1 && "$c" -V 2>/dev/null)" || continue
+        echo "$ver" | grep -qiE 'openssl|gnutls|wolfssl|boringssl' || continue
+        echo "$ver" | grep -qi 'securetransport' && continue
+        command -v "$c" 2>/dev/null || echo "$c"
+        return 0
+    done
+    return 1
+}
+
+if ! CURL="$(find_curl)"; then
+    msg="no curl with --cert-status support found (need an OpenSSL/GnuTLS-backed curl)"
+    if [ "$REQUIRE" = "1" ]; then echo "FATAL: $msg" >&2; exit 1; fi
+    echo "SKIP: $msg" >&2
+    exit 0
+fi
+echo "curl:    $CURL"
+echo "openssl: $OPENSSL"
+
+cargo build --example mitm_ocsp_relay_gate --features=http-full,boring
+BIN=target/debug/examples/mitm_ocsp_relay_gate
+
+WORK="$(mktemp -d)"
+PROXY_PID=""
+cleanup() {
+    [ -n "$PROXY_PID" ] && kill "$PROXY_PID" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+run_scenario() {
+    local kind="$1"
+    local ca="$WORK/ca-$kind.pem"
+    local out="$WORK/out-$kind.log"
+
+    "$BIN" --upstream-revocation "$kind" --ca-out "$ca" >"$out" 2>&1 &
+    PROXY_PID=$!
+
+    local addr=""
+    for _ in $(seq 1 100); do
+        addr="$(sed -n 's/^READY proxy=\([^ ]*\) .*/\1/p' "$out" 2>/dev/null)"
+        [ -n "$addr" ] && break
+        kill -0 "$PROXY_PID" 2>/dev/null || { cat "$out"; fail "$kind: harness exited early"; }
+        sleep 0.1
+    done
+    [ -n "$addr" ] || { cat "$out"; fail "$kind: harness never became READY"; }
+
+    local port="${addr##*:}"
+    local resolve="upstream.example:$port:127.0.0.1"
+    local url="https://upstream.example:$port/"
+    echo "[$kind] proxy=$addr"
+
+    # Chain trust must hold in every scenario.
+    "$CURL" -sS --cacert "$ca" --resolve "$resolve" "$url" >/dev/null \
+        || fail "$kind: plain curl (chain trust) failed"
+
+    local status
+    status="$("$OPENSSL" s_client -connect "127.0.0.1:$port" \
+        -servername upstream.example -status -CAfile "$ca" </dev/null 2>/dev/null || true)"
+
+    case "$kind" in
+    ocsp | crl)
+        "$CURL" -sS --cert-status --cacert "$ca" --resolve "$resolve" "$url" >/dev/null \
+            || fail "$kind: curl --cert-status rejected the stapled leaf"
+        echo "$status" | grep -q "OCSP Response Status: successful" \
+            || fail "$kind: openssl did not report a successful OCSP response"
+        echo "$status" | grep -q "Cert Status: good" \
+            || fail "$kind: openssl did not report 'Cert Status: good'"
+        echo "[$kind] OK — staple present, valid, trusted by curl --cert-status"
+        ;;
+    none)
+        if "$CURL" -sS --cert-status --cacert "$ca" --resolve "$resolve" "$url" >/dev/null 2>&1; then
+            fail "none: curl --cert-status unexpectedly succeeded (a staple was sent?)"
+        fi
+        echo "[none] OK — no staple (parity), chain still trusted, --cert-status correctly fails"
+        ;;
+    esac
+
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+    PROXY_PID=""
+}
+
+# Real crates.io through the CONNECT proxy: mirror the live origin cert + staple,
+# then prove a strict client (curl --cert-status) and cargo both accept it.
+run_connect() {
+    local ca="$WORK/ca-connect.pem"
+    local out="$WORK/out-connect.log"
+
+    "$BIN" --connect --ca-out "$ca" >"$out" 2>&1 &
+    PROXY_PID=$!
+
+    local addr=""
+    for _ in $(seq 1 100); do
+        addr="$(sed -n 's/^READY proxy=\([^ ]*\) .*/\1/p' "$out" 2>/dev/null)"
+        [ -n "$addr" ] && break
+        kill -0 "$PROXY_PID" 2>/dev/null || { cat "$out"; fail "connect: harness exited early"; }
+        sleep 0.1
+    done
+    [ -n "$addr" ] || { cat "$out"; fail "connect: harness never became READY"; }
+    local proxy="http://$addr"
+    echo "[connect] proxy=$addr -> real crates.io"
+
+    "$CURL" -sS --cert-status --proxy "$proxy" --cacert "$ca" \
+        -o /dev/null https://index.crates.io/config.json \
+        || fail "connect: curl --cert-status rejected the mirrored crates.io leaf"
+    echo "[connect] OK - curl --cert-status trusts the stapled crates.io mirror"
+
+    local proj="$WORK/cargo-probe"
+    mkdir -p "$proj/src"
+    : >"$proj/src/lib.rs"
+    printf '[package]\nname = "gate-probe"\nversion = "0.0.0"\nedition = "2021"\n\n[dependencies]\nitoa = "1"\n' >"$proj/Cargo.toml"
+    CARGO_HOME="$WORK/cargo-home" \
+        CARGO_HTTP_PROXY="$proxy" \
+        CARGO_HTTP_CAINFO="$ca" \
+        CARGO_HTTP_CHECK_REVOKE=true \
+        cargo generate-lockfile --manifest-path "$proj/Cargo.toml" \
+        || fail "connect: cargo failed to fetch crates.io through the MITM"
+    grep -q 'name = "itoa"' "$proj/Cargo.lock" \
+        || fail "connect: cargo did not resolve itoa through the MITM"
+    echo "[connect] OK - cargo fetched crates.io through the MITM (CA trusted, staple OK)"
+
+    kill "$PROXY_PID" 2>/dev/null || true
+    wait "$PROXY_PID" 2>/dev/null || true
+    PROXY_PID=""
+}
+
+for kind in ocsp crl none; do run_scenario "$kind"; done
+
+# Real-crates.io leg needs network; CI always has it, local dev may not.
+if "$CURL" -sS --max-time 15 -o /dev/null https://index.crates.io/config.json 2>/dev/null; then
+    run_connect
+else
+    msg="cannot reach index.crates.io (no network?); skipping real-crates.io checks"
+    [ "$REQUIRE" = "1" ] && fail "$msg"
+    echo "SKIP: $msg" >&2
+fi
+
+echo "ALL OCSP RELAY GATE SCENARIOS PASSED"


### PR DESCRIPTION
Staple an issuer-signed OCSP `good` onto mirrored MITM leaves so revocation-strict clients (notably cargo/schannel on Windows) accept them inline instead of `CRYPT_E_NO_REVOCATION_CHECK`.

Generic OCSP builder in rama-crypto + boring adapter/acceptor wiring (gated on the upstream advertising revocation), plus a curl/cargo e2e gate against real crates.io.