### PR TITLE
Adopt octets kib/mib and Duration helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,6 +4142,7 @@ dependencies = [
  "rama-core",
  "rama-dns",
  "rama-net",
+ "rama-utils",
  "tokio",
  "tokio-util",
 ]
@@ -4154,6 +4155,7 @@ dependencies = [
  "pin-project-lite",
  "rama-core",
  "rama-net",
+ "rama-utils",
  "tokio",
 ]
 

--- a/benches/http_core_end_to_end.rs
+++ b/benches/http_core_end_to_end.rs
@@ -15,6 +15,7 @@ use rama::futures::future::join_all;
 use rama::http::body::util::BodyExt;
 use rama::http::{Method, Request, Response};
 use rama::rt::Executor;
+use rama::utils::octets::mib;
 use tokio::sync::Mutex;
 
 #[global_allocator]
@@ -54,7 +55,7 @@ fn http1_consecutive_x1_both_100kb(b: divan::Bencher) {
 
 #[divan::bench]
 fn http1_consecutive_x1_both_10mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 10];
+    let body = &[b'x'; mib(10)];
     opts()
         .method(Method::POST)
         .request_body(body)
@@ -69,7 +70,7 @@ fn http1_parallel_x10_empty(b: divan::Bencher) {
 
 #[divan::bench]
 fn http1_parallel_x10_req_10mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 10];
+    let body = &[b'x'; mib(10)];
     opts()
         .parallel(10)
         .method(Method::POST)
@@ -89,13 +90,13 @@ fn http1_parallel_x10_req_10kb_100_chunks(b: divan::Bencher) {
 
 #[divan::bench]
 fn http1_parallel_x10_res_1mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024];
+    let body = &[b'x'; mib(1)];
     opts().parallel(10).response_body(body).bench(b)
 }
 
 #[divan::bench]
 fn http1_parallel_x10_res_10mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 10];
+    let body = &[b'x'; mib(10)];
     opts().parallel(10).response_body(body).bench(b)
 }
 
@@ -134,7 +135,7 @@ fn http2_parallel_x10_empty(b: divan::Bencher) {
 
 #[divan::bench]
 fn http2_parallel_x10_req_10mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 10];
+    let body = &[b'x'; mib(10)];
     opts()
         .http2()
         .parallel(10)
@@ -183,7 +184,7 @@ fn http2_parallel_x10_req_10kb_100_chunks_max_window(b: divan::Bencher) {
 
 #[divan::bench]
 fn http2_parallel_x10_res_1mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024];
+    let body = &[b'x'; mib(1)];
     opts()
         .http2()
         .parallel(10)
@@ -195,7 +196,7 @@ fn http2_parallel_x10_res_1mb(b: divan::Bencher) {
 
 #[divan::bench]
 fn http2_parallel_x10_res_10mb(b: divan::Bencher) {
-    let body = &[b'x'; 1024 * 1024 * 10];
+    let body = &[b'x'; mib(10)];
     opts()
         .http2()
         .parallel(10)

--- a/examples/grpc/src/shared/tests/integration/max_message_size.rs
+++ b/examples/grpc/src/shared/tests/integration/max_message_size.rs
@@ -10,6 +10,7 @@ use rama::{
     rt::Executor,
     stream,
     telemetry::tracing,
+    utils::octets::mib,
 };
 
 use crate::tests::integration::pb::{Input1, Output1, test1_client, test1_server};
@@ -19,20 +20,20 @@ fn max_message_recv_size() {
     // Server recv
     assert_server_recv_max_success(128);
     // 5 is the size of the gRPC header
-    assert_server_recv_max_success((4 * 1024 * 1024) - 5);
+    assert_server_recv_max_success(mib(4) - 5);
     // 4mb is the max recv size
-    assert_server_recv_max_failure(4 * 1024 * 1024);
-    assert_server_recv_max_failure(4 * 1024 * 1024 + 1);
-    assert_server_recv_max_failure(8 * 1024 * 1024);
+    assert_server_recv_max_failure(mib(4));
+    assert_server_recv_max_failure(mib(4) + 1);
+    assert_server_recv_max_failure(mib(8));
 
     // Client recv
     assert_client_recv_max_success(128);
     // 5 is the size of the gRPC header
-    assert_client_recv_max_success((4 * 1024 * 1024) - 5);
+    assert_client_recv_max_success(mib(4) - 5);
     // 4mb is the max recv size
-    assert_client_recv_max_failure(4 * 1024 * 1024);
-    assert_client_recv_max_failure(4 * 1024 * 1024 + 1);
-    assert_client_recv_max_failure(8 * 1024 * 1024);
+    assert_client_recv_max_failure(mib(4));
+    assert_client_recv_max_failure(mib(4) + 1);
+    assert_client_recv_max_failure(mib(8));
 
     // Custom limit settings
     assert_test_case(TestCase {
@@ -67,7 +68,7 @@ fn max_message_recv_size() {
 fn max_message_send_size() {
     // Check client send limit works
     assert_test_case(TestCase {
-        client_blob_size: 4 * 1024 * 1024,
+        client_blob_size: mib(4),
         server_recv_max: Some(usize::MAX),
         ..Default::default()
     });
@@ -81,7 +82,7 @@ fn max_message_send_size() {
 
     // Check server send limit works
     assert_test_case(TestCase {
-        server_blob_size: 4 * 1024 * 1024,
+        server_blob_size: mib(4),
         client_recv_max: Some(usize::MAX),
         ..Default::default()
     });

--- a/examples/http_connect_proxy.rs
+++ b/examples/http_connect_proxy.rs
@@ -95,6 +95,7 @@ use rama::{
     username::{
         UsernameLabelParser, UsernameLabelState, UsernameLabels, UsernameOpaqueLabelParser,
     },
+    utils::octets::mib,
 };
 
 use serde::Deserialize;
@@ -172,7 +173,7 @@ async fn main() {
 
             tcp_service.serve((
                 // protect the http proxy from too large bodies, both from request and response end
-                BodyLimitLayer::symmetric(2 * 1024 * 1024),
+                BodyLimitLayer::symmetric(mib(2)),
             ).into_layer(http_service)).await;
     });
 

--- a/examples/http_mitm_proxy_boring.rs
+++ b/examples/http_mitm_proxy_boring.rs
@@ -122,6 +122,7 @@ use rama::{
         },
         profile::UserAgentDatabase,
     },
+    utils::octets::mib,
 };
 
 use itertools::Itertools;
@@ -186,7 +187,7 @@ async fn main() -> Result<(), BoxError> {
                 (
                     AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
-                    BodyLimitLayer::symmetric(2 * 1024 * 1024),
+                    BodyLimitLayer::symmetric(mib(2)),
                 )
                     .into_layer(http_service),
             )

--- a/examples/http_mitm_proxy_rustls.rs
+++ b/examples/http_mitm_proxy_rustls.rs
@@ -77,6 +77,7 @@ use rama::{
         subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt},
     },
     tls::rustls::server::{TlsAcceptorData, TlsAcceptorDataBuilder, TlsAcceptorLayer},
+    utils::octets::mib,
 };
 use rama_net::tls::client::{ServerVerifyMode, TlsClientConfig};
 
@@ -139,7 +140,7 @@ async fn main() -> Result<(), BoxError> {
                 (
                     AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
-                    BodyLimitLayer::symmetric(2 * 1024 * 1024),
+                    BodyLimitLayer::symmetric(mib(2)),
                 )
                     .into_layer(http_service),
             )

--- a/examples/http_mitm_relay_proxy_boring.rs
+++ b/examples/http_mitm_relay_proxy_boring.rs
@@ -65,6 +65,7 @@ use rama::{
         subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt},
     },
     tls::boring::proxy::TlsMitmRelay,
+    utils::octets::mib,
 };
 
 use std::{convert::Infallible, sync::Arc, time::Duration};
@@ -125,7 +126,7 @@ async fn main() -> Result<(), BoxError> {
         ));
 
         tcp_service
