### PR TITLE
refactor(otel): scope grpc to opt-in consumers under opentelemetry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -464,7 +464,6 @@ opentelemetry = [
     "rama-core/opentelemetry",
     "rama-http?/opentelemetry",
     "rama-net?/opentelemetry",
-    "grpc",
     "rama-grpc?/opentelemetry",
 ]
 # Optional [dial9] runtime-telemetry support across the rama crate

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -730,7 +730,7 @@ required-features = ["http-full"]
 
 [[example]]
 name = "http_telemetry"
-required-features = ["http-full", "opentelemetry"]
+required-features = ["http-full", "grpc", "opentelemetry"]
 
 [[example]]
 name = "http_user_agent_classifier"

--- a/rama-cli/Cargo.toml
+++ b/rama-cli/Cargo.toml
@@ -32,6 +32,7 @@ rama = { version = "0.3.0-rc1", path = "..", features = [
     "tcp",
     "udp",
     "http-full",
+    "grpc",
     "proxy-full",
     "opentelemetry",
 ] }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -10,6 +10,8 @@ pub mod opentelemetry {
 
     pub use ::rama_core::telemetry::opentelemetry::*;
 
+    #[cfg(feature = "grpc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "grpc")))]
     pub mod collector {
         //! OTLP exporter integrations supported by rama.
 

--- a/tests/integration/examples/example_tests/http_telemetry.rs
+++ b/tests/integration/examples/example_tests/http_telemetry.rs
@@ -40,7 +40,7 @@ async fn test_http_telemetry() {
     let state = Arc::new(CollectorState::default());
     spawn_fake_otlp_collector(Arc::clone(&state)).await;
 
-    let runner = utils::ExampleRunner::interactive("http_telemetry", Some("opentelemetry"));
+    let runner = utils::ExampleRunner::interactive("http_telemetry", Some("opentelemetry,grpc"));
 
     let homepage = runner
         .get("http://127.0.0.1:62012")


### PR DESCRIPTION
Make the opentelemetry feature enable grpc instrumentation only when a consumer opts into grpc, via rama-grpc?/opentelemetry alone. OTel for the core/http/net layers stays available without the grpc transport.

Gate telemetry::opentelemetry::collector behind the grpc feature so the re-exported rama_grpc OTLP exporter is present exactly when grpc is enabled, and the crate builds with opentelemetry on its own.

collector::OtelExporter is reachable with the grpc + opentelemetry feature combination.