### PR TITLE
refactor(http): dedup HTTP layer/io boilerplate

### DIFF
--- a/rama-http/src/io/mod.rs
+++ b/rama-http/src/io/mod.rs
@@ -1,5 +1,12 @@
 //! http I/O utilities, e.g. writing http requests/responses in std http format.
 
+use crate::{Body, HeaderMap, StreamingBody, body::util::BodyExt};
+use rama_core::bytes::Bytes;
+use rama_core::error::{BoxError, ErrorContext as _};
+use rama_core::extensions::Extensions;
+use rama_http_types::{Version, proto::h1::Http1HeaderMap};
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+
 mod request;
 #[doc(inline)]
 pub use request::write_http_request;
@@ -9,3 +16,67 @@ mod response;
 pub use response::write_http_response;
 
 pub mod upgrade;
+
+/// Write the request/response `headers` (combined with `extensions` into an
+/// [`Http1HeaderMap`]) to `w` in std HTTP/1 wire format — lower-cased names for
+/// H2/H3, original casing otherwise. The map is reconstructed back into
+/// `*headers` so callers can keep tracing it after this consumes it.
+///
+/// Shared by [`write_http_request`] and [`write_http_response`].
+pub(crate) async fn write_http1_header_map<W>(
+    w: &mut W,
+    headers: &mut HeaderMap,
+    extensions: &Extensions,
+    version: Version,
+) -> Result<(), BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+{
+    let header_map = Http1HeaderMap::new(std::mem::take(headers), Some(extensions));
+    // put a clone of this data back into headers as we don't really want to
+    // consume it, just trace it
+    *headers = header_map.clone().consume(extensions);
+
+    for (name, value) in header_map {
+        match version {
+            Version::HTTP_2 | Version::HTTP_3 => {
+                // write lower-case for H2/H3
+                w.write_all(
+                    format!("{}: {}\r\n", name.header_name().as_str(), value.to_str()?).as_bytes(),
+                )
+                .await?;
+            }
+            _ => {
+                w.write_all(format!("{}: {}\r\n", name, value.to_str()?).as_bytes())
+                    .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Collect `body`; when `write_body` is set, write the CRLF separator and the
+/// buffered bytes to `w` and return a [`Body`] that re-emits them. When unset,
+/// return the body untouched (headers-only writes). Shared by
+/// [`write_http_request`] and [`write_http_response`].
+pub(crate) async fn write_http1_body<W, B>(
+    w: &mut W,
+    body: B,
+    write_body: bool,
+) -> Result<Body, BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    Ok(if write_body {
+        let body = body.collect().await.into_box_error()?.to_bytes();
+        w.write_all(b"\r\n").await?;
+        if !body.is_empty() {
+            w.write_all(body.as_ref()).await?;
+        }
+        Body::from(body)
+    } else {
+        Body::new(body)
+    })
+}

--- a/rama-http/src/io/request.rs
+++ b/rama-http/src/io/request.rs
@@ -1,12 +1,6 @@
-use crate::{Body, Request, StreamingBody, body::util::BodyExt};
-use rama_core::{
-    bytes::Bytes,
-    error::{BoxError, ErrorContext as _},
-};
-use rama_http_types::proto::{
-    h1::Http1HeaderMap,
-    h2::{PseudoHeader, PseudoHeaderOrder},
-};
+use crate::{Request, StreamingBody};
+use rama_core::{bytes::Bytes, error::BoxError};
+use rama_http_types::proto::h2::{PseudoHeader, PseudoHeaderOrder};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 /// Write an HTTP request to a writer in std http format.
@@ -77,38 +71,11 @@ where
             }
         }
 
-        let header_map = Http1HeaderMap::new(parts.headers, Some(&parts.extensions));
-        // put a clone of this data back into parts as we don't really want to consume it, just trace it
-        parts.headers = header_map.clone().consume(&parts.extensions);
-
-        for (name, value) in header_map {
-            match parts.version {
-                rama_http_types::Version::HTTP_2 | rama_http_types::Version::HTTP_3 => {
-                    // write lower-case for H2/H3
-                    w.write_all(
-                        format!("{}: {}\r\n", name.header_name().as_str(), value.to_str()?)
-                            .as_bytes(),
-                    )
-                    .await?;
-                }
-                _ => {
-                    w.write_all(format!("{}: {}\r\n", name, value.to_str()?).as_bytes())
-                        .await?;
-                }
-            }
-        }
+        super::write_http1_header_map(w, &mut parts.headers, &parts.extensions, parts.version)
+            .await?;
     }
 