-            .serve(BodyLimitLayer::symmetric(2 * 1024 * 1024).into_layer(http_service))
+            .serve(BodyLimitLayer::symmetric(mib(2)).into_layer(http_service))
             .await;
     });
 

--- a/examples/http_record_har.rs
+++ b/examples/http_record_har.rs
@@ -94,6 +94,7 @@ use rama::{
         },
         profile::UserAgentDatabase,
     },
+    utils::octets::mib,
 };
 
 use std::{
@@ -195,7 +196,7 @@ async fn main() -> Result<(), BoxError> {
                 (
                     AddInputExtensionLayer::new(state),
                     // protect the http proxy from too large bodies, both from request and response end
-                    BodyLimitLayer::symmetric(2 * 1024 * 1024),
+                    BodyLimitLayer::symmetric(mib(2)),
                 )
                     .into_layer(http_service),
             )

--- a/examples/https_connect_proxy.rs
+++ b/examples/https_connect_proxy.rs
@@ -56,6 +56,7 @@ use rama::{
         level_filters::LevelFilter,
         subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt},
     },
+    utils::octets::mib,
 };
 
 #[cfg(feature = "boring")]
@@ -149,7 +150,7 @@ async fn main() {
             .serve(
                 (
                     // protect the http proxy from too large bodies, both from request and response end
-                    BodyLimitLayer::symmetric(2 * 1024 * 1024),
+                    BodyLimitLayer::symmetric(mib(2)),
                     TlsAcceptorLayer::new(tls_service_data).with_store_client_hello(true),
                 )
                     .into_layer(http_service),

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/http_h2.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/http_h2.rs
@@ -8,6 +8,7 @@ use rama::{
     bytes::Bytes,
     futures::future::join_all,
     http::{BodyExtractExt as _, Version, body::util::BodyExt as _},
+    utils::octets::kib,
 };
 use serial_test::serial;
 use std::time::Duration;
@@ -257,7 +258,7 @@ async fn run_h2_large_body_case(target: HttpTargetKind, proxy: ProxyKind, size_k
         .expect("body collect should not time out")
         .expect("body bytes")
         .to_bytes();
-    let expected_bytes = size_kb * 1024;
+    let expected_bytes = kib(size_kb);
     assert_eq!(
         body.len(),
         expected_bytes,
@@ -291,7 +292,7 @@ async fn run_h2_concurrent_large_case(
     });
     let proxy_addr = localhost(env.ports.proxy);
     let base = format!("{scheme}://127.0.0.1:{}", ingress_addr.port());
-    let expected_bytes = size_kb * 1024;
+    let expected_bytes = kib(size_kb);
 
     // `stream_count` simultaneous large bodies through the same TCP flow —
     // exercises h2 multiplexing through the bounded per-flow channel +

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/stress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/cases/stress.rs
@@ -6,6 +6,7 @@
 
 use std::time::{Duration, Instant};
 
+use rama::utils::octets::mib;
 use rama::{futures::future::join_all, http::Version};
 use serial_test::serial;
 
@@ -154,7 +155,7 @@ async fn ffi_stress_mixed_concurrent_load_with_large_body() {
     let client = build_http_client(None);
 
     const SMALL_FLOWS: usize = 16;
-    const POST_BYTES: usize = 4 * 1024 * 1024; // 4 MiB upload
+    const POST_BYTES: usize = mib(4); // 4 MiB upload
     let base = format!("http://127.0.0.1:{}", ingress_addr.port());
     let post_body = vec![0xA5_u8; POST_BYTES];
 

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
@@ -7,6 +7,8 @@ use tokio::{
     task::JoinHandle,
 };
 
+use rama::utils::octets::kib;
+
 use super::{bindings, ffi::EngineHandle};
 
 // ── Ingress (client → service) callback context ───────────────────────────────
@@ -321,7 +323,7 @@ async fn serve_one_ingress_connection(
     let egress_read_demand_for_reader = egress_read_demand.clone();
     let egress_reader = tokio::spawn(async move {
         let mut reader = egress_read;
-        let mut buf = [0_u8; 16 * 1024];
+        let mut buf = [0_u8; kib(16)];
         let mut pending: Option<Vec<u8>> = None;
         'outer: loop {
             // Replay any pending rejected chunk before reading new data.
@@ -382,7 +384,7 @@ async fn serve_one_ingress_connection(
     //
     // Same backpressure-honouring shape as the egress reader above.
     let mut reader = client_read;
-    let mut buf = [0_u8; 16 * 1024];
+    let mut buf = [0_u8; kib(16)];
     let mut pending: Option<Vec<u8>> = None;
     'ingress: loop {
         // Replay before reading new data.

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
@@ -48,6 +48,7 @@ use rama::{
     tcp::{proxy::IoToProxyBridgeIoLayer, server::TcpListener},
     telemetry::tracing,
     tls::rustls::server::{TlsAcceptorDataBuilder, TlsAcceptorLayer},
+    utils::octets::kib,
 };
 
 use serde_json::json;
@@ -139,10 +140,10 @@ fn http_app(
                             .and_then(|v| v.parse::<usize>().ok())
                             .unwrap_or(4096)
                             .min(64 * 1024); // cap at 64 MiB to keep test runtime sane
-                        let total = size_kb * 1024;
+                        let total = kib(size_kb);
                         let body = Body::from_stream(stream_fn(move |mut yielder| async move {
                             // 16 KiB chunks — same shape as the bridge's read buffer.
-                            let chunk_size: usize = 16 * 1024;
+                            let chunk_size: usize = kib(16);
                             let mut sent: usize = 0;
                             let mut counter: u8 = 0;
                             while sent < total {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/dial9.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/dial9.rs
@@ -20,14 +20,14 @@ use std::time::Duration;
 use ::dial9_tokio_telemetry::Dial9Config;
 use rama::{
     net::apple::networkextension::tproxy::DefaultTransparentProxyAsyncRuntimeFactory,
-    telemetry::tracing,
+    telemetry::tracing, utils::octets::mib_u64,
 };
 
 /// Hard-coded defaults for the demo. Copy and tune in your own
 /// extension if these don't fit.
 const ROTATION_PERIOD: Duration = Duration::from_mins(1);
-const MAX_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
-const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_TOTAL_BYTES: u64 = mib_u64(256);
+const MAX_FILE_BYTES: u64 = mib_u64(64);
 
 pub(super) fn make_runtime_factory() -> DefaultTransparentProxyAsyncRuntimeFactory {
     let factory = DefaultTransparentProxyAsyncRuntimeFactory::new();

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/udp.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/udp.rs
@@ -12,6 +12,7 @@ use rama::{
     service::service_fn,
     telemetry::tracing,
     udp::{UdpSocket, bind_udp_with_address},
+    utils::octets::kib,
 };
 
 pub(super) async fn try_new_service(
@@ -161,7 +162,7 @@ async fn ensure_bound<'s>(
 ) -> Option<&'s UdpSocket> {
     if slot.is_none() {
         match bind_udp_with_address(bind_addr).await {
-            Ok(s) => *slot = Some((s, vec![0u8; 64 * 1024])),
+            Ok(s) => *slot = Some((s, vec![0u8; kib(64)])),
             Err(err) => {
                 tracing::error!(%err, bind_addr, "tproxy udp failed to bind egress socket");
                 return None;

--- a/rama-cli/src/cmd/serve/fp/mod.rs
+++ b/rama-cli/src/cmd/serve/fp/mod.rs
@@ -46,6 +46,7 @@ use rama::{
     utils::{
         backoff::ExponentialBackoff,
         collections::{NonEmptySmallVec, NonEmptyVec, non_empty_smallvec},
+        octets::mib,
         str::non_empty_str,
     },
 };
@@ -329,7 +330,7 @@ where
             Either::B(UnlimitedPolicy::new())
         }),
         // Limit the body size to 1MB for both request and response
-        BodyLimitLayer::symmetric(1024 * 1024),
+        BodyLimitLayer::symmetric(mib(1)),
         tls_acceptor_data.map(|data| TlsAcceptorLayer::new(data).with_store_client_hello(true)),
     );
 

--- a/rama-cli/src/cmd/serve/httptest/endpoint/bytes.rs
+++ b/rama-cli/src/cmd/serve/httptest/endpoint/bytes.rs
@@ -8,14 +8,14 @@ use rama::{
         service::web::response::{IntoResponse, OctetStream as OctetStreamResponse},
     },
     service::service_fn,
-    utils::octets::mib_u64,
+    utils::octets::{kib, mib, mib_u64},
 };
 use std::{convert::Infallible, time::Duration};
 
 const DEFAULT_BYTES: u64 = 1024;
 const MAX_BYTES: u64 = mib_u64(32);
-const DEFAULT_CHUNK: usize = 16 * 1024;
-const MAX_CHUNK: usize = 4 * 1024 * 1024;
+const DEFAULT_CHUNK: usize = kib(16);
+const MAX_CHUNK: usize = mib(4);
 const MAX_DELAY_MS: u64 = 60_000;
 
 pub(in crate::cmd::serve::httptest) fn service()

--- a/rama-cli/src/cmd/serve/httptest/endpoint/request_compression.rs
+++ b/rama-cli/src/cmd/serve/httptest/endpoint/request_compression.rs
@@ -11,6 +11,7 @@ use rama::{
     },
     layer::ConsumeErrLayer,
     service::service_fn,
+    utils::octets::mib,
 };
 use std::convert::Infallible;
 
@@ -18,7 +19,7 @@ pub(in crate::cmd::serve::httptest) fn service()
 -> impl Service<Request, Output = Response, Error = Infallible> {
     (
         ConsumeErrLayer::trace_as_debug(),
-        BodyLimitLayer::new(8 * 1024 * 1024), // EMS 3.2 4life
+        BodyLimitLayer::new(mib(8)), // EMS 3.2 4life
         RequestDecompressionLayer::new(),
         MapRequestBodyLayer::new_boxed_streaming_body(),
     )

--- a/rama-cli/src/cmd/serve/proxy/mod.rs
+++ b/rama-cli/src/cmd/serve/proxy/mod.rs
@@ -27,6 +27,7 @@ use rama::{
     service::service_fn,
     tcp::{proxy::IoToProxyBridgeIoLayer, server::TcpListener},
     telemetry::tracing,
+    utils::octets::mib,
 };
 use std::{convert::Infallible, time::Duration};
 
@@ -82,7 +83,7 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandProxy) -> Result<(), Bo
 
         let tcp_service_builder = (
             // protect the http proxy from too large bodies, both from request and response end
-            BodyLimitLayer::symmetric(2 * 1024 * 1024),
+            BodyLimitLayer::symmetric(mib(2)),
             LimitLayer::new(if cfg.concurrent > 0 {
                 Either::A(ConcurrentPolicy::max(cfg.concurrent))
             } else {

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -26,6 +26,7 @@ use rama_core::{
 use rama_net::address::Domain;
 use rama_utils::{
     macros::{error::static_str_error, generate_set_and_with},
+    octets::kib,
     str::arcstr::ArcStr,
 };
 
@@ -50,7 +51,7 @@ mod legacy;
 mod res_nsearch;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(5 * 60);
+const DEFAULT_CACHE_TTL: Duration = Duration::from_mins(5);
 const DEFAULT_NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(30);
 const DEFAULT_CACHE_CAPACITY: u64 = 65_536;
 /// Default `res_nsearch` response buffer size.
@@ -59,7 +60,7 @@ const DEFAULT_CACHE_CAPACITY: u64 = 65_536;
 /// (DKIM, long SPF, multi-record AAAA sets) can exceed that. 16 KiB matches
 /// what most TCP-fallback paths advertise via EDNS0 and keeps the per-query
 /// allocation in the blocking thread modest.
-const DEFAULT_RESPONSE_BUFFER_SIZE: usize = 16 * 1024;
+const DEFAULT_RESPONSE_BUFFER_SIZE: usize = kib(16);
 
 #[derive(Debug, Clone)]
 /// Used to build a [`LinuxDnsResolver`] instance.

--- a/rama-dns/src/client/linux/res_nsearch.rs
+++ b/rama-dns/src/client/linux/res_nsearch.rs
@@ -554,6 +554,7 @@ mod ffi {
 #[cfg(test)]
 mod soa_ttl_tests {
     use super::{ffi, parse_authority_soa_ttl};
+    use rama_utils::octets::kib;
 
     /// Build a minimal NXDOMAIN/NODATA DNS response carrying a single SOA RR
     /// in the authority section. Question section uses an A-record query for
@@ -645,7 +646,7 @@ mod soa_ttl_tests {
         // into a larger zeroed buffer: the parser must terminate via header
         // counts, not run off into the padding.
         let mut packet = build_negative_response(120, 90);
-        packet.resize(16 * 1024, 0);
+        packet.resize(kib(16), 0);
         assert_eq!(parse_authority_soa_ttl(&packet), Some(90));
     }
 }

--- a/rama-grpc/src/codec/mod.rs
+++ b/rama-grpc/src/codec/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod compression;
 mod decode;
 mod encode;
 use crate::Status;
+use rama_utils::octets::{kib, mib};
 use std::io;
 
 pub use self::buffer::{DecodeBuf, EncodeBuf};
@@ -23,8 +24,8 @@ pub use self::compression::SingleMessageCompressionOverride;
 /// This is spent per-rpc, so you may wish to adjust it. The default is
 /// pretty good for most uses, but if you have a ton of concurrent rpcs
 /// you may find it too expensive.
-const DEFAULT_CODEC_BUFFER_SIZE: usize = 8 * 1024;
-const DEFAULT_YIELD_THRESHOLD: usize = 32 * 1024;
+const DEFAULT_CODEC_BUFFER_SIZE: usize = kib(8);
+const DEFAULT_YIELD_THRESHOLD: usize = kib(32);
 
 /// Settings for how rama-grpc allocates and grows buffers.
 ///
@@ -99,7 +100,7 @@ pub const HEADER_SIZE: usize =
     std::mem::size_of::<u32>();
 
 // The default maximum uncompressed size in bytes for a message. Defaults to 4MB.
-const DEFAULT_MAX_RECV_MESSAGE_SIZE: usize = 4 * 1024 * 1024;
+const DEFAULT_MAX_RECV_MESSAGE_SIZE: usize = mib(4);
 const DEFAULT_MAX_SEND_MESSAGE_SIZE: usize = usize::MAX;
 
 /// Trait that knows how to encode and decode gRPC messages.

--- a/rama-grpc/src/protobuf/codec.rs
+++ b/rama-grpc/src/protobuf/codec.rs
@@ -160,6 +160,7 @@ mod tests {
     use rama_core::stream;
     use rama_http_types::StreamingBody as _;
     use rama_http_types::body::util::BodyExt as _;
+    use rama_utils::octets::mib;
 
     use crate::codec::SingleMessageCompressionOverride;
     use crate::codec::{EncodeBody, HEADER_SIZE, Streaming};
@@ -168,7 +169,7 @@ mod tests {
 
     const LEN: usize = 10000;
     // The maximum uncompressed size in bytes for a message. Set to 2MB.
-    const MAX_MESSAGE_SIZE: usize = 2 * 1024 * 1024;
+    const MAX_MESSAGE_SIZE: usize = mib(2);
 
     #[tokio::test]
     async fn decode() {

--- a/rama-grpc/src/request.rs
+++ b/rama-grpc/src/request.rs
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn duration_to_grpc_timeout_a_very_long_time() {
-        let one_hour = Duration::from_secs(60 * 60);
+        let one_hour = Duration::from_hours(1);
         let value = duration_to_grpc_timeout(one_hour).unwrap();
         assert_eq!(value, format!("{}m", one_hour.as_millis()));
     }

--- a/rama-grpc/src/service/grpc_timeout.rs
+++ b/rama-grpc/src/service/grpc_timeout.rs
@@ -158,13 +158,13 @@ mod tests {
     #[test]
     fn test_hours() {
         let parsed_duration = setup_map_try_parse(Some("3H")).unwrap().unwrap();
-        assert_eq!(Duration::from_secs(3 * 60 * 60), parsed_duration);
+        assert_eq!(Duration::from_hours(3), parsed_duration);
     }
 
     #[test]
     fn test_minutes() {
         let parsed_duration = setup_map_try_parse(Some("1M")).unwrap().unwrap();
-        assert_eq!(Duration::from_secs(60), parsed_duration);
+        assert_eq!(Duration::from_mins(1), parsed_duration);
     }
 
     #[test]

--- a/rama-grpc/src/service/opentelemetry/http.rs
+++ b/rama-grpc/src/service/opentelemetry/http.rs
@@ -17,6 +17,7 @@ use rama_http::{
     uri::{PathAndQuery, Uri},
 };
 use rama_utils::macros::generate_set_and_with;
+use rama_utils::octets::kib;
 use std::{fmt, str::FromStr};
 
 pub(super) const DEFAULT_OTLP_HTTP_ENDPOINT: &str = "http://localhost:4318";
@@ -257,7 +258,7 @@ where
             compress(
                 CompressionSettings {
                     encoding: compression,
-                    buffer_growth_interval: 8 * 1024,
+                    buffer_growth_interval: kib(8),
                 },
                 &mut body,
                 &mut compressed,

--- a/rama-grpc/src/web/call.rs
+++ b/rama-grpc/src/web/call.rs
@@ -19,6 +19,7 @@ use rama_http_types::{
     body::{Frame, SizeHint, StreamingBody},
     header,
 };
+use rama_utils::octets::kib;
 use rama_utils::str::arcstr::arcstr;
 
 use crate::Status;
@@ -48,7 +49,7 @@ pub(crate) mod content_types {
     }
 }
 
-const BUFFER_SIZE: usize = 8 * 1024;
+const BUFFER_SIZE: usize = kib(8);
 
 const FRAME_HEADER_SIZE: usize = 5;
 

--- a/rama-http-backend/src/tests.rs
+++ b/rama-http-backend/src/tests.rs
@@ -30,6 +30,7 @@ use rama_http_types::{
     conn::{H2ClientContextParams, PeerH2Settings, TargetHttpVersion},
 };
 use rama_net::test_utils::client::{MockConnectorService, MockSocket};
+use rama_utils::octets::kib;
 use tokio_util::sync::CancellationToken;
 
 use crate::proxy::mitm::DefaultErrorResponse;
@@ -198,8 +199,8 @@ fn create_test_request_with_id(version: Version, id: usize) -> Request {
 }
 
 async fn test_mitm_relay_roundtrip_inner(version: Version) {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -261,8 +262,8 @@ async fn test_mitm_relay_roundtrip_inner(version: Version) {
 }
 
 async fn test_mitm_relay_concurrency_inner(version: Version, n: usize) {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -353,8 +354,8 @@ async fn test_http2_mitm_relay_handles_200_concurrent_requests() {
 
 #[tokio::test]
 async fn test_http11_mitm_relay_closes_downstream_after_upstream_close() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -435,8 +436,8 @@ async fn test_http11_mitm_relay_closes_downstream_after_upstream_close() {
 
 #[tokio::test]
 async fn test_http11_mitm_relay_task_finishes_after_ingress_disconnect() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -531,8 +532,8 @@ async fn test_mitm_relay_mirrors_h2_settings_inner(
     upstream_enables_connect: bool,
     upstream_max_concurrent_streams: u32,
 ) {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -634,8 +635,8 @@ async fn test_mitm_relay_mirrors_h2_settings_inner(
 /// client params present. Regression guard for the parity issue.
 #[tokio::test]
 async fn test_h2_mitm_relay_eager_honors_egress_h2_client_params() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -696,8 +697,8 @@ async fn test_h2_mitm_relay_eager_honors_egress_h2_client_params() {
 /// Locks in the narrowed-mirror policy from #932 review feedback.
 #[tokio::test]
 async fn test_h2_mitm_relay_does_not_mirror_per_direction_fields() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -790,8 +791,8 @@ async fn test_h2_mitm_relay_does_not_mirror_per_direction_fields() {
 async fn test_h2_mitm_relay_timeout_forces_connect_off_via_fail_safe() {
     use tokio::io::AsyncReadExt;
 
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, mut silent_upstream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, mut silent_upstream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());
@@ -859,8 +860,8 @@ async fn test_h2_mitm_relay_timeout_forces_connect_off_via_fail_safe() {
 /// advertised. Locks in the dropped-floor change.
 #[tokio::test]
 async fn test_h2_mitm_relay_mirrors_zero_max_concurrent_streams() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(16 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(16 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(16));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(16));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());

--- a/rama-http-backend/tests/h2_mitm_relay_stream_reset.rs
+++ b/rama-http-backend/tests/h2_mitm_relay_stream_reset.rs
@@ -40,6 +40,7 @@ use rama_http::{
 use rama_http_core::h2::{Reason, server as h2_server};
 use rama_http_types::{Body, Request, Response, StatusCode, Version};
 use rama_net::test_utils::client::MockSocket;
+use rama_utils::octets::kib;
 use tokio_util::sync::CancellationToken;
 
 use rama_http_backend::{client::http_connect, proxy::mitm::HttpMitmRelay};
@@ -54,8 +55,8 @@ const CONCURRENCY: usize = 6;
 
 #[tokio::test]
 async fn http2_mitm_relay_stream_reset_does_not_tear_down_ingress() {
-    let (client_stream, relay_ingress_stream) = tokio::io::duplex(64 * 1024);
-    let (relay_egress_stream, server_stream) = tokio::io::duplex(64 * 1024);
+    let (client_stream, relay_ingress_stream) = tokio::io::duplex(kib(64));
+    let (relay_egress_stream, server_stream) = tokio::io::duplex(kib(64));
 
     let token = CancellationToken::new();
     let graceful = Shutdown::new(token.clone().cancelled_owned());

--- a/rama-http-core/tests/h2-support/src/prelude.rs
+++ b/rama-http-core/tests/h2-support/src/prelude.rs
@@ -1,4 +1,5 @@
 use rama_core::extensions::ExtensionsRef;
+use rama_utils::octets::kib;
 // Re-export H2 crate
 pub use rama_http_core::h2;
 
@@ -123,16 +124,16 @@ where
 pub fn build_large_headers() -> Vec<(&'static str, String)> {
     vec![
         ("one", "hello".to_string()),
-        ("two", build_large_string('2', 4 * 1024)),
+        ("two", build_large_string('2', kib(4))),
         ("three", "three".to_string()),
-        ("four", build_large_string('4', 4 * 1024)),
+        ("four", build_large_string('4', kib(4))),
         ("five", "five".to_string()),
-        ("six", build_large_string('6', 4 * 1024)),
+        ("six", build_large_string('6', kib(4))),
         ("seven", "seven".to_string()),
-        ("eight", build_large_string('8', 4 * 1024)),
+        ("eight", build_large_string('8', kib(4))),
         ("nine", "nine".to_string()),
-        ("ten", build_large_string('0', 4 * 1024)),
-        ("eleven", build_large_string('1', 32 * 1024)),
+        ("ten", build_large_string('0', kib(4))),
+        ("eleven", build_large_string('1', kib(32))),
     ]
 }
 

--- a/rama-http-headers/src/common/last_modified.rs
+++ b/rama-http-headers/src/common/last_modified.rs
@@ -30,7 +30,7 @@ use std::time::SystemTime;
 /// use rama_utils::time::now_system_time;
 ///
 /// let modified = LastModified::from(
-///     now_system_time() - Duration::from_secs(60 * 60 * 24)
+///     now_system_time() - Duration::from_hours(24)
 /// );
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/rama-http-types/src/proto/h2/hpack/test/fixture.rs
+++ b/rama-http-types/src/proto/h2/hpack/test/fixture.rs
@@ -2,6 +2,7 @@ use crate::proto::h2::hpack::{Decoder, Encoder, Header};
 
 use hex::FromHex;
 use rama_core::bytes::BytesMut;
+use rama_utils::octets::kib;
 use serde_json::Value;
 
 use std::io::Cursor;
@@ -84,7 +85,7 @@ fn test_story(story: &Value) {
 
         // Now, encode the headers
         for case in &cases {
-            let limit = 64 * 1024;
+            let limit = kib(64);
             let mut buf = BytesMut::with_capacity(limit);
 
             if let Some(size) = case.header_table_size {

--- a/rama-http-types/src/proto/h2/hpack/test/fuzz.rs
+++ b/rama-http-types/src/proto/h2/hpack/test/fuzz.rs
@@ -9,13 +9,14 @@ use crate::{HeaderName, HeaderValue};
 
 use quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
 use rama_core::bytes::BytesMut;
+use rama_utils::octets::kib;
 use rand::distr::slice::Choose;
 use rand::rngs::StdRng;
 use rand::{RngExt as _, SeedableRng, rng};
 
 use std::io::Cursor;
 
-const MAX_CHUNK: usize = 2 * 1024;
+const MAX_CHUNK: usize = kib(2);
 
 #[test]
 fn hpack_fuzz() {

--- a/rama-http/src/body/zip_bomb.rs
+++ b/rama-http/src/body/zip_bomb.rs
@@ -6,6 +6,7 @@ use rama_core::telemetry::tracing;
 use rama_core::{bytes::Bytes, futures::Stream};
 use rama_http_types::{Body, HeaderValue, Response};
 use rama_utils::macros::generate_set_and_with;
+use rama_utils::octets::{kib, mib};
 use rama_utils::str::arcstr::{ArcStr, arcstr};
 use rawzip::{CompressionMethod, ZipArchiveWriter};
 use std::fmt;
@@ -46,7 +47,7 @@ impl Default for ZipBomb {
 impl ZipBomb {
     const DEFAULT_DEPTH: usize = 8;
     const DEFAULT_FANOUT: usize = 32;
-    const DEFAULT_FILE_SIZE: usize = 512 * 1024 * 1024;
+    const DEFAULT_FILE_SIZE: usize = mib(512);
 
     #[must_use]
     /// Create a new [`ZipBomb`].
@@ -189,12 +190,12 @@ impl fmt::Debug for RecursiveZipBomb {
 
 impl RecursiveZipBomb {
     fn new(filename: ArcStr, depth: usize, fanout: usize, file_size: usize) -> Self {
-        let mut buffer_size = 64 * 1024;
-        buffer_size += fanout * 32 * 1024;
-        buffer_size += file_size.min(4 * 1024 * 1024);
-        buffer_size += depth * 16 * 1024;
+        let mut buffer_size = kib(64);
+        buffer_size += fanout * kib(32);
+        buffer_size += file_size.min(mib(4));
+        buffer_size += depth * kib(16);
 
-        let (writer, reader) = duplex(buffer_size.min(8 * 1024 * 1024));
+        let (writer, reader) = duplex(buffer_size.min(mib(8)));
 
         tokio::task::spawn_blocking(move || {
             generate_recursive_base_zip(

--- a/rama-http/src/protocols/rss/stream.rs
+++ b/rama-http/src/protocols/rss/stream.rs
@@ -31,6 +31,7 @@ use rama_core::error::BoxError;
 use rama_core::futures::Stream;
 use rama_core::futures::stream::{self, BoxStream, StreamExt as _};
 use rama_net::uri::Uri;
+use rama_utils::octets::kib;
 
 use super::atom::{
     AtomEntry, AtomFeed, AtomFeedStream, AtomHeader, write_atom_entry, write_atom_feed_close,
@@ -489,7 +490,7 @@ impl FeedStream {
         // document, even though we consumed those bytes for detection.
         let prefix = std::io::Cursor::new(probe);
         let chained = tokio::io::AsyncReadExt::chain(prefix, reader);
-        let buf_reader = tokio::io::BufReader::with_capacity(8 * 1024, chained);
+        let buf_reader = tokio::io::BufReader::with_capacity(kib(8), chained);
 
         if is_atom {
             return Ok(Self::Atom(
@@ -763,7 +764,7 @@ fn body_reader(
         .map(|r| r.map_err(std::io::Error::other))
         .boxed();
     let inner = StreamReader::new(stream);
-    tokio::io::BufReader::with_capacity(8 * 1024, inner)
+    tokio::io::BufReader::with_capacity(kib(8), inner)
 }
 
 type BodyDataStream = BoxStream<'static, std::io::Result<rama_core::bytes::Bytes>>;

--- a/rama-http/src/service/web/endpoint/extract/body/multipart.rs
+++ b/rama-http/src/service/web/endpoint/extract/body/multipart.rs
@@ -412,6 +412,7 @@ mod test {
     use crate::StatusCode;
     use crate::service::web::WebService;
     use rama_core::Service;
+    use rama_utils::octets::kib_u64;
 
     const BOUNDARY: &str = "X-RAMA-TEST-BOUNDARY";
 
@@ -817,14 +818,14 @@ mod test {
     fn test_config_merge_floor_keeps_min() {
         let mut a = MultipartConfig::new()
             .with_default_field_limit(1024)
-            .with_field_limit("avatar", 8 * 1024);
+            .with_field_limit("avatar", kib_u64(8));
         let b = MultipartConfig::new()
             .with_default_field_limit(2048)
-            .with_field_limit("avatar", 4 * 1024)
+            .with_field_limit("avatar", kib_u64(4))
             .with_field_limit("doc", 100);
         a.merge_floor(&b);
         assert_eq!(a.default_field_limit, Some(1024));
-        assert_eq!(a.field_limits.get("avatar").copied(), Some(4 * 1024));
+        assert_eq!(a.field_limits.get("avatar").copied(), Some(kib_u64(4)));
         assert_eq!(a.field_limits.get("doc").copied(), Some(100));
     }
 }

--- a/rama-http/tests/rss_corpus.rs
+++ b/rama-http/tests/rss_corpus.rs
@@ -908,7 +908,10 @@ async fn podlove_chapters_preserved() {
     );
 
     assert_eq!(ch.chapters[2].title, "Main topic");
-    assert_eq!(ch.chapters[2].start, Duration::from_secs(5 * 60 + 42));
+    assert_eq!(
+        ch.chapters[2].start,
+        Duration::from_mins(5) + Duration::from_secs(42)
+    );
     assert_eq!(
         ch.chapters[2].image.as_deref(),
         Some("https://example.com/chapter3.png"),

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -16,6 +16,7 @@ use rama_core::{
     service::Service,
 };
 use rama_net::proxy::{BridgeCloseReason, IdleGuard, ProxyTarget};
+use rama_utils::octets::kib;
 
 use atomic_waker::AtomicWaker;
 use tokio::sync::{
@@ -134,7 +135,7 @@ impl std::fmt::Display for DecisionDeadlineAction {
 /// Default for the [`TransparentProxyEngineBuilder::tcp_flow_buffer_size`]
 /// setter, which has no effect — per-flow buffering is bounded by
 /// [`DEFAULT_TCP_CHANNEL_CAPACITY`].
-const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = 16 * 1024;
+const DEFAULT_TCP_FLOW_BUFFER_SIZE: usize = kib(16);
 /// Number of `Bytes` chunks each TCP per-flow channel (ingress and egress)
 /// buffers before backpressuring Swift. Each chunk is whatever Swift hands
 /// us in one `flow.readData` / `connection.receive` callback (typically

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/e2e_loopback.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/e2e_loopback.rs
@@ -37,6 +37,7 @@ use crate::tproxy::{TransparentProxyFlowMeta, TransparentProxyFlowProtocol};
 use rama_core::io::BridgeIo;
 use rama_core::service::service_fn;
 use rama_net::address::HostWithPort;
+use rama_utils::octets::kib;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -63,7 +64,7 @@ async fn run_peer_listener(addr: SocketAddr, behavior: PeerBehavior) {
         tokio::spawn(async move {
             match behavior {
                 PeerBehavior::EchoAndClose => {
-                    let mut buf = vec![0u8; 8 * 1024];
+                    let mut buf = vec![0u8; kib(8)];
                     if let Ok(n) = socket.read(&mut buf).await
                         && n > 0
                     {
@@ -72,7 +73,7 @@ async fn run_peer_listener(addr: SocketAddr, behavior: PeerBehavior) {
                     _ = socket.shutdown().await;
                 }
                 PeerBehavior::EchoThenHalfClose => {
-                    let mut buf = vec![0u8; 8 * 1024];
+                    let mut buf = vec![0u8; kib(8)];
                     if let Ok(n) = socket.read(&mut buf).await
                         && n > 0
                     {
@@ -101,7 +102,7 @@ async fn run_peer_listener(addr: SocketAddr, behavior: PeerBehavior) {
                     tokio::time::sleep(Duration::from_secs(60)).await;
                 }
                 PeerBehavior::EchoThenAbort => {
-                    let mut buf = vec![0u8; 8 * 1024];
+                    let mut buf = vec![0u8; kib(8)];
                     if let Ok(n) = socket.read(&mut buf).await
                         && n > 0
                     {

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -5,6 +5,7 @@ use rama_core::extensions::Extension;
 use rama_net::address::{Host, HostWithPort};
 use rama_utils::{
     macros::generate_set_and_with,
+    octets::kib,
     str::{NonEmptyStr, arcstr::ArcStr},
 };
 
@@ -551,7 +552,7 @@ impl TransparentProxyConfig {
             // on the Swift side — kept in lockstep so the Swift fallback
             // isn't dead code and the documented per-flow cap is what's
             // actually applied at runtime.
-            tcp_write_pump_max_pending_bytes: 256 * 1024,
+            tcp_write_pump_max_pending_bytes: kib(256),
         }
     }
 
@@ -626,7 +627,7 @@ mod transparent_proxy_config_tests {
         let cfg = TransparentProxyConfig::new();
         assert_eq!(
             cfg.tcp_write_pump_max_pending_bytes(),
-            256 * 1024,
+            kib(256),
             "Swift Provider defaults `writePumpMaxPendingBytes` to 256 KiB \
              and overrides it from this value; if the two drift, the \
              intended per-flow cap silently turns into something else."

--- a/rama-net/src/proxy/forward.rs
+++ b/rama-net/src/proxy/forward.rs
@@ -11,6 +11,7 @@ use rama_core::{
     io::{BridgeIo, Io},
 };
 use rama_utils::macros::generate_set_and_with;
+use rama_utils::octets::kib;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use super::IdleGuard;
@@ -34,7 +35,7 @@ enum CopyDirection {
 // flow stays cheap under high connection concurrency. Override per service via
 // [`IoForwardService::with_buf_size`] when a workload wants a different point on
 // that throughput-vs-resident-memory curve.
-const DEFAULT_BUF_SIZE: usize = 16 * 1024;
+const DEFAULT_BUF_SIZE: usize = kib(16);
 const DEFAULT_SHUTDOWN_GRACE: Duration = Duration::from_millis(50);
 
 /// A proxy [`Service`] which takes a [`BridgeIo`]

--- a/rama-net/src/tls/server/peek_client_hello.rs
+++ b/rama-net/src/tls/server/peek_client_hello.rs
@@ -10,6 +10,7 @@ use rama_core::{
     service::RejectService,
     telemetry::tracing,
 };
+use rama_utils::octets::kib;
 use tokio::time::Instant;
 
 use crate::tls::client::{ClientHello, parse_client_hello_handshake};
@@ -130,7 +131,7 @@ where
     // "no extensions", that made us mirror a bare default ClientHello
     // and get rejected by SNI-routed upstreams. The bound still guards
     // against a malformed huge length triggering an unbounded alloc.
-    const MAX_TLS_RECORD_BODY: usize = 16 * 1024;
+    const MAX_TLS_RECORD_BODY: usize = kib(16);
     let record_size = (n + TLS_HEADER_PEEK_LEN).min(MAX_TLS_RECORD_BODY + TLS_HEADER_PEEK_LEN);
 
     let mut v = vec![0u8; record_size];

--- a/rama-socks5/src/client/udp.rs
+++ b/rama-socks5/src/client/udp.rs
@@ -8,6 +8,7 @@ use rama_core::telemetry::tracing;
 use rama_net::address::HostWithPort;
 use rama_net::address::SocketAddress;
 use rama_udp::{UdpSocket, bind_udp_with_address};
+use rama_utils::octets::kib;
 use std::pin::Pin;
 use std::task::{Context, Poll, ready};
 use std::{fmt, io, net::SocketAddr};
@@ -350,8 +351,8 @@ impl<C: Send + Sync + 'static, S: Send + Sync + 'static> rama_net::stream::Socke
     }
 }
 
-const INITIAL_RD_CAPACITY: usize = 64 * 1024;
-const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+const INITIAL_RD_CAPACITY: usize = kib(64);
+const INITIAL_WR_CAPACITY: usize = kib(8);
 
 impl<C, S: Unpin> Unpin for UdpFramedRelay<C, S> {}
 

--- a/rama-udp/Cargo.toml
+++ b/rama-udp/Cargo.toml
@@ -31,6 +31,7 @@ default = []
 rama-core = { workspace = true }
 rama-dns = { workspace = true }
 rama-net = { workspace = true }
+rama-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net"] }
 tokio-util = { workspace = true, features = ["net"] }
 

--- a/rama-udp/src/connected_framed.rs
+++ b/rama-udp/src/connected_framed.rs
@@ -26,10 +26,11 @@ use std::task::{Context, Poll, ready};
 use rama_core::bytes::{BufMut, BytesMut};
 use rama_core::futures::{Sink, Stream};
 use rama_core::stream::codec::{Decoder, Encoder};
+use rama_utils::octets::kib;
 use tokio::net::UdpSocket;
 
-const INITIAL_RD_CAPACITY: usize = 64 * 1024;
-const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+const INITIAL_RD_CAPACITY: usize = kib(64);
+const INITIAL_WR_CAPACITY: usize = kib(8);
 
 /// A unified [`Stream`] and [`Sink`] of frames over a connected [`UdpSocket`].
 ///

--- a/rama-unix/Cargo.toml
+++ b/rama-unix/Cargo.toml
@@ -31,6 +31,7 @@ libc = { workspace = true }
 pin-project-lite = { workspace = true }
 rama-core = { workspace = true }
 rama-net = { workspace = true }
+rama-utils = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net"] }
 
 [dev-dependencies]

--- a/rama-unix/src/frame.rs
+++ b/rama-unix/src/frame.rs
@@ -2,6 +2,7 @@ use rama_core::bytes::{BufMut, BytesMut};
 use rama_core::futures::Sink;
 use rama_core::futures::Stream;
 use rama_core::stream::codec::{Decoder, Encoder};
+use rama_utils::octets::kib;
 use std::borrow::Borrow;
 use std::io;
 use std::pin::Pin;
@@ -41,8 +42,8 @@ pub struct UnixDatagramFramed<C, T = UnixDatagram> {
     current_addr: Option<UnixSocketAddress>,
 }
 
-const INITIAL_RD_CAPACITY: usize = 64 * 1024;
-const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+const INITIAL_RD_CAPACITY: usize = kib(64);
+const INITIAL_WR_CAPACITY: usize = kib(8);
 
 impl<C, T> Unpin for UnixDatagramFramed<C, T> {}
 

--- a/rama-ws/src/handshake/mitm.rs
+++ b/rama-ws/src/handshake/mitm.rs
@@ -319,6 +319,7 @@ mod tests {
         io::BridgeIo,
     };
     use rama_net::test_utils::client::MockSocket;
+    use rama_utils::octets::kib;
     use tokio::io::duplex;
 
     use crate::{
@@ -398,8 +399,8 @@ mod tests {
         // Two duplex pairs: one for the ingress side of the relay, one for
         // the egress side. `MockSocket` wraps each end in an `ExtensionsRef`
         // shell so the relay's `from_raw_socket` is happy.
-        let (relay_ingress_dup, peer_ingress_dup) = duplex(16 * 1024);
-        let (relay_egress_dup, peer_egress_dup) = duplex(16 * 1024);
+        let (relay_ingress_dup, peer_ingress_dup) = duplex(kib(16));
+        let (relay_egress_dup, peer_egress_dup) = duplex(kib(16));
 
         let relay_ingress = MockSocket::new(relay_ingress_dup);
         let relay_egress = MockSocket::new(relay_egress_dup);

--- a/rama-ws/src/protocol/frame/mod.rs
+++ b/rama-ws/src/protocol/frame/mod.rs
@@ -5,6 +5,7 @@ use rama_core::{
     bytes::{self, BytesMut},
     telemetry::tracing::trace,
 };
+use rama_utils::octets::kib;
 use std::io::{self, Cursor, Error as IoError, ErrorKind as IoErrorKind, Read, Write};
 
 pub mod coding;
@@ -19,7 +20,7 @@ pub use self::{
 };
 
 /// Read buffer size used for `FrameSocket`.
-const READ_BUF_LEN: usize = 128 * 1024;
+const READ_BUF_LEN: usize = kib(128);
 
 /// A reader and writer for WebSocket frames.
 #[derive(Debug)]

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -9,6 +9,7 @@ use rama_core::error::{BoxError, BoxErrorExt as _};
 use rama_core::extensions::{Extensions, ExtensionsRef};
 use rama_core::telemetry::tracing;
 use rama_core::telemetry::tracing::{debug, trace};
+use rama_utils::octets::kib;
 use std::{
     fmt,
     io::{self, Read, Write},
@@ -268,8 +269,8 @@ impl Default for PerMessageDeflateConfig {
 impl Default for WebSocketConfig {
     fn default() -> Self {
         Self {
-            read_buffer_size: 128 * 1024,
-            write_buffer_size: 128 * 1024,
+            read_buffer_size: kib(128),
+            write_buffer_size: kib(128),
             max_write_buffer_size: usize::MAX,
             max_message_size: Some(64 << 20),
             max_frame_size: Some(16 << 20),

--- a/src/cli/service/echo.rs
+++ b/src/cli/service/echo.rs
@@ -41,6 +41,7 @@ use crate::{
     tcp::TcpStream,
     telemetry::tracing,
     ua::{UserAgent, layer::classifier::UserAgentClassifierLayer, profile::UserAgentDatabase},
+    utils::octets::mib,
 };
 
 use rama_core::error::ErrorExt as _;
@@ -100,7 +101,7 @@ impl Default for EchoServiceBuilder<()> {
     fn default() -> Self {
         Self {
             concurrent_limit: 0,
-            body_limit: 1024 * 1024,
+            body_limit: mib(1),
             timeout: Duration::ZERO,
             forward: None,
 

--- a/src/cli/service/fs.rs
+++ b/src/cli/service/fs.rs
@@ -28,6 +28,7 @@ use crate::{
     tcp::TcpStream,
     telemetry::tracing,
     ua::layer::classifier::UserAgentClassifierLayer,
+    utils::octets::mib,
 };
 
 use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
@@ -72,7 +73,7 @@ impl Default for FsServiceBuilder<()> {
     fn default() -> Self {
         Self {
             concurrent_limit: 0,
-            body_limit: 1024 * 1024,
+            body_limit: mib(1),
             timeout: Duration::ZERO,
             forward: None,
 

--- a/src/cli/service/ip.rs
+++ b/src/cli/service/ip.rs
@@ -37,6 +37,7 @@ use crate::{
     rt::Executor,
     tcp::TcpStream,
     telemetry::tracing,
+    utils::octets::mib,
 };
 
 #[cfg(all(feature = "rustls", not(feature = "boring")))]
@@ -455,7 +456,7 @@ impl<M> IpServiceBuilder<M> {
             (!self.timeout.is_zero()).then(|| TimeoutLayer::new(self.timeout)),
             tcp_forwarded_layer,
             // Limit the body size to 1MB for requests
-            BodyLimitLayer::request_only(1024 * 1024),
+            BodyLimitLayer::request_only(mib(1)),
             #[cfg(any(feature = "rustls", feature = "boring"))]
             maybe_tls_accept_layer,
         );

--- a/tests/http-core/h1_server/fixture.rs
+++ b/tests/http-core/h1_server/fixture.rs
@@ -7,6 +7,7 @@ use rama::http::core::service::RamaHttpService;
 use rama::http::{Request, Response, StatusCode};
 use rama::service::service_fn;
 use rama::telemetry::tracing::{error, info};
+use rama::utils::octets::kib;
 use rama_http_core::server::conn::http1;
 use std::convert::Infallible;
 use std::time::Duration;
@@ -24,7 +25,7 @@ impl TestConfig {
     pub(crate) fn with_timeout(chunk_timeout: Duration) -> Self {
         Self {
             total_chunks: 16,
-            chunk_size: 64 * 1024,
+            chunk_size: kib(64),
             chunk_timeout,
         }
     }

--- a/tests/integration/cli/cli_tests/serve_http_test.rs
+++ b/tests/integration/cli/cli_tests/serve_http_test.rs
@@ -16,6 +16,7 @@ use rama::{
     net::tls::client::{ServerVerifyMode, TlsClientConfig},
     rt::Executor,
     service::BoxService,
+    utils::octets::{kib, mib},
     utils::str::any_submatch_ignore_ascii_case,
 };
 
@@ -345,7 +346,7 @@ async fn run_http_test_endpoint_multipart(
     // early-error responses. Either outcome proves the cap was
     // enforced; we accept both to keep the test stable across CI
     // load.
-    let big = vec![b'x'; 300 * 1024];
+    let big = vec![b'x'; kib(300)];
     let oversized = multipart::Form::new().part("blob", multipart::Part::bytes(big));
     match client
         .post(format!("{base_uri}/multipart"))
@@ -469,7 +470,7 @@ async fn run_http_test_endpoint_sink(
     assert_eq!(body["bytes"].as_u64(), Some(payload.len() as u64));
 
     // larger body (1 MiB) — exercises multi-frame draining
-    let big = vec![0u8; 1024 * 1024];
+    let big = vec![0u8; mib(1)];
     let resp = client
         .post(format!("{base_uri}/sink"))
         .version(http_version)


### PR DESCRIPTION
Replace `* 1024` byte math with `octets::kib`/`mib` and `from_secs(N*60)` with `Duration::from_mins`/`from_hours` across the workspace.