### PR TITLE
Harden client and file-serving edge cases

### DIFF
--- a/rama-cli/src/cmd/send/http/client/mod.rs
+++ b/rama-cli/src/cmd/send/http/client/mod.rs
@@ -3,7 +3,7 @@ use rama::{
     error::{BoxError, BoxErrorExt, ErrorContext, ErrorExt, extra::OpaqueError},
     extensions::Extension,
     http::{
-        Request, Response, StreamingBody,
+        Body, Request, Response, StreamingBody,
         client::{
             EasyHttpWebClient, ProxyConnectorLayer,
             proxy::layer::{
@@ -12,7 +12,10 @@ use rama::{
         },
         layer::{
             auth::AddAuthorizationLayer,
-            follow_redirect::{FollowRedirectLayer, policy::Limited},
+            follow_redirect::{
+                FollowRedirectLayer,
+                policy::{FilterCredentials, Limited, PolicyExt},
+            },
             required_header::AddRequiredRequestHeadersLayer,
         },
     },
@@ -81,12 +84,17 @@ pub(super) async fn new(
                 ))
             })
             .transpose()?,
-        FollowRedirectLayer::with_policy(Limited::new(if cfg.location && cfg.max_redirs > 0 {
-            cfg.max_redirs as usize
-        } else {
-            0
-        })),
         OptDnsOverwriteLayer::new(cfg.resolve.clone()),