-    let body = if write_body {
-        let body = body.collect().await.into_box_error()?.to_bytes();
-        w.write_all(b"\r\n").await?;
-        if !body.is_empty() {
-            w.write_all(body.as_ref()).await?;
-        }
-        Body::from(body)
-    } else {
-        Body::new(body)
-    };
+    let body = super::write_http1_body(w, body, write_body).await?;
 
     let req = Request::from_parts(parts, body);
     Ok(req)
@@ -117,6 +84,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Body;
 
     #[tokio::test]
     async fn test_write_http_request_get() {

--- a/rama-http/src/io/response.rs
+++ b/rama-http/src/io/response.rs
@@ -1,12 +1,6 @@
-use crate::{Body, Response, StreamingBody, body::util::BodyExt};
-use rama_core::{
-    bytes::Bytes,
-    error::{BoxError, ErrorContext as _},
-};
-use rama_http_types::proto::{
-    h1::Http1HeaderMap,
-    h2::{PseudoHeader, PseudoHeaderOrder},
-};
+use crate::{Response, StreamingBody};
+use rama_core::{bytes::Bytes, error::BoxError};
+use rama_http_types::proto::h2::{PseudoHeader, PseudoHeaderOrder};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 /// Write an HTTP response to a writer in std http format.
@@ -66,38 +60,11 @@ where
             }
         }
 
-        let header_map = Http1HeaderMap::new(parts.headers, Some(&parts.extensions));
-        // put a clone of this data back into parts as we don't really want to consume it, just trace it
-        parts.headers = header_map.clone().consume(&parts.extensions);
-
-        for (name, value) in header_map {
-            match parts.version {
-                rama_http_types::Version::HTTP_2 | rama_http_types::Version::HTTP_3 => {
-                    // write lower-case for H2/H3
-                    w.write_all(
-                        format!("{}: {}\r\n", name.header_name().as_str(), value.to_str()?)
-                            .as_bytes(),
-                    )
-                    .await?;
-                }
-                _ => {
-                    w.write_all(format!("{}: {}\r\n", name, value.to_str()?).as_bytes())
-                        .await?;
-                }
-            }
-        }
+        super::write_http1_header_map(w, &mut parts.headers, &parts.extensions, parts.version)
+            .await?;
     }
 
-    let body = if write_body {
-        let body = body.collect().await.into_box_error()?.to_bytes();
-        w.write_all(b"\r\n").await?;
-        if !body.is_empty() {
-            w.write_all(body.as_ref()).await?;
-        }
-        Body::from(body)
-    } else {
-        Body::new(body)
-    };
+    let body = super::write_http1_body(w, body, write_body).await?;
 
     let req = Response::from_parts(parts, body);
     Ok(req)
