### PR TITLE
Fix duplicate port usage

### DIFF
--- a/examples/http_octet_stream.rs
+++ b/examples/http_octet_stream.rs
@@ -1,6 +1,6 @@
 //! A simple example demonstrating `OctetStream` responses for binary data.
 //!
-//! This example will create a server that listens on `127.0.0.1:62003`.
+//! This example will create a server that listens on `127.0.0.1:62056`.
 //!
 //! # Run the example
 //!
@@ -12,10 +12,10 @@
 //!
 //! ```sh
 //! # Simple binary data
-//! curl http://127.0.0.1:62003/data -o output.bin
+//! curl http://127.0.0.1:62056/data -o output.bin
 //!
 //! # Download with filename
-//! curl -O -J http://127.0.0.1:62003/download
+//! curl -O -J http://127.0.0.1:62056/download
 //! ```
 
 #![expect(
@@ -33,7 +33,7 @@ use rama::{Layer, http::server::HttpServer};
 async fn main() {
     HttpServer::default()
         .listen(
-            "127.0.0.1:62003",
+            "127.0.0.1:62056",
             TraceLayer::new_for_http().layer(
                 WebService::default()
                     .with_get("/data", serve_binary_data)

--- a/examples/http_rss_blog.rs
+++ b/examples/http_rss_blog.rs
@@ -12,11 +12,11 @@
 //!
 //! # Expected output
 //!
-//! The server will start and listen on `:62053`. You can fetch the feeds with:
+//! The server will start and listen on `:62055`. You can fetch the feeds with:
 //!
 //! ```sh
-//! curl http://127.0.0.1:62053/feed.rss
-//! curl http://127.0.0.1:62053/feed.atom
+//! curl http://127.0.0.1:62055/feed.rss
+//! curl http://127.0.0.1:62055/feed.atom
 //! ```
 
 #![expect(
@@ -120,7 +120,7 @@ async fn main() {
     let graceful = rama::graceful::Shutdown::default();
     let exec = Executor::graceful(graceful.guard());
 
-    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62053), exec.clone())
+    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62055), exec.clone())
         .await
         .expect("bind address");
     let bind_address = listener.local_addr().expect("local addr");

--- a/examples/http_rss_podcast.rs
+++ b/examples/http_rss_podcast.rs
@@ -18,11 +18,11 @@
 //!
 //! # Expected output
 //!
-//! The server will start and listen on `:62054`. You can fetch the feeds with:
+//! The server will start and listen on `:62057`. You can fetch the feeds with:
 //!
 //! ```sh
-//! curl http://127.0.0.1:62054/podcast.rss
-//! curl http://127.0.0.1:62054/podcast-stream.rss
+//! curl http://127.0.0.1:62057/podcast.rss
+//! curl http://127.0.0.1:62057/podcast-stream.rss
 //! ```
 
 #![expect(
@@ -212,7 +212,7 @@ async fn main() {
     let graceful = rama::graceful::Shutdown::default();
     let exec = Executor::graceful(graceful.guard());
 
-    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62054), exec.clone())
+    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62057), exec.clone())
         .await
         .expect("bind address");
     let bind_address = listener.local_addr().expect("local addr");

--- a/examples/http_sse_json.rs
+++ b/examples/http_sse_json.rs
@@ -18,10 +18,10 @@
 //!
 //! # Expected output
 //!
-//! The server will start and listen on `:62028`. You open the url in your browser to easily interact:
+//! The server will start and listen on `:62058`. You open the url in your browser to easily interact:
 //!
 //! ```sh
-//! open http://127.0.0.1:62028
+//! open http://127.0.0.1:62058
 //! ```
 //!
 //! This will open a web page which should populate a table with
@@ -110,7 +110,7 @@ async fn main() {
     let graceful = rama::graceful::Shutdown::default();
     let exec = Executor::graceful(graceful.guard());
 
-    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62028), exec.clone())
+    let listener = TcpListener::bind_address(SocketAddress::default_ipv4(62058), exec.clone())
         .await
         .expect("tcp port to be bound");
     let bind_address = listener.local_addr().expect("retrieve bind address");

