### PR TITLE
feat(http): typed Accept-CH/Critical-CH headers

### DIFF
--- a/rama-cli/src/cmd/serve/fp/endpoints.rs
+++ b/rama-cli/src/cmd/serve/fp/endpoints.rs
@@ -3,7 +3,7 @@ use rama::{
     extensions::ExtensionsRef,
     http::{
         BodyExtractExt, Request, Response, StatusCode, Version,
-        headers::ContentType,
+        headers::{ContentType, all_client_hints},
         proto::h2,
         protocols::html::*,
         service::web::{
@@ -757,12 +757,6 @@ const FAVICON_DATA_URL: PreEscaped<&str> = PreEscaped(
      <text y=%22.90em%22 font-size=%2290%22>🦙</text></svg>",
 );
 
-const CH_HEADERS: &str = "Width, Downlink, Sec-CH-UA, Sec-CH-UA-Mobile, Sec-CH-UA-Full-Version, \
-                          ETC, Save-Data, Sec-CH-UA-Platform, Sec-CH-Prefers-Reduced-Motion, \
-                          Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, \
-                          Sec-CH-UA-Platform-Version, Sec-CH-UA-Prefers-Color-Scheme, \
-                          Device-Memory, RTT, Sec-GPC";
-
 /// Render the standard page chrome (head + body shell) with the given
 /// per-page h1 title, optional extra `<head>` content, and body content.
 ///
@@ -807,7 +801,10 @@ where
                 content =
                     "https://raw.githubusercontent.com/plabayo/rama/main/docs/img/rama_banner.jpeg"
             ),
-            meta!("http-equiv" = "Accept-CH", content = CH_HEADERS),
+            meta!(
+                "http-equiv" = "Accept-CH",
+                content = join_display(all_client_hints(), ", ")
+            ),
             link!(
                 rel = "stylesheet",
                 r#type = "text/css",

--- a/rama-cli/src/cmd/serve/fp/mod.rs
+++ b/rama-cli/src/cmd/serve/fp/mod.rs
@@ -12,7 +12,8 @@ use rama::{
         HeaderName, HeaderValue, Request,
         header::COOKIE,
         headers::{
-            Cookie, HeaderMapExt, SecWebSocketProtocol, all_client_hint_header_name_strings,
+            AcceptCh, ClientHint, Cookie, CriticalCh, HeaderMapExt, SecWebSocketProtocol, Vary,
+            all_client_hint_header_names, all_client_hints,
             exotic::XClacksOverhead,
             forwarded::{CFConnectingIp, ClientIp, TrueClientIp, XClientIp, XRealIp},
             sec_websocket_extensions,
@@ -42,7 +43,11 @@ use rama::{
     telemetry::tracing,
     tls::boring::server::TlsAcceptorLayer,
     ua::layer::classifier::UserAgentClassifierLayer,
-    utils::{backoff::ExponentialBackoff, collections::non_empty_smallvec, str::non_empty_str},
+    utils::{
+        backoff::ExponentialBackoff,
+        collections::{NonEmptySmallVec, NonEmptyVec, non_empty_smallvec},
+        str::non_empty_str,
+    },
 };
 
 use clap::Args;
@@ -166,10 +171,17 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandFingerprint) -> Result<
             })),
     );
 
-    let ch_headers = all_client_hint_header_name_strings()
-        .join(", ")
-        .parse::<HeaderValue>()
-        .context("parse header value")?;
+    // advertise (and mark critical) every client hint we know about, encoded
+    // via each hint's canonical `Sec-CH-` name.
+    let client_hints: NonEmptySmallVec<16, ClientHint> =
+        NonEmptySmallVec::collect(all_client_hints()).context("collect known client hints")?;
+
+    // `Vary` lists the request header names the response depends on, so it keeps
+    // every advertised client-hint name (incl. legacy aliases).
+    let vary_client_hints = Vary::headers(
+        NonEmptyVec::collect(all_client_hint_header_names())
+            .context("collect client hint header names")?,
+    );
 
     // --- defence-in-depth response headers ---
     //
@@ -203,15 +215,9 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandFingerprint) -> Result<
         referrer_layer,
         frame_layer,
         StorageAuthLayer::new(&state),