@@ -106,6 +73,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Body;
 
     #[tokio::test]
     async fn test_write_response_ok() {

--- a/rama-http/src/layer/compression/body.rs
+++ b/rama-http/src/layer/compression/body.rs
@@ -3,6 +3,7 @@
 use crate::HeaderMap;
 use crate::layer::util::compression::{
     AsyncReadBody, BodyIntoStream, CompressionLevel, DecorateAsyncRead, WrapBody,
+    compressed_body_poll_frame, impl_decorate_async_read,
 };
 use rama_core::{
     bytes::{Buf, Bytes},
@@ -129,20 +130,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        match self.project().inner.project() {
-            BodyInnerProj::Gzip { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Deflate { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Brotli { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Zstd { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Identity { inner } => match ready!(inner.poll_frame(cx)) {
-                Some(Ok(frame)) => {
-                    let frame = frame.map_data(|mut buf| buf.copy_to_bytes(buf.remaining()));
-                    Poll::Ready(Some(Ok(frame)))
-                }
-                Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
-                None => Poll::Ready(None),
-            },
-        }
+        compressed_body_poll_frame!(self, cx)
     }
 
     fn size_hint(&self) -> rama_http_types::body::SizeHint {
@@ -162,97 +150,49 @@ where
     }
 }
 
-impl<B> DecorateAsyncRead for GzipEncoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = GzipEncoder<Self::Input>;
+impl_decorate_async_read!(GzipEncoder: |input, quality| {
+    GzipEncoder::with_quality(input, quality.into_async_compression())
+});
 
-    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        GzipEncoder::with_quality(input, quality.into_async_compression())
+impl_decorate_async_read!(ZlibEncoder: |input, quality| {
+    ZlibEncoder::with_quality(input, quality.into_async_compression())
+});
+
+impl_decorate_async_read!(BrotliEncoder: |input, quality| {
+    // The brotli crate used under the hood here has a default compression level of 11,
+    // which is the max for brotli. This causes extremely slow compression times, so we
+    // manually set a default of 4 here.
+    //
+    // This is the same default used by NGINX for on-the-fly brotli compression.
+    let level = match quality {
+        CompressionLevel::Default => async_compression::Level::Precise(4),
+        other => other.into_async_compression(),
+    };
+    BrotliEncoder::with_quality(input, level)
+});
+
+impl_decorate_async_read!(ZstdEncoder: |input, quality| {
+    // See https://issues.chromium.org/issues/41493659:
+    //  "For memory usage reasons, Chromium limits the window size to 8MB"
+    // See https://datatracker.ietf.org/doc/html/rfc8878#name-window-descriptor
+    //  "For improved interoperability, it's recommended for decoders to support values
+    //  of Window_Size up to 8 MB and for encoders not to generate frames requiring a
+    //  Window_Size larger than 8 MB."
+    // Level 17 in zstd (as of v1.5.6) is the first level with a window size of 8 MB (2^23):
+    // https://github.com/facebook/zstd/blob/v1.5.6/lib/compress/clevels.h#L25-L51
+    // Set the parameter for all levels >= 17. This will either have no effect (but reduce
+    // the risk of future changes in zstd) or limit the window log to 8MB.
+    let needs_window_limit = match quality {
+        CompressionLevel::Best => true, // level 20
+        CompressionLevel::Precise(level) => level >= 17,
+        CompressionLevel::Default | CompressionLevel::Fastest => false,
+    };
+    // The parameter is not set for levels below 17 as it will increase the window size
+    // for those levels.
+    if needs_window_limit {
+        let params = [async_compression::zstd::CParameter::window_log(23)];
+        ZstdEncoder::with_quality_and_params(input, quality.into_async_compression(), &params)
+    } else {
+        ZstdEncoder::with_quality(input, quality.into_async_compression())
     }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
-
-impl<B> DecorateAsyncRead for ZlibEncoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = ZlibEncoder<Self::Input>;
-
-    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        ZlibEncoder::with_quality(input, quality.into_async_compression())
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
-
-impl<B> DecorateAsyncRead for BrotliEncoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = BrotliEncoder<Self::Input>;
-
-    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        // The brotli crate used under the hood here has a default compression level of 11,
-        // which is the max for brotli. This causes extremely slow compression times, so we
-        // manually set a default of 4 here.
-        //
-        // This is the same default used by NGINX for on-the-fly brotli compression.
-        let level = match quality {
-            CompressionLevel::Default => async_compression::Level::Precise(4),
-            other => other.into_async_compression(),
-        };
-        BrotliEncoder::with_quality(input, level)
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
-
-impl<B> DecorateAsyncRead for ZstdEncoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = ZstdEncoder<Self::Input>;
-
-    fn apply(input: Self::Input, quality: CompressionLevel) -> Self::Output {
-        // See https://issues.chromium.org/issues/41493659:
-        //  "For memory usage reasons, Chromium limits the window size to 8MB"
-        // See https://datatracker.ietf.org/doc/html/rfc8878#name-window-descriptor
-        //  "For improved interoperability, it's recommended for decoders to support values
-        //  of Window_Size up to 8 MB and for encoders not to generate frames requiring a
-        //  Window_Size larger than 8 MB."
-        // Level 17 in zstd (as of v1.5.6) is the first level with a window size of 8 MB (2^23):
-        // https://github.com/facebook/zstd/blob/v1.5.6/lib/compress/clevels.h#L25-L51
-        // Set the parameter for all levels >= 17. This will either have no effect (but reduce
-        // the risk of future changes in zstd) or limit the window log to 8MB.
-        let needs_window_limit = match quality {
-            CompressionLevel::Best => true, // level 20
-            CompressionLevel::Precise(level) => level >= 17,
-            CompressionLevel::Default | CompressionLevel::Fastest => false,
-        };
-        // The parameter is not set for levels below 17 as it will increase the window size
-        // for those levels.
-        if needs_window_limit {
-            let params = [async_compression::zstd::CParameter::window_log(23)];
-            ZstdEncoder::with_quality_and_params(input, quality.into_async_compression(), &params)
-        } else {
-            ZstdEncoder::with_quality(input, quality.into_async_compression())
-        }
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
+});

--- a/rama-http/src/layer/decompression/body.rs
+++ b/rama-http/src/layer/decompression/body.rs
@@ -4,6 +4,7 @@ use crate::HeaderMap;
 use crate::body::{Body, Frame, SizeHint, StreamingBody};
 use crate::layer::util::compression::{
     AsyncReadBody, BodyIntoStream, CompressionLevel, DecorateAsyncRead, WrapBody,
+    compressed_body_poll_frame, impl_decorate_async_read,
 };
 use rama_core::error::BoxError;
 
@@ -121,20 +122,7 @@ where
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        match self.project().inner.project() {
-            BodyInnerProj::Gzip { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Deflate { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Brotli { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Zstd { inner } => inner.poll_frame(cx),
-            BodyInnerProj::Identity { inner } => match ready!(inner.poll_frame(cx)) {
-                Some(Ok(frame)) => {
-                    let frame = frame.map_data(|mut buf| buf.copy_to_bytes(buf.remaining()));
-                    Poll::Ready(Some(Ok(frame)))
-                }
-                Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
-                None => Poll::Ready(None),
-            },
-        }
+        compressed_body_poll_frame!(self, cx)
     }
 
     fn size_hint(&self) -> SizeHint {
@@ -148,68 +136,20 @@ where
     }
 }
 
-impl<B> DecorateAsyncRead for GzipDecoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = GzipDecoder<Self::Input>;
+impl_decorate_async_read!(GzipDecoder: |input, _quality| {
+    GzipDecoder::new(input)
+});
 
-    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
-        GzipDecoder::new(input)
-    }
+impl_decorate_async_read!(ZlibDecoder: |input, _quality| {
+    ZlibDecoder::new(input)
+});
 
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
+impl_decorate_async_read!(BrotliDecoder: |input, _quality| {
+    BrotliDecoder::new(input)
+});
 
-impl<B> DecorateAsyncRead for ZlibDecoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = ZlibDecoder<Self::Input>;
-
-    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
-        ZlibDecoder::new(input)
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
-
-impl<B> DecorateAsyncRead for BrotliDecoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = BrotliDecoder<Self::Input>;
-
-    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
-        BrotliDecoder::new(input)
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
-
-impl<B> DecorateAsyncRead for ZstdDecoder<B>
-where
-    B: StreamingBody,
-{
-    type Input = AsyncReadBody<B>;
-    type Output = ZstdDecoder<Self::Input>;
-
-    fn apply(input: Self::Input, _quality: CompressionLevel) -> Self::Output {
-        let mut decoder = ZstdDecoder::new(input);
-        decoder.multiple_members(true);
-        decoder
-    }
-
-    fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
-        pinned.get_pin_mut()
-    }
-}
+impl_decorate_async_read!(ZstdDecoder: |input, _quality| {
+    let mut decoder = ZstdDecoder::new(input);
+    decoder.multiple_members(true);
+    decoder
+});

--- a/rama-http/src/layer/sensitive_headers.rs
+++ b/rama-http/src/layer/sensitive_headers.rs
@@ -43,31 +43,6 @@ use rama_core::{Layer, Service};
 use rama_utils::macros::define_inner_service_accessors;
 use std::sync::Arc;
 
-/// Generate the `new` / `from_shared` constructors shared verbatim by the three
-/// `SetSensitive*HeadersLayer` types (identical but for the type named in their
-/// doc comments).
-macro_rules! impl_sensitive_headers_layer_ctors {
-    ($layer:ident) => {
-        impl $layer {
-            #[doc = concat!("Create a new [`", stringify!($layer), "`].")]
-            pub fn new<I>(headers: I) -> Self
-            where
-                I: IntoIterator<Item = HeaderName>,
-            {
-                let headers = headers.into_iter().collect::<Vec<_>>();
-                Self::from_shared(headers.into())
-            }
-
-            #[doc = concat!(
-                        "Create a new [`", stringify!($layer), "`] from a shared slice of headers."
-                    )]
-            pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
-                Self { headers }
-            }
-        }
-    };
-}
-
 /// Mark headers as [sensitive] on both requests and responses.
 ///
 /// Produces [`SetSensitiveHeaders`] services.
@@ -80,7 +55,21 @@ pub struct SetSensitiveHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl_sensitive_headers_layer_ctors!(SetSensitiveHeadersLayer);
+impl SetSensitiveHeadersLayer {
+    /// Create a new [`SetSensitiveHeadersLayer`].
+    pub fn new<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        let headers = headers.into_iter().collect::<Vec<_>>();
+        Self::from_shared(headers.into())
+    }
+
+    /// Create a new [`SetSensitiveHeadersLayer`] from a shared slice of headers.
+    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
+        Self { headers }
+    }
+}
 
 impl<S> Layer<S> for SetSensitiveHeadersLayer {
     type Service = SetSensitiveHeaders<S>;
@@ -119,7 +108,21 @@ pub struct SetSensitiveRequestHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl_sensitive_headers_layer_ctors!(SetSensitiveRequestHeadersLayer);
+impl SetSensitiveRequestHeadersLayer {
+    /// Create a new [`SetSensitiveRequestHeadersLayer`].
+    pub fn new<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        let headers = headers.into_iter().collect::<Vec<_>>();
+        Self::from_shared(headers.into())
+    }
+
+    /// Create a new [`SetSensitiveRequestHeadersLayer`] from a shared slice of headers.
+    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
+        Self { headers }
+    }
+}
 
 impl<S> Layer<S> for SetSensitiveRequestHeadersLayer {
     type Service = SetSensitiveRequestHeaders<S>;
@@ -203,7 +206,21 @@ pub struct SetSensitiveResponseHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl_sensitive_headers_layer_ctors!(SetSensitiveResponseHeadersLayer);
+impl SetSensitiveResponseHeadersLayer {
+    /// Create a new [`SetSensitiveResponseHeadersLayer`].
+    pub fn new<I>(headers: I) -> Self
+    where
+        I: IntoIterator<Item = HeaderName>,
+    {
+        let headers = headers.into_iter().collect::<Vec<_>>();
+        Self::from_shared(headers.into())
+    }
+
+    /// Create a new [`SetSensitiveResponseHeadersLayer`] from a shared slice of headers.
+    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
+        Self { headers }
+    }
+}
 
 impl<S> Layer<S> for SetSensitiveResponseHeadersLayer {
     type Service = SetSensitiveResponseHeaders<S>;

--- a/rama-http/src/layer/sensitive_headers.rs
+++ b/rama-http/src/layer/sensitive_headers.rs
@@ -43,6 +43,31 @@ use rama_core::{Layer, Service};
 use rama_utils::macros::define_inner_service_accessors;
 use std::sync::Arc;
 
+/// Generate the `new` / `from_shared` constructors shared verbatim by the three
+/// `SetSensitive*HeadersLayer` types (identical but for the type named in their
+/// doc comments).
+macro_rules! impl_sensitive_headers_layer_ctors {
+    ($layer:ident) => {
+        impl $layer {
+            #[doc = concat!("Create a new [`", stringify!($layer), "`].")]
+            pub fn new<I>(headers: I) -> Self
+            where
+                I: IntoIterator<Item = HeaderName>,
+            {
+                let headers = headers.into_iter().collect::<Vec<_>>();
+                Self::from_shared(headers.into())
+            }
+
+            #[doc = concat!(
+                        "Create a new [`", stringify!($layer), "`] from a shared slice of headers."
+                    )]
+            pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
+                Self { headers }
+            }
+        }
+    };
+}
+
 /// Mark headers as [sensitive] on both requests and responses.
 ///
 /// Produces [`SetSensitiveHeaders`] services.
