### PR TITLE
Security hardening: path traversal, command injection, unsafe audit

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,7 +1,7 @@
 # Builds & deploys the mdBook site + per-target rustdoc trees to GitHub Pages.
 #
 # - Linux is the default (root /docs/).
-# - macOS, Windows, Android, iOS each get their own subdirectory under /docs/.
+# - macOS and Windows each get their own subdirectory under /docs/.
 # - A `target-picker.html` is injected into every rustdoc page via
 #   `--html-before-content` so users can switch platform from any deep link.
 #
@@ -104,94 +104,10 @@ jobs:
           path: target/doc
           retention-days: 1
 
-  # Android: cross-compile from ubuntu-latest using the runner's pre-installed
-  # NDK (via $ANDROID_NDK_HOME). Mirrors the toolchain env setup from
-  # `precheck-rust-tier2` in CI.yml — keep these in sync.
-  doc-android:
-    runs-on: ubuntu-latest
-    env:
-      TARGET_TRIPLE: aarch64-linux-android
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
-        with:
-          toolchain: nightly
-          targets: aarch64-linux-android
-      - uses: ./.github/actions/rust-cache
-        with:
-          key: doc-android
-          cache-bin: "false"
-      - name: Configure Android toolchain env
-        shell: bash
-        run: |
-          ANDROID_API=21
-
-          # Normalize NDK env vars
-          echo "ANDROID_NDK_HOME=${ANDROID_NDK_HOME:-$ANDROID_NDK}" >> "$GITHUB_ENV"
-          echo "ANDROID_NDK=${ANDROID_NDK:-$ANDROID_NDK_HOME}" >> "$GITHUB_ENV"
-
-          TOOLCHAIN="${ANDROID_NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
-          echo "${TOOLCHAIN}" >> "$GITHUB_PATH"
-
-          TRIPLE="${TARGET_TRIPLE}"
-          TARGET_UPPER="$(echo "${TRIPLE}" | tr '[:lower:]-' '[:upper:]_')"
-          TARGET_LOWER_UNDERSCORES="$(echo "${TRIPLE}" | tr '-' '_' | tr '[:upper:]' '[:lower:]')"
-          NDK_TRIPLE="$(echo "${TRIPLE}" | sed 's/^armv7/armv7a/')"
-
-          CC_PATH="${TOOLCHAIN}/${NDK_TRIPLE}${ANDROID_API}-clang"
-          CXX_PATH="${TOOLCHAIN}/${NDK_TRIPLE}${ANDROID_API}-clang++"
-          AR_PATH="${TOOLCHAIN}/llvm-ar"
-
-          echo "CARGO_TARGET_${TARGET_UPPER}_LINKER=${CXX_PATH}" >> "$GITHUB_ENV"
-
-          echo "CC_${TARGET_LOWER_UNDERSCORES}=${CC_PATH}" >> "$GITHUB_ENV"
-          echo "CXX_${TARGET_LOWER_UNDERSCORES}=${CXX_PATH}" >> "$GITHUB_ENV"
-          echo "AR_${TARGET_LOWER_UNDERSCORES}=${AR_PATH}" >> "$GITHUB_ENV"
-
-          echo "CC=${CC_PATH}" >> "$GITHUB_ENV"
-          echo "CXX=${CXX_PATH}" >> "$GITHUB_ENV"
-          echo "AR=${AR_PATH}" >> "$GITHUB_ENV"
-      - name: cargo doc (android)
-        run: cargo +nightly doc --all-features --no-deps -p rama --target $TARGET_TRIPLE
-        env:
-          RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS_BASE}}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: doc-android
-          path: target/aarch64-linux-android/doc
-          retention-days: 1
-
-  # iOS: native macos-latest runner with `aarch64-apple-ios` target. Mirrors
-  # `precheck-rust-tier2` (same `IPHONEOS_DEPLOYMENT_TARGET`).
-  doc-ios:
-    runs-on: macos-latest
-    env:
-      TARGET_TRIPLE: aarch64-apple-ios
-      IPHONEOS_DEPLOYMENT_TARGET: 17.5
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
-        with:
-          toolchain: nightly
-          targets: aarch64-apple-ios
-      - uses: ./.github/actions/rust-cache
-        with:
-          key: doc-ios
-          cache-bin: "false"
-      - name: cargo doc (ios)
-        run: cargo +nightly doc --all-features --no-deps -p rama --target $TARGET_TRIPLE
-        env:
-          RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS_BASE}}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: doc-ios
-          path: target/aarch64-apple-ios/doc
-          retention-days: 1
-
   # ---- Compose the site --------------------------------------------------
   build:
     runs-on: ubuntu-latest
-    needs: [doc-linux, doc-macos, doc-windows, doc-android, doc-ios]
+    needs: [doc-linux, doc-macos, doc-windows]
     env:
       MDBOOK_VERSION: 0.5.2
       MDBOOK_GRAPHVIZ_VERSION: 0.3.1
@@ -204,8 +120,8 @@ jobs:
         run: sudo apt-get install -y graphviz
       - name: Install mdBook
         run: |
-          cargo install --version ${MDBOOK_VERSION} mdbook 2>/dev/null || true
-          cargo install --version ${MDBOOK_GRAPHVIZ_VERSION} mdbook-graphviz 2>/dev/null || true
+          cargo install --version "${MDBOOK_VERSION}" mdbook 2>/dev/null || true
+          cargo install --version "${MDBOOK_GRAPHVIZ_VERSION}" mdbook-graphviz 2>/dev/null || true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
@@ -225,7 +141,7 @@ jobs:
           # Linux at the root of /docs/ — the canonical default target.
           cp -r ../doc-artifacts/doc-linux/. www/docs/
           # Other targets in their own subdirectory.
-          for t in macos windows android ios; do
+          for t in macos windows; do
             mkdir -p "www/docs/${t}"
             cp -r "../doc-artifacts/doc-${t}/." "www/docs/${t}/"
           done

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -43,7 +43,7 @@ jobs:
   doc-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
@@ -55,7 +55,7 @@ jobs:
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
           RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS_BASE}}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: doc-linux
           path: target/doc
@@ -64,7 +64,7 @@ jobs:
   doc-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
@@ -76,7 +76,7 @@ jobs:
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
           RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS_BASE}}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: doc-macos
           path: target/doc
@@ -85,8 +85,8 @@ jobs:
   doc-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: ilammy/setup-nasm@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
@@ -98,7 +98,7 @@ jobs:
         run: cargo +nightly doc --all-features --no-deps -p rama
         env:
           RUSTDOCFLAGS: ${{env.RUSTDOCFLAGS_BASE}}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: doc-windows
           path: target/doc
@@ -112,7 +112,7 @@ jobs:
       MDBOOK_VERSION: 0.5.2
       MDBOOK_GRAPHVIZ_VERSION: 0.3.1
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: dtolnay/rust-toolchain@5b842231ba77f5c045dba54ac5560fed2db780e2
         with:
           toolchain: nightly
@@ -151,7 +151,7 @@ jobs:
           cp sitemap.xml www/sitemap.xml
           cp robots.txt www/robots.txt
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./docs/www
 
@@ -169,4 +169,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tui-logger",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ dependencies = [
  "rand 0.10.1",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-graceful",
  "tokio-stream",

--- a/docs/target-picker.html
+++ b/docs/target-picker.html
@@ -65,8 +65,6 @@
             { name: "linux", subpath: "" },
             { name: "macos", subpath: "macos/" },
             { name: "windows", subpath: "windows/" },
-            { name: "android", subpath: "android/" },
-            { name: "ios", subpath: "ios/" },
         ];
 
         var DOCS_MARKER = "/docs/";