-        SetResponseHeaderLayer::if_not_present(
-            HeaderName::from_static("accept-ch"),
-            ch_headers.clone(),
-        ),
-        SetResponseHeaderLayer::if_not_present(
-            HeaderName::from_static("critical-ch"),
-            ch_headers.clone(),
-        ),
-        SetResponseHeaderLayer::if_not_present(HeaderName::from_static("vary"), ch_headers),
+        SetResponseHeaderLayer::if_not_present_typed(AcceptCh(client_hints.clone())),
+        SetResponseHeaderLayer::if_not_present_typed(CriticalCh(client_hints)),
+        SetResponseHeaderLayer::if_not_present_typed(vary_client_hints),
         UserAgentClassifierLayer::new(),
         ConsumeErrLayer::trace_as(tracing::Level::WARN),
         http_forwarded_layer,

--- a/rama-http-headers/src/client_hints.rs
+++ b/rama-http-headers/src/client_hints.rs
@@ -224,6 +224,73 @@ client_hint! {
 }
 
 // ---------------------------------------------------------------------------
+// Client-hint negotiation headers: a server advertises which [`ClientHint`]s
+// it wants (`Accept-CH`) and which of those are critical (`Critical-CH`).
+// Both are flat comma-separated lists of client-hint header names, encoded
+// using each hint's preferred (`Sec-CH-` prefixed) form.
+// ---------------------------------------------------------------------------
+
+derive_non_empty_flat_csv_header! {
+    #[header(name = ACCEPT_CH, sep = Comma)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    /// `Accept-CH` header, defined in [RFC8942](https://datatracker.ietf.org/doc/html/rfc8942#section-3.1).
+    ///
+    /// Sent by a server to advertise the set of [`ClientHint`]s it would like
+    /// the user agent to send on subsequent requests to the same origin. Each
+    /// entry is encoded using the hint's preferred (`Sec-CH-` prefixed) header
+    /// name; entries that do not map to a known [`ClientHint`] are rejected on
+    /// decode.
+    ///
+    /// # ABNF
+    ///
+    /// ```text
+    /// Accept-CH = #client-hint-name
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rama_utils::collections::non_empty_smallvec;
+    /// use rama_http_headers::{AcceptCh, ClientHint};
+    ///
+    /// let accept_ch = AcceptCh(
+    ///     non_empty_smallvec![ClientHint::Ua, ClientHint::Platform, ClientHint::Mobile; 16],
+    /// );
+    /// ```
+    pub struct AcceptCh(pub NonEmptySmallVec<16, ClientHint>);
+}
+
+derive_non_empty_flat_csv_header! {
+    #[header(name = CRITICAL_CH, sep = Comma)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    /// `Critical-CH` header, defined by the
+    /// [Client Hints Infrastructure](https://wicg.github.io/client-hints-infrastructure/#critical-ch).
+    ///
+    /// Sent alongside [`AcceptCh`] to mark a subset of the advertised
+    /// [`ClientHint`]s as *critical*: if the original request was not sent with
+    /// these hints, a conforming user agent retries the request before handing
+    /// the response to the page. Same wire format as `Accept-CH`.
+    ///
+    /// # ABNF
+    ///
+    /// ```text
+    /// Critical-CH = #client-hint-name
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rama_utils::collections::non_empty_smallvec;
+    /// use rama_http_headers::{ClientHint, CriticalCh};
+    ///
+    /// let critical_ch = CriticalCh(
+    ///     non_empty_smallvec![ClientHint::Ua, ClientHint::Platform; 16],
+    /// );
+    /// ```
+    pub struct CriticalCh(pub NonEmptySmallVec<16, ClientHint>);
+}
+
+// ---------------------------------------------------------------------------
 // Typed value parsers for a subset of the client hints above.
 //
 // Each parses a single header value with a strict spec, following the same