+        match cfg.proxy.clone() {
+            None => HttpProxyAddressLayer::try_from_env_default()?,
+            Some(mut proxy_address) => {
+                if let Some(credentials) = cfg.proxy_user.clone() {
+                    proxy_address.credential = Some(ProxyCredential::Basic(credentials));
+                }
+                HttpProxyAddressLayer::maybe(Some(proxy_address))
+            }
+        },
+        SetProxyAuthHttpHeaderLayer::default(),
         cfg.user
             .as_deref()
             .map(|auth| {
@@ -105,17 +113,14 @@ pub(super) async fn new(
             })
             .transpose()?
             .unwrap_or_else(AddAuthorizationLayer::none),
+        FollowRedirectLayer::with_policy(
+            Limited::new(redirect_limit(cfg)).and::<_, Body, OpaqueError>(
+                FilterCredentials::new()
+                    .with_block_cross_origin(!cfg.location_trusted)
+                    .with_remove_blocklisted(!cfg.location_trusted),
+            ),
+        ),
         AddRequiredRequestHeadersLayer::default(),
-        match cfg.proxy.clone() {
-            None => HttpProxyAddressLayer::try_from_env_default()?,
-            Some(mut proxy_address) => {
-                if let Some(credentials) = cfg.proxy_user.clone() {
-                    proxy_address.credential = Some(ProxyCredential::Basic(credentials));
-                }
-                HttpProxyAddressLayer::maybe(Some(proxy_address))
-            }
-        },
-        SetProxyAuthHttpHeaderLayer::default(),
         HijackLayer::new(cfg.curl, curl_writer::CurlWriter { writer }),
         MapErrLayer::into_box_error(),
         layer_fn(move |svc| logger_headers_res::ResponseHeaderLogger {
@@ -125,6 +130,18 @@ pub(super) async fn new(
     );
 
     Ok(client_builder.into_layer(inner_client))
+}
+
+fn redirect_limit(cfg: &SendCommand) -> usize {
+    if !(cfg.location || cfg.location_trusted) {
+        return 0;
+    }
+
+    if cfg.max_redirs < 0 {
+        usize::MAX
+    } else {
+        cfg.max_redirs as usize
+    }
 }
 
 fn new_inner_client(

--- a/rama-cli/src/cmd/send/http/client/mod.rs
+++ b/rama-cli/src/cmd/send/http/client/mod.rs
@@ -94,7 +94,6 @@ pub(super) async fn new(
                 HttpProxyAddressLayer::maybe(Some(proxy_address))
             }
         },
-        SetProxyAuthHttpHeaderLayer::default(),
         cfg.user
             .as_deref()
             .map(|auth| {
@@ -120,6 +119,10 @@ pub(super) async fn new(
                     .with_remove_blocklisted(!cfg.location_trusted),
             ),
         ),
+        // Inner to FollowRedirect: proxy credentials are per-hop and authenticate
+        // to the (same) proxy, so they must be re-applied on every redirect rather
+        // than stripped by FilterCredentials' cross-origin rule like origin creds.
+        SetProxyAuthHttpHeaderLayer::default(),
         AddRequiredRequestHeadersLayer::default(),
         HijackLayer::new(cfg.curl, curl_writer::CurlWriter { writer }),
         MapErrLayer::into_box_error(),
@@ -133,14 +136,20 @@ pub(super) async fn new(
 }
 
 fn redirect_limit(cfg: &SendCommand) -> usize {
-    if !(cfg.location || cfg.location_trusted) {
+    compute_redirect_limit(cfg.location, cfg.location_trusted, cfg.max_redirs)
+}
+
+fn compute_redirect_limit(location: bool, location_trusted: bool, max_redirs: isize) -> usize {
+    // Redirects only follow when --location or --location-trusted is set.
+    if !(location || location_trusted) {
         return 0;
     }
 
-    if cfg.max_redirs < 0 {
+    // curl semantics: --max-redirs -1 means unlimited.
+    if max_redirs < 0 {
         usize::MAX
     } else {
-        cfg.max_redirs as usize
+        max_redirs as usize
     }
 }
 
@@ -237,5 +246,34 @@ where
     match result {
         Ok(response) => Ok(response.map(rama::http::Body::new)),
         Err(err) => Err(err.into_opaque_error()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_redirect_limit;
+
+    #[test]
+    fn redirect_limit_disabled_without_location() {
+        // No redirects unless --location or --location-trusted is set.
+        assert_eq!(compute_redirect_limit(false, false, 50), 0);
+        assert_eq!(compute_redirect_limit(false, false, -1), 0);
+    }
+
+    #[test]
+    fn redirect_limit_location_trusted_alone_enables_redirects() {
+        assert_eq!(compute_redirect_limit(false, true, 50), 50);
+    }
+
+    #[test]
+    fn redirect_limit_respects_max_redirs() {
+        assert_eq!(compute_redirect_limit(true, false, 0), 0);
+        assert_eq!(compute_redirect_limit(true, false, 7), 7);
+    }
+
+    #[test]
+    fn redirect_limit_negative_is_unlimited() {
+        assert_eq!(compute_redirect_limit(true, false, -1), usize::MAX);
+        assert_eq!(compute_redirect_limit(false, true, -1), usize::MAX);
     }
 }

--- a/rama-cli/src/cmd/send/mod.rs
+++ b/rama-cli/src/cmd/send/mod.rs
@@ -57,6 +57,10 @@ pub struct SendCommand {
     /// Limit the amount of redirects to follow by using the --max-redirs option.
     location: bool,
 
+    #[arg(long, default_value_t = false)]
+    /// (HTTP) Like --location, but allows credentials to be forwarded to redirected hosts.
+    location_trusted: bool,
+
     #[arg(long, default_value_t = 50)]
     /// (HTTP) the maximum number of redirects to follow (set to -1 to put no limit)
     max_redirs: isize,

--- a/rama-cli/src/cmd/serve/fs/mod.rs
+++ b/rama-cli/src/cmd/serve/fs/mod.rs
@@ -4,7 +4,7 @@ use rama::{
     cli::{ForwardKind, service::fs::FsServiceBuilder},
     error::{BoxError, ErrorContext},
     graceful::ShutdownGuard,
-    http::service::fs::DirectoryServeMode,
+    http::service::fs::{DirectoryServeMode, ServeDirSymlinkPolicy},
     net::{address::SocketAddress, tls::ApplicationProtocol},
     rt::Executor,
     tcp::server::TcpListener,
@@ -76,6 +76,16 @@ pub struct CliCommandFs {
     ///
     /// only applies when serving a directory
     html_as_default_extension: bool,
+
+    #[arg(long, default_value_t = ServeDirSymlinkPolicy::default())]
+    /// how to handle filesystem symlinks in requested paths
+    ///
+    /// 'reject-all': reject any symlinked request path component (default)
+    ///
+    /// 'allow-final-component': allow only the final requested component to be a symlink
+    ///
+    /// 'allow-all': follow all symlinks (historical behavior)
+    symlink_policy: ServeDirSymlinkPolicy,
 }
 
 /// run the rama serve service
@@ -102,6 +112,7 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandFs) -> Result<(), BoxEr
         .maybe_with_content_path(cfg.path)
         .with_directory_serve_mode(cfg.dir_serve)
         .with_html_as_default_extension(cfg.html_as_default_extension)
+        .with_symlink_policy(cfg.symlink_policy)
         .build(exec.clone())
         .context("build serve service")?;
 

--- a/rama-cli/src/cmd/serve/httptest/endpoint/request_compression.rs
+++ b/rama-cli/src/cmd/serve/httptest/endpoint/request_compression.rs
@@ -19,8 +19,8 @@ pub(in crate::cmd::serve::httptest) fn service()
 -> impl Service<Request, Output = Response, Error = Infallible> {
     (
         ConsumeErrLayer::trace_as_debug(),
-        BodyLimitLayer::new(mib(8)), // EMS 3.2 4life
         RequestDecompressionLayer::new(),
+        BodyLimitLayer::new(mib(8)), // EMS 3.2 4life
         MapRequestBodyLayer::new_boxed_streaming_body(),
     )
         .into_layer(service_fn(async |req: Request| {

--- a/rama-http/src/convert/curl.rs
+++ b/rama-http/src/convert/curl.rs
@@ -59,8 +59,12 @@ trait CurlCommandWriter {
 }
 
 impl CurlCommandWriter for Command {
+    // `Command::arg` passes each value as a distinct argv element straight to
+    // the curl process (no shell), so values must NOT be quoted: any surrounding
+    // quotes would become literal bytes of the argument. This is the dual of the
+    // `String` writer below, which builds shell text and therefore must quote.
     fn write_uri(&mut self, uri: Uri) -> &mut Self {
-        self.arg(format!("'{uri}'"))
+        self.arg(uri.to_string())
     }
 
     fn write_single(&mut self, one: impl fmt::Display) -> &mut Self {
@@ -71,17 +75,14 @@ impl CurlCommandWriter for Command {
         &mut self,
         one: impl fmt::Display,
         two: impl fmt::Display,
-        quote_value: bool,
+        _quote_value: bool,
     ) -> &mut Self {
-        self.arg(one.to_string()).arg(if quote_value {
-            format!("'{two}'")
-        } else {
-            two.to_string()
-        })
+        // `quote_value` only governs shell-text quoting; argv needs none.
+        self.arg(one.to_string()).arg(two.to_string())
     }
 
     fn write_header(&mut self, key: Http1HeaderName, value: Cow<'_, str>) -> &mut Self {
-        self.arg("-H").arg(format!("'{key}: {value}'"))
+        self.arg("-H").arg(format!("{key}: {value}"))
     }
 }
 
@@ -733,6 +734,47 @@ mod tests {
                 r##"curl 'http://example.com/a'\''b?x=y'\''z' \{NL}  --http1.1"##,
                 NL = rama_utils::str::NATIVE_NEWLINE
             ),
+        );
+    }
+
+    #[test]
+    fn test_cmd_for_request_passes_unquoted_argv() {
+        // The `Command` path executes curl directly (no shell), so values must
+        // be passed as bare argv elements: surrounding shell quotes would become
+        // literal bytes of the argument and break curl.
+        let (parts, _) = crate::Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/path?q=a'b")
+            .header("x-test", "a'b")
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let cmd = cmd_for_request_parts_and_payload(&parts, &Bytes::from_static(b"source='web'"));
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+
+        // URI, header value and --data-raw payload are all unquoted argv elements.
+        assert!(
+            args.contains(&"https://example.com/path?q=a'b".to_owned()),
+            "uri must be a bare argv element, got {args:?}",
+        );
+        assert!(
+            args.contains(&"x-test: a'b".to_owned()),
+            "header must be a bare argv element, got {args:?}",
+        );
+        assert!(
+            args.contains(&"source='web'".to_owned()),
+            "payload must be a bare argv element, got {args:?}",
+        );
+        // No argv element should be wrapped in literal shell quotes.
+        assert!(
+            !args
+                .iter()
+                .any(|a| a.starts_with('\'') && a.ends_with('\'')),
+            "no argv element may be shell-quoted, got {args:?}",
         );
     }
 }

--- a/rama-http/src/convert/curl.rs
+++ b/rama-http/src/convert/curl.rs
@@ -87,7 +87,8 @@ impl CurlCommandWriter for Command {
 
 impl CurlCommandWriter for String {
     fn write_uri(&mut self, uri: Uri) -> &mut Self {
-        _ = write!(self, " '{uri}'");
+        self.push(' ');
+        write_shell_single_quoted(self, uri);
         self
     }
 
@@ -102,23 +103,43 @@ impl CurlCommandWriter for String {
         two: impl fmt::Display,
         quote_value: bool,
     ) -> &mut Self {
-        let quote = if quote_value { "'" } else { "" };
-        _ = write!(
-            self,
-            " \\{}  {one} {quote}{two}{quote}",
-            rama_utils::str::NATIVE_NEWLINE
-        );
+        _ = write!(self, " \\{}  {one} ", rama_utils::str::NATIVE_NEWLINE);
+        if quote_value {
+            write_shell_single_quoted(self, two);
+        } else {
+            _ = write!(self, "{two}");
+        }
         self
     }
 
     fn write_header(&mut self, key: Http1HeaderName, value: Cow<'_, str>) -> &mut Self {
-        _ = write!(
-            self,
-            " \\{}  -H '{key}: {value}'",
-            rama_utils::str::NATIVE_NEWLINE
-        );
+        _ = write!(self, " \\{}  -H ", rama_utils::str::NATIVE_NEWLINE);
+        write_shell_single_quoted(self, format_args!("{key}: {value}"));
         self
     }
+}
+
+fn write_shell_single_quoted(out: &mut String, value: impl fmt::Display) {
+    struct ShellSingleQuoted<'a>(&'a mut String);
+
+    impl fmt::Write for ShellSingleQuoted<'_> {
+        fn write_str(&mut self, value: &str) -> fmt::Result {
+            let mut start = 0;
+            for (idx, ch) in value.char_indices() {
+                if ch == '\'' {
+                    self.0.push_str(&value[start..idx]);
+                    self.0.push_str("'\\''");
+                    start = idx + ch.len_utf8();
+                }
+            }
+            self.0.push_str(&value[start..]);
+            Ok(())
+        }
+    }
+
+    out.push('\'');
+    _ = write!(&mut ShellSingleQuoted(out), "{value}");
+    out.push('\'');
 }
 
 fn write_curl_command_for_request_parts(
@@ -668,6 +689,28 @@ mod tests {
             s,
             format!(
                 r##"curl 'example.com' \{NL}  --http3 \{NL}  -x 'socks5://user:pass@127.0.0.1:8080'"##,
+                NL = rama_utils::str::NATIVE_NEWLINE
+            ),
+        );
+    }
+
+    #[test]
+    fn test_cmd_string_for_request_shell_escapes_quoted_values() {
+        let (parts, _) = crate::Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/")
+            .header("x-test", "a'b")
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let payload = Bytes::from_static(b"source='web'&rating=3");
+        let s = cmd_string_for_request_parts_and_payload(&parts, &payload);
+
+        assert_eq!(
+            s,
+            format!(
+                r##"curl 'https://example.com/' \{NL}  -X POST \{NL}  --http1.1 \{NL}  -H 'x-test: a'\''b' \{NL}  --data-raw 'source='\''web'\''&rating=3'"##,
                 NL = rama_utils::str::NATIVE_NEWLINE
             ),
         );

--- a/rama-http/src/convert/curl.rs
+++ b/rama-http/src/convert/curl.rs
@@ -715,4 +715,24 @@ mod tests {
             ),
         );
     }
+
+    #[test]
+    fn test_cmd_string_for_request_shell_escapes_uri() {
+        // A single quote is a valid RFC 3986 sub-delim and reaches the URI
+        // writer verbatim, so it must be shell-escaped like any other value.
+        let (parts, _) = crate::Request::builder()
+            .uri("http://example.com/a'b?x=y'z")
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let s = cmd_string_for_request_parts(&&parts);
+        assert_eq!(
+            s,
+            format!(
+                r##"curl 'http://example.com/a'\''b?x=y'\''z' \{NL}  --http1.1"##,
+                NL = rama_utils::str::NATIVE_NEWLINE
+            ),
+        );
+    }
 }

--- a/rama-http/src/layer/follow_redirect/policy/filter_credentials.rs
+++ b/rama-http/src/layer/follow_redirect/policy/filter_credentials.rs
@@ -175,4 +175,42 @@ mod tests {
         Policy::<(), ()>::on_request(&mut policy, &mut request);
         assert!(!request.headers().contains_key(header::COOKIE));
     }
+
+    #[test]
+    fn strips_all_blocklisted_headers_cross_origin() {
+        let mut policy = FilterCredentials::default();
+
+        let initial = Uri::from_static("http://example.com/old");
+        let cross_origin = Uri::from_static("http://other.example.com/new");
+
+        let attempt = Attempt {
+            status: Default::default(),
+            method: &Method::GET,
+            location: &cross_origin,
+            previous_method: &Method::GET,
+            previous: &initial,
+        };
+        assert!(
+            Policy::<(), ()>::redirect(&mut policy, &attempt)
+                .unwrap()
+                .is_follow()
+        );
+
+        let mut request = Request::builder()
+            .uri(cross_origin)
+            .header(header::AUTHORIZATION, "Bearer secret")
+            .header(header::COOKIE, "session=42")
+            .header(header::PROXY_AUTHORIZATION, "Basic proxy")
+            .header(header::ACCEPT, "text/plain")
+            .body(())
+            .unwrap();
+        Policy::<(), ()>::on_request(&mut policy, &mut request);
+
+        // Every blocklisted credential header is stripped on a cross-origin hop.
+        assert!(!request.headers().contains_key(header::AUTHORIZATION));
+        assert!(!request.headers().contains_key(header::COOKIE));
+        assert!(!request.headers().contains_key(header::PROXY_AUTHORIZATION));
+        // Non-blocklisted headers are preserved.
+        assert!(request.headers().contains_key(header::ACCEPT));
+    }
 }

--- a/rama-http/src/service/fs/mod.rs
+++ b/rama-http/src/service/fs/mod.rs
@@ -17,7 +17,7 @@ mod serve_file;
 
 #[doc(inline)]
 pub use self::{
-    serve_dir::{DefaultServeDirFallback, DirectoryServeMode, ServeDir},
+    serve_dir::{DefaultServeDirFallback, DirectoryServeMode, ServeDir, ServeDirSymlinkPolicy},
     serve_file::ServeFile,
 };
 

--- a/rama-http/src/service/fs/serve_dir/mod.rs
+++ b/rama-http/src/service/fs/serve_dir/mod.rs
@@ -390,16 +390,70 @@ where
     }
 }
 
+/// Controls whether [`ServeDir`]/[`ServeFile`](super::ServeFile) follow filesystem
+/// symlinks when resolving a requested path.
+///
+/// The policy governs the **request-supplied** path components below the
+/// configured root: those are the path-traversal escape vector. The configured
+/// root (or single-file target) is operator-trusted and is served even if it is
+/// itself a symlink (e.g. a blue-green `current -> releases/N` deploy).
+///
+/// # Security caveat
+///
+/// Symlink rejection is **best-effort**: it is enforced by stat-ing each path
+/// component and then opening the file, which is two separate resolutions
+/// (a TOCTOU window). If the served tree is writable by untrusted parties a
+/// component could be swapped for a symlink between the check and the open.
+/// `RejectAll` is therefore not a substitute for serving from a root that is
+/// not writable by untrusted parties.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ServeDirSymlinkPolicy {
     #[default]
-    /// Reject symlinks in the configured root and in every requested path component.
+    /// Reject any requested path component that is a symlink (final or intermediate).
     RejectAll,
     /// Allow the final requested path component to be a symlink, but reject symlinked
-    /// roots and intermediate directory components.
+    /// intermediate directory components.
     AllowFinalComponent,
     /// Allow filesystem symlinks. This restores the historical follow-symlinks behavior.
     AllowAll,
+}
+
+impl fmt::Display for ServeDirSymlinkPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::RejectAll => "reject-all",
+                Self::AllowFinalComponent => "allow-final-component",
+                Self::AllowAll => "allow-all",
+            }
+        )
+    }
+}
+
+impl FromStr for ServeDirSymlinkPolicy {
+    type Err = BoxError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        rama_utils::macros::match_ignore_ascii_case_str! {
+            match(s) {
+                "reject-all" | "reject_all" => Ok(Self::RejectAll),
+                "allow-final-component" | "allow_final_component" => Ok(Self::AllowFinalComponent),
+                "allow-all" | "allow_all" => Ok(Self::AllowAll),
+                _ => Err(BoxError::from_static_str("invalid ServeDirSymlinkPolicy str")),
+            }
+        }
+    }
+}
+
+impl TryFrom<&str> for ServeDirSymlinkPolicy {
+    type Error = BoxError;
+
+    #[inline]
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/rama-http/src/service/fs/serve_dir/mod.rs
+++ b/rama-http/src/service/fs/serve_dir/mod.rs
@@ -50,6 +50,7 @@ const DEFAULT_CAPACITY: usize = 65536;
 pub struct ServeDir<F = DefaultServeDirFallback> {
     base: DirSource,
     buf_chunk_size: usize,
+    symlink_policy: ServeDirSymlinkPolicy,
     precompressed_variants: Option<PrecompressedVariants>,
     // This is used to specialise implementation for
     // single files
@@ -81,6 +82,7 @@ impl ServeDir<DefaultServeDirFallback> {
         Self {
             base,
             buf_chunk_size: DEFAULT_CAPACITY,
+            symlink_policy: ServeDirSymlinkPolicy::default(),
             precompressed_variants: None,
             variant: ServeVariant::Directory {
                 serve_mode: Default::default(),
@@ -99,6 +101,7 @@ impl ServeDir<DefaultServeDirFallback> {
         Self {
             base: DirSource::Filesystem(path.as_ref().to_path_buf()),
             buf_chunk_size: DEFAULT_CAPACITY,
+            symlink_policy: ServeDirSymlinkPolicy::default(),
             precompressed_variants: None,
             variant: ServeVariant::SingleFile { mime },
             fallback: None,
@@ -146,6 +149,18 @@ impl<F> ServeDir<F> {
         /// The default capacity is 64kb.
         pub fn buf_chunk_size(mut self, chunk_size: usize) -> Self {
             self.buf_chunk_size = chunk_size;
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the filesystem symlink policy.
+        ///
+        /// Defaults to [`ServeDirSymlinkPolicy::RejectAll`].
+        /// This only applies to filesystem-backed services; embedded services
+        /// do not resolve filesystem symlinks.
+        pub fn symlink_policy(mut self, policy: ServeDirSymlinkPolicy) -> Self {
+            self.symlink_policy = policy;
             self
         }
     }
@@ -236,6 +251,7 @@ impl<F> ServeDir<F> {
         ServeDir {
             base: self.base,
             buf_chunk_size: self.buf_chunk_size,
+            symlink_policy: self.symlink_policy,
             precompressed_variants: self.precompressed_variants,
             variant: self.variant,
             fallback: Some(new_fallback),
@@ -348,6 +364,7 @@ impl<F> ServeDir<F> {
             buf_chunk_size,
             &self.base,
             precompression_configured,
+            self.symlink_policy,
         )
         .await;
 
@@ -371,6 +388,18 @@ where
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }))
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ServeDirSymlinkPolicy {
+    #[default]
+    /// Reject symlinks in the configured root and in every requested path component.
+    RejectAll,
+    /// Allow the final requested path component to be a symlink, but reject symlinked
+    /// roots and intermediate directory components.
+    AllowFinalComponent,
+    /// Allow filesystem symlinks. This restores the historical follow-symlinks behavior.
+    AllowAll,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/rama-http/src/service/fs/serve_dir/open_file.rs
+++ b/rama-http/src/service/fs/serve_dir/open_file.rs
@@ -1,5 +1,5 @@
 use super::{
-    DirSource, DirectoryServeMode, ServeVariant,
+    DirSource, DirectoryServeMode, ServeDirSymlinkPolicy, ServeVariant,
     headers::{IfModifiedSince, IfUnmodifiedSince, LastModified, etag_from_metadata},
 };
 use crate::headers::{ETag, HeaderMapExt as _, IfMatch, IfNoneMatch};
@@ -134,6 +134,7 @@ pub(super) async fn open_file(
     buf_chunk_size: usize,
     source: &DirSource,
     precompression_configured: bool,
+    symlink_policy: ServeDirSymlinkPolicy,
 ) -> io::Result<OpenFileOutput> {
     let mime = match variant {
         ServeVariant::Directory {
@@ -149,6 +150,7 @@ pub(super) async fn open_file(
                 serve_mode,
                 html_as_default_extension,
                 source,
+                symlink_policy,
             )
             .await?
             {
@@ -166,8 +168,13 @@ pub(super) async fn open_file(
     if req.method() == Method::HEAD {
         match source {
             DirSource::Filesystem(_) => {
-                let (meta, maybe_encoding) =
-                    file_metadata_with_fallback(path_to_file, negotiated_encodings).await?;
+                let (meta, maybe_encoding) = file_metadata_with_fallback(
+                    source,
+                    path_to_file,
+                    negotiated_encodings,
+                    symlink_policy,
+                )
+                .await?;
 
                 let last_modified = meta.modified().ok().map(LastModified::from);
                 let etag = meta
@@ -228,14 +235,20 @@ pub(super) async fn open_file(
     } else {
         match source {
             DirSource::Filesystem(_) => {
-                let (mut file, maybe_encoding) =
-                    match open_file_with_fallback(path_to_file, negotiated_encodings).await {
-                        Ok(result) => result,
-                        Err(err) if is_invalid_filename_error(&err) => {
-                            return Ok(OpenFileOutput::InvalidFilename);
-                        }
-                        Err(err) => return Err(err),
-                    };
+                let (mut file, maybe_encoding) = match open_file_with_fallback(
+                    source,
+                    path_to_file,
+                    negotiated_encodings,
+                    symlink_policy,
+                )
+                .await
+                {
+                    Ok(result) => result,
+                    Err(err) if is_invalid_filename_error(&err) => {
+                        return Ok(OpenFileOutput::InvalidFilename);
+                    }
+                    Err(err) => return Err(err),
+                };
                 let meta = file.metadata().await?;
                 let last_modified = meta.modified().ok().map(LastModified::from);
                 let etag = meta
@@ -460,14 +473,19 @@ fn preferred_encoding(
 /// Attempt to open a file with any of the negotiated encodings in preferred order.
 /// Falls back to uncompressed file if no precompressed variants are found.
 async fn open_file_with_fallback(
+    source: &DirSource,
     mut path: PathBuf,
     mut negotiated_encoding: Vec<QualityValue<Encoding>>,
+    symlink_policy: ServeDirSymlinkPolicy,
 ) -> io::Result<(File, Option<Encoding>)> {
     let (file, encoding) = loop {
         // Get the preferred encoding among the negotiated ones.
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
-        match (File::open(&path).await, encoding) {
-            (Ok(file), maybe_encoding) => break (file, maybe_encoding),
+        match (
+            filesystem_metadata(source, &path, symlink_policy).await,
+            encoding,
+        ) {
+            (Ok(_), maybe_encoding) => break (File::open(&path).await?, maybe_encoding),
             // Identity has no file extension to strip, so falling through to
             // the strip-and-retry path would clobber the originally requested
             // extension (e.g. `/foo.foobar` would become `/foo`). Only strip
@@ -524,13 +542,18 @@ fn open_embedded_file_with_fallback(
 // file the uncompressed file is used as a fallback.
 /// Get file metadata with fallback for different encodings.
 async fn file_metadata_with_fallback(
+    source: &DirSource,
     mut path: PathBuf,
     mut negotiated_encoding: Vec<QualityValue<Encoding>>,
+    symlink_policy: ServeDirSymlinkPolicy,
 ) -> io::Result<(Metadata, Option<Encoding>)> {
     let (file, encoding) = loop {
         // Get the preferred encoding among the negotiated ones.
         let encoding = preferred_encoding(&mut path, &negotiated_encoding);
-        match (tokio::fs::metadata(&path).await, encoding) {
+        match (
+            filesystem_metadata(source, &path, symlink_policy).await,
+            encoding,
+        ) {
             (Ok(file), maybe_encoding) => break (file, maybe_encoding),
             // See `open_file_with_fallback` for why Identity is skipped here.
             (Err(err), Some(encoding))
@@ -548,6 +571,72 @@ async fn file_metadata_with_fallback(
     Ok((file, encoding))
 }
 
+async fn filesystem_metadata(
+    source: &DirSource,
+    path: &Path,
+    symlink_policy: ServeDirSymlinkPolicy,
+) -> io::Result<Metadata> {
+    match source {
+        DirSource::Filesystem(root) => {
+            filesystem_metadata_from_root(root, path, symlink_policy).await
+        }
+        DirSource::Embedded(_) => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "embedded sources do not use filesystem metadata",
+        )),
+    }
+}
+
+async fn filesystem_metadata_from_root(
+    root: &Path,
+    path: &Path,
+    symlink_policy: ServeDirSymlinkPolicy,
+) -> io::Result<Metadata> {
+    if symlink_policy == ServeDirSymlinkPolicy::AllowAll {
+        return tokio::fs::metadata(path).await;
+    }
+
+    let root = if path.strip_prefix(root).is_ok() {
+        root
+    } else {
+        root.parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."))
+    };
+
+    reject_symlink(root).await?;
+
+    if let Ok(relative_path) = path.strip_prefix(root) {
+        let mut current_path = root.to_path_buf();
+        let mut components = relative_path.components().peekable();
+        while let Some(component) = components.next() {
+            current_path.push(component);
+            if symlink_policy == ServeDirSymlinkPolicy::AllowFinalComponent
+                && components.peek().is_none()
+            {
+                break;
+            }
+            reject_symlink(&current_path).await?;
+        }
+    } else {
+        reject_symlink(path).await?;
+    }
+
+    tokio::fs::metadata(path).await
+}
+
+async fn reject_symlink(path: &Path) -> io::Result<()> {
+    let meta = tokio::fs::symlink_metadata(path).await?;
+    if meta.file_type().is_symlink() {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "symlink paths are not served",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
 /// Handle directory requests based on the configured directory serve mode.
 /// Can append index.html, return 404, or generate HTML file listing.
 async fn maybe_serve_directory(
@@ -556,12 +645,13 @@ async fn maybe_serve_directory(
     mode: DirectoryServeMode,
     html_as_default_extension: bool,
     source: &DirSource,
+    symlink_policy: ServeDirSymlinkPolicy,
 ) -> Result<Option<OpenFileOutput>, std::io::Error> {
     let uri_path = uri.path();
 
     // `Some(true)` => directory, `Some(false)` => file, `None` => does not exist.
     let is_directory: Option<bool> = match source {
-        DirSource::Filesystem(_) => is_dir(path_to_file).await,
+        DirSource::Filesystem(_) => is_dir(source, path_to_file, symlink_policy).await,
         DirSource::Embedded(base) => is_dir_embedded(path_to_file, base).await,
     };
 
@@ -625,8 +715,12 @@ fn try_parse_range(
 /// not a directory (i.e. file). `None` => does not exist. Distinguishing
 /// "missing" from "is a file" is what lets us decide whether to apply
 /// `html_as_default_extension` or reject a trailing slash as a 404.
-async fn is_dir(path_to_file: &Path) -> Option<bool> {
-    tokio::fs::metadata(path_to_file)
+async fn is_dir(
+    source: &DirSource,
+    path_to_file: &Path,
+    symlink_policy: ServeDirSymlinkPolicy,
+) -> Option<bool> {
+    filesystem_metadata(source, path_to_file, symlink_policy)
         .await
         .ok()
         .map(|meta_data| meta_data.is_dir())

--- a/rama-http/src/service/fs/serve_dir/open_file.rs
+++ b/rama-http/src/service/fs/serve_dir/open_file.rs
@@ -604,8 +604,12 @@ async fn filesystem_metadata_from_root(
             .unwrap_or_else(|| Path::new("."))
     };
 
-    reject_symlink(root).await?;
-
+    // The configured root (or single-file target) is operator-trusted and may
+    // legitimately be a symlink — e.g. a blue-green `current -> releases/N`
+    // deploy, or `ServeFile` pointed at `latest.log -> 2026-06-19.log`. The
+    // policy therefore governs only the *request-supplied* components below the
+    // root, which are the path-traversal escape vector; the root itself is not
+    // policed.
     if let Ok(relative_path) = path.strip_prefix(root) {
         let mut current_path = root.to_path_buf();
         let mut components = relative_path.components().peekable();
@@ -619,6 +623,8 @@ async fn filesystem_metadata_from_root(
             reject_symlink(&current_path).await?;
         }
     } else {
+        // Path is not under the configured root (unexpected); police it
+        // defensively rather than trusting it.
         reject_symlink(path).await?;
     }
 
@@ -627,7 +633,7 @@ async fn filesystem_metadata_from_root(
 
 async fn reject_symlink(path: &Path) -> io::Result<()> {
     let meta = tokio::fs::symlink_metadata(path).await?;
-    if meta.file_type().is_symlink() {
+    if is_symlink_like(&meta) {
         Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             "symlink paths are not served",
@@ -635,6 +641,28 @@ async fn reject_symlink(path: &Path) -> io::Result<()> {
     } else {
         Ok(())
     }
+}
+
+/// Whether `meta` describes a symlink-like entry that should be rejected.
+///
+/// Beyond POSIX symlinks this also catches Windows reparse points (directory
+/// junctions, mount points, ...), which [`std::fs::FileType::is_symlink`] does
+/// *not* report yet redirect outside the served tree just like a symlink.
+fn is_symlink_like(meta: &Metadata) -> bool {
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt as _;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+
+    false
 }
 
 /// Handle directory requests based on the configured directory serve mode.

--- a/rama-http/src/service/fs/serve_dir/tests.rs
+++ b/rama-http/src/service/fs/serve_dir/tests.rs
@@ -1,7 +1,7 @@
 use crate::body::util::BodyExt;
 use crate::header::ALLOW;
 use crate::service::fs::serve_dir::DirSource;
-use crate::service::fs::{DirectoryServeMode, ServeDir, ServeFile};
+use crate::service::fs::{DirectoryServeMode, ServeDir, ServeDirSymlinkPolicy, ServeFile};
 use crate::{Body, Request, StatusCode, StreamingBody};
 use crate::{Method, Response, header};
 use brotli::BrotliDecompress;
@@ -622,6 +622,105 @@ async fn empty_directory_without_index_no_information_leak() {
 
     let body = body_into_text(res.into_body()).await;
     assert!(body.is_empty());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlink_file_is_not_served() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let secret_path = outside.path().join("secret.txt");
+    std::fs::write(&secret_path, "secret").unwrap();
+    std::os::unix::fs::symlink(&secret_path, root.path().join("link.txt")).unwrap();
+
+    let svc = ServeDir::new(root.path());
+    let req = Request::builder()
+        .uri("/link.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlink_file_can_be_served_with_final_component_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let secret_path = outside.path().join("secret.txt");
+    std::fs::write(&secret_path, "secret").unwrap();
+    std::os::unix::fs::symlink(&secret_path, root.path().join("link.txt")).unwrap();
+
+    let svc =
+        ServeDir::new(root.path()).with_symlink_policy(ServeDirSymlinkPolicy::AllowFinalComponent);
+    let req = Request::builder()
+        .uri("/link.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(body_into_text(res.into_body()).await, "secret");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlink_directory_component_is_not_served() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let secret_path = outside.path().join("secret.txt");
+    std::fs::write(&secret_path, "secret").unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.path().join("linked")).unwrap();
+
+    let svc = ServeDir::new(root.path());
+    let req = Request::builder()
+        .uri("/linked/secret.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlink_directory_component_is_not_served_with_final_component_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let secret_path = outside.path().join("secret.txt");
+    std::fs::write(&secret_path, "secret").unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.path().join("linked")).unwrap();
+
+    let svc =
+        ServeDir::new(root.path()).with_symlink_policy(ServeDirSymlinkPolicy::AllowFinalComponent);
+    let req = Request::builder()
+        .uri("/linked/secret.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlink_directory_component_can_be_served_with_allow_all_policy() {
+    let root = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let secret_path = outside.path().join("secret.txt");
+    std::fs::write(&secret_path, "secret").unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.path().join("linked")).unwrap();
+
+    let svc = ServeDir::new(root.path()).with_symlink_policy(ServeDirSymlinkPolicy::AllowAll);
+    let req = Request::builder()
+        .uri("/linked/secret.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(body_into_text(res.into_body()).await, "secret");
 }
 
 async fn body_into_text<B>(body: B) -> String

--- a/rama-http/src/service/fs/serve_dir/tests.rs
+++ b/rama-http/src/service/fs/serve_dir/tests.rs
@@ -1,7 +1,9 @@
 use crate::body::util::BodyExt;
 use crate::header::ALLOW;
+#[cfg(unix)]
+use crate::service::fs::ServeDirSymlinkPolicy;
 use crate::service::fs::serve_dir::DirSource;
-use crate::service::fs::{DirectoryServeMode, ServeDir, ServeDirSymlinkPolicy, ServeFile};
+use crate::service::fs::{DirectoryServeMode, ServeDir, ServeFile};
 use crate::{Body, Request, StatusCode, StreamingBody};
 use crate::{Method, Response, header};
 use brotli::BrotliDecompress;
@@ -641,6 +643,49 @@ async fn symlink_file_is_not_served() {
     let res = svc.serve(req).await.unwrap();
 
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symlinked_root_is_served() {
+    // The configured root may itself be a symlink (e.g. a blue-green
+    // `current -> releases/N` deploy); the default RejectAll must still serve
+    // content beneath it — only request-supplied components are policed.
+    let real_root = tempfile::tempdir().unwrap();
+    std::fs::write(real_root.path().join("file.txt"), "hello").unwrap();
+    let link_parent = tempfile::tempdir().unwrap();
+    let symlinked_root = link_parent.path().join("root-link");
+    std::os::unix::fs::symlink(real_root.path(), &symlinked_root).unwrap();
+
+    let svc = ServeDir::new(&symlinked_root);
+    let req = Request::builder()
+        .uri("/file.txt")
+        .body(Body::empty())
+        .unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(body_into_text(res.into_body()).await, "hello");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn servefile_symlinked_target_is_served() {
+    // ServeFile points at an operator-chosen file; serving it is correct even
+    // under the default RejectAll if that file is a symlink (e.g.
+    // `latest.log -> 2026-06-19.log`), since there is no request-driven traversal.
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("2026-06-19.log");
+    std::fs::write(&target, "log-line").unwrap();
+    let link = dir.path().join("latest.log");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let svc = ServeFile::new(link);
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let res = svc.serve(req).await.unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(body_into_text(res.into_body()).await, "log-line");
 }
 
 #[cfg(unix)]

--- a/rama-http/src/service/fs/serve_file.rs
+++ b/rama-http/src/service/fs/serve_file.rs
@@ -1,6 +1,6 @@
 //! Service that serves a file.
 
-use super::ServeDir;
+use super::{ServeDir, ServeDirSymlinkPolicy};
 use crate::mime::{Mime, guess as mime_guess};
 use crate::{Request, Response};
 use rama_core::Service;
@@ -108,6 +108,16 @@ impl ServeFile {
         /// The default capacity is 64kb.
         pub fn buf_chunk_size(mut self, chunk_size: usize) -> Self {
             self.0.set_buf_chunk_size(chunk_size);
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the filesystem symlink policy.
+        ///
+        /// Defaults to [`ServeDirSymlinkPolicy::RejectAll`].
+        pub fn symlink_policy(mut self, policy: ServeDirSymlinkPolicy) -> Self {
+            self.0.set_symlink_policy(policy);
             self
         }
     }

--- a/rama-socks5/src/server/udp/inspect.rs
+++ b/rama-socks5/src/server/udp/inspect.rs
@@ -1,4 +1,4 @@
-use super::relay::{UdpRelayState, UdpSocketRelay};
+use super::relay::{UdpRelayState, UdpSocketRelay, UnspecifiedClientUdpAddressPolicy};
 use crate::server::Error;
 use rama_core::bytes::Bytes;
 use rama_core::error::ErrorContext as _;
@@ -7,6 +7,7 @@ use rama_core::telemetry::tracing;
 use rama_core::{Service, error::BoxError};
 use rama_net::address::SocketAddress;
 use rama_udp::UdpSocket;
+use std::net::IpAddr;
 
 use ::rama_dns::client::resolver::BoxDnsAddressResolver;
 
@@ -22,6 +23,8 @@ pub(super) trait UdpPacketProxy: Send + Sync + 'static {
         south: UdpSocket,
         south_read_buf_size: usize,
         dns_resolver: Option<BoxDnsAddressResolver>,
+        unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy,
+        tcp_peer_ip: Option<IpAddr>,
     ) -> impl Future<Output = Result<(), Error>> + Send;
 }
 
@@ -40,6 +43,8 @@ impl UdpPacketProxy for DirectUdpRelay {
         south: UdpSocket,
         south_read_buf_size: usize,
         dns_resolver: Option<BoxDnsAddressResolver>,
+        unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy,
+        tcp_peer_ip: Option<IpAddr>,
     ) -> Result<(), Error> {
         let relay = UdpSocketRelay::new(
             client_address,
@@ -47,7 +52,8 @@ impl UdpPacketProxy for DirectUdpRelay {
             north_read_buf_size,
             south,
             south_read_buf_size,
-        );
+        )
+        .with_unspecified_client_address_policy(unspecified_client_udp_address_policy, tcp_peer_ip);
 
         let relay = relay.maybe_with_dns_resolver(&extensions, dns_resolver);
 
@@ -134,6 +140,8 @@ where
         south: UdpSocket,
         south_read_buf_size: usize,
         dns_resolver: Option<BoxDnsAddressResolver>,
+        unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy,
+        tcp_peer_ip: Option<IpAddr>,
     ) -> Result<(), Error> {
         let relay = UdpSocketRelay::new(
             client_address,
@@ -141,7 +149,8 @@ where
             north_read_buf_size,
             south,
             south_read_buf_size,
-        );
+        )
+        .with_unspecified_client_address_policy(unspecified_client_udp_address_policy, tcp_peer_ip);
 
         let relay = relay.maybe_with_dns_resolver(&extensions, dns_resolver);
 
@@ -305,6 +314,8 @@ where
         south: UdpSocket,
         south_read_buf_size: usize,
         dns_resolver: Option<BoxDnsAddressResolver>,
+        unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy,
+        tcp_peer_ip: Option<IpAddr>,
     ) -> Result<(), Error> {
         let relay = UdpSocketRelay::new(
             client_address,
@@ -312,7 +323,8 @@ where
             north_read_buf_size,
             south,
             south_read_buf_size,
-        );
+        )
+        .with_unspecified_client_address_policy(unspecified_client_udp_address_policy, tcp_peer_ip);
 
         let relay = relay.maybe_with_dns_resolver(&extensions, dns_resolver);
 
@@ -465,6 +477,8 @@ mod tests {
             4096,
             south,
             4096,
+            None,
+            UnspecifiedClientUdpAddressPolicy::default(),
             None,
         );
 

--- a/rama-socks5/src/server/udp/mod.rs
+++ b/rama-socks5/src/server/udp/mod.rs
@@ -7,6 +7,7 @@ use rama_core::{
 use rama_net::{
     address::{HostWithPort, SocketAddress},
     socket::SocketService,
+    stream::SocketInfo,
 };
 use rama_udp::{UdpSocket, bind_udp_with_address};
 use rama_utils::macros::generate_set_and_with;
@@ -24,6 +25,7 @@ pub use inspect::{
 };
 
 mod relay;
+pub use relay::UnspecifiedClientUdpAddressPolicy;
 
 /// Types which can be used as socks5 [`Command::UdpAssociate`] drivers on the server side.
 ///
@@ -118,6 +120,8 @@ pub struct UdpRelay<B, I> {
     south_buffer_size: usize,
 
     relay_timeout: Option<Duration>,
+
+    unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy,
 }
 
 impl<B> UdpRelay<B, DirectUdpRelay> {
@@ -132,6 +136,7 @@ impl<B> UdpRelay<B, DirectUdpRelay> {
             north_buffer_size: 4096,
             south_buffer_size: 4096,
             relay_timeout: None,
+            unspecified_client_udp_address_policy: UnspecifiedClientUdpAddressPolicy::default(),
         }
     }
 
@@ -147,6 +152,7 @@ impl<B> UdpRelay<B, DirectUdpRelay> {
             north_buffer_size: self.north_buffer_size,
             south_buffer_size: self.south_buffer_size,
             relay_timeout: self.relay_timeout,
+            unspecified_client_udp_address_policy: self.unspecified_client_udp_address_policy,
         }
     }
 
@@ -162,6 +168,7 @@ impl<B> UdpRelay<B, DirectUdpRelay> {
             north_buffer_size: self.north_buffer_size,
             south_buffer_size: self.south_buffer_size,
             relay_timeout: self.relay_timeout,
+            unspecified_client_udp_address_policy: self.unspecified_client_udp_address_policy,
         }
     }
 }
@@ -180,6 +187,7 @@ impl<B, I> UdpRelay<B, I> {
             north_buffer_size: self.north_buffer_size,
             south_buffer_size: self.south_buffer_size,
             relay_timeout: self.relay_timeout,
+            unspecified_client_udp_address_policy: self.unspecified_client_udp_address_policy,
         }
     }
 
@@ -244,6 +252,19 @@ impl<B, I> UdpRelay<B, I> {
         /// Define the relay timeout for this socks5 UDP server.
         pub fn relay_timeout(mut self, timeout: Option<Duration>) -> Self {
             self.relay_timeout = timeout;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set how a UDP ASSOCIATE relay handles an all-zero client UDP address.
+        ///
+        /// Defaults to [`UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp`].
+        pub fn unspecified_client_udp_address_policy(
+            mut self,
+            policy: UnspecifiedClientUdpAddressPolicy,
+        ) -> Self {
+            self.unspecified_client_udp_address_policy = policy;
             self
         }
     }
@@ -322,6 +343,9 @@ where
             return Err(Error::aborted("udp relay failed").with_context(reply_kind));
         };
         let client_address = SocketAddress::new(dest_addr, dest_port);
+        let tcp_peer_ip = extensions
+            .get_ref::<SocketInfo>()
+            .map(|info| info.peer_addr().ip_addr);
 
         let socket_north = match self
             .binder
@@ -414,6 +438,8 @@ where
             socket_south,
             self.south_buffer_size,
             self.dns_resolver.clone(),
+            self.unspecified_client_udp_address_policy,
+            tcp_peer_ip,
         );
 
         tokio::select! {

--- a/rama-socks5/src/server/udp/mod.rs
+++ b/rama-socks5/src/server/udp/mod.rs
@@ -347,6 +347,17 @@ where
             .get_ref::<SocketInfo>()
             .map(|info| info.peer_addr().ip_addr);
 
+        if client_address.ip_addr.is_unspecified()
+            && self.unspecified_client_udp_address_policy
+                == UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp
+            && tcp_peer_ip.is_none()
+        {
+            tracing::warn!(
+                "socks5 udp associate: PinToTcpPeerIp cannot enforce IP filtering \
+                 (no SocketInfo / TCP peer IP available); degrading to first-packet pinning",
+            );
+        }
+
         let socket_north = match self
             .binder
             .bind_socket_with_address(self.bind_north_address)

--- a/rama-socks5/src/server/udp/relay.rs
+++ b/rama-socks5/src/server/udp/relay.rs
@@ -18,6 +18,9 @@ use ::{
 #[derive(Debug)]
 pub(super) struct UdpSocketRelay {
     client_address: SocketAddress,
+    pinned_client_address: Option<SocketAddress>,
+    unspecified_client_address_policy: UnspecifiedClientUdpAddressPolicy,
+    tcp_peer_ip: Option<IpAddr>,
 
     north: UdpSocket,
     north_max_size: usize,
@@ -31,6 +34,21 @@ pub(super) struct UdpSocketRelay {
 
     dns_resolve_mode: DnsResolveIpMode,
     dns_resolver: Option<BoxDnsAddressResolver>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum UnspecifiedClientUdpAddressPolicy {
+    #[default]
+    /// Accept the first UDP packet only when it matches the TCP peer IP, if known,
+    /// then pin to that packet's full UDP source address.
+    PinToTcpPeerIp,
+    /// Accept the first UDP packet from any source, then pin to that packet's full
+    /// UDP source address.
+    PinToFirstPacket,
+    /// Accept UDP packets from any source. Replies are sent to the most recent
+    /// accepted source address.
+    AnySource,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -49,6 +67,9 @@ impl UdpSocketRelay {
     ) -> Self {
         Self {
             client_address,
+            pinned_client_address: None,
+            unspecified_client_address_policy: UnspecifiedClientUdpAddressPolicy::default(),
+            tcp_peer_ip: None,
 
             north,
             north_max_size: south_read_buf_size,
@@ -70,6 +91,16 @@ impl UdpSocketRelay {
             dns_resolve_mode: DnsResolveIpMode::default(),
             dns_resolver: None,
         }
+    }
+
+    pub(super) fn with_unspecified_client_address_policy(
+        mut self,
+        policy: UnspecifiedClientUdpAddressPolicy,
+        tcp_peer_ip: Option<IpAddr>,
+    ) -> Self {
+        self.unspecified_client_address_policy = policy;
+        self.tcp_peer_ip = tcp_peer_ip;
+        self
     }
 
     pub(super) fn north_read_buf_slice(&self) -> &[u8] {
@@ -95,12 +126,7 @@ impl UdpSocketRelay {
                             "north socket: received packet (len = {len}; src = {src})",
                         );
 
-                        // Per RFC 1928 §7 the client MAY send all-zeros when it does not
-                        // know its own address/port yet; in that case we skip source
-                        // filtering and accept packets from any sender.
-                        if !self.client_address.ip_addr.is_unspecified()
-                            && !self.client_address.eq(&src)
-                        {
+                        if !self.accept_north_source(src.into()) {
                             tracing::debug!(
                                 network.peer.address = %self.client_address.ip_addr,
                                 network.peer.port = %self.client_address.port,
@@ -267,6 +293,17 @@ impl UdpSocketRelay {
         data: Option<Bytes>,
         server_address: SocketAddress,
     ) -> Result<(), BoxError> {
+        let Some(client_address) = self.north_send_address() else {
+            tracing::trace!(
+                network.peer.address = %self.client_address.ip_addr,
+                network.peer.port = %self.client_address.port,
+                server.address = %server_address.ip_addr,
+                server.port = %server_address.port,
+                "drop packet north: client UDP address is not known yet",
+            );
+            return Ok(());
+        };
+
         let header = UdpHeader {
             fragment_number: 0,
             destination: server_address.into(),
@@ -314,7 +351,7 @@ impl UdpSocketRelay {
 
         match self
             .north
-            .send_to(&self.north_write_buf, self.client_address.into_std())
+            .send_to(&self.north_write_buf, client_address.into_std())
             .await
         {
             Ok(len) => {
@@ -346,6 +383,49 @@ impl UdpSocketRelay {
                     Err(err.context("north socket fatal unknown write error"))
                 }
             },
+        }
+    }
+}
+
+impl UdpSocketRelay {
+    fn accept_north_source(&mut self, src: SocketAddress) -> bool {
+        if !self.client_address.ip_addr.is_unspecified() {
+            return self.client_address.eq(&src);
+        }
+
+        match self.unspecified_client_address_policy {
+            UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp => {
+                if let Some(tcp_peer_ip) = self.tcp_peer_ip
+                    && src.ip_addr != tcp_peer_ip
+                {
+                    return false;
+                }
+                self.pin_or_match_client_source(src)
+            }
+            UnspecifiedClientUdpAddressPolicy::PinToFirstPacket => {
+                self.pin_or_match_client_source(src)
+            }
+            UnspecifiedClientUdpAddressPolicy::AnySource => {
+                self.pinned_client_address = Some(src);
+                true
+            }
+        }
+    }
+
+    fn pin_or_match_client_source(&mut self, src: SocketAddress) -> bool {
+        if let Some(address) = self.pinned_client_address {
+            address == src
+        } else {
+            self.pinned_client_address = Some(src);
+            true
+        }
+    }
+
+    fn north_send_address(&self) -> Option<SocketAddress> {
+        if self.client_address.ip_addr.is_unspecified() {
+            self.pinned_client_address
+        } else {
+            Some(self.client_address)
         }
     }
 }
@@ -494,9 +574,10 @@ mod tests {
 
     // Regression for Bug 3: when the client sends 0.0.0.0:0 in the UDP ASSOCIATE
     // request (RFC 1928 §7 allows this when the client doesn't know its address),
-    // the relay was dropping ALL north packets because no source ever matches 0.0.0.0.
+    // the relay accepts and pins the first valid UDP source instead of dropping
+    // everything or accepting every later source.
     #[tokio::test]
-    async fn test_recv_north_unspecified_client_addr_accepts_any_source() {
+    async fn test_recv_north_unspecified_client_addr_pins_first_source() {
         // client_address = 0.0.0.0:0 — the RFC 1928 §7 all-zeros sentinel
         let client_addr = SocketAddress::default_ipv4(0);
 
@@ -522,11 +603,77 @@ mod tests {
             .await
             .expect("timed out")
             .unwrap()
-            .expect("packet must not be dropped when client_address is 0.0.0.0:0");
+            .expect("first packet must not be dropped when client_address is 0.0.0.0:0");
 
         assert!(
             matches!(state, UdpRelayState::ReadNorth(_)),
-            "RFC 1928 §7: packets from any source must be accepted when client_address is 0.0.0.0:0"
+            "RFC 1928 §7: the first packet selects the client UDP source when client_address is 0.0.0.0:0"
         );
+
+        let second_sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        second_sender.send_to(&packet, north_addr).await.unwrap();
+        let state = tokio::time::timeout(std::time::Duration::from_millis(500), relay.recv())
+            .await
+            .expect("timed out")
+            .unwrap();
+
+        assert!(
+            state.is_none(),
+            "packets from a different UDP source must be dropped after the first source is pinned"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_recv_north_unspecified_client_addr_any_source_policy() {
+        let client_addr = SocketAddress::default_ipv4(0);
+
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let north_addr = north.local_addr().unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096)
+            .with_unspecified_client_address_policy(
+                UnspecifiedClientUdpAddressPolicy::AnySource,
+                None,
+            );
+
+        let target: SocketAddress = SocketAddress::local_ipv4(9999);
+        let header = UdpHeader {
+            fragment_number: 0,
+            destination: target.into(),
+        };
+        let mut packet = BytesMut::new();
+        header.write_to_buf(&mut packet).unwrap();
+        packet.extend_from_slice(b"data");
+
+        for _ in 0..2 {
+            let sender = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+            sender.send_to(&packet, north_addr).await.unwrap();
+
+            let state = tokio::time::timeout(std::time::Duration::from_millis(500), relay.recv())
+                .await
+                .expect("timed out")
+                .unwrap();
+
+            assert!(
+                matches!(state, Some(UdpRelayState::ReadNorth(_))),
+                "AnySource policy must preserve the historical accept-any-source behavior"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unspecified_client_addr_tcp_peer_ip_policy_rejects_other_ip() {
+        let client_addr = SocketAddress::default_ipv4(0);
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096)
+            .with_unspecified_client_address_policy(
+                UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp,
+                Some(std::net::IpAddr::from([127, 0, 0, 2])),
+            );
+
+        assert!(!relay.accept_north_source(SocketAddress::local_ipv4(12345)));
     }
 }

--- a/rama-socks5/src/server/udp/relay.rs
+++ b/rama-socks5/src/server/udp/relay.rs
@@ -42,6 +42,12 @@ pub enum UnspecifiedClientUdpAddressPolicy {
     #[default]
     /// Accept the first UDP packet only when it matches the TCP peer IP, if known,
     /// then pin to that packet's full UDP source address.
+    ///
+    /// The IP match is canonicalized, so a v4-mapped IPv6 TCP peer matches the
+    /// equivalent plain IPv4 UDP source. When the TCP peer IP is unknown (no
+    /// [`SocketInfo`] in the extensions) this degrades to [`Self::PinToFirstPacket`].
+    ///
+    /// [`SocketInfo`]: rama_net::stream::SocketInfo
     PinToTcpPeerIp,
     /// Accept the first UDP packet from any source, then pin to that packet's full
     /// UDP source address.
@@ -395,8 +401,11 @@ impl UdpSocketRelay {
 
         match self.unspecified_client_address_policy {
             UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp => {
+                // Compare canonical forms so a v4-mapped IPv6 TCP peer
+                // (`::ffff:a.b.c.d`, e.g. an IPv4 client on a dual-stack TCP
+                // listener) matches the plain IPv4 source the UDP socket reports.
                 if let Some(tcp_peer_ip) = self.tcp_peer_ip
-                    && src.ip_addr != tcp_peer_ip
+                    && src.ip_addr.to_canonical() != tcp_peer_ip.to_canonical()
                 {
                     return false;
                 }
@@ -675,5 +684,68 @@ mod tests {
             );
 
         assert!(!relay.accept_north_source(SocketAddress::local_ipv4(12345)));
+    }
+
+    #[tokio::test]
+    async fn test_unspecified_client_addr_tcp_peer_ip_policy_accepts_and_pins_matching_ip() {
+        let client_addr = SocketAddress::default_ipv4(0);
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096)
+            .with_unspecified_client_address_policy(
+                UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp,
+                Some(std::net::IpAddr::from([127, 0, 0, 1])),
+            );
+
+        // First packet from the matching TCP peer IP is accepted and pins the
+        // full (ip, port) source.
+        assert!(relay.accept_north_source(SocketAddress::local_ipv4(40000)));
+        // A later packet from the same IP but a different port is rejected.
+        assert!(!relay.accept_north_source(SocketAddress::local_ipv4(40001)));
+        // North-bound replies now target the pinned source.
+        assert_eq!(
+            relay.north_send_address(),
+            Some(SocketAddress::local_ipv4(40000))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unspecified_client_addr_tcp_peer_ip_policy_canonicalizes_v4_mapped() {
+        let client_addr = SocketAddress::default_ipv4(0);
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        // A v4-mapped IPv6 TCP peer (as a dual-stack listener reports an IPv4
+        // client) must match the plain IPv4 UDP source.
+        let v4_mapped = std::net::Ipv4Addr::new(127, 0, 0, 1).to_ipv6_mapped();
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096)
+            .with_unspecified_client_address_policy(
+                UnspecifiedClientUdpAddressPolicy::PinToTcpPeerIp,
+                Some(std::net::IpAddr::V6(v4_mapped)),
+            );
+
+        assert!(relay.accept_north_source(SocketAddress::local_ipv4(40000)));
+    }
+
+    #[tokio::test]
+    async fn test_send_to_north_dropped_when_unspecified_client_not_yet_pinned() {
+        let client_addr = SocketAddress::default_ipv4(0);
+        let north = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+        let south = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
+
+        let mut relay = UdpSocketRelay::new(client_addr, north, 4096, south, 4096);
+
+        // No north packet has pinned the client yet, so the reply target is unknown.
+        assert_eq!(relay.north_send_address(), None);
+        // Sending north in that state is a silent no-op (dropped), not an error.
+        relay
+            .send_to_north(
+                Some(Bytes::from_static(b"data")),
+                SocketAddress::local_ipv4(9999),
+            )
+            .await
+            .unwrap();
+        assert_eq!(relay.north_send_address(), None);
     }
 }

--- a/rama-ws/src/protocol/error.rs
+++ b/rama-ws/src/protocol/error.rs
@@ -23,6 +23,11 @@ pub enum ProtocolError {
     /// Message is bigger than the maximum allowed size.
     MessageTooLong {
         /// The size of the message.
+        ///
+        /// For permessage-deflate messages rejected mid-inflation this is a
+        /// lower-bound sentinel (`max_size + 1`) rather than the exact decoded
+        /// length: inflation is aborted once the cap is exceeded, so the true
+        /// size is never computed.
         size: usize,
         /// The maximum allowed message size.
         max_size: usize,

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -996,23 +996,19 @@ impl WebSocketContext {
                                         frame.into_payload(),
                                         self.config.max_message_size,
                                     )?;
-                                return match deflate_state.decoder.decode(compressed_data.as_ref())
+                                return match deflate_state
+                                    .decoder
+                                    .decode(compressed_data.as_ref(), self.config.max_message_size)
                                 {
-                                    Ok(raw_data) => {
-                                        check_max_size(
-                                            raw_data.len(),
-                                            self.config.max_message_size,
-                                        )?;
-                                        match msg_type {
-                                            IncompleteMessageType::Text => Ok(Some(Message::Text(
-                                                Utf8Bytes::try_from(raw_data)?,
-                                            ))),
-                                            IncompleteMessageType::Binary => {
-                                                Ok(Some(Message::Binary(raw_data.into())))
-                                            }
+                                    Ok(raw_data) => match msg_type {
+                                        IncompleteMessageType::Text => {
+                                            Ok(Some(Message::Text(Utf8Bytes::try_from(raw_data)?)))
                                         }
-                                    }
-                                    Err(err) => Err(ProtocolError::DeflateError(err)),
+                                        IncompleteMessageType::Binary => {
+                                            Ok(Some(Message::Binary(raw_data.into())))
+                                        }
+                                    },
+                                    Err(err) => Err(err),
                                 };
                             }
 
@@ -1065,9 +1061,7 @@ impl WebSocketContext {
                                 let compressed_data = payload;
                                 let raw_data = deflate_state
                                     .decoder
-                                    .decode(&compressed_data)
-                                    .map_err(ProtocolError::DeflateError)?;
-                                check_max_size(raw_data.len(), self.config.max_message_size)?;
+                                    .decode(&compressed_data, self.config.max_message_size)?;
                                 match t {
                                     IncompleteMessageType::Text => {
                                         Ok(Some(Message::Text(Utf8Bytes::try_from(raw_data)?)))

--- a/rama-ws/src/protocol/per_message_deflate.rs
+++ b/rama-ws/src/protocol/per_message_deflate.rs
@@ -380,4 +380,41 @@ mod tests {
         let decoded = decoder.decode(&compressed, Some(payload.len())).unwrap();
         assert_eq!(decoded, payload);
     }
+
+    #[test]
+    fn deflate_decoder_unbounded_limit_inflates_correctly() {
+        // No size limit (the `max_message_size = None` path => usize::MAX): the
+        // decoder must still inflate the full payload across multiple buffer
+        // grow cycles without spuriously rejecting it.
+        for len in [0usize, 1, 200, 5000, 100_000] {
+            let payload = vec![b'a'; len];
+            let mut encoder = DeflateEncoder::new(Compression::default(), 15, false);
+            let compressed = encoder.encode(&payload).unwrap();
+
+            let mut decoder = DeflateDecoder::new(15, false);
+            let decoded = decoder.decode(&compressed, None).unwrap();
+            assert_eq!(decoded, payload, "unbounded decode mismatch for len={len}");
+        }
+    }
+
+    #[test]
+    fn deflate_decoder_boundary_accepts_n_rejects_n_minus_one() {
+        // For a payload larger than the initial buffer capacity (so several
+        // grow cycles run), `Some(n)` accepts exactly and `Some(n - 1)` rejects.
+        let payload = vec![b'a'; 4096];
+        let mut encoder = DeflateEncoder::new(Compression::default(), 15, false);
+        let compressed = encoder.encode(&payload).unwrap();
+
+        let mut decoder = DeflateDecoder::new(15, false);
+        assert_eq!(
+            decoder.decode(&compressed, Some(payload.len())).unwrap(),
+            payload,
+        );
+
+        let mut decoder = DeflateDecoder::new(15, false);
+        assert!(matches!(
+            decoder.decode(&compressed, Some(payload.len() - 1)),
+            Err(ProtocolError::MessageTooLong { max_size, .. }) if max_size == payload.len() - 1,
+        ));
+    }
 }

--- a/rama-ws/src/protocol/per_message_deflate.rs
+++ b/rama-ws/src/protocol/per_message_deflate.rs
@@ -192,8 +192,16 @@ impl DeflateDecoder {
         }
     }
 
-    pub(super) fn decode(&mut self, compressed_data: &[u8]) -> Result<Vec<u8>, BoxError> {
-        let mut buf = Vec::with_capacity((compressed_data.len() + DEFLATE_TRAILER.len()) * 2);
+    pub(super) fn decode(
+        &mut self,
+        compressed_data: &[u8],
+        size_limit: Option<usize>,
+    ) -> Result<Vec<u8>, ProtocolError> {
+        let max_size = size_limit.unwrap_or_else(usize::max_value);
+        let initial_capacity = (compressed_data.len() + DEFLATE_TRAILER.len())
+            .saturating_mul(2)
+            .min(max_size);
+        let mut buf = Vec::with_capacity(initial_capacity);
 
         for payload in [compressed_data, &DEFLATE_TRAILER] {
             let before_in = self.decompress.total_in();
@@ -202,13 +210,15 @@ impl DeflateDecoder {
                 let i = self.decompress.total_in() as usize - before_in as usize;
                 match self
                     .decompress
-                    .buf_decompress(&payload[i..], &mut buf, FlushDecompress::Sync)
-                    .context("flate2 decode next chunk")?
+                    .buf_decompress(&payload[i..], &mut buf, FlushDecompress::Sync, max_size)
+                    .context("flate2 decode next chunk")
+                    .map_err(ProtocolError::DeflateError)?
                 {
-                    Status::BufError => buf.reserve((buf.len() as f64 * 1.5) as usize),
+                    Status::BufError => grow_inflate_buffer(&mut buf, max_size)?,
                     Status::Ok => (),
                     Status::StreamEnd => break,
                 }
+                check_decode_size(buf.len(), max_size)?;
             }
         }
 
@@ -218,6 +228,29 @@ impl DeflateDecoder {
 
         Ok(buf)
     }
+}
+
+fn grow_inflate_buffer(buf: &mut Vec<u8>, max_size: usize) -> Result<(), ProtocolError> {
+    if buf.capacity() >= max_size {
+        return Err(ProtocolError::MessageTooLong {
+            size: max_size.saturating_add(1),
+            max_size,
+        });
+    }
+
+    let next_capacity = buf
+        .capacity()
+        .saturating_add((buf.capacity() / 2).max(1))
+        .min(max_size);
+    buf.reserve(next_capacity - buf.capacity());
+    Ok(())
+}
+
+fn check_decode_size(size: usize, max_size: usize) -> Result<(), ProtocolError> {
+    if size > max_size {
+        return Err(ProtocolError::MessageTooLong { size, max_size });
+    }
+    Ok(())
 }
 
 trait BufCompress {
@@ -235,6 +268,7 @@ trait BufDecompress {
         input: &[u8],
         output: &mut Vec<u8>,
         flush: FlushDecompress,
+        max_size: usize,
     ) -> Result<Status, DecompressError>;
 }
 
@@ -258,8 +292,9 @@ impl BufDecompress for Decompress {
         input: &[u8],
         output: &mut Vec<u8>,
         flush: FlushDecompress,
+        max_size: usize,
     ) -> Result<Status, DecompressError> {
-        op_buf(input, output, self.total_out(), |input, out| {
+        op_buf_limited(input, output, self.total_out(), max_size, |input, out| {
             let ret = self.decompress(input, out, flush);
             (ret, self.total_out())
         })
@@ -285,5 +320,64 @@ where
         let (ret, total_out) = op(input, out);
         output.set_len((total_out - before) as usize + len);
         ret
+    }
+}
+
+fn op_buf_limited<Fn, E>(
+    input: &[u8],
+    output: &mut Vec<u8>,
+    before: u64,
+    max_size: usize,
+    op: Fn,
+) -> Result<Status, E>
+where
+    Fn: FnOnce(&[u8], &mut [u8]) -> (Result<Status, E>, u64),
+{
+    let cap = output.capacity().min(max_size);
+    let len = output.len();
+
+    #[expect(
+        clippy::multiple_unsafe_ops_per_block,
+        reason = "single uninitialized-tail write sequence: ptr.add → from_raw_parts_mut → set_len; splitting them harms readability without changing the safety contract"
+    )]
+    unsafe {
+        let ptr = output.as_mut_ptr().add(len);
+        let out = slice::from_raw_parts_mut(ptr, cap - len);
+        let (ret, total_out) = op(input, out);
+        output.set_len((total_out - before) as usize + len);
+        ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deflate_decoder_rejects_output_past_size_limit() {
+        let payload = vec![b'a'; 1024];
+        let mut encoder = DeflateEncoder::new(Compression::default(), 15, false);
+        let compressed = encoder.encode(&payload).unwrap();
+        assert!(compressed.len() < payload.len());
+
+        let mut decoder = DeflateDecoder::new(15, false);
+        assert!(matches!(
+            decoder.decode(&compressed, Some(128)),
+            Err(ProtocolError::MessageTooLong {
+                size: 129,
+                max_size: 128
+            })
+        ));
+    }
+
+    #[test]
+    fn deflate_decoder_allows_output_at_size_limit() {
+        let payload = vec![b'a'; 128];
+        let mut encoder = DeflateEncoder::new(Compression::default(), 15, false);
+        let compressed = encoder.encode(&payload).unwrap();
+
+        let mut decoder = DeflateDecoder::new(15, false);
+        let decoded = decoder.decode(&compressed, Some(payload.len())).unwrap();
+        assert_eq!(decoded, payload);
     }
 }

--- a/rama-ws/src/protocol/tests/write.rs
+++ b/rama-ws/src/protocol/tests/write.rs
@@ -254,13 +254,17 @@ fn deflate_bomb_single_frame_rejected() {
         ..Default::default()
     };
     let mut socket = WebSocket::from_raw_socket(WriteMoc::new(incoming), Role::Client, Some(limit));
-    assert!(matches!(
-        socket.read(),
+    match socket.read() {
         Err(ProtocolError::MessageTooLong {
-            size: PLAIN_LEN,
-            max_size: _,
-        })
-    ));
+            size,
+            max_size: reported_max,
+        }) => {
+            assert_eq!(reported_max, max_size);
+            assert!(size > reported_max);
+            assert!(size < PLAIN_LEN);
+        }
+        result => panic!("expected compressed payload to exceed decoded size limit: {result:?}"),
+    }
 }
 
 #[cfg(feature = "compression")]
@@ -295,11 +299,15 @@ fn deflate_bomb_fragmented_rejected() {
         ..Default::default()
     };
     let mut socket = WebSocket::from_raw_socket(WriteMoc::new(incoming), Role::Client, Some(limit));
-    assert!(matches!(
-        socket.read(),
+    match socket.read() {
         Err(ProtocolError::MessageTooLong {
-            size: PLAIN_LEN,
-            max_size: _,
-        })
-    ));
+            size,
+            max_size: reported_max,
+        }) => {
+            assert_eq!(reported_max, max_size);
+            assert!(size > reported_max);
+            assert!(size < PLAIN_LEN);
+        }
+        result => panic!("expected compressed payload to exceed decoded size limit: {result:?}"),
+    }
 }

--- a/src/cli/service/fs.rs
+++ b/src/cli/service/fs.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         server::HttpServer,
         service::{
-            fs::{DirectoryServeMode, ServeDir, ServeFile},
+            fs::{DirectoryServeMode, ServeDir, ServeDirSymlinkPolicy, ServeFile},
             web::response::{Html, IntoResponse},
         },
     },
@@ -67,6 +67,7 @@ pub struct FsServiceBuilder<H> {
     content_path: Option<PathBuf>,
     dir_serve_mode: DirectoryServeMode,
     html_as_default_extension: bool,
+    symlink_policy: ServeDirSymlinkPolicy,
 }
 
 impl Default for FsServiceBuilder<()> {
@@ -87,6 +88,7 @@ impl Default for FsServiceBuilder<()> {
             content_path: None,
             dir_serve_mode: DirectoryServeMode::HtmlFileList,
             html_as_default_extension: false,
+            symlink_policy: ServeDirSymlinkPolicy::default(),
         }
     }
 }
@@ -183,6 +185,7 @@ impl<H> FsServiceBuilder<H> {
             content_path: self.content_path,
             dir_serve_mode: self.dir_serve_mode,
             html_as_default_extension: self.html_as_default_extension,
+            symlink_policy: self.symlink_policy,
         }
     }
 
@@ -231,6 +234,16 @@ impl<H> FsServiceBuilder<H> {
         /// Defaults to `false`.
         pub fn html_as_default_extension(mut self, html_as_default_extension: bool) -> Self {
             self.html_as_default_extension = html_as_default_extension;
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the [`ServeDirSymlinkPolicy`] used when serving a file or directory.
+        ///
+        /// Defaults to [`ServeDirSymlinkPolicy::RejectAll`].
+        pub fn symlink_policy(mut self, policy: ServeDirSymlinkPolicy) -> Self {
+            self.symlink_policy = policy;
             self
         }
     }
@@ -310,11 +323,14 @@ where
             None => Either3::A(IntoResponseService::new(StaticOutput::new(Html(
                 include_str!("../../../docs/index.html"),
             )))),
-            Some(path) if path.is_file() => Either3::B(ServeFile::new(path.clone())),
+            Some(path) if path.is_file() => {
+                Either3::B(ServeFile::new(path.clone()).with_symlink_policy(self.symlink_policy))
+            }
             Some(path) if path.is_dir() => Either3::C(
                 ServeDir::new(path)
                     .with_directory_serve_mode(self.dir_serve_mode)
-                    .with_html_as_default_extension(self.html_as_default_extension),
+                    .with_html_as_default_extension(self.html_as_default_extension)
+                    .with_symlink_policy(self.symlink_policy),
             ),
             Some(path) => {
                 return Err(

--- a/src/http/tls.rs
+++ b/src/http/tls.rs
@@ -40,7 +40,8 @@ pub struct CertOrderOutput {
 /// An http client used to fetch certs dynamically ([`DynamicCertIssuer`]).
 ///
 /// There is no server implementation in Rama.
-/// It is up to the user of this client to provide their own server.
+/// It is up to the user of this client to provide their own server, including
+/// authentication and authorization for every certificate order.
 pub struct CertIssuerHttpClient {
     endpoint: Uri,
     // Trie value `None` means an exact entry; `Some(wildcard)` is a subtree
@@ -148,7 +149,8 @@ impl CertIssuerHttpClient {
         /// Only allow fetching certs for the given domain.
         ///
         /// By default, if none of the `allow_*` setters are called
-        /// the client will fetch for any client.
+        /// the client will fetch for any client. This is a local pre-filter;
+        /// the remote issuer remains responsible for authorizing each order.
         pub fn allow_domain(mut self, domain: impl AsDomainRef) -> Self {
             // The trie's smart insert handles "*.x" -> subtree at x and bare
             // "x" -> exact at x. The stored value is just the wildcard form
@@ -165,7 +167,8 @@ impl CertIssuerHttpClient {
         /// Only allow fetching certs for the given domains.
         ///
         /// By default, if none of the `allow_*` setters are called
-        /// the client will fetch for any client.
+        /// the client will fetch for any client. This is a local pre-filter;
+        /// the remote issuer remains responsible for authorizing each order.
         pub fn allow_domains(mut self, domains: impl IntoIterator<Item: AsDomainRef>) -> Self {
             for domain in domains {
                 self.set_allow_domain(domain);

--- a/tests/integration/cli/cli_tests/serve_http_test.rs
+++ b/tests/integration/cli/cli_tests/serve_http_test.rs
@@ -128,6 +128,26 @@ async fn run_http_test_endpoint_request_compression(
         assert_eq!(6, content_length);
         assert_eq!("Hello?", resp.try_into_string().await.unwrap());
     }
+
+    // Decompression bomb: a small gzip payload that inflates past the endpoint's
+    // 8 MiB body limit must be rejected. The limit is applied *after*
+    // decompression, so a tiny compressed body cannot smuggle a huge one through.
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&vec![0u8; 9 * 1024 * 1024]).unwrap();
+    let bomb = encoder.finish().unwrap();
+    let req = Request::builder()
+        .uri(format!("{base_uri}/request-compression"))
+        .version(http_version)
+        .method(Method::POST)
+        .header(CONTENT_ENCODING, "gzip")
+        .body(Body::from(bomb))
+        .unwrap();
+    let resp = client.serve(req).await.unwrap();
+    assert!(
+        resp.status().is_client_error(),
+        "decompression bomb must be rejected, got status {}",
+        resp.status(),
+    );
 }
 
 async fn run_http_test_endpoint_response_compression(


### PR DESCRIPTION
Escape generated curl commands without extra heap churn.
Clarify remote certificate issuer authorization expectations.
Filter CLI redirect credentials by default and add trusted redirect opt-in.
Limit httptest request bodies after decompression.
Reject served symlinks by default and expose opt-out policies.
Pin SOCKS5 UDP all-zero client sources with a compatibility opt-out.
Enforce WebSocket permessage-deflate limits while inflating.