--- a/rama-cli/Cargo.toml
+++ b/rama-cli/Cargo.toml
@@ -50,6 +50,11 @@ jemallocator = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 mimalloc = { workspace = true }
+windows-sys = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [lints]
 workspace = true

--- a/rama-cli/src/cmd/send/file.rs
+++ b/rama-cli/src/cmd/send/file.rs
@@ -18,9 +18,13 @@ use std::path::{Path, PathBuf};
 /// - Missing file → `io::ErrorKind::NotFound`, surfaced as
 ///   `Couldn't open file <path>` (matching curl's exit-37 message).
 pub async fn run(uri: &Uri) -> Result<(), BoxError> {
-    let path = extract_path(uri)?;
+    // Canonicalize first so `.`/`..` segments (incl. percent-encoded ones) are
+    // resolved and clamped to root per RFC 3986 before touching the filesystem;
+    // `safe_open` is then the defensive backstop against any residual traversal.
+    let uri = uri.clone().canonicalize();
+    let path = extract_path(&uri)?;
 
-    let mut file = tokio::fs::File::open(&path)
+    let mut file = rama::fs::safe_open(&path)
         .await
         .with_context(|| format!("Couldn't open file {}", path.display()))?;
 

--- a/rama-cli/src/cmd/send/http/feed/tui.rs
+++ b/rama-cli/src/cmd/send/http/feed/tui.rs
@@ -19,6 +19,7 @@ use rama::{
         },
         rss::{Feed, FeedItem, FeedStream},
     },
+    net::{Protocol, address::HostRef, uri::Uri},
     telemetry::tracing,
 };
 
@@ -989,35 +990,105 @@ fn extract_attr(tag: &StartTag<'_>, name: &[u8]) -> Option<String> {
         .map(|attr| attr.value_decoded().into_owned())
 }
 
-fn open_url(url: &str) {
-    use std::process::{Command, Stdio};
+/// Normalize `url` into a browser-safe absolute URL, or `None` if it isn't one.
+///
+/// Feed-provided links are untrusted, so rather than launch the raw string we
+/// strict-parse + canonicalize it per RFC 3986 (`parse_canonical_strict`): the
+/// result is normalized (lowercased scheme/host, resolved dot-segments) and
+/// guaranteed to be properly percent-encoded — anything under-encoded is
+/// rejected rather than opened. We then require an `http`/`https` scheme and a
+/// real host (domain or IP literal), rejecting other schemes (`file:`,
+/// `javascript:`, ...) and host-less URLs. The returned, normalized URL is what
+/// we hand to the browser.
+fn to_browser_safe_url(url: &str) -> Option<Uri> {
+    let uri = Uri::parse_canonical_strict(url).ok()?;
 
-    #[cfg(target_os = "macos")]
-    let mut command = {
-        let mut c = Command::new("open");
-        c.arg(url);
-        c
+    let scheme = uri.scheme();
+    if scheme != Some(&Protocol::HTTP) && scheme != Some(&Protocol::HTTPS) {
+        return None;
+    }
+
+    // Require a validated host (DNS name or IP literal); reject authority-less
+    // URLs (`http:///x`) and unvalidated reg-names.
+    matches!(uri.host(), Some(HostRef::Name(_) | HostRef::Address(_))).then_some(uri)
+}
+
+fn open_url(raw_url: &str) {
+    let Some(url) = to_browser_safe_url(raw_url).map(|uri| uri.to_string()) else {
+        tracing::debug!("refusing to open non-http(s) url in browser: {raw_url}");
+        return;
     };
+
     #[cfg(target_os = "windows")]
-    let mut command = {
-        let mut c = Command::new("cmd");
-        c.args(["/C", "start", "", url]);
-        c
-    };
-    #[cfg(all(unix, not(target_os = "macos")))]
-    let mut command = {
-        let mut c = Command::new("xdg-open");
-        c.arg(url);
-        c
+    open_url_windows(&url);
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::process::{Command, Stdio};
+
+        #[cfg(target_os = "macos")]
+        let program = "open";
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let program = "xdg-open";
+
+        // `open`/`xdg-open` receive the URL as a single argv element with no
+        // shell involved, so it cannot inject commands.
+        if let Err(err) = Command::new(program)
+            .arg(&url)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            tracing::debug!("failed to open url {url} in browser: {err}");
+        }
+    }
+}
+
+/// Open `url` via the Win32 `ShellExecuteW` "open" verb.
+///
+/// Replaces the previous `cmd /C start "" <url>`, which routed the URL through
+/// `cmd.exe` whose metacharacters (`&`, `|`, `^`, ...) are interpreted after
+/// argv escaping — a command-injection vector (cf. CVE-2024-24576).
+/// `ShellExecuteW` performs no shell parsing: the URL is handed as a UTF-16
+/// string straight to the default protocol handler.
+#[cfg(target_os = "windows")]
+fn open_url_windows(url: &str) {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        OsStr::new(s)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect()
+    }
+
+    let verb = to_wide("open");
+    let target = to_wide(url);
+
+    // SAFETY: `verb` and `target` are NUL-terminated UTF-16 buffers that
+    // outlive the call; the remaining arguments are null. `ShellExecuteW` does
+    // not retain any pointer past the call.
+    let result = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            verb.as_ptr(),
+            target.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            SW_SHOWNORMAL,
+        )
     };
 
-    if let Err(err) = command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        tracing::debug!("failed to open url {url} in browser: {err}");
+    // ShellExecuteW returns a value greater than 32 on success.
+    if (result as isize) <= 32 {
+        tracing::debug!(
+            "failed to open url {url} in browser (ShellExecuteW returned {})",
+            result as isize,
+        );
     }
 }
 