@@ -728,6 +795,71 @@ mod tests {
         assert_eq!(encode(Downlink::new(1.5)), "1.5");
         assert_eq!(encode(Downlink::new(100.0)), "100");
         assert_eq!(decode::<Downlink>(&["1.5"]), Some(Downlink::new(1.5)));
+    }
+
+    #[test]
+    fn test_accept_ch_decode() {
+        use rama_utils::collections::non_empty_smallvec;
+
+        assert_eq!(
+            decode::<AcceptCh>(&["sec-ch-ua, sec-ch-ua-platform, sec-ch-ua-mobile"]),
+            Some(AcceptCh(non_empty_smallvec![
+                ClientHint::Ua,
+                ClientHint::Platform,
+                ClientHint::Mobile; 16
+            ])),
+        );
+        // case-insensitive and legacy aliases both map onto the canonical hint
+        assert_eq!(
+            decode::<AcceptCh>(&["DPR, save-data"]),
+            Some(AcceptCh(non_empty_smallvec![
+                ClientHint::Dpr,
+                ClientHint::SaveData; 16
+            ])),
+        );
+        // multiple header lines fold into a single list
+        assert_eq!(
+            decode::<AcceptCh>(&["sec-ch-ua", "sec-ch-ua-platform"]),
+            Some(AcceptCh(non_empty_smallvec![
+                ClientHint::Ua,
+                ClientHint::Platform; 16
+            ])),
+        );
+        // an unknown hint poisons the whole list
+        assert!(decode::<AcceptCh>(&["sec-ch-ua, not-a-hint"]).is_none());
+        assert!(decode::<AcceptCh>(&[""]).is_none());
+        assert!(decode::<AcceptCh>(&[]).is_none());
+    }
+
+    #[test]
+    fn test_accept_ch_round_trip() {
+        use rama_utils::collections::non_empty_smallvec;
+
+        let header = AcceptCh(non_empty_smallvec![
+            ClientHint::Ua,
+            ClientHint::Platform,
+            ClientHint::Mobile; 16
+        ]);
+        assert_eq!(
+            encode(header.clone()),
+            "sec-ch-ua, sec-ch-ua-platform, sec-ch-ua-mobile",
+        );
+        assert_eq!(
+            decode::<AcceptCh>(&[encode(header.clone()).as_str()]),
+            Some(header)
+        );
+    }
+
+    #[test]
+    fn test_critical_ch_round_trip() {
+        use rama_utils::collections::non_empty_smallvec;
+
+        let header = CriticalCh(non_empty_smallvec![ClientHint::Ua, ClientHint::Platform; 16]);
+        assert_eq!(encode(header.clone()), "sec-ch-ua, sec-ch-ua-platform");
+        assert_eq!(
+            decode::<CriticalCh>(&[encode(header.clone()).as_str()]),
+            Some(header),
+        );
     }
 
     #[test]

--- a/rama-http-headers/src/lib.rs
+++ b/rama-http-headers/src/lib.rs
@@ -58,6 +58,6 @@ pub mod forwarded;
 
 pub mod client_hints;
 pub use client_hints::{
-    ClientHint, Downlink, Ect, Rtt, SaveData, all_client_hint_header_name_strings,
-    all_client_hint_header_names, all_client_hints,
+    AcceptCh, ClientHint, CriticalCh, Downlink, Ect, Rtt, SaveData,
+    all_client_hint_header_name_strings, all_client_hint_header_names, all_client_hints,
 };

--- a/rama-http-types/src/lib.rs
+++ b/rama-http-types/src/lib.rs
@@ -133,6 +133,9 @@ pub mod header {
         "sec-ch-downlink",
     ];
 
+    // client hint negotiation response headers (advertised by servers)
+    static_header!["accept-ch", "critical-ch"];
+
     /// Static Header Value that is can be used as `User-Agent` or `Server` header.
     pub static RAMA_ID_HEADER_VALUE: HeaderValue = HeaderValue::from_static(
         const_format::formatcp!("{}/{}", rama_utils::info::NAME, rama_utils::info::VERSION),

--- a/rama-http/src/protocols/html/join.rs
+++ b/rama-http/src/protocols/html/join.rs
@@ -1,0 +1,62 @@
+//! Render an iterator of values as a separated (e.g. comma-separated) list,
+//! without the element type having to know anything about HTML.
+
+use std::fmt::{self, Write as _};
+
+use super::core::{IntoHtml, escape_into};
+
+/// Render the items of `iter` into HTML, separated by `sep`.
+///
+/// Each item is rendered through its [`Display`](std::fmt::Display) impl and
+/// HTML-escaped, so the element type only needs `Display` — it does **not**
+/// need to implement [`IntoHtml`]. The separator is written verbatim: it is
+/// treated as trusted, developer-provided structure, exactly like the static
+/// parts of a template (so the *data* is escaped, the *structure* is not).
+///
+/// This is the idiomatic way to build a CSV-style attribute value (or body)
+/// straight from an iterator, instead of pre-joining into a `String`:
+///
+/// ```ignore
+/// use rama_http::protocols::html::*;
+///
+/// // any `Display` iterator works; here: a list of language tags
+/// let langs = ["en", "fr", "de"];
+/// let tag = meta!("http-equiv" = "Content-Language", content = join_display(langs, ", "));
+/// assert_eq!(
+///     tag.into_string(),
+///     r#"<meta http-equiv="Content-Language" content="en, fr, de">"#,
+/// );
+/// ```
+pub fn join_display<I, S>(iter: I, sep: S) -> impl IntoHtml
+where
+    I: IntoIterator,
+    I::Item: fmt::Display,
+    S: AsRef<str>,
+{
+    // A `FnOnce(&mut String)` is itself `IntoHtml` (see `core`), so the
+    // closure is all we need — it renders lazily at write time.
+    move |buf: &mut String| {
+        let sep = sep.as_ref();
+        for (i, item) in iter.into_iter().enumerate() {
+            if i > 0 {
+                buf.push_str(sep);
+            }
+            // `Display` straight into the buffer, escaping on the fly so we
+            // never allocate a per-item scratch `String`.
+            _ = write!(EscapeWriter(buf), "{item}");
+        }
+    }
+}
+
+/// A [`fmt::Write`] that HTML-escapes everything written through it into the
+/// wrapped buffer. Escaping per write is correct because every escapable byte
+/// is a single ASCII byte, so chunk boundaries never split one.
+struct EscapeWriter<'a>(&'a mut String);
+
+impl fmt::Write for EscapeWriter<'_> {
+    #[inline]
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        escape_into(self.0, s);
+        Ok(())
+    }
+}