@@ -55,21 +80,7 @@ pub struct SetSensitiveHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl SetSensitiveHeadersLayer {
-    /// Create a new [`SetSensitiveHeadersLayer`].
-    pub fn new<I>(headers: I) -> Self
-    where
-        I: IntoIterator<Item = HeaderName>,
-    {
-        let headers = headers.into_iter().collect::<Vec<_>>();
-        Self::from_shared(headers.into())
-    }
-
-    /// Create a new [`SetSensitiveHeadersLayer`] from a shared slice of headers.
-    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
-        Self { headers }
-    }
-}
+impl_sensitive_headers_layer_ctors!(SetSensitiveHeadersLayer);
 
 impl<S> Layer<S> for SetSensitiveHeadersLayer {
     type Service = SetSensitiveHeaders<S>;
@@ -108,21 +119,7 @@ pub struct SetSensitiveRequestHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl SetSensitiveRequestHeadersLayer {
-    /// Create a new [`SetSensitiveRequestHeadersLayer`].
-    pub fn new<I>(headers: I) -> Self
-    where
-        I: IntoIterator<Item = HeaderName>,
-    {
-        let headers = headers.into_iter().collect::<Vec<_>>();
-        Self::from_shared(headers.into())
-    }
-
-    /// Create a new [`SetSensitiveRequestHeadersLayer`] from a shared slice of headers.
-    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
-        Self { headers }
-    }
-}
+impl_sensitive_headers_layer_ctors!(SetSensitiveRequestHeadersLayer);
 
 impl<S> Layer<S> for SetSensitiveRequestHeadersLayer {
     type Service = SetSensitiveRequestHeaders<S>;
@@ -206,21 +203,7 @@ pub struct SetSensitiveResponseHeadersLayer {
     headers: Arc<[HeaderName]>,
 }
 
-impl SetSensitiveResponseHeadersLayer {
-    /// Create a new [`SetSensitiveResponseHeadersLayer`].
-    pub fn new<I>(headers: I) -> Self
-    where
-        I: IntoIterator<Item = HeaderName>,
-    {
-        let headers = headers.into_iter().collect::<Vec<_>>();
-        Self::from_shared(headers.into())
-    }
-
-    /// Create a new [`SetSensitiveResponseHeadersLayer`] from a shared slice of headers.
-    pub fn from_shared(headers: Arc<[HeaderName]>) -> Self {
-        Self { headers }
-    }
-}
+impl_sensitive_headers_layer_ctors!(SetSensitiveResponseHeadersLayer);
 
 impl<S> Layer<S> for SetSensitiveResponseHeadersLayer {
     type Service = SetSensitiveResponseHeaders<S>;

--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -46,6 +46,41 @@ pub(super) fn write_headers_body_flags(mode: Option<WriterMode>) -> (bool, bool)
     }
 }
 