@@ -1031,6 +1102,51 @@ mod tests {
     use rama::http::Body;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
+
+    #[test]
+    fn browser_safe_url_accepts_and_normalizes_http_https() {
+        for url in [
+            "http://example.com/",
+            "https://example.com/feed?a=1&b=2#frag",
+            "HTTPS://EXAMPLE.COM/",
+        ] {
+            assert!(
+                to_browser_safe_url(url).is_some(),
+                "expected `{url}` to be accepted",
+            );
+        }
+
+        // The returned URL is canonicalized: scheme/host lowercased and
+        // dot-segments resolved.
+        assert_eq!(
+            to_browser_safe_url("HTTPS://Example.COM/a/b/../c")
+                .unwrap()
+                .to_string(),
+            "https://example.com/a/c",
+        );
+    }
+
+    #[test]
+    fn browser_safe_url_rejects_dangerous_or_non_web() {
+        for url in [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "data:text/html,x",
+            "vbscript:msgbox(1)",
+            "ftp://example.com/x",
+            "ws://example.com",
+            "http:///no-host",
+            "/relative/path",
+            "-flag",
+            "not a url",
+            "",
+        ] {
+            assert!(
+                to_browser_safe_url(url).is_none(),
+                "expected `{url}` to be rejected",
+            );
+        }
+    }
 
     const RSS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">

--- a/rama-core/Cargo.toml
+++ b/rama-core/Cargo.toml
@@ -65,6 +65,7 @@ tracing-opentelemetry = { workspace = true, optional = true }
 
 [dev-dependencies]
 rand = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-test = { workspace = true }
 

--- a/rama-core/src/fs/mod.rs
+++ b/rama-core/src/fs/mod.rs
@@ -245,7 +245,7 @@ impl Default for OpenOptions {
 async fn ensure_within_root(root: &Path, target: &Path) -> io::Result<()> {
     let canonical_root = tokio::fs::canonicalize(root).await?;
     if let Some(existing) = nearest_existing_ancestor(target).await {
-        let canonical_target = tokio::fs::canonicalize(&existing).await?;
+        let canonical_target = canonicalize_existing_path(&existing).await?;
         if !canonical_target.starts_with(&canonical_root) {
             return Err(UnsafePathError::EscapesRoot.into());
         }
@@ -253,11 +253,24 @@ async fn ensure_within_root(root: &Path, target: &Path) -> io::Result<()> {
     Ok(())
 }
 
+async fn canonicalize_existing_path(path: &Path) -> io::Result<PathBuf> {
+    match tokio::fs::canonicalize(path).await {
+        Ok(path) => Ok(path),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {
+            if tokio::fs::symlink_metadata(path).await.is_ok() {
+                return Err(UnsafePathError::EscapesRoot.into());
+            }
+            Err(err)
+        }
+        Err(err) => Err(err),
+    }
+}
+
 /// Walk up from `path` until an existing path is found, returning it.
 async fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
     let mut current = Some(path);
     while let Some(candidate) = current {
-        if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
+        if tokio::fs::symlink_metadata(candidate).await.is_ok() {
             return Some(candidate.to_path_buf());
         }
         current = candidate.parent();
@@ -379,6 +392,29 @@ mod tests {
 
         let file = safe_open_in(root.path(), "link").await.unwrap();
         assert_eq!(read_to_string(file).await, "data");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn jail_create_rejects_dangling_symlink_escape() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("public");
+        let outside = parent.path().join("outside");
+        tokio::fs::create_dir(&root).await.unwrap();
+        tokio::fs::create_dir(&outside).await.unwrap();
+
+        let outside_target = outside.join("created.txt");
+        std::os::unix::fs::symlink(&outside_target, root.join("upload.txt")).unwrap();
+
+        let result = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .jail(&root)
+            .open("upload.txt")
+            .await;
+
+        assert_eq!(err_kind(result), io::ErrorKind::InvalidInput);
+        assert!(!outside_target.exists());
     }
 
     #[cfg(unix)]

--- a/rama-core/src/fs/mod.rs
+++ b/rama-core/src/fs/mod.rs
@@ -1,0 +1,444 @@
+//! Filesystem helpers that guard against path-traversal attacks.
+//!
+//! Opening files whose path is influenced by untrusted input (an HTTP request
+//! target, a query parameter, a header value, ...) is a classic source of
+//! path-traversal vulnerabilities: a request for `../../etc/passwd` escapes the
+//! directory the application meant to expose.
+//!
+//! This module provides drop-in replacements for [`tokio::fs::File::open`] and
+//! [`tokio::fs::OpenOptions`] that reject such paths:
+//!
+//! - [`safe_open`] opens a file read-only after rejecting `..` traversal,
+//!   reserved device names and smuggled path prefixes. Use it when the *base*
+//!   of the path is trusted but parts of it may be attacker-controlled.
+//! - [`safe_open_in`] / [`OpenOptions::jail`] additionally confine the opened
+//!   file to a trusted root directory: absolute paths are rejected and symbolic
+//!   links are resolved so they cannot point outside the root.
+//!
+//! The underlying lexical check is exposed as [`sanitize_path`] for callers
+//! that want to validate a path without opening it.
+//!
+//! # Examples
+//!
+//! Reject traversal while serving from a fixed directory:
+//!
+//! ```
+//! # async fn docs() {
+//! use rama_core::fs;
+//!
+//! // Whatever the request asks for, nothing outside `./public` is reachable.
+//! assert!(fs::safe_open_in("./public", "../../etc/passwd").await.is_err());
+//! # }
+//! ```
+//!
+//! Open a (possibly absolute) trusted path while still rejecting `..`:
+//!
+//! ```
+//! # async fn docs() {
+//! use rama_core::fs;
+//!
+//! assert!(fs::safe_open("/srv/data/report.bin").await.is_err()); // missing file -> NotFound
+//! assert!(fs::safe_open("/srv/../etc/passwd").await.is_err()); // traversal -> InvalidInput
+//! # }
+//! ```
+
+mod sanitize;
+#[doc(inline)]
+pub use sanitize::{
+    UnsafePathError, is_reserved_device_name, sanitize_path, sanitize_relative_path,
+};
+
+use std::io;
+use std::path::{Path, PathBuf};
+use tokio::fs::File;
+
+/// How symbolic links are treated when opening a file confined to a root
+/// directory via [`OpenOptions::jail`].
+///
+/// Symlink handling only applies when a jail root is set; without one there is
+/// no boundary to confine to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum SymlinkPolicy {
+    /// Symlinks may be followed, but the fully resolved path must stay within
+    /// the jail root. A symlink that resolves outside the root is rejected with
+    /// [`UnsafePathError::EscapesRoot`]. This is the default.
+    #[default]
+    RestrictToRoot,
+    /// Symlinks are followed even when they resolve outside the jail root. The
+    /// lexical confinement (no `..`, no absolute paths) still applies, but the
+    /// resolved target is not checked against the root. Opt in only when the
+    /// linked targets are trusted.
+    Allow,
+}
+
+/// Open `path` read-only with path-traversal protection.
+///
+/// Equivalent to `OpenOptions::new().read(true).open(path)`. Rejects `..`
+/// traversal, reserved device names and smuggled path prefixes (see
+/// [`sanitize_path`]). Absolute paths are permitted; use [`safe_open_in`] to
+/// confine the path to a trusted root directory instead.
+///
+/// Path rejection surfaces as [`io::ErrorKind::InvalidInput`].
+pub async fn safe_open(path: impl AsRef<Path>) -> io::Result<File> {
+    OpenOptions::new().read(true).open(path).await
+}
+
+/// Open a file read-only, confined to within the trusted directory `root`.
+///
+/// `path` is treated as relative to `root`; absolute paths, `..` traversal,
+/// reserved device names, smuggled prefixes, and symbolic links that resolve
+/// outside `root` are all rejected. `root` itself must exist.
+///
+/// Equivalent to `OpenOptions::new().read(true).jail(root).open(path)`.
+pub async fn safe_open_in(root: impl AsRef<Path>, path: impl AsRef<Path>) -> io::Result<File> {
+    OpenOptions::new()
+        .read(true)
+        .jail(root.as_ref())
+        .open(path)
+        .await
+}
+
+/// Options to open a file with path-traversal protection.
+///
+/// Mirrors the access-mode setters of [`tokio::fs::OpenOptions`]
+/// (read/write/append/truncate/create/create_new) and adds
+/// [`jail`](Self::jail) to confine every opened path to a trusted root
+/// directory.
+///
+/// Lexical traversal protection (rejecting `..`, reserved device names and
+/// smuggled prefixes) is *always* applied. [`jail`](Self::jail) additionally
+/// rejects absolute paths and resolves symlinks against the root so they cannot
+/// escape it.
+#[derive(Debug, Clone)]
+pub struct OpenOptions {
+    read: bool,
+    write: bool,
+    append: bool,
+    truncate: bool,
+    create: bool,
+    create_new: bool,
+    jail: Option<PathBuf>,
+    symlinks: SymlinkPolicy,
+}
+
+impl OpenOptions {
+    /// Create a new set of options with every flag disabled, matching
+    /// [`tokio::fs::OpenOptions::new`]. Enable at least one access mode (e.g.
+    /// [`read`](Self::read)) before calling [`open`](Self::open).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            read: false,
+            write: false,
+            append: false,
+            truncate: false,
+            create: false,
+            create_new: false,
+            jail: None,
+            symlinks: SymlinkPolicy::RestrictToRoot,
+        }
+    }
+
+    /// Set the option for read access.
+    pub fn read(&mut self, read: bool) -> &mut Self {
+        self.read = read;
+        self
+    }
+
+    /// Set the option for write access.
+    pub fn write(&mut self, write: bool) -> &mut Self {
+        self.write = write;
+        self
+    }
+
+    /// Set the option for append mode.
+    pub fn append(&mut self, append: bool) -> &mut Self {
+        self.append = append;
+        self
+    }
+
+    /// Set the option for truncating a previous file.
+    pub fn truncate(&mut self, truncate: bool) -> &mut Self {
+        self.truncate = truncate;
+        self
+    }
+
+    /// Set the option to create a new file, or open it if it already exists.
+    pub fn create(&mut self, create: bool) -> &mut Self {
+        self.create = create;
+        self
+    }
+
+    /// Set the option to create a new file, failing if it already exists.
+    pub fn create_new(&mut self, create_new: bool) -> &mut Self {
+        self.create_new = create_new;
+        self
+    }
+
+    /// Confine every opened path to within `root`.
+    ///
+    /// The path passed to [`open`](Self::open) is then interpreted as relative
+    /// to `root`; absolute paths are rejected, and the resolved path (with
+    /// symlinks followed) must remain within `root` or the open fails with
+    /// [`UnsafePathError::EscapesRoot`]. `root` must exist when opening.
+    pub fn jail(&mut self, root: impl Into<PathBuf>) -> &mut Self {
+        self.jail = Some(root.into());
+        self
+    }
+
+    /// Set how symbolic links are treated within the [`jail`](Self::jail) root.
+    ///
+    /// Defaults to [`SymlinkPolicy::RestrictToRoot`]. Has no effect unless a
+    /// jail root is configured.
+    pub fn symlinks(&mut self, policy: SymlinkPolicy) -> &mut Self {
+        self.symlinks = policy;
+        self
+    }
+
+    /// Open the file at `path` with the configured options, after validating it
+    /// against path-traversal attacks.
+    pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
+        let path = self.resolve(path.as_ref()).await?;
+        self.tokio_options().open(path).await
+    }
+
+    fn tokio_options(&self) -> tokio::fs::OpenOptions {
+        let mut opts = tokio::fs::OpenOptions::new();
+        opts.read(self.read)
+            .write(self.write)
+            .append(self.append)
+            .truncate(self.truncate)
+            .create(self.create)
+            .create_new(self.create_new);
+        opts
+    }
+
+    /// Validate `path` and produce the concrete filesystem path to open.
+    async fn resolve(&self, path: &Path) -> io::Result<PathBuf> {
+        match &self.jail {
+            None => Ok(sanitize_path(path)?),
+            Some(root) => {
+                let relative = sanitize_relative_path(path)?;
+                let full = root.join(relative);
+                if self.symlinks == SymlinkPolicy::RestrictToRoot {
+                    ensure_within_root(root, &full).await?;
+                }
+                Ok(full)
+            }
+        }
+    }
+}
+
+impl Default for OpenOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Verify, by canonicalizing, that `target` resolves to a location within
+/// `root`. This defends against symbolic links that point outside the jail.
+///
+/// Only the portion of `target` that already exists is canonicalized; the
+/// lexical sanitization already guarantees the not-yet-existing tail contains
+/// no `..` components.
+async fn ensure_within_root(root: &Path, target: &Path) -> io::Result<()> {
+    let canonical_root = tokio::fs::canonicalize(root).await?;
+    if let Some(existing) = nearest_existing_ancestor(target).await {
+        let canonical_target = tokio::fs::canonicalize(&existing).await?;
+        if !canonical_target.starts_with(&canonical_root) {
+            return Err(UnsafePathError::EscapesRoot.into());
+        }
+    }
+    Ok(())
+}
+
+/// Walk up from `path` until an existing path is found, returning it.
+async fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut current = Some(path);
+    while let Some(candidate) = current {
+        if tokio::fs::try_exists(candidate).await.unwrap_or(false) {
+            return Some(candidate.to_path_buf());
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    async fn read_to_string(mut file: File) -> String {
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).await.unwrap();
+        buf
+    }
+
+    fn err_kind(result: io::Result<File>) -> io::ErrorKind {
+        result.expect_err("expected error").kind()
+    }
+
+    #[tokio::test]
+    async fn safe_open_reads_a_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        tokio::fs::write(&path, b"hello world").await.unwrap();
+
+        let file = safe_open(&path).await.unwrap();
+        assert_eq!(read_to_string(file).await, "hello world");
+    }
+
+    #[tokio::test]
+    async fn safe_open_rejects_parent_dir_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sub/../secret.txt");
+        // The file would exist after lexical resolution, but `..` is refused
+        // before we ever touch the filesystem.
+        assert_eq!(
+            err_kind(safe_open(&path).await),
+            io::ErrorKind::InvalidInput,
+        );
+    }
+
+    #[tokio::test]
+    async fn safe_open_missing_file_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.txt");
+        assert_eq!(err_kind(safe_open(&path).await), io::ErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn safe_open_in_serves_files_within_root() {
+        let root = tempfile::tempdir().unwrap();
+        tokio::fs::create_dir(root.path().join("assets"))
+            .await
+            .unwrap();
+        tokio::fs::write(root.path().join("assets/app.js"), b"console.log(1)")
+            .await
+            .unwrap();
+
+        let file = safe_open_in(root.path(), "assets/app.js").await.unwrap();
+        assert_eq!(read_to_string(file).await, "console.log(1)");
+
+        // A leading slash is interpreted relative to the root, not the FS root.
+        let file = safe_open_in(root.path(), "/assets/app.js").await;
+        assert_eq!(err_kind(file), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn safe_open_in_rejects_traversal_out_of_root() {
+        let parent = tempfile::tempdir().unwrap();
+        tokio::fs::write(parent.path().join("secret.txt"), b"top secret")
+            .await
+            .unwrap();
+        let root = parent.path().join("public");
+        tokio::fs::create_dir(&root).await.unwrap();
+        tokio::fs::write(root.join("index.html"), b"<h1>hi</h1>")
+            .await
+            .unwrap();
+
+        // Sanity: the legitimate file is reachable.
+        safe_open_in(&root, "index.html").await.unwrap();
+
+        for payload in ["../secret.txt", "../../etc/passwd", "..\\secret.txt"] {
+            let result = safe_open_in(&root, payload).await;
+            assert!(
+                result.is_err(),
+                "expected `{payload}` to be rejected, got Ok",
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn safe_open_in_rejects_symlink_escaping_root() {
+        let parent = tempfile::tempdir().unwrap();
+        tokio::fs::write(parent.path().join("secret.txt"), b"top secret")
+            .await
+            .unwrap();
+        let root = parent.path().join("public");
+        tokio::fs::create_dir(&root).await.unwrap();
+
+        // A symlink living *inside* the root but pointing outside of it.
+        std::os::unix::fs::symlink(parent.path().join("secret.txt"), root.join("escape")).unwrap();
+
+        let result = safe_open_in(&root, "escape").await;
+        assert_eq!(err_kind(result), io::ErrorKind::InvalidInput);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn safe_open_in_allows_symlink_within_root() {
+        let root = tempfile::tempdir().unwrap();
+        tokio::fs::write(root.path().join("real.txt"), b"data")
+            .await
+            .unwrap();
+        std::os::unix::fs::symlink(root.path().join("real.txt"), root.path().join("link")).unwrap();
+
+        let file = safe_open_in(root.path(), "link").await.unwrap();
+        assert_eq!(read_to_string(file).await, "data");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn jail_allow_symlinks_follows_escaping_link_but_keeps_lexical_guard() {
+        let parent = tempfile::tempdir().unwrap();
+        tokio::fs::write(parent.path().join("secret.txt"), b"top secret")
+            .await
+            .unwrap();
+        let root = parent.path().join("public");
+        tokio::fs::create_dir(&root).await.unwrap();
+        std::os::unix::fs::symlink(parent.path().join("secret.txt"), root.join("escape")).unwrap();
+
+        // Default policy rejects the escaping symlink.
+        assert_eq!(
+            err_kind(safe_open_in(&root, "escape").await),
+            io::ErrorKind::InvalidInput,
+        );
+
+        // Opting in to allow symlinks follows it.
+        let file = OpenOptions::new()
+            .read(true)
+            .jail(&root)
+            .symlinks(SymlinkPolicy::Allow)
+            .open("escape")
+            .await
+            .unwrap();
+        assert_eq!(read_to_string(file).await, "top secret");
+
+        // Lexical confinement (no `..`) still applies even when symlinks escape.
+        let traversal = OpenOptions::new()
+            .read(true)
+            .jail(&root)
+            .symlinks(SymlinkPolicy::Allow)
+            .open("../secret.txt")
+            .await;
+        assert_eq!(err_kind(traversal), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn open_options_can_create_within_jail() {
+        let root = tempfile::tempdir().unwrap();
+        OpenOptions::new()
+            .write(true)
+            .create(true)
+            .jail(root.path())
+            .open("nested/created.txt")
+            .await
+            .expect_err("parent dir does not exist yet");
+
+        tokio::fs::create_dir(root.path().join("nested"))
+            .await
+            .unwrap();
+        let _file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .jail(root.path())
+            .open("nested/created.txt")
+            .await
+            .unwrap();
+        assert!(root.path().join("nested/created.txt").exists());
+    }
+}

--- a/rama-core/src/fs/sanitize.rs
+++ b/rama-core/src/fs/sanitize.rs
@@ -1,0 +1,385 @@
+//! Lexical path sanitization used to guard against path-traversal attacks.
+
+use std::ffi::OsStr;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+/// Error returned when a path is rejected as unsafe.
+///
+/// Produced by [`sanitize_path`] and the safe-open helpers in this module
+/// ([`safe_open`](crate::fs::safe_open), [`safe_open_in`](crate::fs::safe_open_in),
+/// [`OpenOptions`](crate::fs::OpenOptions)). Converts into an
+/// [`std::io::Error`] with [`std::io::ErrorKind::InvalidInput`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnsafePathError {
+    /// The path contained a parent-directory (`..`) component, which can be
+    /// used to escape the intended directory ("dot-dot" traversal).
+    ParentDir,
+    /// An absolute path (or one carrying a root/drive/UNC prefix) was supplied
+    /// where only a relative path is permitted (e.g. when confined to a root).
+    Absolute,
+    /// A component matched a reserved device name (e.g. Windows `CON`, `NUL`,
+    /// `COM1`), which has special and surprising filesystem semantics.
+    ReservedName,
+    /// The fully resolved path escaped the configured root directory, e.g.
+    /// through a symbolic link pointing outside of it.
+    EscapesRoot,
+}
+
+impl fmt::Display for UnsafePathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            Self::ParentDir => "path contains a parent-directory (`..`) component",
+            Self::Absolute => "path is absolute but only a relative path is allowed",
+            Self::ReservedName => "path contains a reserved device name",
+            Self::EscapesRoot => "path escapes the permitted root directory",
+        };
+        f.write_str(msg)
+    }
+}
+
+impl std::error::Error for UnsafePathError {}
+
+impl From<UnsafePathError> for std::io::Error {
+    fn from(err: UnsafePathError) -> Self {
+        Self::new(std::io::ErrorKind::InvalidInput, err)
+    }
+}
+
+/// Validate `path` and return a cleaned, lexically-equivalent path that is safe
+/// from "dot-dot" traversal.
+///
+/// `.` (current-dir) components are dropped and `..` (parent-dir) components are
+/// rejected ([`UnsafePathError::ParentDir`]). Components that smuggle in a path
+/// prefix (e.g. a Windows drive letter in `foo/c:/bar`) and reserved device
+/// names (Windows `CON`, `NUL`, `COM1`, ...) are rejected too.
+///
+/// Absolute paths are permitted: a leading root/prefix is preserved. The
+/// guarantee is only that the result never points *above* its own starting
+/// point. When the path must stay within a known directory, use
+/// [`safe_open_in`](crate::fs::safe_open_in) /
+/// [`OpenOptions::jail`](crate::fs::OpenOptions::jail), which additionally
+/// reject absolute paths and resolve symlinks against the root.
+///
+/// Note: this works on already-decoded paths. Percent-decoding (e.g. of an HTTP
+/// target like `%2e%2e%2f`) is the caller's responsibility and must happen
+/// *before* calling this function.
+pub fn sanitize_path(path: impl AsRef<Path>) -> Result<PathBuf, UnsafePathError> {
+    sanitize(path.as_ref(), false)
+}
+
+/// Like [`sanitize_path`] but additionally requires the path to be relative,
+/// rejecting absolute paths and drive/UNC prefixes ([`UnsafePathError::Absolute`]).
+///
+/// Returns the cleaned relative path with `.` components dropped; join it onto
+/// a trusted root directory to confine filesystem access to within that root.
+/// This is the lexical primitive shared by safe filesystem mapping of
+/// untrusted relative paths (e.g. a static file server).
+pub fn sanitize_relative_path(path: impl AsRef<Path>) -> Result<PathBuf, UnsafePathError> {
+    sanitize(path.as_ref(), true)
+}
+
+fn sanitize(path: &Path, relative_only: bool) -> Result<PathBuf, UnsafePathError> {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir => {
+                if relative_only {
+                    return Err(UnsafePathError::Absolute);
+                }
+                out.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => return Err(UnsafePathError::ParentDir),
+            Component::Normal(name) => {
+                check_normal_component(name)?;
+                out.push(name);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Validate a single `Normal` path component.
+fn check_normal_component(name: &OsStr) -> Result<(), UnsafePathError> {
+    // A normal component must not itself decompose into anything other than a
+    // single normal component. This rejects a smuggled prefix/root such as a
+    // Windows drive letter in `foo/c:/bar` (rama #204).
+    if !Path::new(name)
+        .components()
+        .all(|c| matches!(c, Component::Normal(_)))
+    {
+        return Err(UnsafePathError::Absolute);
+    }
+
+    // Reserved device names only have special semantics on Windows, where a
+    // valid Unix filename like `CON` would resolve to a device.
+    #[cfg(windows)]
+    if is_reserved_device_name(name) {
+        return Err(UnsafePathError::ReservedName);
+    }
+
+    Ok(())
+}
+
+/// Whether `name` matches a reserved Windows device name (e.g. `CON`, `NUL`,
+/// `COM1`, `LPT9`), independent of the current platform.
+///
+/// Accepts any OS-string-like value (`&str`, `String`, `&OsStr`, `&Path`, ...),
+/// mirroring how the path helpers in this module take [`AsRef<Path>`](Path).
+///
+/// This answers a property of the *name*, not of the running OS: on a Windows
+/// host such a name resolves to a device rather than a file, so it must be
+/// rejected when mapping untrusted input to the filesystem (see
+/// [`check_normal_component`], which only consults it on Windows). Exposed so
+/// other crates can reuse the exact same check instead of duplicating it.
+#[must_use]
+pub fn is_reserved_device_name(name: impl AsRef<OsStr>) -> bool {
+    let name = name.as_ref();
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        is_reserved_dos_name(|| name.encode_wide())
+    }
+    #[cfg(not(windows))]
+    {
+        let name = name.to_string_lossy();
+        is_reserved_dos_name(|| name.encode_utf16())
+    }
+}
+
+/// Check whether a component name matches a reserved Windows DOS device name.
+/// See: <https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions>
+///
+/// We explicitly check for the Unicode superscript characters `¹` (0x00B9),
+/// `²` (0x00B2) and `³` (0x00B3) because legacy Win32 file parsing resolves
+/// them natively as the port numbers 1/2/3.
+///
+/// Uses an iterator and a stack array to avoid allocating. The closure is used
+/// because the input is iterated twice and must yield the same iterator each
+/// time it is called.
+fn is_reserved_dos_name<F, I>(mut get_iter: F) -> bool
+where
+    F: FnMut() -> I,
+    I: Iterator<Item = u16>,
+{
+    const CON: [u16; 3] = [b'C' as u16, b'O' as u16, b'N' as u16];
+    const PRN: [u16; 3] = [b'P' as u16, b'R' as u16, b'N' as u16];
+    const AUX: [u16; 3] = [b'A' as u16, b'U' as u16, b'X' as u16];
+    const NUL: [u16; 3] = [b'N' as u16, b'U' as u16, b'L' as u16];
+    const CONIN: [u16; 6] = [
+        b'C' as u16,
+        b'O' as u16,
+        b'N' as u16,
+        b'I' as u16,
+        b'N' as u16,
+        b'$' as u16,
+    ];
+    const CONOUT: [u16; 7] = [
+        b'C' as u16,
+        b'O' as u16,
+        b'N' as u16,
+        b'O' as u16,
+        b'U' as u16,
+        b'T' as u16,
+        b'$' as u16,
+    ];
+
+    const COM: [u16; 3] = [b'C' as u16, b'O' as u16, b'M' as u16];
+    const LPT: [u16; 3] = [b'L' as u16, b'P' as u16, b'T' as u16];
+
+    const ZERO: u16 = b'0' as u16;
+    const NINE: u16 = b'9' as u16;
+    const SUPERSCRIPT_ONE: u16 = 0x00B9;
+    const SUPERSCRIPT_TWO: u16 = 0x00B2;
+    const SUPERSCRIPT_THREE: u16 = 0x00B3;
+
+    fn is_whitespace(c: u16) -> bool {
+        c <= 0x7F && ((c as u8).is_ascii_whitespace() || c == 0x000B)
+    }
+
+    // In a first pass over the string, obtain the length of the basename.
+    let trimmed_len = get_iter()
+        .enumerate()
+        // We want the base name, so stop at '.' or ':' characters.
+        .take_while(|&(_idx, c)| c != b'.' as u16 && c != b':' as u16)
+        // We want to trim whitespace from the end, so ignore whitespace chars.
+        .filter(|&(_idx, c)| !is_whitespace(c))
+        // Get the last non-whitespace char before the first '.'/':' character.
+        .last()
+        // Convert index of that char into length of string.
+        .map(|(idx, _)| idx + 1)
+        .unwrap_or(0);
+
+    // If the trimmed base name is longer than 7, it cannot be a reserved name.
+    if trimmed_len > 7 {
+        return false;
+    }
+
+    // At this point, we can store the string in an array, which is more convenient to work with.
+    let mut buf = [0u16; 7];
+    get_iter()
+        .take(trimmed_len)
+        .enumerate()
+        .for_each(|(i, c)| buf[i] = c);
+
+    for b in &mut buf {
+        if *b <= 0x7F {
+            *b = (*b as u8).to_ascii_uppercase() as u16;
+        }
+        if *b == SUPERSCRIPT_ONE {
+            *b = b'1' as u16;
+        }
+        if *b == SUPERSCRIPT_TWO {
+            *b = b'2' as u16;
+        }
+        if *b == SUPERSCRIPT_THREE {
+            *b = b'3' as u16;
+        }
+    }
+    let name = &buf[..trimmed_len];
+
+    // Check basic fixed-length strings
+    if name == CON || name == PRN || name == AUX || name == NUL || name == CONIN || name == CONOUT {
+        return true;
+    }
+
+    // COMx / LPTx
+    if name.len() == 4 {
+        let prefix = &name[..3];
+        let suffix = name[3];
+
+        if (prefix == COM || prefix == LPT) && matches!(suffix, ZERO..=NINE) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn clean(path: &str) -> Result<PathBuf, UnsafePathError> {
+        sanitize_path(path)
+    }
+
+    #[test]
+    fn accepts_plain_relative_paths() {
+        assert_eq!(clean("a/b/c").unwrap(), PathBuf::from("a/b/c"));
+        assert_eq!(clean("foo.txt").unwrap(), PathBuf::from("foo.txt"));
+        assert_eq!(
+            clean("dir/file.bin").unwrap(),
+            PathBuf::from("dir/file.bin")
+        );
+    }
+
+    #[test]
+    fn drops_current_dir_components() {
+        assert_eq!(clean("./a/./b").unwrap(), PathBuf::from("a/b"));
+        assert_eq!(clean("a/./b/c").unwrap(), PathBuf::from("a/b/c"));
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        for payload in [
+            "..",
+            "../",
+            "../etc/passwd",
+            "../../../../etc/passwd",
+            "foo/../bar",
+            "foo/../../bar",
+            "a/b/../../../c",
+            "dir/..",
+        ] {
+            assert_eq!(
+                clean(payload),
+                Err(UnsafePathError::ParentDir),
+                "expected `{payload}` to be rejected as traversal",
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_absolute_paths_without_a_root() {
+        // Without a configured root, absolute paths are allowed (but never
+        // permitted to walk upward via `..`).
+        #[cfg(unix)]
+        {
+            assert_eq!(clean("/etc/hosts").unwrap(), PathBuf::from("/etc/hosts"));
+            assert_eq!(
+                clean("/var/./www/index.html").unwrap(),
+                PathBuf::from("/var/www/index.html"),
+            );
+            assert_eq!(clean("/a/../b"), Err(UnsafePathError::ParentDir));
+        }
+    }
+
+    #[test]
+    fn rejects_absolute_paths_when_relative_only() {
+        #[cfg(unix)]
+        {
+            assert_eq!(
+                sanitize_relative_path("/etc/passwd"),
+                Err(UnsafePathError::Absolute),
+            );
+            assert_eq!(sanitize_relative_path("/"), Err(UnsafePathError::Absolute),);
+        }
+        assert_eq!(sanitize_relative_path("a/b").unwrap(), PathBuf::from("a/b"));
+        assert_eq!(
+            sanitize_relative_path("../a"),
+            Err(UnsafePathError::ParentDir),
+        );
+    }
+
+    #[test]
+    fn error_converts_to_invalid_input_io_error() {
+        let io_err: std::io::Error = UnsafePathError::ParentDir.into();
+        assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    // -- reserved Windows device names (tested on all platforms) -------------
+
+    fn is_reserved(name: &str) -> bool {
+        is_reserved_device_name(name)
+    }
+
+    #[test]
+    fn detects_reserved_dos_names() {
+        for name in [
+            "CON", "con", "Con", "PRN", "AUX", "NUL", "nul", "COM1", "COM9", "com1", "LPT1",
+            "LPT9", "CONIN$", "CONOUT$", "CON.txt", "NUL.log", "com1.dat", "LPT3.bin", "CON  ",
+            "CON.", "CON:",
+            // The suffix range is `0..=9`, so `COM0`/`LPT0` are rejected too
+            // (conservative — they are not strictly reserved on Windows).
+            "COM0", "LPT0",
+        ] {
+            assert!(is_reserved(name), "expected `{name}` to be reserved");
+        }
+        // Superscript port numbers resolve to COM1/COM2/COM3.
+        assert!(is_reserved("COM\u{00B9}"));
+        assert!(is_reserved("COM\u{00B2}"));
+        assert!(is_reserved("COM\u{00B3}"));
+    }
+
+    #[test]
+    fn allows_non_reserved_names() {
+        for name in [
+            "CONSOLE",
+            "COM",
+            "COM10",
+            "LPT",
+            "LPT10",
+            "NULL",
+            "file.txt",
+            "console.log",
+            "communication",
+            "prnt",
+            "auxiliary",
+        ] {
+            assert!(!is_reserved(name), "expected `{name}` to be allowed");
+        }
+    }
+}

--- a/rama-core/src/fs/sanitize.rs
+++ b/rama-core/src/fs/sanitize.rs
@@ -132,7 +132,7 @@ fn check_normal_component(name: &OsStr) -> Result<(), UnsafePathError> {
 /// This answers a property of the *name*, not of the running OS: on a Windows
 /// host such a name resolves to a device rather than a file, so it must be
 /// rejected when mapping untrusted input to the filesystem (see
-/// [`check_normal_component`], which only consults it on Windows). Exposed so
+/// the normal-component validator, which only consults it on Windows). Exposed so
 /// other crates can reuse the exact same check instead of duplicating it.
 #[must_use]
 pub fn is_reserved_device_name(name: impl AsRef<OsStr>) -> bool {

--- a/rama-core/src/lib.rs
+++ b/rama-core/src/lib.rs
@@ -39,6 +39,8 @@ pub use service::Service;
 pub mod layer;
 pub use layer::Layer;
 
+pub mod fs;
+
 pub mod io;
 pub mod stream;
 

--- a/rama-grpc/src/codec/buffer.rs
+++ b/rama-grpc/src/codec/buffer.rs
@@ -78,6 +78,10 @@ unsafe impl BufMut for EncodeBuf<'_> {
 
     #[inline]
     unsafe fn advance_mut(&mut self, cnt: usize) {
+        // SAFETY: `BufMut::advance_mut`'s precondition (the first `cnt` bytes of
+        // the chunk have been initialized) is the caller's to uphold and is
+        // forwarded verbatim to the inner buffer, which has the identical
+        // precondition.
         unsafe { self.buf.advance_mut(cnt) }
     }
 

--- a/rama-http/src/service/fs/serve_dir/mod.rs
+++ b/rama-http/src/service/fs/serve_dir/mod.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use std::str::FromStr;
 use std::{
     convert::Infallible,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
 };
 
 pub(crate) mod future;
@@ -329,9 +329,15 @@ impl<F> ServeDir<F> {
             (fallback, fallback_req)
         });
 
+        // Canonicalize per RFC 3986 first so `.`/`..` segments (including
+        // percent-encoded ones) are resolved and clamped to the path root
+        // before mapping to the filesystem; `build_and_validate_path` then
+        // rejects anything that survives as a defensive backstop.
+        let canonical_uri = req.uri().clone().canonicalize();
+
         let Some(path_to_file) = self
             .variant
-            .build_and_validate_path(&self.base, req.uri().path_or_root())
+            .build_and_validate_path(&self.base, canonical_uri.path_or_root())
         else {
             return if let Some((fallback, request)) = fallback_and_request {
                 future::serve_fallback(fallback, request).await
@@ -549,40 +555,18 @@ impl ServeVariant {
                 let path = requested_path.trim_start_matches('/');
 
                 let path_decoded = percent_decode(path.as_ref()).decode_utf8().ok()?;
-                let path_decoded = Path::new(&*path_decoded);
+
+                // Reject path-traversal (`..`), absolute paths, smuggled
+                // prefixes (`/foo/c:/bar`, #204) and reserved device names via
+                // the shared core primitive, then map the cleaned relative path
+                // under the configured root.
+                let relative = rama_core::fs::sanitize_relative_path(&*path_decoded).ok()?;
 
                 let mut path_to_file = match source {
                     DirSource::Filesystem(base_path) => base_path.clone(),
                     DirSource::Embedded(_) => PathBuf::new(), // For embedded files, we don't need a filesystem path
                 };
-
-                for component in path_decoded.components() {
-                    match component {
-                        Component::Normal(comp) => {
-                            // protect against paths like `/foo/c:/bar/baz` (#204)
-                            if Path::new(&comp)
-                                .components()
-                                .all(|c| matches!(c, Component::Normal(_)))
-                            {
-                                #[cfg(windows)]
-                                {
-                                    use std::os::windows::ffi::OsStrExt;
-                                    if is_reserved_dos_name(|| comp.encode_wide()) {
-                                        return None;
-                                    }
-                                }
-
-                                path_to_file.push(comp)
-                            } else {
-                                return None;
-                            }
-                        }
-                        Component::CurDir => {}
-                        Component::Prefix(_) | Component::RootDir | Component::ParentDir => {
-                            return None;
-                        }
-                    }
-                }
+                path_to_file.push(relative);
                 Some(path_to_file)
             }
             Self::SingleFile { mime: _ } => match source {
@@ -591,116 +575,6 @@ impl ServeVariant {
             },
         }
     }
-}
-
-/// Check whether a component name matches a reserved Windows DOS device name.
-/// See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
-///
-/// We explicitly check for Unicode superscript characters `¹` (0x00B9), `²` (0x00B2),
-/// and `³` (0x00B3) because older character tables (ISO/IEC 8859-1) define these values,
-/// which legacy Win32 file parsing resolves natively as valid port numbers (0..9).
-///
-/// This uses an iterator and stack array to avoid allocating. A closure is used because it
-/// iterates the characters twice. The closure must return the same iterator each time it is
-/// called.
-#[cfg(any(windows, test))]
-fn is_reserved_dos_name<F, I>(mut get_iter: F) -> bool
-where
-    F: FnMut() -> I,
-    I: Iterator<Item = u16>,
-{
-    const CON: [u16; 3] = [b'C' as u16, b'O' as u16, b'N' as u16];
-    const PRN: [u16; 3] = [b'P' as u16, b'R' as u16, b'N' as u16];
-    const AUX: [u16; 3] = [b'A' as u16, b'U' as u16, b'X' as u16];
-    const NUL: [u16; 3] = [b'N' as u16, b'U' as u16, b'L' as u16];
-    const CONIN: [u16; 6] = [
-        b'C' as u16,
-        b'O' as u16,
-        b'N' as u16,
-        b'I' as u16,
-        b'N' as u16,
-        b'$' as u16,
-    ];
-    const CONOUT: [u16; 7] = [
-        b'C' as u16,
-        b'O' as u16,
-        b'N' as u16,
-        b'O' as u16,
-        b'U' as u16,
-        b'T' as u16,
-        b'$' as u16,
-    ];
-
-    const COM: [u16; 3] = [b'C' as u16, b'O' as u16, b'M' as u16];
-    const LPT: [u16; 3] = [b'L' as u16, b'P' as u16, b'T' as u16];
-
-    const ZERO: u16 = b'0' as u16;
-    const NINE: u16 = b'9' as u16;
-    const SUPERSCRIPT_ONE: u16 = 0x00B9;
-    const SUPERSCRIPT_TWO: u16 = 0x00B2;
-    const SUPERSCRIPT_THREE: u16 = 0x00B3;
-
-    fn is_whitespace(c: u16) -> bool {
-        c <= 0x7F && ((c as u8).is_ascii_whitespace() || c == 0x000B)
-    }
-
-    // In a first pass over the string, obtain the length of the basename.
-    let trimmed_len = get_iter()
-        .enumerate()
-        // We want the base name, so stop at '.' or ':' characters.
-        .take_while(|&(_idx, c)| c != b'.' as u16 && c != b':' as u16)
-        // We want to trim whitespace from the end, so ignore whitespace chars.
-        .filter(|&(_idx, c)| !is_whitespace(c))
-        // Get the last non-whitespace char before the first '.'/':' character.
-        .last()
-        // Convert index of that char into length of string.
-        .map(|(idx, _)| idx + 1)
-        .unwrap_or(0);
-
-    // If the trimmed base name is longer than 7, it cannot be a reserved name.
-    if trimmed_len > 7 {
-        return false;
-    }
-
-    // At this point, we can store the string in an array, which is more convenient to work with.
-    let mut buf = [0u16; 7];
-    get_iter()
-        .take(trimmed_len)
-        .enumerate()
-        .for_each(|(i, c)| buf[i] = c);
-
-    for b in &mut buf {
-        if *b <= 0x7F {
-            *b = (*b as u8).to_ascii_uppercase() as u16;
-        }
-        if *b == SUPERSCRIPT_ONE {
-            *b = b'1' as u16;
-        }
-        if *b == SUPERSCRIPT_TWO {
-            *b = b'2' as u16;
-        }
-        if *b == SUPERSCRIPT_THREE {
-            *b = b'3' as u16;
-        }
-    }
-    let name = &buf[..trimmed_len];
-
-    // Check basic fixed-length strings
-    if name == CON || name == PRN || name == AUX || name == NUL || name == CONIN || name == CONOUT {
-        return true;
-    }
-
-    // COMx / LPTx
-    if name.len() == 4 {
-        let prefix = &name[..3];
-        let suffix = name[3];
-
-        if (prefix == COM || prefix == LPT) && matches!(suffix, ZERO..=NINE) {
-            return true;
-        }
-    }
-
-    false
 }
 
 /// The default fallback service used with [`ServeDir`].

--- a/rama-http/src/service/fs/serve_dir/tests.rs
+++ b/rama-http/src/service/fs/serve_dir/tests.rs
@@ -44,6 +44,25 @@ async fn test_basic(svc: ServeDir) {
 }
 
 #[tokio::test]
+async fn dot_dot_traversal_is_clamped_to_root() {
+    let svc = ServeDir::new("../rama-http");
+
+    // `..` segments are resolved and clamped at the path root (RFC 3986), so
+    // each of these canonicalizes to `/README.md` and is served rather than
+    // escaping the root or 404ing.
+    for uri in [
+        "/foo/../README.md",
+        "/../../../README.md",
+        "/a/b/../../README.md",
+    ] {
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let res = svc.serve(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "uri: {uri}");
+        assert_eq!(res.headers()["content-type"], "text/markdown", "uri: {uri}");
+    }
+}
+
+#[tokio::test]
 async fn basic_with_index() {
     let svc = ServeDir::new("../test-files");
     test_basic_with_index(svc).await;
@@ -1594,7 +1613,7 @@ fn verify_windows_device(name: &str, is_positive: bool) {
 
 #[test]
 fn test_is_reserved_dos_name() {
-    use super::is_reserved_dos_name;
+    use rama_core::fs::is_reserved_device_name;
 
     let positives = [
         "CON",
@@ -1643,10 +1662,7 @@ fn test_is_reserved_dos_name() {
     ];
 
     for name in positives {
-        assert!(
-            is_reserved_dos_name(|| name.encode_utf16()),
-            "Expected true for {name:?}",
-        );
+        assert!(is_reserved_device_name(name), "Expected true for {name:?}",);
 
         #[cfg(windows)]
         verify_windows_device(name, true);
@@ -1671,7 +1687,7 @@ fn test_is_reserved_dos_name() {
 
     for name in negatives {
         assert!(
-            !is_reserved_dos_name(|| name.encode_utf16()),
+            !is_reserved_device_name(name),
             "Expected false for {name:?}",
         );
 

--- a/rama-http/src/service/web/endpoint/response/octet_stream.rs
+++ b/rama-http/src/service/web/endpoint/response/octet_stream.rs
@@ -182,7 +182,9 @@ impl<S> OctetStream<S> {
     async fn open_file_with_metadata(
         path: &Path,
     ) -> std::io::Result<(File, Option<u64>, Option<String>)> {
-        let file = File::open(path).await?;
+        // Reject path-traversal (`..`) and other unsafe paths: this is reachable
+        // with request-derived input, so guard it at the source.
+        let file = rama_core::fs::safe_open(path).await?;
 
         let metadata = file.metadata().await.ok();
         let content_size = metadata.as_ref().map(|m| m.len());
@@ -203,6 +205,9 @@ impl<S> OctetStream<S> {
     ///
     /// Both operations are graceful - if metadata cannot be read or the filename cannot
     /// be extracted, the corresponding field will be `None`.
+    ///
+    /// The file is opened with `rama_core::fs::safe_open`, which rejects
+    /// path-traversal (`..`) and other unsafe paths.
     ///
     /// # Arguments
     ///
@@ -244,6 +249,9 @@ impl<S> OctetStream<S> {
     /// This is a convenience method that combines file opening, seeking to the range start,
     /// and creating a partial content (HTTP 206) response in one step. It automatically
     /// extracts the filename from the path and uses the file size as the complete length.
+    ///
+    /// The file is opened with `rama_core::fs::safe_open`, which rejects
+    /// path-traversal (`..`) and other unsafe paths.
     ///
     /// # Arguments
     ///
@@ -417,8 +425,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_try_from_path() {
-        let file_path = "../test-files/hello.txt";
-        let stream = OctetStream::<ReaderStream<File>>::try_from_path(file_path)
+        // Canonicalize so the path carries no `..` traversal component, which
+        // `safe_open` rejects by design.
+        let file_path = std::fs::canonicalize("../test-files/hello.txt").unwrap();
+        let stream = OctetStream::<ReaderStream<File>>::try_from_path(&file_path)
             .await
             .unwrap();
 
@@ -434,9 +444,9 @@ mod tests {
     async fn test_try_range_response_from_path() {
         use crate::header::{CONTENT_DISPOSITION, CONTENT_RANGE};
 
-        let file_path = "../test-files/hello.txt";
+        let file_path = std::fs::canonicalize("../test-files/hello.txt").unwrap();
         let response =
-            OctetStream::<ReaderStream<File>>::try_range_response_from_path(file_path, 0, 5)
+            OctetStream::<ReaderStream<File>>::try_range_response_from_path(&file_path, 0, 5)
                 .await
                 .unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@
 #[doc(inline)]
 pub use ::rama_core::{
     Layer, Service, ServiceInput, bytes, combinators, conversion, error, error_sink, extensions,
-    futures, geo, graceful, io, layer, matcher, rt, service, stream, username,
+    fs, futures, geo, graceful, io, layer, matcher, rt, service, stream, username,
 };
 
 #[cfg(feature = "crypto")]


### PR DESCRIPTION
- Add `rama-core::fs` (`safe_open`/`OpenOptions` jail + symlink policy); `ServeDir`/`OctetStream`/`file://` canonicalize then open through it
- Open feed-TUI links via Win32 `ShellExecuteW` instead of `cmd /C start`, after normalizing to a canonical http/https URL
- Audit 8 reported `unsafe` blocks (all sound); document the one undocumented grpc forwarding