### PR TITLE
refactor(net): dedup serde str (de)serialize boilerplate via macro

### DIFF
--- a/rama-http/tests/rss_corpus.rs
+++ b/rama-http/tests/rss_corpus.rs
@@ -287,10 +287,8 @@ fn harvest_significant_tokens(xml: &[u8]) -> Vec<String> {
                     text_acc.push_str(&t);
                 }
             }
-            Event::GeneralRef(e) => {
-                if *stack.last().unwrap_or(&true) {
-                    append_general_ref(&e, &mut text_acc);
-                }
+            Event::GeneralRef(e) if *stack.last().unwrap_or(&true) => {
+                append_general_ref(&e, &mut text_acc);
             }
             Event::CData(e) => {
                 // CDATA is its own token (never entity-expanded); flush any

--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -809,24 +809,7 @@ impl fmt::Display for AuthorityRef<'_> {
     }
 }
 
-impl serde::Serialize for Authority {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Authority {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display Authority);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/domain/mod.rs
+++ b/rama-net/src/address/domain/mod.rs
@@ -1049,24 +1049,7 @@ impl PartialEq<Domain> for String {
     }
 }
 
-impl serde::Serialize for Domain {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.as_str().serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Domain {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str Domain);
 
 #[expect(private_bounds)]
 /// A trait which is used by the `rama-net` crate

--- a/rama-net/src/address/domain_address.rs
+++ b/rama-net/src/address/domain_address.rs
@@ -156,24 +156,7 @@ impl TryFrom<&[u8]> for DomainAddress {
     }
 }
 
-impl serde::Serialize for DomainAddress {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for DomainAddress {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display DomainAddress);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -897,24 +897,7 @@ impl TryFrom<&[u8]> for Host {
     }
 }
 
-impl serde::Serialize for Host {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Host {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display Host);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -601,24 +601,7 @@ impl TryFrom<&[u8]> for HostWithOptPort {
     }
 }
 
-impl serde::Serialize for HostWithOptPort {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for HostWithOptPort {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display HostWithOptPort);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -353,24 +353,7 @@ impl TryFrom<&[u8]> for HostWithPort {
     }
 }
 
-impl serde::Serialize for HostWithPort {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for HostWithPort {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display HostWithPort);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -106,24 +106,7 @@ impl Display for ProxyAddress {
     }
 }
 
-impl serde::Serialize for ProxyAddress {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for ProxyAddress {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display ProxyAddress);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -388,24 +388,7 @@ impl TryFrom<&[u8]> for SocketAddress {
     }
 }
 
-impl serde::Serialize for SocketAddress {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for SocketAddress {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display SocketAddress);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -412,24 +412,7 @@ impl std::str::FromStr for NodePort {
     }
 }
 
-impl serde::Serialize for NodeId {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for NodeId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display NodeId);
 
 #[cfg(test)]
 mod tests {

--- a/rama-net/src/lib.rs
+++ b/rama-net/src/lib.rs
@@ -15,6 +15,9 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
+#[macro_use]
+mod macros;
+
 pub mod address;
 pub mod asn;
 pub mod client;

--- a/rama-net/src/macros.rs
+++ b/rama-net/src/macros.rs
@@ -1,0 +1,50 @@
+//! Internal helper macros shared across `rama-net` modules.
+
+/// Implement `serde::Serialize` + `serde::Deserialize` for a string-like type.
+///
+/// Both arms deserialize by parsing a borrowed-or-owned string through the
+/// type's [`FromStr`](std::str::FromStr) impl. They differ only in how the
+/// value is serialized:
+///
+/// - `display $t` serializes via [`Display`](std::fmt::Display)
+///   (`serializer.collect_str`) — use when the canonical wire form is the
+///   `Display` output.
+/// - `as_str $t` serializes the borrowed `self.as_str()` slice directly — use
+///   when the type already holds its canonical string.
+macro_rules! impl_serde_str {
+    (display $t:ty) => {
+        impl serde::Serialize for $t {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.collect_str(self)
+            }
+        }
+        $crate::macros::impl_serde_str!(@de $t);
+    };
+    (as_str $t:ty) => {
+        impl serde::Serialize for $t {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.as_str().serialize(serializer)
+            }
+        }
+        $crate::macros::impl_serde_str!(@de $t);
+    };
+    (@de $t:ty) => {
+        impl<'de> serde::Deserialize<'de> for $t {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+                s.parse().map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_serde_str;

--- a/rama-net/src/socket/device_name.rs
+++ b/rama-net/src/socket/device_name.rs
@@ -100,25 +100,7 @@ impl TryFrom<&[u8]> for DeviceName {
     }
 }
 
-impl serde::Serialize for DeviceName {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let name = self.as_str();
-        name.serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for DeviceName {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str DeviceName);
 
 pub(super) const fn is_valid(s: &[u8]) -> bool {
     if s.is_empty() || s.len() > DEVICE_MAX_LEN {

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -1049,24 +1049,7 @@ uri_try_from!(&str, String, &[u8], Vec<u8>, rama_core::bytes::Bytes,);
 // implements `Deserialize` via `FromStr`. URIs constructed via
 // [`Uri::parse_authority_form`] or [`Uri::parse_reference`] are out of
 // scope for round-trip — those forms aren't reachable through `parse`.
-impl serde::Serialize for Uri {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.collect_str(self)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Uri {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        Self::parse(s.as_ref()).map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(display Uri);
 
 impl Uri {
     /// Shared walker for [`Display`](std::fmt::Display) and


### PR DESCRIPTION
Replace 11 hand-written serde::Serialize/Deserialize impl pairs across the address, forwarded, socket and uri modules with a single crate-local impl_serde_str! macro.