+/// Drive a bidirectional-writer receive loop: write each request/response to
+/// `$writer` (logging any error), emit a `\r\n` separator between messages, and
+/// flush when the channel closes. Shared by the unbounded and bounded
+/// constructors, which differ only in receiver type and tracing span — both
+/// satisfied by passing `$rx` (`recv()` is common to both receivers).
+macro_rules! drive_bidirectional_writer {
+    ($writer:ident, $rx:ident, $req_headers:ident, $req_body:ident, $res_headers:ident, $res_body:ident) => {{
+        while let Some(msg) = $rx.recv().await {
+            match msg {
+                BidirectionalMessage::Request(req) => {
+                    if let Err(err) =
+                        write_http_request(&mut $writer, req, $req_headers, $req_body).await
+                    {
+                        tracing::error!("failed to write http request to writer: {err:?}")
+                    }
+                }
+                BidirectionalMessage::Response(res) => {
+                    if let Err(err) =
+                        write_http_response(&mut $writer, res, $res_headers, $res_body).await
+                    {
+                        tracing::error!("failed to write http response to writer: {err:?}")
+                    }
+                }
+            }
+            if let Err(err) = $writer.write_all(b"\r\n").await {
+                tracing::error!("failed to write separator to writer: {err:?}")
+            }
+        }
+
+        if let Err(err) = $writer.flush().await {
+            tracing::error!("failed to flush writer: {err:?}")
+        }
+    }};
+}
+
 /// A writer that can write both requests and responses.
 #[derive(Clone)]
 pub struct BidirectionalWriter<S> {
@@ -76,41 +111,14 @@ impl BidirectionalWriter<UnboundedSender<BidirectionalMessage>> {
         let (write_response_headers, write_response_body) = write_headers_body_flags(response_mode);
 
         executor.spawn_task(async move {
-            while let Some(msg) = rx.recv().await {
-                match msg {
-                    BidirectionalMessage::Request(req) => {
-                        if let Err(err) = write_http_request(
-                            &mut writer,
-                            req,
-                            write_request_headers,
-                            write_request_body,
-                        )
-                        .await
-                        {
-                            tracing::error!("failed to write http request to writer: {err:?}")
-                        }
-                    }
-                    BidirectionalMessage::Response(res) => {
-                        if let Err(err) = write_http_response(
-                            &mut writer,
-                            res,
-                            write_response_headers,
-                            write_response_body,
-                        )
-                        .await
-                        {
-                            tracing::error!("failed to write http response to writer: {err:?}")
-                        }
-                    }
-                }
-                if let Err(err) = writer.write_all(b"\r\n").await {
-                    tracing::error!("failed to write separator to writer: {err:?}")
-                }
-            }
-
-            if let Err(err) = writer.flush().await {
-                tracing::error!("failed to flush writer: {err:?}")
-            }
+            drive_bidirectional_writer!(
+                writer,
+                rx,
+                write_request_headers,
+                write_request_body,
+                write_response_headers,
+                write_response_body
+            );
         });
 
         Self { sender: tx }
@@ -162,41 +170,14 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
 
         executor.spawn_task(
             async move {
-                while let Some(msg) = rx.recv().await {
-                    match msg {
-                        BidirectionalMessage::Request(req) => {
-                            if let Err(err) = write_http_request(
-                                &mut writer,
-                                req,
-                                write_request_headers,
-                                write_request_body,
-                            )
-                            .await
-                            {
-                                tracing::error!("failed to write http request to writer: {err:?}")
-                            }
-                        }
-                        BidirectionalMessage::Response(res) => {
-                            if let Err(err) = write_http_response(
-                                &mut writer,
-                                res,
-                                write_response_headers,
-                                write_response_body,
-                            )
-                            .await
-                            {
-                                tracing::error!("failed to write http response to writer: {err:?}")
-                            }
-                        }
-                    }
-                    if let Err(err) = writer.write_all(b"\r\n").await {
-                        tracing::error!("failed to write separator to writer: {err:?}")
-                    }
-                }
-
-                if let Err(err) = writer.flush().await {
-                    tracing::error!("failed to flush writer: {err:?}")
-                }
+                drive_bidirectional_writer!(
+                    writer,
+                    rx,
+                    write_request_headers,
+                    write_request_body,
+                    write_response_headers,
+                    write_response_body
+                );
             }
             .instrument(span),
         );

--- a/rama-http/src/layer/util/compression.rs
+++ b/rama-http/src/layer/util/compression.rs
@@ -24,6 +24,55 @@ use std::{
 };
 use tokio::io::AsyncRead;
 
+/// The `StreamingBody::poll_frame` body shared verbatim by the compression and
+/// decompression `BodyInner` enums: forward the four codec variants and rechunk
+/// the `Identity` passthrough into `Bytes`.
+///
+/// `BodyInnerProj`, `ready!`, `Frame`, `Buf` and `Poll` resolve at the call
+/// site — both `body.rs` modules import the same set.
+macro_rules! compressed_body_poll_frame {
+    ($self:expr, $cx:expr) => {
+        match $self.project().inner.project() {
+            BodyInnerProj::Gzip { inner } => inner.poll_frame($cx),
+            BodyInnerProj::Deflate { inner } => inner.poll_frame($cx),
+            BodyInnerProj::Brotli { inner } => inner.poll_frame($cx),
+            BodyInnerProj::Zstd { inner } => inner.poll_frame($cx),
+            BodyInnerProj::Identity { inner } => match ready!(inner.poll_frame($cx)) {
+                Some(Ok(frame)) => {
+                    let frame = frame.map_data(|mut buf| buf.copy_to_bytes(buf.remaining()));
+                    Poll::Ready(Some(Ok(frame)))
+                }
+                Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
+                None => Poll::Ready(None),
+            },
+        }
+    };
+}
+pub(crate) use compressed_body_poll_frame;
+
+/// Generate a [`DecorateAsyncRead`] impl for a codec type. The four codec
+/// `Input`/`Output` aliases and the `get_pin_mut` delegation are identical
+/// across every (de)compression codec; only the `apply` body differs, so it is
+/// supplied as a closure-shaped block.
+macro_rules! impl_decorate_async_read {
+    ($codec:ident: |$input:pat_param, $quality:pat_param| $apply:block) => {
+        impl<B> DecorateAsyncRead for $codec<B>
+        where
+            B: StreamingBody,
+        {
+            type Input = AsyncReadBody<B>;
+            type Output = $codec<Self::Input>;
+
+            fn apply($input: Self::Input, $quality: CompressionLevel) -> Self::Output $apply
+
+            fn get_pin_mut(pinned: Pin<&mut Self::Output>) -> Pin<&mut Self::Input> {
+                pinned.get_pin_mut()
+            }
+        }
+    };
+}
+pub(crate) use impl_decorate_async_read;
+
 /// A `Body` that has been converted into an `AsyncRead`.
 pub(crate) type AsyncReadBody<B> = StreamReader<
     StreamErrorIntoIoError<BodyIntoStream<B>, <B as StreamingBody>::Error>,

--- a/rama-http/src/service/web/endpoint/response/into_response.rs
+++ b/rama-http/src/service/web/endpoint/response/into_response.rs
@@ -28,6 +28,23 @@ use std::{
     task::{Context, Poll},
 };
 
+/// Implement [`IntoResponse`] for an owned, sized body type by streaming it
+/// through [`Body`] and tagging the response with the given `Content-Type` plus
+/// an exact `Content-Length` (from the value's `len()`).
+macro_rules! impl_into_response_sized_body {
+    ($t:ty, $content_type:expr) => {
+        impl IntoResponse for $t {
+            fn into_response(self) -> Response {
+                let len = self.len();
+                let mut res = Body::from(self).into_response();
+                res.headers_mut().typed_insert($content_type);
+                res.headers_mut().typed_insert(ContentLength(len as u64));
+                res
+            }
+        }
+    };
+}
+
 /// Trait for generating responses.
 ///
 /// Types that implement `IntoResponse` can be returned from handlers.
@@ -122,45 +139,10 @@ impl IntoResponse for Box<str> {
     }
 }
 
-impl IntoResponse for Cow<'static, str> {
-    fn into_response(self) -> Response {
-        let len = self.len();
-        let mut res = Body::from(self).into_response();
-        res.headers_mut().typed_insert(ContentType::text_utf8());
-        res.headers_mut().typed_insert(ContentLength(len as u64));
-        res
-    }
-}
-
-impl IntoResponse for ArcStr {
-    fn into_response(self) -> Response {
-        let len = self.len();
-        let mut res = Body::from(self).into_response();
-        res.headers_mut().typed_insert(ContentType::text_utf8());
-        res.headers_mut().typed_insert(ContentLength(len as u64));
-        res
-    }
-}
-
-impl IntoResponse for &ArcStr {
-    fn into_response(self) -> Response {
-        let len = self.len();
-        let mut res = Body::from(self).into_response();
-        res.headers_mut().typed_insert(ContentType::text_utf8());
-        res.headers_mut().typed_insert(ContentLength(len as u64));
-        res
-    }
-}
-
-impl IntoResponse for Bytes {
-    fn into_response(self) -> Response {
-        let len = self.len();
-        let mut res = Body::from(self).into_response();
-        res.headers_mut().typed_insert(ContentType::octet_stream());
-        res.headers_mut().typed_insert(ContentLength(len as u64));
-        res
-    }
-}
+impl_into_response_sized_body!(Cow<'static, str>, ContentType::text_utf8());
+impl_into_response_sized_body!(ArcStr, ContentType::text_utf8());
+impl_into_response_sized_body!(&ArcStr, ContentType::text_utf8());
+impl_into_response_sized_body!(Bytes, ContentType::octet_stream());
 
 impl IntoResponse for BytesMut {
     fn into_response(self) -> Response {
@@ -276,15 +258,7 @@ impl IntoResponse for Box<[u8]> {
     }
 }
 
-impl IntoResponse for Cow<'static, [u8]> {
-    fn into_response(self) -> Response {
-        let len = self.len();
-        let mut res = Body::from(self).into_response();
-        res.headers_mut().typed_insert(ContentType::octet_stream());
-        res.headers_mut().typed_insert(ContentLength(len as u64));
-        res
-    }
-}
+impl_into_response_sized_body!(Cow<'static, [u8]>, ContentType::octet_stream());
 
 impl<R> IntoResponse for (StatusCode, R)
 where


### PR DESCRIPTION
Removes duplicated logic across the http layers and io writers, found with AST
clone detection. No behavior change; rama-http checks clean with
`--all-features` and the relevant layer/io tests pass.

- compression/decompression body: share the identical `StreamingBody::poll_frame`
  and the eight `DecorateAsyncRead` impls (`compressed_body_poll_frame!` and
  `impl_decorate_async_read!` macros)
- macro-generate the three `SetSensitive*HeadersLayer` `new`/`from_shared`
  constructors (docs rebuilt per type via `concat!`/`stringify!`)
- macro the five sized-body `IntoResponse` impls (`Cow<str>`, `ArcStr`,
  `&ArcStr`, `Bytes`, `Cow<[u8]>`)
- share the HTTP/1 header- and body-writing blocks between `write_http_request`
  and `write_http_response` (`write_http1_header_map` / `write_http1_body`)
- dedup the unbounded/bounded `BidirectionalWriter` receive loop via a
  `drive_bidirectional_writer!` macro