--- a/rama-http/src/protocols/html/mod.rs
+++ b/rama-http/src/protocols/html/mod.rs
@@ -67,6 +67,7 @@
 
 mod core;
 mod either_impls;
+mod join;
 mod rama_impls;
 mod response;
 
@@ -79,6 +80,8 @@ pub use self::core::{
     End, IntoHtml, Marker, PreEscaped, Start, decode_entities, end, escape, escape_into, marker,
     start,
 };
+#[doc(inline)]
+pub use self::join::join_display;
 #[doc(inline)]
 pub use self::response::HtmlBuf;
 

--- a/rama-http/src/protocols/html/tests/join.rs
+++ b/rama-http/src/protocols/html/tests/join.rs
@@ -1,0 +1,61 @@
+//! `join_display` — render an iterator of `Display` values as a separated list,
+//! escaping each item while writing the separator verbatim.
+
+use crate::protocols::html::*;
+
+#[test]
+fn csv_attribute_from_iter() {
+    let langs = ["en", "fr", "de"];
+    assert_eq!(
+        meta!(
+            "http-equiv" = "Content-Language",
+            content = join_display(langs, ", ")
+        )
+        .into_string(),
+        r#"<meta http-equiv="Content-Language" content="en, fr, de">"#,
+    );
+}
+
+#[test]
+fn single_item_has_no_separator() {
+    assert_eq!(
+        div!(class = join_display(["solo"], " ")).into_string(),
+        r#"<div class="solo"></div>"#,
+    );
+}
+
+#[test]
+fn empty_iter_renders_nothing() {
+    let empty: [&str; 0] = [];
+    assert_eq!(
+        div!(class = join_display(empty, ", ")).into_string(),
+        r#"<div class=""></div>"#,
+    );
+}
+
+#[test]
+fn non_string_display_items() {
+    // works for any `Display` type, not just strings
+    assert_eq!(
+        div!("data-x" = join_display([1, 2, 3], "-")).into_string(),
+        r#"<div data-x="1-2-3"></div>"#,
+    );
+}
+
+#[test]
+fn items_are_escaped_separator_is_verbatim() {
+    // each item is HTML-escaped (data), the separator is written as-is
+    // (trusted structure). The interior quote in an item must be escaped so
+    // it cannot break out of the attribute.
+    let items = ["a<b", "c\"d"];
+    let out = div!(title = join_display(items, " | ")).into_string();
+    assert_eq!(out, r#"<div title="a&lt;b | c&quot;d"></div>"#);
+}
+
+#[test]
+fn works_in_body_content() {
+    assert_eq!(
+        p!(join_display(["x", "y", "z"], ", ")).into_string(),
+        r#"<p>x, y, z</p>"#,
+    );
+}

--- a/rama-http/src/protocols/html/tests/mod.rs
+++ b/rama-http/src/protocols/html/tests/mod.rs
@@ -13,6 +13,7 @@ mod content;
 mod custom_elements;
 mod elements;
 mod escape;
+mod join;
 mod rama_types;
 mod response;
 mod user_types;


### PR DESCRIPTION
Adds typed `AcceptCh`/`CriticalCh` client-hint headers and wires rama-fp's Accept-CH/Critical-CH/Vary through them (plus an `html::join_display` helper for CSV attribute values).