### PR TITLE
refactor(grpc-otel): extract shared send_proto scaffolding

### DIFF
--- a/rama-grpc/src/service/opentelemetry/grpc.rs
+++ b/rama-grpc/src/service/opentelemetry/grpc.rs
@@ -1,6 +1,6 @@
 use super::{
     HeaderBag, OtelExporter, OtelExporterConfigError, OtlpTransport, SignalKind,
-    parse_header_string,
+    await_with_timeout, internal_failure, parse_header_string,
 };
 use crate::{
     Request,
@@ -12,7 +12,7 @@ use prost::Message;
 use rama_core::{error::BoxError, telemetry::opentelemetry::sdk::error::OTelSdkError};
 use rama_http::{Body, StreamingBody, uri::PathAndQuery};
 use rama_utils::macros::generate_set_and_with;
-use std::{fmt, str::FromStr, sync::atomic::Ordering};
+use std::{fmt, str::FromStr};
 
 pub(super) const DEFAULT_OTLP_GRPC_ENDPOINT: &str = "http://localhost:4317";
 const TRACE_EXPORT_PATH: &str = "/opentelemetry.proto.collector.trace.v1.TraceService/Export";
@@ -123,9 +123,7 @@ where
         Req: Message + Send + 'static,
         Resp: Message + Default + Send + 'static,
     {
-        if self.shutdown_flag(signal).load(Ordering::Acquire) {
-            return Err(OTelSdkError::AlreadyShutdown);
-        }
+        self.ensure_not_shutdown(signal)?;
 
         let path = match signal {
             SignalKind::Traces => TRACE_EXPORT_PATH,
@@ -136,7 +134,7 @@ where
         // gRPC endpoints are host:port URIs without a per-signal path suffix.
         let config = self
             .resolve_config(signal, DEFAULT_OTLP_GRPC_ENDPOINT, Ok)
-            .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
+            .map_err(internal_failure)?;
 
         let service = self.service.clone();
         let endpoint = config.endpoint;
@@ -155,9 +153,7 @@ where
             let mut request = Request::new(request_body);
             *request.metadata_mut() = metadata;
             if let Some(timeout) = timeout {
-                request
-                    .try_set_timeout(timeout)
-                    .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
+                request.try_set_timeout(timeout).map_err(internal_failure)?;
             }
 
             let rpc = grpc.unary(
@@ -166,14 +162,9 @@ where
                 ProstCodec::<Req, Resp>::new(),
             );
 
-            let response = match timeout {
-                Some(timeout) => match tokio::time::timeout(timeout, rpc).await {
-                    Ok(result) => result,
-                    Err(_) => return Err(OTelSdkError::Timeout(timeout)),
-                },
-                None => rpc.await,
-            }
-            .map_err(|status| OTelSdkError::InternalFailure(format!("export error: {status:?}")))?;
+            let response = await_with_timeout(timeout, rpc)
+                .await?
+                .map_err(|status| internal_failure(format!("export error: {status:?}")))?;
             Ok(response.into_inner())
         };
         self.run_on_runtime(work).await

--- a/rama-grpc/src/service/opentelemetry/grpc.rs
+++ b/rama-grpc/src/service/opentelemetry/grpc.rs
@@ -1,6 +1,6 @@
 use super::{
     HeaderBag, OtelExporter, OtelExporterConfigError, OtlpTransport, SignalKind,
-    await_with_timeout, internal_failure, parse_header_string,
+    await_with_optional_timeout, internal_failure, parse_header_string,
 };
 use crate::{
     Request,
@@ -162,7 +162,7 @@ where
                 ProstCodec::<Req, Resp>::new(),
             );
 
-            let response = await_with_timeout(timeout, rpc)
+            let response = await_with_optional_timeout(timeout, rpc)
                 .await?
                 .map_err(|status| internal_failure(format!("export error: {status:?}")))?;
             Ok(response.into_inner())

--- a/rama-grpc/src/service/opentelemetry/http.rs
+++ b/rama-grpc/src/service/opentelemetry/http.rs
@@ -1,6 +1,6 @@
 use super::{
     HeaderBag, OtelExporter, OtelExporterConfigError, OtlpTransport, SignalKind,
-    parse_header_string,
+    await_with_timeout, internal_failure, parse_header_string,
 };
 use crate::codec::{
     CompressionEncoding,
@@ -17,7 +17,7 @@ use rama_http::{
     uri::{PathAndQuery, Uri},
 };
 use rama_utils::macros::generate_set_and_with;
-use std::{fmt, str::FromStr, sync::atomic::Ordering};
+use std::{fmt, str::FromStr};
 
 pub(super) const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:4318";
 const OTLP_HTTP_TRACE_PATH: &str = "/v1/traces";
@@ -124,9 +124,7 @@ where
         Req: Message + Send + 'static,
         Resp: Message + Default + Send + 'static,
     {
-        if self.shutdown_flag(signal).load(Ordering::Acquire) {
-            return Err(OTelSdkError::AlreadyShutdown);
-        }
+        self.ensure_not_shutdown(signal)?;
 
         let path = match signal {
             SignalKind::Traces => OTLP_HTTP_TRACE_PATH,
@@ -138,16 +136,15 @@ where
             .resolve_config(signal, DEFAULT_OTLP_HTTP_ENDPOINT, |base| {
                 append_signal_path(base, path)
             })
-            .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
+            .map_err(internal_failure)?;
 
-        let body = encode_body(request_body, config.compression)
-            .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
+        let body = encode_body(request_body, config.compression).map_err(internal_failure)?;
 
         let mut request = Request::builder()
             .method(Method::POST)
             .uri(config.endpoint)
             .body(Body::from(body.freeze()))
-            .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?;
+            .map_err(internal_failure)?;
 
         request.headers_mut().insert(
             CONTENT_TYPE,
@@ -156,8 +153,7 @@ where
         if let Some(compression) = config.compression {
             request.headers_mut().insert(
                 HeaderName::from_static(CONTENT_ENCODING),
-                HeaderValue::from_str(compression.as_str())
-                    .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?,
+                HeaderValue::from_str(compression.as_str()).map_err(internal_failure)?,
             );
         }
         merge_headers(request.headers_mut(), &config.metadata);
@@ -165,16 +161,9 @@ where
         let service = self.service.clone();
         let timeout = config.timeout;
         let work = async move {
-            let response = match timeout {
-                Some(timeout) => {
-                    match tokio::time::timeout(timeout, service.serve(request)).await {
-                        Ok(result) => result,
-                        Err(_) => return Err(OTelSdkError::Timeout(timeout)),
-                    }
-                }
-                None => service.serve(request).await,
-            }
-            .map_err(|err| OTelSdkError::InternalFailure(err.into().to_string()))?;
+            let response = await_with_timeout(timeout, service.serve(request))
+                .await?
+                .map_err(|err| internal_failure(err.into()))?;
 
             decode_response(response).await
         };
@@ -236,20 +225,18 @@ where
         .into_body()
         .collect()
         .await
-        .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?
+        .map_err(internal_failure)?
         .to_bytes();
 
     if !status.is_success() {
-        return Err(OTelSdkError::InternalFailure(format!(
-            "export error: HTTP {status}"
-        )));
+        return Err(internal_failure(format!("export error: HTTP {status}")));
     }
 
     if body.is_empty() {
         return Ok(T::default());
     }
 
-    T::decode(body).map_err(|err| OTelSdkError::InternalFailure(err.to_string()))
+    T::decode(body).map_err(internal_failure)
 }
 
 #[expect(clippy::needless_pass_by_value)]

--- a/rama-grpc/src/service/opentelemetry/http.rs
+++ b/rama-grpc/src/service/opentelemetry/http.rs
@@ -1,6 +1,6 @@
 use super::{
     HeaderBag, OtelExporter, OtelExporterConfigError, OtlpTransport, SignalKind,
-    await_with_timeout, internal_failure, parse_header_string,
+    await_with_optional_timeout, internal_failure, parse_header_string,
 };
 use crate::codec::{
     CompressionEncoding,
@@ -161,7 +161,7 @@ where
         let service = self.service.clone();
         let timeout = config.timeout;
         let work = async move {
-            let response = await_with_timeout(timeout, service.serve(request))
+            let response = await_with_optional_timeout(timeout, service.serve(request))
                 .await?
                 .map_err(|err| internal_failure(err.into()))?;
 

--- a/rama-grpc/src/service/opentelemetry/mod.rs
+++ b/rama-grpc/src/service/opentelemetry/mod.rs
@@ -108,6 +108,25 @@ pub trait OtlpTransport {
         Resp: Message + Default + Send + 'static;
 }
 
+/// Map any displayable error into an [`OTelSdkError::InternalFailure`].
+pub(super) fn internal_failure(err: impl fmt::Display) -> OTelSdkError {
+    OTelSdkError::InternalFailure(err.to_string())
+}
+
+/// Await `fut`, enforcing `timeout` when set and surfacing
+/// [`OTelSdkError::Timeout`] on expiry. Shared by the HTTP and gRPC transports.
+pub(super) async fn await_with_timeout<F: Future>(
+    timeout: Option<Duration>,
+    fut: F,
+) -> Result<F::Output, OTelSdkError> {
+    match timeout {
+        Some(timeout) => tokio::time::timeout(timeout, fut)
+            .await
+            .map_err(|_elapsed| OTelSdkError::Timeout(timeout)),
+        None => Ok(fut.await),
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct SignalSettings<H> {
     pub(crate) endpoint: Option<Uri>,
@@ -345,12 +364,17 @@ impl<S, H: HeaderBag> OtelExporter<S, H> {
         }
     }
 
-    pub(crate) fn force_flush_signal(&self, signal: SignalKind) -> OTelSdkResult {
+    /// Returns [`OTelSdkError::AlreadyShutdown`] if `signal` has been shut down.
+    pub(crate) fn ensure_not_shutdown(&self, signal: SignalKind) -> OTelSdkResult {
         if self.shutdown_flag(signal).load(Ordering::Acquire) {
             Err(OTelSdkError::AlreadyShutdown)
         } else {
             Ok(())
         }
+    }
+
+    pub(crate) fn force_flush_signal(&self, signal: SignalKind) -> OTelSdkResult {
+        self.ensure_not_shutdown(signal)
     }
 
     pub(crate) fn store_resource(&self, resource: &sdk::Resource) {
@@ -413,10 +437,7 @@ impl<S, H: HeaderBag> OtelExporter<S, H> {
         T: Send + 'static,
     {
         match self.runtime.as_ref() {
-            Some(handle) => handle
-                .spawn(work)
-                .await
-                .map_err(|err| OTelSdkError::InternalFailure(err.to_string()))?,
+            Some(handle) => handle.spawn(work).await.map_err(internal_failure)?,
             None => work.await,
         }
     }

--- a/rama-grpc/src/service/opentelemetry/mod.rs
+++ b/rama-grpc/src/service/opentelemetry/mod.rs
@@ -115,7 +115,7 @@ pub(super) fn internal_failure(err: impl fmt::Display) -> OTelSdkError {
 
 /// Await `fut`, enforcing `timeout` when set and surfacing
 /// [`OTelSdkError::Timeout`] on expiry. Shared by the HTTP and gRPC transports.
-pub(super) async fn await_with_timeout<F: Future>(
+pub(super) async fn await_with_optional_timeout<F: Future>(
     timeout: Option<Duration>,
     fut: F,
 ) -> Result<F::Output, OTelSdkError> {


### PR DESCRIPTION
The HTTP and gRPC OTLP transports duplicated the same send_proto control flow: a shutdown guard, a timeout-or-await match arm, and the `InternalFailure(err.to_string())` error mapping repeated ~12 times.

Introduce three shared helpers in the module root:
- internal_failure(err): map any Display error into InternalFailure
- await_with_timeout(timeout, fut): enforce the optional timeout and surface OTelSdkError::Timeout, shared by both transports
- ensure_not_shutdown(signal): the AlreadyShutdown guard, also reused by force_flush_signal

No behavior change; rama-grpc tests and clippy --all-features pass.