### PR TITLE
refactor(utils,net,ua): promote serde str macro to rama-utils, dedup rama-ua

### DIFF
--- a/rama-net/src/address/authority.rs
+++ b/rama-net/src/address/authority.rs
@@ -809,6 +809,8 @@ impl fmt::Display for AuthorityRef<'_> {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display Authority);
 
 #[cfg(test)]

--- a/rama-net/src/address/domain/mod.rs
+++ b/rama-net/src/address/domain/mod.rs
@@ -1049,6 +1049,8 @@ impl PartialEq<Domain> for String {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(as_str Domain);
 
 #[expect(private_bounds)]

--- a/rama-net/src/address/domain_address.rs
+++ b/rama-net/src/address/domain_address.rs
@@ -156,6 +156,8 @@ impl TryFrom<&[u8]> for DomainAddress {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display DomainAddress);
 
 #[cfg(test)]

--- a/rama-net/src/address/host.rs
+++ b/rama-net/src/address/host.rs
@@ -897,6 +897,8 @@ impl TryFrom<&[u8]> for Host {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display Host);
 
 #[cfg(test)]

--- a/rama-net/src/address/host_with_opt_port.rs
+++ b/rama-net/src/address/host_with_opt_port.rs
@@ -601,6 +601,8 @@ impl TryFrom<&[u8]> for HostWithOptPort {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display HostWithOptPort);
 
 #[cfg(test)]

--- a/rama-net/src/address/host_with_port.rs
+++ b/rama-net/src/address/host_with_port.rs
@@ -353,6 +353,8 @@ impl TryFrom<&[u8]> for HostWithPort {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display HostWithPort);
 
 #[cfg(test)]

--- a/rama-net/src/address/proxy.rs
+++ b/rama-net/src/address/proxy.rs
@@ -106,6 +106,8 @@ impl Display for ProxyAddress {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display ProxyAddress);
 
 #[cfg(test)]

--- a/rama-net/src/address/socket_address.rs
+++ b/rama-net/src/address/socket_address.rs
@@ -388,6 +388,8 @@ impl TryFrom<&[u8]> for SocketAddress {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display SocketAddress);
 
 #[cfg(test)]

--- a/rama-net/src/forwarded/node.rs
+++ b/rama-net/src/forwarded/node.rs
@@ -412,6 +412,8 @@ impl std::str::FromStr for NodePort {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display NodeId);
 
 #[cfg(test)]

--- a/rama-net/src/lib.rs
+++ b/rama-net/src/lib.rs
@@ -15,9 +15,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
-#[macro_use]
-mod macros;
-
 pub mod address;
 pub mod asn;
 pub mod client;

--- a/rama-net/src/socket/device_name.rs
+++ b/rama-net/src/socket/device_name.rs
@@ -100,6 +100,8 @@ impl TryFrom<&[u8]> for DeviceName {
     }
 }
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(as_str DeviceName);
 
 pub(super) const fn is_valid(s: &[u8]) -> bool {

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -1049,6 +1049,8 @@ uri_try_from!(&str, String, &[u8], Vec<u8>, rama_core::bytes::Bytes,);
 // implements `Deserialize` via `FromStr`. URIs constructed via
 // [`Uri::parse_authority_form`] or [`Uri::parse_reference`] are out of
 // scope for round-trip — those forms aren't reachable through `parse`.
+use rama_utils::macros::serde_str::impl_serde_str;
+
 impl_serde_str!(display Uri);
 
 impl Uri {

--- a/rama-ua/src/profile/runtime_hints.rs
+++ b/rama-ua/src/profile/runtime_hints.rs
@@ -3,7 +3,6 @@ use rama_core::error::{BoxError, ErrorExt as _};
 use rama_core::extensions::Extension;
 use rama_http::headers::ClientHint;
 use rama_utils::macros::match_ignore_ascii_case_str;
-use serde::{Deserialize, Deserializer, Serialize};
 use std::sync::Arc;
 use std::{fmt, ops::Deref, str::FromStr};
 
@@ -99,24 +98,9 @@ impl fmt::Display for RequestInitiator {
     }
 }
 
-impl Serialize for RequestInitiator {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
+use rama_utils::macros::serde_str::impl_serde_str;
 
-impl<'de> Deserialize<'de> for RequestInitiator {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str RequestInitiator);
 
 impl FromStr for RequestInitiator {
     type Err = BoxError;

--- a/rama-ua/src/ua/info.rs
+++ b/rama-ua/src/ua/info.rs
@@ -3,7 +3,6 @@ use rama_core::error::BoxErrorExt as _;
 use rama_core::error::{BoxError, ErrorExt};
 use rama_core::extensions::Extension;
 use rama_utils::{macros::match_ignore_ascii_case_str, str::arcstr::ArcStr};
-use serde::{Deserialize, Deserializer, Serialize};
 use std::{convert::Infallible, fmt, str::FromStr};
 
 /// User Agent (UA) information.
@@ -248,24 +247,9 @@ impl FromStr for UserAgentKind {
     }
 }
 
-impl Serialize for UserAgentKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
+use rama_utils::macros::serde_str::impl_serde_str;
 
-impl<'de> Deserialize<'de> for UserAgentKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str UserAgentKind);
 
 /// Device on which the [`UserAgent`] operates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -300,24 +284,7 @@ impl FromStr for DeviceKind {
     }
 }
 