--- a/scripts/extra-checks.sh
+++ b/scripts/extra-checks.sh
@@ -21,4 +21,26 @@ for example in $(cd $SCRIPT_DIR/.. && find examples -maxdepth 1 -type f -name '*
     fi
 done
 
+# Make sure every example reserves its own unique port. By convention each
+# example binds to a port in the 6xxxx range (referenced both in its doc
+# comment and its bind call); two examples sharing one would collide when run
+# together (CI, docs tests, local experimentation).
+echo "Checking example port uniqueness..."
+declare -A port_owner
+port_clash=0
+for example in $(cd $SCRIPT_DIR/.. && find examples -maxdepth 1 -type f -name '*.rs' -not -name 'mod.rs'); do
+    for port in $(cd $SCRIPT_DIR/.. && grep -hoE '6[0-9]{4}' "$example" | sort -u); do
+        if [ -n "${port_owner[$port]}" ]; then
+            echo "❌ Port $port used by both ${port_owner[$port]} and $example"
+            port_clash=1
+            exit_code=1
+        else
+            port_owner[$port]=$example
+        fi
+    done
+done
+if [ "$port_clash" -eq 0 ]; then
+    echo "✅ All examples use unique ports"
+fi
+
 exit $exit_code

--- a/tests/integration/examples/example_tests/http_rss_blog.rs
+++ b/tests/integration/examples/example_tests/http_rss_blog.rs
@@ -13,7 +13,7 @@ async fn test_http_rss_blog() {
 
     // RSS 2.0 feed
     let rss_response = runner
-        .get("http://127.0.0.1:62053/feed.rss")
+        .get("http://127.0.0.1:62055/feed.rss")
         .send()
         .await
         .unwrap();
@@ -36,7 +36,7 @@ async fn test_http_rss_blog() {
 
     // Atom feed
     let atom_response = runner
-        .get("http://127.0.0.1:62053/feed.atom")
+        .get("http://127.0.0.1:62055/feed.atom")
         .send()
         .await
         .unwrap();

--- a/tests/integration/examples/example_tests/http_rss_podcast.rs
+++ b/tests/integration/examples/example_tests/http_rss_podcast.rs
@@ -13,7 +13,7 @@ async fn test_http_rss_podcast() {
 
     // One-shot podcast feed
     let resp = runner
-        .get("http://127.0.0.1:62054/podcast.rss")
+        .get("http://127.0.0.1:62057/podcast.rss")
         .send()
         .await
         .unwrap();
@@ -37,7 +37,7 @@ async fn test_http_rss_podcast() {
 
     // Streaming podcast feed — same content, different path
     let stream_resp = runner
-        .get("http://127.0.0.1:62054/podcast-stream.rss")
+        .get("http://127.0.0.1:62057/podcast-stream.rss")
         .send()
         .await
         .unwrap();

--- a/tests/integration/examples/example_tests/http_sse_json.rs
+++ b/tests/integration/examples/example_tests/http_sse_json.rs
@@ -23,7 +23,7 @@ async fn test_http_sse_json() {
     // basic html page sanity checks,
     // to at least give some basic guarantees for the human experience
 
-    let index_response = runner.get("http://127.0.0.1:62028").send().await.unwrap();
+    let index_response = runner.get("http://127.0.0.1:62058").send().await.unwrap();
     assert_eq!(StatusCode::OK, index_response.status());
     assert!(
         index_response
@@ -48,7 +48,7 @@ async fn test_http_sse_json() {
     let mut unique_events = HashSet::new();
     let mut event_count = 0;
     let mut stream = runner
-        .get("http://127.0.0.1:62028/api/events")
+        .get("http://127.0.0.1:62058/api/events")
         .send()
         .await
         .unwrap()


### PR DESCRIPTION
- Fix duplicate ports in examples causing flacky tests
- Add logic to extra_checks to prevent this in the future