### PR TITLE
refactor(cli): extract shared forwarded-header layer builder

### DIFF
--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -8,7 +8,7 @@
 use crate::{
     Layer, Service,
     cli::ForwardKind,
-    combinators::{Either, Either3, Either7},
+    combinators::{Either, Either3},
     error::{BoxError, BoxErrorExt, ErrorContext},
     extensions::ExtensionsRef,
     http::{
@@ -18,12 +18,8 @@ use crate::{
         core::h2::frame::EarlyFrameCapture,
         header::USER_AGENT,
         headers::exotic::XClacksOverhead,
-        headers::forwarded::{CFConnectingIp, ClientIp, TrueClientIp, XClientIp, XRealIp},
         layer::set_header::SetResponseHeaderLayer,
-        layer::{
-            forwarded::GetForwardedHeaderLayer, required_header::AddRequiredResponseHeadersLayer,
-            trace::TraceLayer,
-        },
+        layer::{required_header::AddRequiredResponseHeadersLayer, trace::TraceLayer},
         proto::h1::Http1HeaderMap,
         proto::h2::PseudoHeaderOrder,
         server::HttpServer,
@@ -313,28 +309,7 @@ where
         &self,
         exec: Executor,
     ) -> impl Service<Request, Output: IntoResponse, Error = Infallible> + use<H> {
-        let http_forwarded_layer = match &self.forward {
-            None | Some(ForwardKind::HaProxy) => None,
-            Some(ForwardKind::Forwarded) => Some(Either7::A(GetForwardedHeaderLayer::forwarded())),
-            Some(ForwardKind::XForwardedFor) => {
-                Some(Either7::B(GetForwardedHeaderLayer::x_forwarded_for()))
-            }
-            Some(ForwardKind::XClientIp) => {
-                Some(Either7::C(GetForwardedHeaderLayer::<XClientIp>::new()))
-            }
-            Some(ForwardKind::ClientIp) => {
-                Some(Either7::D(GetForwardedHeaderLayer::<ClientIp>::new()))
-            }
-            Some(ForwardKind::XRealIp) => {
-                Some(Either7::E(GetForwardedHeaderLayer::<XRealIp>::new()))
-            }
-            Some(ForwardKind::CFConnectingIp) => {
-                Some(Either7::F(GetForwardedHeaderLayer::<CFConnectingIp>::new()))
-            }
-            Some(ForwardKind::TrueClientIp) => {
-                Some(Either7::G(GetForwardedHeaderLayer::<TrueClientIp>::new()))
-            }
-        };
+        let http_forwarded_layer = super::http_forwarded_layer(self.forward.as_ref());
 
         (
             TraceLayer::new_for_http(),

--- a/src/cli/service/fs.rs
+++ b/src/cli/service/fs.rs
@@ -3,17 +3,15 @@
 use crate::{
     Layer, Service,
     cli::ForwardKind,
-    combinators::Either,
-    combinators::{Either3, Either7},
+    combinators::{Either, Either3},
     error::{BoxError, BoxErrorExt, ErrorExt},
     http::{
         Request, Response, Version,
         headers::exotic::XClacksOverhead,
-        headers::forwarded::{CFConnectingIp, ClientIp, TrueClientIp, XClientIp, XRealIp},
         layer::set_header::SetResponseHeaderLayer,
         layer::{
-            forwarded::GetForwardedHeaderLayer, into_response::IntoResponseService,
-            required_header::AddRequiredResponseHeadersLayer, trace::TraceLayer,
+            into_response::IntoResponseService, required_header::AddRequiredResponseHeadersLayer,
+            trace::TraceLayer,
         },
         server::HttpServer,
         service::{
@@ -305,28 +303,7 @@ where
         &self,
     ) -> Result<impl Service<Request, Output: IntoResponse, Error = Infallible> + use<H>, BoxError>
     {
-        let http_forwarded_layer = match &self.forward {
-            None | Some(ForwardKind::HaProxy) => None,
-            Some(ForwardKind::Forwarded) => Some(Either7::A(GetForwardedHeaderLayer::forwarded())),
-            Some(ForwardKind::XForwardedFor) => {
-                Some(Either7::B(GetForwardedHeaderLayer::x_forwarded_for()))
-            }
-            Some(ForwardKind::XClientIp) => {
-                Some(Either7::C(GetForwardedHeaderLayer::<XClientIp>::new()))
-            }
-            Some(ForwardKind::ClientIp) => {
-                Some(Either7::D(GetForwardedHeaderLayer::<ClientIp>::new()))
-            }
-            Some(ForwardKind::XRealIp) => {
-                Some(Either7::E(GetForwardedHeaderLayer::<XRealIp>::new()))
-            }
-            Some(ForwardKind::CFConnectingIp) => {
-                Some(Either7::F(GetForwardedHeaderLayer::<CFConnectingIp>::new()))
-            }
-            Some(ForwardKind::TrueClientIp) => {
-                Some(Either7::G(GetForwardedHeaderLayer::<TrueClientIp>::new()))
-            }
-        };
+        let http_forwarded_layer = super::http_forwarded_layer(self.forward.as_ref());
 
         let serve_service = match &self.content_path {
             None => Either3::A(IntoResponseService::new(StaticOutput::new(Html(

--- a/src/cli/service/mod.rs
+++ b/src/cli/service/mod.rs
@@ -9,3 +9,53 @@ pub mod echo;
 pub mod fs;
 pub mod http_security;
 pub mod ip;
+
+use crate::{
+    cli::ForwardKind,
+    combinators::Either7,
+    http::{
+        headers::forwarded::{
+            CFConnectingIp, ClientIp, TrueClientIp, XClientIp, XForwardedFor, XRealIp,
+        },
+        layer::forwarded::GetForwardedHeaderLayer,
+    },
+};
+
+/// The forwarded-header extraction layer selected by a [`ForwardKind`].
+///
+/// `None` means no extraction: the default, and `HaProxy` (which forwards at
+/// the transport layer instead).
+type HttpForwardedLayer = Option<
+    Either7<
+        GetForwardedHeaderLayer,
+        GetForwardedHeaderLayer<XForwardedFor>,
+        GetForwardedHeaderLayer<XClientIp>,
+        GetForwardedHeaderLayer<ClientIp>,
+        GetForwardedHeaderLayer<XRealIp>,
+        GetForwardedHeaderLayer<CFConnectingIp>,
+        GetForwardedHeaderLayer<TrueClientIp>,
+    >,
+>;
+
+/// Build the HTTP forwarded-header extraction layer selected by `forward`,
+/// shared by the echo and fs CLI services.
+pub(super) fn http_forwarded_layer(forward: Option<&ForwardKind>) -> HttpForwardedLayer {
+    match forward {
+        None | Some(ForwardKind::HaProxy) => None,
+        Some(ForwardKind::Forwarded) => Some(Either7::A(GetForwardedHeaderLayer::forwarded())),
+        Some(ForwardKind::XForwardedFor) => {
+            Some(Either7::B(GetForwardedHeaderLayer::x_forwarded_for()))
+        }
+        Some(ForwardKind::XClientIp) => {
+            Some(Either7::C(GetForwardedHeaderLayer::<XClientIp>::new()))
+        }
+        Some(ForwardKind::ClientIp) => Some(Either7::D(GetForwardedHeaderLayer::<ClientIp>::new())),
+        Some(ForwardKind::XRealIp) => Some(Either7::E(GetForwardedHeaderLayer::<XRealIp>::new())),
+        Some(ForwardKind::CFConnectingIp) => {
+            Some(Either7::F(GetForwardedHeaderLayer::<CFConnectingIp>::new()))
+        }
+        Some(ForwardKind::TrueClientIp) => {
+            Some(Either7::G(GetForwardedHeaderLayer::<TrueClientIp>::new()))
+        }
+    }
+}


### PR DESCRIPTION
The echo and fs CLI services each carried an identical 22-line match mapping ForwardKind to a GetForwardedHeaderLayer variant. 

No behavior change.