-impl Serialize for DeviceKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for DeviceKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str DeviceKind);
 
 impl fmt::Display for DeviceKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -378,24 +345,7 @@ impl FromStr for PlatformKind {
     }
 }
 
-impl Serialize for PlatformKind {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for PlatformKind {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str PlatformKind);
 
 impl fmt::Display for PlatformKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -437,24 +387,7 @@ impl fmt::Display for HttpAgent {
     }
 }
 
-impl Serialize for HttpAgent {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for HttpAgent {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str HttpAgent);
 
 impl FromStr for HttpAgent {
     type Err = BoxError;
@@ -508,24 +441,7 @@ impl fmt::Display for TlsAgent {
     }
 }
 
-impl Serialize for TlsAgent {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::ser::Serializer,
-    {
-        serializer.serialize_str(self.as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for TlsAgent {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
-    }
-}
+impl_serde_str!(as_str TlsAgent);
 
 impl FromStr for TlsAgent {
     type Err = BoxError;

--- a/rama-utils/src/macros/mod.rs
+++ b/rama-utils/src/macros/mod.rs
@@ -13,6 +13,10 @@ pub mod error;
 pub mod str;
 
 #[doc(hidden)]
+#[macro_use]
+pub mod serde_str;
+
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __opaque_body {
     ($(#[$m:meta])* pub type $name:ident = $actual:ty;) => {

--- a/rama-utils/src/macros/serde_str.rs
+++ b/rama-utils/src/macros/serde_str.rs
@@ -1,17 +1,44 @@
-//! Internal helper macros shared across `rama-net` modules.
+//! Shared `serde` glue for string-like types.
 
-/// Implement `serde::Serialize` + `serde::Deserialize` for a string-like type.
+/// Implement [`serde::Serialize`] + [`serde::Deserialize`] for a type whose
+/// canonical wire form is a single string.
 ///
 /// Both arms deserialize by parsing a borrowed-or-owned string through the
 /// type's [`FromStr`](std::str::FromStr) impl. They differ only in how the
 /// value is serialized:
 ///
 /// - `display $t` serializes via [`Display`](std::fmt::Display)
-///   (`serializer.collect_str`) — use when the canonical wire form is the
+///   (`serializer.collect_str`) — use when the canonical string is the
 ///   `Display` output.
 /// - `as_str $t` serializes the borrowed `self.as_str()` slice directly — use
 ///   when the type already holds its canonical string.
-macro_rules! impl_serde_str {
+///
+/// The macro relies on `serde` being importable as `serde::` at the call site.
+///
+/// # Example
+///
+/// ```
+/// # use rama_utils::macros::serde_str::impl_serde_str;
+/// struct Tag(String);
+///
+/// impl std::fmt::Display for Tag {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         f.write_str(&self.0)
+///     }
+/// }
+///
+/// impl std::str::FromStr for Tag {
+///     type Err = std::convert::Infallible;
+///     fn from_str(s: &str) -> Result<Self, Self::Err> {
+///         Ok(Self(s.to_owned()))
+///     }
+/// }
+///
+/// impl_serde_str!(display Tag);
+/// ```
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __impl_serde_str {
     (display $t:ty) => {
         impl serde::Serialize for $t {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -21,7 +48,7 @@ macro_rules! impl_serde_str {
                 serializer.collect_str(self)
             }
         }
-        $crate::macros::impl_serde_str!(@de $t);
+        $crate::__impl_serde_str!(@de $t);
     };
     (as_str $t:ty) => {
         impl serde::Serialize for $t {
@@ -32,7 +59,7 @@ macro_rules! impl_serde_str {
                 self.as_str().serialize(serializer)
             }
         }
-        $crate::macros::impl_serde_str!(@de $t);
+        $crate::__impl_serde_str!(@de $t);
     };
     (@de $t:ty) => {
         impl<'de> serde::Deserialize<'de> for $t {
@@ -47,4 +74,5 @@ macro_rules! impl_serde_str {
     };
 }
 
-pub(crate) use impl_serde_str;
+#[doc(inline)]
+pub use crate::__impl_serde_str as impl_serde_str;


### PR DESCRIPTION
Follow-up to #987, which already replaced the 11 hand-written serde
Serialize/Deserialize string pairs in rama-net with a crate-local
`impl_serde_str!` macro. This PR does **not** re-dedup those; it relocates the
macro and extends its reach:

- move the macro definition from rama-net's crate-local `macros` module into the
  shared `rama-utils::macros::serde_str` (following the existing
  `eq_ignore_ascii_case!` convention). rama-net's 11 call sites are unchanged
  except for importing the macro from its new home; `rama-net/src/macros.rs`
  and the `#[macro_use] mod macros;` are removed
- adopt the shared macro in rama-ua for its six string enums (`UserAgentKind`,
  `DeviceKind`, `PlatformKind`, `HttpAgent`, `TlsAgent`, `RequestInitiator`),
  whose `serialize_str(self.as_str())` + `parse::<Self>()` boilerplate matches
  the macro's `as_str` arm; drop the now-unused serde imports

No behavior change; rama-net/rama-ua/rama-utils check clean and tests pass.
