### PR TITLE
Apple NE: expose flow egress interface + remote hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3967,6 +3967,7 @@ name = "rama-net"
 version = "0.3.0-rc1"
 dependencies = [
  "ahash",
+ "bitflags 2.13.0",
  "const_format",
  "csv",
  "dial9-tokio-telemetry",

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -170,6 +170,32 @@ typedef struct {
     int32_t source_app_pid;
     /// Whether `source_app_pid` is explicitly set.
     bool source_app_pid_is_set;
+    /// Remote hostname (DNS name, not resolved IP) the originating app
+    /// connected to, when exposed by the OS. UTF-8 bytes (not NUL-terminated).
+    /// May be NULL.
+    const char* remote_hostname_utf8;
+    /// Length of `remote_hostname_utf8`.
+    size_t remote_hostname_utf8_len;
+    /// Name of the network interface this flow egresses on (e.g. `en0`,
+    /// `utun4`). UTF-8 bytes (not NUL-terminated). May be NULL.
+    const char* local_interface_name_utf8;
+    /// Length of `local_interface_name_utf8`.
+    size_t local_interface_name_utf8_len;
+    /// Egress interface index. Only valid when `local_interface_index_is_set`.
+    uint32_t local_interface_index;
+    /// Whether `local_interface_index` is explicitly set.
+    bool local_interface_index_is_set;
+    /// Egress interface type, as a `RamaNwInterfaceType` discriminant. Swift
+    /// maps `nw_interface_type_t` to this. Only valid when
+    /// `local_interface_type_is_set`.
+    uint8_t local_interface_type;
+    /// Whether `local_interface_type` is explicitly set.
+    bool local_interface_type_is_set;
+    /// Whether the app bound this flow to a specific interface.
+    /// Only valid when `is_bound_is_set`.
+    bool is_bound;
+    /// Whether `is_bound` is explicitly set.
+    bool is_bound_is_set;
 } RamaTransparentProxyFlowMeta;
 
 /// One transparent-proxy network rule used to build Apple NE settings.
@@ -251,9 +277,13 @@ _Static_assert(sizeof(RamaBytesView) == 16, "RamaBytesView ABI drift");
 _Static_assert(sizeof(RamaBytesOwned) == 24, "RamaBytesOwned ABI drift");
 _Static_assert(sizeof(RamaBytesOwnedView) == 32, "RamaBytesOwnedView ABI drift");
 _Static_assert(sizeof(RamaTransparentProxyFlowEndpoint) == 24, "RamaTransparentProxyFlowEndpoint ABI drift");
-_Static_assert(sizeof(RamaTransparentProxyFlowMeta) == 112, "RamaTransparentProxyFlowMeta ABI drift");
+_Static_assert(sizeof(RamaTransparentProxyFlowMeta) == 160, "RamaTransparentProxyFlowMeta ABI drift");
 _Static_assert(offsetof(RamaTransparentProxyFlowMeta, remote_endpoint) == 8, "RamaTransparentProxyFlowMeta.remote_endpoint offset drift");
 _Static_assert(offsetof(RamaTransparentProxyFlowMeta, source_app_pid) == 104, "RamaTransparentProxyFlowMeta.source_app_pid offset drift");
+_Static_assert(offsetof(RamaTransparentProxyFlowMeta, remote_hostname_utf8) == 112, "RamaTransparentProxyFlowMeta.remote_hostname_utf8 offset drift");
+_Static_assert(offsetof(RamaTransparentProxyFlowMeta, local_interface_name_utf8) == 128, "RamaTransparentProxyFlowMeta.local_interface_name_utf8 offset drift");
+_Static_assert(offsetof(RamaTransparentProxyFlowMeta, local_interface_index) == 144, "RamaTransparentProxyFlowMeta.local_interface_index offset drift");
+_Static_assert(offsetof(RamaTransparentProxyFlowMeta, is_bound) == 151, "RamaTransparentProxyFlowMeta.is_bound offset drift");
 _Static_assert(sizeof(RamaTransparentProxyNetworkRule) == 56, "RamaTransparentProxyNetworkRule ABI drift");
 _Static_assert(offsetof(RamaTransparentProxyNetworkRule, local_network_utf8) == 24, "RamaTransparentProxyNetworkRule.local_network_utf8 offset drift");
 _Static_assert(offsetof(RamaTransparentProxyNetworkRule, protocol) == 44, "RamaTransparentProxyNetworkRule.protocol offset drift");

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -11,6 +11,17 @@ struct RamaTransparentProxyFlowMetaBridge {
     var sourceAppBundleIdentifier: String?
     var sourceAppAuditToken: Data?
     var sourceAppPid: Int32?
+    /// Remote hostname (DNS name) the app connected to, when known.
+    var remoteHostname: String?
+    /// Egress interface name (e.g. `en0`, `utun4`), when known.
+    var localInterfaceName: String?
+    /// Egress interface type as a `NwInterfaceType` discriminant (the Rust wire
+    /// value), already mapped from `nw_interface_type_t` by the caller.
+    var localInterfaceType: UInt8?
+    /// Egress interface index, when known.
+    var localInterfaceIndex: UInt32?
+    /// Whether the app bound this flow to a specific interface, when known.
+    var isBound: Bool?
 }
 
 struct RamaTransparentProxyRuleBridge {
@@ -302,29 +313,45 @@ private func withFlowMeta<T>(
             withUtf8OrNil(meta.sourceAppSigningIdentifier) { signingIdPtr, signingIdLen in
                 withUtf8OrNil(meta.sourceAppBundleIdentifier) { bundleIdPtr, bundleIdLen in
                     withDataOrNil(meta.sourceAppAuditToken) { auditTokenPtr, auditTokenLen in
-                        var cMeta = RamaTransparentProxyFlowMeta(
-                            protocol: meta.protocolRaw,
-                            remote_endpoint: RamaTransparentProxyFlowEndpoint(
-                                host_utf8: remoteHostPtr,
-                                host_utf8_len: remoteHostLen,
-                                port: meta.remotePort,
-                            ),
-                            local_endpoint: RamaTransparentProxyFlowEndpoint(
-                                host_utf8: localHostPtr,
-                                host_utf8_len: localHostLen,
-                                port: meta.localPort,
-                            ),
-                            source_app_signing_identifier_utf8: signingIdPtr,
-                            source_app_signing_identifier_utf8_len: signingIdLen,
-                            source_app_bundle_identifier_utf8: bundleIdPtr,
-                            source_app_bundle_identifier_utf8_len: bundleIdLen,
-                            source_app_audit_token_bytes: auditTokenPtr,
-                            source_app_audit_token_bytes_len: auditTokenLen,
-                            source_app_pid: meta.sourceAppPid ?? 0,
-                            source_app_pid_is_set: meta.sourceAppPid != nil
-                        )
-                        return withUnsafePointer(to: &cMeta) { metaPtr in
-                            body(metaPtr)
+                        // Two more scoped UTF-8 buffers; like the others above
+                        // they are valid only for the synchronous `body` call.
+                        withUtf8OrNil(meta.remoteHostname) { remoteHostnamePtr, remoteHostnameLen in
+                            withUtf8OrNil(meta.localInterfaceName) { ifaceNamePtr, ifaceNameLen in
+                                var cMeta = RamaTransparentProxyFlowMeta(
+                                    protocol: meta.protocolRaw,
+                                    remote_endpoint: RamaTransparentProxyFlowEndpoint(
+                                        host_utf8: remoteHostPtr,
+                                        host_utf8_len: remoteHostLen,
+                                        port: meta.remotePort,
+                                    ),
+                                    local_endpoint: RamaTransparentProxyFlowEndpoint(
+                                        host_utf8: localHostPtr,
+                                        host_utf8_len: localHostLen,
+                                        port: meta.localPort,
+                                    ),
+                                    source_app_signing_identifier_utf8: signingIdPtr,
+                                    source_app_signing_identifier_utf8_len: signingIdLen,
+                                    source_app_bundle_identifier_utf8: bundleIdPtr,
+                                    source_app_bundle_identifier_utf8_len: bundleIdLen,
+                                    source_app_audit_token_bytes: auditTokenPtr,
+                                    source_app_audit_token_bytes_len: auditTokenLen,
+                                    source_app_pid: meta.sourceAppPid ?? 0,
+                                    source_app_pid_is_set: meta.sourceAppPid != nil,
+                                    remote_hostname_utf8: remoteHostnamePtr,
+                                    remote_hostname_utf8_len: remoteHostnameLen,
+                                    local_interface_name_utf8: ifaceNamePtr,
+                                    local_interface_name_utf8_len: ifaceNameLen,
+                                    local_interface_index: meta.localInterfaceIndex ?? 0,
+                                    local_interface_index_is_set: meta.localInterfaceIndex != nil,
+                                    local_interface_type: meta.localInterfaceType ?? 0,
+                                    local_interface_type_is_set: meta.localInterfaceType != nil,
+                                    is_bound: meta.isBound ?? false,
+                                    is_bound_is_set: meta.isBound != nil
+                                )
+                                return withUnsafePointer(to: &cMeta) { metaPtr in
+                                    body(metaPtr)
+                                }
+                            }
                         }
                     }
                 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/FlowInterfaceMeta.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/FlowInterfaceMeta.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Network
+import NetworkExtension
+
+// Egress-interface + remote-hostname extraction lives in its own file because
+// it needs `import Network` (for the `nw_interface_*` C API). Importing Network
+// into a file that also uses NetworkExtension's deprecated `NWEndpoint` class
+// (e.g. the UDP datagram path in RamaTransparentProxyProvider) makes the bare
+// `NWEndpoint` name ambiguous — recent SDKs surface `Network.NWEndpoint`
+// through NetworkExtension's namespace, so even `NetworkExtension.NWEndpoint`
+// no longer disambiguates. Isolating this code avoids touching that existing
+// path; this file never references `NWEndpoint`.
+
+/// Extracts egress-interface facts (name / type / index), the bound flag, and
+/// the remote hostname from a flow. Supplements `sourceAppMeta`; every field is
+/// optional and only populated when the OS exposes it for the flow. The
+/// package's macOS 12 deployment target covers all the APIs used here
+/// (`networkInterface` 10.15.4+, `remoteHostname` 11.0+, `isBound` 11.1+), so no
+/// `#available` guards are required.
+func flowInterfaceMeta(_ flow: NEAppProxyFlow?) -> (
+    interfaceName: String?, interfaceType: UInt8?, interfaceIndex: UInt32?,
+    isBound: Bool?, remoteHostname: String?
+) {
+    guard let flow else { return (nil, nil, nil, nil, nil) }
+    var interfaceName: String?
+    var interfaceType: UInt8?
+    var interfaceIndex: UInt32?
+    if let iface = flow.networkInterface {
+        // The nw_interface_t reference is only valid in this scope, so read its
+        // name/type/index immediately and copy out owned values.
+        interfaceName = String(cString: nw_interface_get_name(iface))
+        interfaceType = ramaInterfaceTypeRaw(nw_interface_get_type(iface))
+        let idx = nw_interface_get_index(iface)
+        interfaceIndex = idx != 0 ? idx : nil  // 0 == invalid per if_nametoindex
+    }
+    let hostname = flow.remoteHostname
+    return (
+        interfaceName, interfaceType, interfaceIndex, flow.isBound,
+        (hostname?.isEmpty == false) ? hostname : nil
+    )
+}
+
+/// Maps an `nw_interface_type_t` (read off a flow's egress `networkInterface`)
+/// to the `NwInterfaceType` discriminant the Rust side decodes via
+/// `interface_type_from_u8`. Returns `nil` for unknown types so Rust fails safe
+/// to "interface type unknown".
+///
+/// IMPORTANT: Apple's `nw_interface_type_t` raw values
+/// (`other`=0, `wifi`=1, `cellular`=2, `wired`=3, `loopback`=4 — stable ABI
+/// since macOS 10.14) intentionally DIFFER from rama's `NwInterfaceType`
+/// discriminants (`Cellular`=0, `Loopback`=1, `Other`=2, `Wifi`=3, `Wired`=4),
+/// so the raw value must NOT be passed through unmapped. Switching on
+/// `.rawValue` keeps this correct regardless of how the C enum imports.
+private func ramaInterfaceTypeRaw(_ type: nw_interface_type_t) -> UInt8? {
+    switch type.rawValue {
+    case 0: return 2  // nw other    -> NwInterfaceType.Other
+    case 1: return 3  // nw wifi     -> NwInterfaceType.Wifi
+    case 2: return 0  // nw cellular -> NwInterfaceType.Cellular
+    case 3: return 4  // nw wired    -> NwInterfaceType.Wired
+    case 4: return 1  // nw loopback -> NwInterfaceType.Loopback
+    default: return nil
+    }
+}

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -1124,6 +1124,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         let remoteEndpoint = endpointHostPort(remote)
         let localEndpoint = endpointHostPort(bestEffortLocalEndpoint(flow))
         let appMeta = sourceAppMeta(flow)
+        let ifaceMeta = flowInterfaceMeta(flow)
         return RamaTransparentProxyFlowMetaBridge(
             protocolRaw: UInt32(RAMA_FLOW_PROTOCOL_TCP.rawValue),
             remoteHost: remoteEndpoint?.host,
@@ -1133,7 +1134,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             sourceAppSigningIdentifier: appMeta.signingIdentifier,
             sourceAppBundleIdentifier: appMeta.bundleIdentifier,
             sourceAppAuditToken: appMeta.auditToken,
-            sourceAppPid: appMeta.pid
+            sourceAppPid: appMeta.pid,
+            remoteHostname: ifaceMeta.remoteHostname,
+            localInterfaceName: ifaceMeta.interfaceName,
+            localInterfaceType: ifaceMeta.interfaceType,
+            localInterfaceIndex: ifaceMeta.interfaceIndex,
+            isBound: ifaceMeta.isBound
         )
     }
 
@@ -1145,6 +1151,7 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         let remote = endpointHostPort(remoteEndpoint)
         let local = endpointHostPort(localEndpoint)
         let appMeta = sourceAppMeta(flow)
+        let ifaceMeta = flowInterfaceMeta(flow)
         return RamaTransparentProxyFlowMetaBridge(
             protocolRaw: UInt32(RAMA_FLOW_PROTOCOL_UDP.rawValue),
             remoteHost: remote?.host,
@@ -1154,7 +1161,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             sourceAppSigningIdentifier: appMeta.signingIdentifier,
             sourceAppBundleIdentifier: appMeta.bundleIdentifier,
             sourceAppAuditToken: appMeta.auditToken,
-            sourceAppPid: appMeta.pid
+            sourceAppPid: appMeta.pid,
+            remoteHostname: ifaceMeta.remoteHostname,
+            localInterfaceName: ifaceMeta.interfaceName,
+            localInterfaceType: ifaceMeta.interfaceType,
+            localInterfaceIndex: ifaceMeta.interfaceIndex,
+            isBound: ifaceMeta.isBound
         )
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -40,6 +40,11 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
     // Late-bound: only set once the engine decision is .intercept.
     var sessionHandle: RamaTcpSessionHandle?
 
+    // Set when the engine decided `.passthrough` up front: instead of closing
+    // the flow (returning false — which Apple terminates), we claim it and
+    // splice it directly to egress with no Rust hop. See `handleBornSplicedReady`.
+    var bornSpliced = false
+
     // Configured by `start`; defaults applied here so phase methods
     // can run in tests without going through the engine decision.
     var lingerCloseMs: UInt32 = defaultLingerCloseMs
@@ -118,8 +123,14 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             }
             return admitted
         case .passthrough:
-            core?.logDebug("handleNewFlow tcp bypassed by rust flow policy")
-            return false
+            // Up-front passthrough: do NOT return false (Apple closes the flow
+            // — it is not a hand-off to the default route). Claim it and splice
+            // it directly, no Rust hop. Register so the idle/wedge reaper +
+            // detachEngine see it (the reaper keys on `ctx.mode == .promoted`).
+            core?.logDebug("handleNewFlow tcp up-front passthrough -> born-spliced")
+            bornSpliced = true
+            _ = core?.registerTcpFlow(flowId, anchor: self)
+            return startEgressConnection(session: nil)
         case .blocked:
             core?.logLifecycle("handleNewFlow tcp blocked by rust flow policy")
             let error = blockedFlowError()
@@ -194,7 +205,7 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
 
     // MARK: - Phase: egress connection
 
-    func startEgressConnection(session: RamaTcpSessionHandle) -> Bool {
+    func startEgressConnection(session: RamaTcpSessionHandle?) -> Bool {
         guard let remoteHost = meta.remoteHost, meta.remotePort > 0 else {
             core?.logDebug("handleTcpFlow: missing remote endpoint; rejecting flow")
             // Reject (close the claimed flow) rather than strand the app's
@@ -203,7 +214,8 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             return true
         }
 
-        let egressOpts = session.getEgressConnectOptions()
+        // Born-spliced flows have no Rust session; fall back to defaults.
+        let egressOpts = session?.getEgressConnectOptions()
         let connectTimeoutMs = egressOpts?.connectTimeoutMs ?? 10_000
         lingerCloseMs = egressOpts?.lingerCloseMs ?? defaultLingerCloseMs
         egressEofGraceMs = egressOpts?.egressEofGraceMs ?? defaultEgressEofGraceMs
@@ -365,6 +377,14 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         // exactly the hang the re-check exists to prevent. Arm it now. No-op
         // when the path is viable or the feature is disabled.
         if !ctx.lastPathViable { core?.handleEgressViabilityLoss(ctx) }
+
+        if bornSpliced {
+            // Up-front passthrough: splice directly to egress. No Rust session,
+            // no session-bound read pumps, no promote callback — the forwarder
+            // owns both read directions from birth.
+            handleBornSplicedReady(connection: connection)
+            return
+        }
         guard let session = sessionHandle else { return }
 
         let writePump = buildEgressWritePump(connection: connection)
@@ -409,6 +429,46 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         )
 
         openKernelFlow(connection: connection, readPump: readPump, session: session)
+    }
+
+    /// Egress reached `.ready` for an up-front passthrough (born-spliced) flow.
+    /// Build the egress write pump, open the kernel flow, then hand both
+    /// directions to the direct splice forwarder. No Rust session and no
+    /// session-bound read pumps (`TcpClientReadPump` / `NwTcpConnectionReadPump`
+    /// require a session) — `beginBornSplicedCutover` starts the forwarder's own
+    /// `flow.readData` / `connection.receive` loops. Teardown is the same
+    /// hardened promoted path (`applyPromotedTerminal` + linger watchdog).
+    func handleBornSplicedReady(connection: any NwConnectionLike) {
+        _ = buildEgressWritePump(connection: connection)  // stored on `ctx`
+        flow.open(withLocalEndpoint: nil) { [weak self] error in
+            self?.flowQueue.async { [weak self] in
+                guard let self else { return }
+                if let error {
+                    self.core?.logDebug("born-splice flow.open error: \(error)")
+                    self.ctx.applyFlowOpenFailure(error)
+                    return
+                }
+                // Teardown may have raced ahead while flow.open was in flight;
+                // `ctx.connection == nil` is the canonical signal.
+                guard let conn = self.ctx.connection,
+                    let clientWritePump = self.ctx.clientWritePump,
+                    let egressWritePump = self.ctx.egressWritePump
+                else {
+                    self.core?.logTrace("born-splice flow.open observed teardown; dropping")
+                    return
+                }
+                self.core?.logTrace("flow.open ok (tcp, born-spliced)")
+                self.ctx.clientWritePump?.markOpened()
+                self.core?.beginBornSplicedCutover(
+                    ctx: self.ctx,
+                    flow: self.flow,
+                    connection: conn,
+                    clientWritePump: clientWritePump,
+                    egressWritePump: egressWritePump,
+                    flowQueue: self.flowQueue
+                )
+            }
+        }
     }
 
     func handleEgressFailed(_ error: NWError?) {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -129,8 +129,16 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             // detachEngine see it (the reaper keys on `ctx.mode == .promoted`).
             core?.logDebug("handleNewFlow tcp up-front passthrough -> born-spliced")
             bornSpliced = true
-            _ = core?.registerTcpFlow(flowId, anchor: self)
-            return startEgressConnection(session: nil)
+            // Mirror the intercept path: admit unconditionally, but if this
+            // registration reached the soft cap, nudge the idle reaper so a
+            // born-splice-heavy workload can't pile up slots past the cap
+            // without the pressure reaper ever running.
+            let occupancy = core?.registerTcpFlow(flowId, anchor: self) ?? 0
+            let admitted = startEgressConnection(session: nil)
+            if defaultFlowPressureSoftCap > 0, occupancy >= Int(defaultFlowPressureSoftCap) {
+                core?.reapIdleUnderPressure()
+            }
+            return admitted
         case .blocked:
             core?.logLifecycle("handleNewFlow tcp blocked by rust flow policy")
             let error = blockedFlowError()

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -1060,51 +1060,14 @@ final class TransparentProxyCore: @unchecked Sendable {
         ctx.lastActivityAt = .now()
         logTrace("promote: cutover begin")
 
-        let forwarder = TcpDirectForwarder(
+        let forwarder = makePromotedForwarder(
+            ctx: ctx,
             flow: flow,
             connection: connection,
             clientWritePump: clientWritePump,
             egressWritePump: egressWritePump,
-            queue: flowQueue,
-            logger: { [weak self] message in self?.logFlowMessage(message) },
-            drainStallDeadline: .milliseconds(Int(ctx.lingerCloseMs)),
-            onClosing: { [weak ctx] in
-                // The forwarder began winding a direction down. Mark the
-                // ctx so the on-`stateQueue` maintenance watchdog reaps
-                // this promoted flow too if `flowQueue` later starves —
-                // the same `terminalSignalled` net the `viaRust` close
-                // path arms. Set on `flowQueue`; read off-queue by the
-                // watchdog (same relaxation as `egressReady`).
-                ctx?.terminalSignalled = true
-            },
-            onDrainStall: { [weak ctx] in
-                // A finishing direction's drain wedged (peer stopped
-                // reading). Route through the shared full-teardown reaper
-                // — cancels the write pumps, closes the kernel flow,
-                // cancels + detaches the egress NWConnection, cancels the
-                // forwarder, and drops the registry entry. Idempotent via
-                // the sticky `isDone`.
-                ctx?.applyDrainBackstop()
-            },
-            onActivity: { [weak ctx] in
-                // Bump the promoted-idle reaper clock on every byte moved in
-                // either direction. Runs on `flowQueue`, the same queue as
-                // every other `ctx` mutation; read off-queue by the
-                // maintenance watchdog (same relaxation as `egressReady` /
-                // `terminalSignalled`).
-                ctx?.lastActivityAt = .now()
-            },
-            onTerminal: { [weak ctx] in
-                // Both direct directions done. Route through the shared
-                // teardown so the close marks `done` (a racing post-terminal
-                // wake-recheck / watchdog then no-ops instead of a second,
-                // connection-cancelling teardown) and detaches handlers —
-                // WITHOUT cancelling the egress NWConnection, whose FIN/linger
-                // the egress write pump owns. See `applyPromotedTerminal`.
-                ctx?.applyPromotedTerminal()
-            }
+            flowQueue: flowQueue
         )
-        ctx.directForwarder = forwarder
 
         // Cancel the Rust-bound read pumps. Their in-flight
         // bytes (the `.paused` replay buffer plus any
@@ -1139,6 +1102,86 @@ final class TransparentProxyCore: @unchecked Sendable {
         // the mode-aware handlers transition the forwarder's
         // per-direction state to `.active`.
         session.confirmPromoted(.ok)
+    }
+
+    /// Build the direct kernel↔egress forwarder shared by the `viaRust`→promote
+    /// cutover and the born-spliced (up-front passthrough) path. Wires the same
+    /// lifecycle callbacks onto `ctx` and stores it as `ctx.directForwarder`.
+    /// The caller drives the cutover sequencing (read-pump carryover for the
+    /// promote path; the immediate Rust-done/read-drained signals for
+    /// born-spliced).
+    func makePromotedForwarder<F: TcpFlowLike>(
+        ctx: TcpFlowContext,
+        flow: F,
+        connection: any NwConnectionLike,
+        clientWritePump: TcpClientWritePump,
+        egressWritePump: NwTcpConnectionWritePump,
+        flowQueue: DispatchQueue
+    ) -> TcpDirectForwarder {
+        let forwarder = TcpDirectForwarder(
+            flow: flow,
+            connection: connection,
+            clientWritePump: clientWritePump,
+            egressWritePump: egressWritePump,
+            queue: flowQueue,
+            logger: { [weak self] message in self?.logFlowMessage(message) },
+            drainStallDeadline: .milliseconds(Int(ctx.lingerCloseMs)),
+            // Mark the ctx so the on-`stateQueue` maintenance watchdog can also
+            // reap this promoted flow if `flowQueue` later starves — the same
+            // `terminalSignalled` net the `viaRust` close path arms.
+            onClosing: { [weak ctx] in ctx?.terminalSignalled = true },
+            // A finishing direction's drain wedged (peer stopped reading):
+            // route through the shared full-teardown reaper. Idempotent via
+            // the sticky `isDone`.
+            onDrainStall: { [weak ctx] in ctx?.applyDrainBackstop() },
+            // Bump the promoted-idle reaper clock on every byte moved.
+            onActivity: { [weak ctx] in ctx?.lastActivityAt = .now() },
+            // Both directions done. Route through the shared teardown so the
+            // close marks `done` and detaches handlers — WITHOUT cancelling the
+            // egress NWConnection, whose FIN/linger the egress write pump owns.
+            onTerminal: { [weak ctx] in ctx?.applyPromotedTerminal() }
+        )
+        ctx.directForwarder = forwarder
+        return forwarder
+    }
+
+    /// Born-spliced cutover: a flow decided up-front as passthrough was claimed
+    /// (returning `true` so the kernel does NOT close it) but never routed
+    /// through Rust. It goes straight to the direct splice. Unlike
+    /// `beginPromoteCutover` there is no Rust service to unwind — no session,
+    /// no session-bound read pumps to cancel-with-carryover, no
+    /// `confirmPromoted`. Build the forwarder over the (empty) write pumps +
+    /// live connection and fire all four cutover signals immediately: with no
+    /// Rust bytes pending and no in-flight read to drain, both directions go
+    /// straight to `.active` and start their direct `flow.readData` /
+    /// `connection.receive` loops. The teardown path is identical to the
+    /// promote path (`applyPromotedTerminal` + the linger watchdog), so the
+    /// hardened, leak-fixed close is reused verbatim.
+    func beginBornSplicedCutover<F: TcpFlowLike>(
+        ctx: TcpFlowContext,
+        flow: F,
+        connection: any NwConnectionLike,
+        clientWritePump: TcpClientWritePump,
+        egressWritePump: NwTcpConnectionWritePump,
+        flowQueue: DispatchQueue
+    ) {
+        ctx.mode = .promoted
+        ctx.lastActivityAt = .now()
+        logTrace("born-splice: cutover begin")
+        let forwarder = makePromotedForwarder(
+            ctx: ctx,
+            flow: flow,
+            connection: connection,
+            clientWritePump: clientWritePump,
+            egressWritePump: egressWritePump,
+            flowQueue: flowQueue
+        )
+        // Order is irrelevant — whichever signal lands second per direction
+        // kicks off that direction's read loop (over empty carryover buffers).
+        forwarder.markClientReadDrained()
+        forwarder.markEgressReadDrained()
+        forwarder.markRustC2SDone()
+        forwarder.markRustS2CDone()
     }
 
     // MARK: - Per-flow handling (UDP)

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
@@ -17,7 +17,7 @@ final class FFIAbiLayoutTests: XCTestCase {
     func testTransparentProxyMetadataLayouts() {
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowEndpoint>.size, 24)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowEndpoint>.alignment, 8)
-        XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowMeta>.size, 112)
+        XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowMeta>.size, 160)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowMeta>.alignment, 8)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyNetworkRule>.size, 56)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyNetworkRule>.alignment, 8)

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionTests.swift
@@ -88,6 +88,53 @@ final class TcpFlowSessionTests: XCTestCase {
         XCTAssertNotNil(fx.session.ctx.clientWritePump)
     }
 
+    // MARK: - born-spliced (up-front passthrough → claim + direct splice)
+
+    private func poll(_ timeout: TimeInterval = 2.0, _ cond: () -> Bool) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !cond() && Date() < deadline { Thread.sleep(forTimeInterval: 0.002) }
+    }
+
+    /// An up-front passthrough decision must NOT close the flow. The
+    /// born-spliced path claims it, builds the direct forwarder, and flips
+    /// `ctx.mode` to `.promoted` — no Rust session and no session-bound read
+    /// pumps. Drives the phase methods directly (no engine).
+    func testBornSplicedReadyBuildsForwarderAndPromotes() {
+        let fx = Fixture()
+        fx.session.buildClientWritePump()  // `start()` does this for every path
+        fx.session.bornSpliced = true
+        XCTAssertEqual(fx.session.ctx.mode, .viaRust, "mode is viaRust until the splice")
+
+        fx.session.handleBornSplicedReady(connection: fx.conn)
+        poll { fx.flow.openWasInvoked }
+        XCTAssertTrue(fx.flow.completeOpen(error: nil), "flow.open should be pending")
+
+        poll { fx.session.ctx.mode == .promoted }
+        XCTAssertEqual(
+            fx.session.ctx.mode, .promoted,
+            "born-spliced flow must promote to the direct splice, not close")
+        XCTAssertNotNil(fx.session.ctx.directForwarder, "the direct forwarder must be built")
+        XCTAssertNotNil(fx.session.ctx.egressWritePump, "the egress write pump must be built")
+    }
+
+    /// Born-spliced teardown routes through the SAME hardened promoted close
+    /// as the via-Rust→promote path (`applyPromotedTerminal`): cancelling the
+    /// forwarder marks the flow done (the shared, leak-fixed teardown).
+    func testBornSplicedForwarderCancelMarksDone() {
+        let fx = Fixture()
+        fx.session.buildClientWritePump()
+        fx.session.bornSpliced = true
+        fx.session.handleBornSplicedReady(connection: fx.conn)
+        poll { fx.flow.openWasInvoked }
+        XCTAssertTrue(fx.flow.completeOpen(error: nil))
+        poll { fx.session.ctx.directForwarder != nil }
+        XCTAssertNotNil(fx.session.ctx.directForwarder)
+
+        fx.session.ctx.directForwarder?.cancel()
+        poll { fx.session.ctx.isDone == true }
+        XCTAssertEqual(fx.session.ctx.isDone, true, "promoted teardown marks the flow done")
+    }
+
     // MARK: - viability handler wiring
 
     /// The wired `viabilityUpdateHandler` MUST update `ctx.lastPathViable`

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/clients.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/clients.rs
@@ -475,6 +475,16 @@ pub(crate) async fn udp_roundtrip(
             source_app_audit_token_bytes_len: 0,
             source_app_pid: 0,
             source_app_pid_is_set: false,
+            remote_hostname_utf8: ptr::null(),
+            remote_hostname_utf8_len: 0,
+            local_interface_name_utf8: ptr::null(),
+            local_interface_name_utf8_len: 0,
+            local_interface_index: 0,
+            local_interface_index_is_set: false,
+            local_interface_type: 0,
+            local_interface_type_is_set: false,
+            is_bound: false,
+            is_bound_is_set: false,
         };
         let result = unsafe {
             bindings::rama_transparent_proxy_engine_new_udp_session(

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/ingress.rs
@@ -243,6 +243,16 @@ async fn serve_one_ingress_connection(
             source_app_audit_token_bytes_len: 0,
             source_app_pid: 0,
             source_app_pid_is_set: false,
+            remote_hostname_utf8: ptr::null(),
+            remote_hostname_utf8_len: 0,
+            local_interface_name_utf8: ptr::null(),
+            local_interface_name_utf8_len: 0,
+            local_interface_index: 0,
+            local_interface_index_is_set: false,
+            local_interface_type: 0,
+            local_interface_type_is_set: false,
+            is_bound: false,
+            is_bound_is_set: false,
         };
 
         let result = unsafe {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -2515,6 +2515,7 @@ name = "rama-net"
 version = "0.3.0-rc1"
 dependencies = [
  "ahash",
+ "bitflags 2.13.0",
  "const_format",
  "csv",
  "dial9-tokio-telemetry",

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/config.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/config.rs
@@ -57,6 +57,23 @@ impl Default for DemoProxyConfig {
                 "*.gstatic.com".to_owned(),
                 "*.cloudflare.com".to_owned(),
                 "*.jsdelivr.net".to_owned(),
+                // More common high-traffic domains so a soak run drives the
+                // promote → Swift-splice → teardown path with heavy, realistic
+                // volume (the path we want to prove leak-free).
+                "*.apple.com".to_owned(),
+                "*.icloud.com".to_owned(),
+                "*.microsoft.com".to_owned(),
+                "*.azureedge.net".to_owned(),
+                "*.fastly.net".to_owned(),
+                "*.akamaized.net".to_owned(),
+                "*.amazonaws.com".to_owned(),
+                "*.cloudfront.net".to_owned(),
+                "*.google.com".to_owned(),
+                "*.googlevideo.com".to_owned(),
+                "*.slack-edge.com".to_owned(),
+                "registry.npmjs.org".to_owned(),
+                "*.pythonhosted.org".to_owned(),
+                "*.docker.io".to_owned(),
             ],
             ca_cert_pem: None,
             ca_key_pem: None,

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_trace_traffic.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/demo_trace_traffic.rs
@@ -98,7 +98,7 @@ where
         let method = req.method().clone();
         let uri = req.uri().clone();
 
-        let (app_bundle_id, pid, info) = req
+        let (app_bundle_id, pid, info, egress_interface, remote_hostname) = req
             .extensions()
             .get_ref::<TransparentProxyFlowMeta>()
             .map(|meta| {
@@ -112,7 +112,13 @@ where
                         })
                     })
                     .unwrap_or_default();
-                (app_bundle_id, maybe_pid, info)
+                (
+                    app_bundle_id,
+                    maybe_pid,
+                    info,
+                    meta.local_interface_name.as_deref(),
+                    meta.remote_hostname.as_deref(),
+                )
             })
             .unwrap_or_default();
         let process_path_display = info.path.as_deref().map(|p| p.display());
@@ -123,6 +129,8 @@ where
             pid,
             ?process_path_display,
             ?process_args,
+            egress_interface,
+            remote_hostname,
             "demo traffic logger: http ingress: {method} {uri}: request",
         );
 

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -4,10 +4,7 @@ use rama::{
     Service,
     bytes::Bytes,
     net::{
-        address::{
-            HostWithPort,
-            ip::{IpScopes, private::is_private_ip},
-        },
+        address::ip::{IpScopes, private::is_private_ip},
         apple::networkextension::{
             self as apple_ne,
             tproxy::{
@@ -53,11 +50,33 @@ fn init(config: Option<&apple_ne::ffi::tproxy::TransparentProxyInitConfig>) -> b
     init_status
 }
 
+/// Domains spliced *up-front* (born-spliced: claim + direct Swift splice, no
+/// Rust hop), keyed on the OS-provided destination hostname (`remote_hostname`,
+/// available before any TLS peek). Distinct from `exclude_domains`, which
+/// promote *after* the peek. A few common, easy-to-drive names here let a soak
+/// run exercise the born-spliced TCP path on demand — just
+/// `curl https://example.com/` in a loop.
+const BORN_SPLICE_DOMAINS: &[&str] = &["example.com", "example.org", "example.net", "neverssl.com"];
+
+/// `true` if `host` equals or is a subdomain of any suffix in `suffixes`.
+fn host_matches_suffix(host: &str, suffixes: &[&str]) -> bool {
+    suffixes
+        .iter()
+        .any(|s| host == *s || host.strip_suffix(s).is_some_and(|p| p.ends_with('.')))
+}
+
 #[inline(always)]
-fn flow_action_for_remote_endpoint(
-    remote_endpoint: Option<&HostWithPort>,
-) -> TransparentProxyFlowAction {
-    let Some(target) = remote_endpoint else {
+fn flow_action_for_flow(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
+    // Up-front born-splice by destination hostname (OS-provided, no TLS peek).
+    // For TCP, `Passthrough` now means claim + direct splice (born-spliced),
+    // not a flow-closing `return false`.
+    if let Some(host) = meta.remote_hostname.as_deref()
+        && host_matches_suffix(host, BORN_SPLICE_DOMAINS)
+    {
+        return TransparentProxyFlowAction::Passthrough;
+    }
+
+    let Some(target) = meta.remote_endpoint.as_ref() else {
         return TransparentProxyFlowAction::Passthrough;
     };
 
@@ -249,7 +268,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
     > + Send
     + '_ {
         log_new_flow("tcp", &meta);
-        let action = flow_action_for_remote_endpoint(meta.remote_endpoint.as_ref());
+        let action = flow_action_for_flow(&meta);
         let concurrency_limiter = self.concurrency_limiter.clone();
         let tcp_mitm_service = self.tcp_mitm_service.clone();
         std::future::ready(match action {
@@ -298,7 +317,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
         if meta.remote_endpoint.as_ref().map(|e| e.port) == Some(53) {
             return std::future::ready(FlowAction::Passthrough);
         }
-        let action = flow_action_for_remote_endpoint(meta.remote_endpoint.as_ref());
+        let action = flow_action_for_flow(&meta);
         let udp_service = self.udp_service.clone();
         std::future::ready(match action {
             TransparentProxyFlowAction::Intercept => FlowAction::Intercept {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -4,7 +4,10 @@ use rama::{
     Service,
     bytes::Bytes,
     net::{
-        address::{HostWithPort, ip::private::is_private_ip},
+        address::{
+            HostWithPort,
+            ip::{IpScopes, private::is_private_ip},
+        },
         apple::networkextension::{
             self as apple_ne,
             tproxy::{
@@ -142,10 +145,17 @@ impl DemoTransparentProxyHandler {
             });
         }
 
-        let proxy_config = TransparentProxyConfig::new().with_rules(vec![
-            TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Tcp),
-            TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Udp),
-        ]);
+        let proxy_config = TransparentProxyConfig::new()
+            .with_rules(vec![
+                TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Tcp),
+                TransparentProxyNetworkRule::any().with_protocol(TransparentProxyRuleProtocol::Udp),
+            ])
+            // Exclude non-loopback private/local ranges (RFC1918, link-local,
+            // CGNAT) at the kernel level: they take the default route untouched
+            // and are never diverted to the provider. This is the *correct*
+            // way to passthrough whole ranges — declining a flow in the handler
+            // closes it instead. Loopback is intentionally left handled.
+            .exclude_ip_scopes(IpScopes::LOCAL.difference(IpScopes::LOOPBACK));
 
         let concurrency_limiter =
             Arc::new(concurrency::ConcurrencyLimiter::new(Default::default()));

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -66,11 +66,16 @@ fn host_matches_suffix(host: &str, suffixes: &[&str]) -> bool {
 }
 
 #[inline(always)]
-fn flow_action_for_flow(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
+fn flow_action_for_flow(
+    meta: &TransparentProxyFlowMeta,
+    allow_born_splice: bool,
+) -> TransparentProxyFlowAction {
     // Up-front born-splice by destination hostname (OS-provided, no TLS peek).
-    // For TCP, `Passthrough` now means claim + direct splice (born-spliced),
-    // not a flow-closing `return false`.
-    if let Some(host) = meta.remote_hostname.as_deref()
+    // TCP-ONLY: for TCP, `Passthrough` means claim + direct splice (born-spliced).
+    // For UDP, `Passthrough` is still a `return false` that Apple CLOSES, so the
+    // hostname trigger must NOT apply there — it would kill UDP/QUIC flows.
+    if allow_born_splice
+        && let Some(host) = meta.remote_hostname.as_deref()
         && host_matches_suffix(host, BORN_SPLICE_DOMAINS)
     {
         return TransparentProxyFlowAction::Passthrough;
@@ -268,7 +273,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
     > + Send
     + '_ {
         log_new_flow("tcp", &meta);
-        let action = flow_action_for_flow(&meta);
+        let action = flow_action_for_flow(&meta, true); // TCP can born-splice
         let concurrency_limiter = self.concurrency_limiter.clone();
         let tcp_mitm_service = self.tcp_mitm_service.clone();
         std::future::ready(match action {
@@ -317,7 +322,9 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
         if meta.remote_endpoint.as_ref().map(|e| e.port) == Some(53) {
             return std::future::ready(FlowAction::Passthrough);
         }
-        let action = flow_action_for_flow(&meta);
+        // UDP cannot born-splice (no UDP splice path) — never trigger the
+        // hostname born-splice here, or UDP `Passthrough` would close the flow.
+        let action = flow_action_for_flow(&meta, false);
         let udp_service = self.udp_service.clone();
         std::future::ready(match action {
             TransparentProxyFlowAction::Intercept => FlowAction::Intercept {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -68,6 +68,22 @@ fn flow_action_for_remote_endpoint(
     }
 }
 
+/// One line per new flow surfacing the Apple NE interface metadata: egress
+/// interface (name/type/index/bound) and remote hostname, when the OS exposes them.
+fn log_new_flow(protocol: &str, meta: &TransparentProxyFlowMeta) {
+    tracing::info!(
+        protocol,
+        remote = ?meta.remote_endpoint,
+        remote_hostname = meta.remote_hostname.as_deref(),
+        egress_interface = meta.local_interface_name.as_deref(),
+        egress_interface_type = ?meta.local_interface_type,
+        egress_interface_index = ?meta.local_interface_index,
+        is_bound = ?meta.is_bound,
+        bundle_identifier = meta.source_app_bundle_identifier.as_deref(),
+        "transparent proxy: new flow",
+    );
+}
+
 #[derive(Clone, Copy, Default)]
 struct DemoEngineFactory;
 
@@ -222,6 +238,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
         >,
     > + Send
     + '_ {
+        log_new_flow("tcp", &meta);
         let action = flow_action_for_remote_endpoint(meta.remote_endpoint.as_ref());
         let concurrency_limiter = self.concurrency_limiter.clone();
         let tcp_mitm_service = self.tcp_mitm_service.clone();
@@ -264,6 +281,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
         Output = FlowAction<impl rama::Service<apple_ne::UdpFlow, Output = (), Error = Infallible>>,
     > + Send
     + '_ {
+        log_new_flow("udp", &meta);
         // Pass through DNS (port 53) — letting the system resolver
         // hit the wire directly avoids a circular dependency between
         // the proxy service and the resolver it might itself use.

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/policy.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/policy.rs
@@ -55,6 +55,23 @@ impl Default for DomainExclusionList {
             "*.gstatic.com",
             "*.cloudflare.com",
             "*.jsdelivr.net",
+            // More common high-traffic domains so a soak run drives the
+            // promote → Swift-splice → teardown path with heavy, realistic
+            // volume (kept in sync with `config::DemoProxyConfig::default`).
+            "*.apple.com",
+            "*.icloud.com",
+            "*.microsoft.com",
+            "*.azureedge.net",
+            "*.fastly.net",
+            "*.akamaized.net",
+            "*.amazonaws.com",
+            "*.cloudfront.net",
+            "*.google.com",
+            "*.googlevideo.com",
+            "*.slack-edge.com",
+            "registry.npmjs.org",
+            "*.pythonhosted.org",
+            "*.docker.io",
         ])
     }
 }

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -51,6 +51,30 @@ pub struct TransparentProxyFlowMeta {
     pub source_app_audit_token_bytes_len: usize,
     pub source_app_pid: i32,
     pub source_app_pid_is_set: bool,
+    /// Remote hostname the originating app connected to (the DNS name, not the
+    /// resolved IP), when the OS exposes it. `null` / `0` when absent.
+    pub remote_hostname_utf8: *const c_char,
+    /// Length of `remote_hostname_utf8`.
+    pub remote_hostname_utf8_len: usize,
+    /// Name of the network interface the flow egresses on (e.g. `en0`,
+    /// `utun4`), when known. `null` / `0` when absent.
+    pub local_interface_name_utf8: *const c_char,
+    /// Length of `local_interface_name_utf8`.
+    pub local_interface_name_utf8_len: usize,
+    /// Egress interface index. Only valid when `local_interface_index_is_set`.
+    pub local_interface_index: u32,
+    /// Whether `local_interface_index` is set.
+    pub local_interface_index_is_set: bool,
+    /// Egress interface type, as a [`NwInterfaceType`] discriminant. Only valid
+    /// when `local_interface_type_is_set`.
+    pub local_interface_type: u8,
+    /// Whether `local_interface_type` is set.
+    pub local_interface_type_is_set: bool,
+    /// Whether the app bound this flow to a specific interface. Only valid when
+    /// `is_bound_is_set`.
+    pub is_bound: bool,
+    /// Whether `is_bound` is set.
+    pub is_bound_is_set: bool,
 }
 
 #[repr(u32)]
@@ -97,6 +121,16 @@ impl TransparentProxyFlowMeta {
             source_app_audit_token.as_ref().map(AuditToken::pid)
         };
 
+        let local_interface_type = if self.local_interface_type_is_set {
+            interface_type_from_u8(self.local_interface_type)
+        } else {
+            None
+        };
+        let local_interface_index = self
+            .local_interface_index_is_set
+            .then_some(self.local_interface_index);
+        let is_bound = self.is_bound_is_set.then_some(self.is_bound);
+
         Ok(tproxy::TransparentProxyFlowMeta::new(protocol)
             .maybe_with_remote_endpoint(
                 // SAFETY: pointer + length validity is guaranteed by caller contract.
@@ -125,7 +159,25 @@ impl TransparentProxyFlowMeta {
                 },
             )
             .maybe_with_source_app_audit_token(source_app_audit_token)
-            .maybe_with_source_app_pid(source_app_pid))
+            .maybe_with_source_app_pid(source_app_pid)
+            .maybe_with_remote_hostname(
+                // SAFETY: pointer + length validity is guaranteed by caller contract.
+                unsafe {
+                    opt_utf8_to_boxed_str(self.remote_hostname_utf8, self.remote_hostname_utf8_len)
+                },
+            )
+            .maybe_with_local_interface_name(
+                // SAFETY: pointer + length validity is guaranteed by caller contract.
+                unsafe {
+                    opt_utf8_to_boxed_str(
+                        self.local_interface_name_utf8,
+                        self.local_interface_name_utf8_len,
+                    )
+                },
+            )
+            .maybe_with_local_interface_type(local_interface_type)
+            .maybe_with_local_interface_index(local_interface_index)
+            .maybe_with_is_bound(is_bound))
     }
 }
 
@@ -429,6 +481,21 @@ fn interface_type_to_u8(t: NwInterfaceType) -> u8 {
     }
 }
 
+/// Inverse of [`interface_type_to_u8`]: decode an FFI discriminant back into a
+/// [`NwInterfaceType`]. Returns `None` for unknown codes (fail-safe: the egress
+/// interface is simply treated as unknown rather than coerced). The Swift side
+/// is responsible for mapping `nw_interface_type_t` to these discriminants.
+fn interface_type_from_u8(raw: u8) -> Option<NwInterfaceType> {
+    match raw {
+        0 => Some(NwInterfaceType::Cellular),
+        1 => Some(NwInterfaceType::Loopback),
+        2 => Some(NwInterfaceType::Other),
+        3 => Some(NwInterfaceType::Wifi),
+        4 => Some(NwInterfaceType::Wired),
+        _ => None,
+    }
+}
+
 fn attribution_to_u8(a: NwAttribution) -> u8 {
     match a {
         NwAttribution::Developer => 0,
@@ -617,6 +684,20 @@ unsafe fn opt_utf8_to_non_empty_str(ptr: *const c_char, len: usize) -> Option<No
     raw.try_into().ok()
 }
 
+/// Copy a borrowed FFI string into an owned `Box<str>` (trimmed, non-empty),
+/// or `None` when the pointer is null / empty. Used for transient flow-meta
+/// strings the Swift side only keeps alive for the duration of the FFI call,
+/// so they must be copied out rather than borrowed.
+///
+/// # Safety
+///
+/// `ptr` must be null or readable for `len` bytes and contain UTF-8.
+unsafe fn opt_utf8_to_boxed_str(ptr: *const c_char, len: usize) -> Option<Box<str>> {
+    // SAFETY: pointer + length validity is guaranteed by caller contract.
+    let raw = unsafe { opt_utf8(ptr, len) }?;
+    Some(Box::from(raw))
+}
+
 /// # Safety
 ///
 /// `ptr` must be null or readable for `len` bytes and contain UTF-8.
@@ -660,14 +741,14 @@ mod tests {
 
     use crate::ffi::{BytesOwned, BytesOwnedView, BytesView};
     use crate::tproxy::{
-        self, TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
+        self, NwInterfaceType, TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
         TransparentProxyRuleProtocol,
     };
 
     use super::{
         NwEgressParameters, PromoteConfirmStatus, TransparentFlowEndpoint, TransparentProxyConfig,
         TransparentProxyFlowMeta, TransparentProxyInitConfig as FfiTransparentProxyInitConfig,
-        TransparentProxyNetworkRule as FfiTransparentProxyNetworkRule,
+        TransparentProxyNetworkRule as FfiTransparentProxyNetworkRule, interface_type_from_u8,
     };
 
     #[test]
@@ -766,7 +847,7 @@ mod tests {
         assert_eq!(offset_of!(TransparentFlowEndpoint, host_utf8_len), 8);
         assert_eq!(offset_of!(TransparentFlowEndpoint, port), 16);
 
-        assert_eq!(size_of::<TransparentProxyFlowMeta>(), 112);
+        assert_eq!(size_of::<TransparentProxyFlowMeta>(), 160);
         assert_eq!(offset_of!(TransparentProxyFlowMeta, protocol), 0);
         assert_eq!(offset_of!(TransparentProxyFlowMeta, remote_endpoint), 8);
         assert_eq!(offset_of!(TransparentProxyFlowMeta, source_app_pid), 104);
@@ -774,6 +855,19 @@ mod tests {
             offset_of!(TransparentProxyFlowMeta, source_app_pid_is_set),
             108
         );
+        assert_eq!(
+            offset_of!(TransparentProxyFlowMeta, remote_hostname_utf8),
+            112
+        );
+        assert_eq!(
+            offset_of!(TransparentProxyFlowMeta, local_interface_name_utf8),
+            128
+        );
+        assert_eq!(
+            offset_of!(TransparentProxyFlowMeta, local_interface_index),
+            144
+        );
+        assert_eq!(offset_of!(TransparentProxyFlowMeta, is_bound), 151);
 
         assert_eq!(size_of::<FfiTransparentProxyNetworkRule>(), 56);
         assert_eq!(
@@ -914,6 +1008,16 @@ mod tests {
             source_app_audit_token_bytes_len: 0,
             source_app_pid: 4242,
             source_app_pid_is_set: true,
+            remote_hostname_utf8: ptr::null(),
+            remote_hostname_utf8_len: 0,
+            local_interface_name_utf8: ptr::null(),
+            local_interface_name_utf8_len: 0,
+            local_interface_index: 0,
+            local_interface_index_is_set: false,
+            local_interface_type: 0,
+            local_interface_type_is_set: false,
+            is_bound: false,
+            is_bound_is_set: false,
         };
 
         // SAFETY: every pointer field is null with matching len 0 above, so
@@ -921,6 +1025,12 @@ mod tests {
         let owned = unsafe { meta.as_owned_rust_type() }.expect("known protocol decodes");
         assert_eq!(owned.source_app_pid, Some(4242));
         assert!(owned.source_app_audit_token.is_none());
+        // Unset interface / hostname fields decode to None.
+        assert!(owned.remote_hostname.is_none());
+        assert!(owned.local_interface_name.is_none());
+        assert!(owned.local_interface_type.is_none());
+        assert!(owned.local_interface_index.is_none());
+        assert!(owned.is_bound.is_none());
     }
 
     /// Unknown protocol values must surface as `Err(raw)` so the FFI
@@ -949,9 +1059,76 @@ mod tests {
             source_app_audit_token_bytes_len: 0,
             source_app_pid: 0,
             source_app_pid_is_set: false,
+            remote_hostname_utf8: ptr::null(),
+            remote_hostname_utf8_len: 0,
+            local_interface_name_utf8: ptr::null(),
+            local_interface_name_utf8_len: 0,
+            local_interface_index: 0,
+            local_interface_index_is_set: false,
+            local_interface_type: 0,
+            local_interface_type_is_set: false,
+            is_bound: false,
+            is_bound_is_set: false,
         };
         // SAFETY: same as above.
         let result = unsafe { meta.as_owned_rust_type() };
         assert_eq!(result.unwrap_err(), 0xDEAD_BEEF);
+    }
+
+    #[test]
+    fn flow_meta_decodes_interface_and_hostname() {
+        let hostname = "api.github.com";
+        let iface = "utun4";
+        let meta = TransparentProxyFlowMeta {
+            protocol: TransparentProxyFlowProtocol::Tcp.as_u32(),
+            remote_endpoint: TransparentFlowEndpoint {
+                host_utf8: ptr::null(),
+                host_utf8_len: 0,
+                port: 0,
+            },
+            local_endpoint: TransparentFlowEndpoint {
+                host_utf8: ptr::null(),
+                host_utf8_len: 0,
+                port: 0,
+            },
+            source_app_signing_identifier_utf8: ptr::null(),
+            source_app_signing_identifier_utf8_len: 0,
+            source_app_bundle_identifier_utf8: ptr::null(),
+            source_app_bundle_identifier_utf8_len: 0,
+            source_app_audit_token_bytes: ptr::null(),
+            source_app_audit_token_bytes_len: 0,
+            source_app_pid: 0,
+            source_app_pid_is_set: false,
+            remote_hostname_utf8: hostname.as_ptr().cast(),
+            remote_hostname_utf8_len: hostname.len(),
+            local_interface_name_utf8: iface.as_ptr().cast(),
+            local_interface_name_utf8_len: iface.len(),
+            local_interface_index: 14,
+            local_interface_index_is_set: true,
+            // 2 == NwInterfaceType::Other (utun/VPN tunnels report as "other").
+            local_interface_type: 2,
+            local_interface_type_is_set: true,
+            is_bound: true,
+            is_bound_is_set: true,
+        };
+
+        // SAFETY: the two utf8 fields point at the `hostname`/`iface` str
+        // literals (valid for this scope, matching lengths); all other
+        // pointers are null with len 0.
+        let owned = unsafe { meta.as_owned_rust_type() }.expect("known protocol decodes");
+        assert_eq!(owned.remote_hostname.as_deref(), Some("api.github.com"));
+        assert_eq!(owned.local_interface_name.as_deref(), Some("utun4"));
+        assert_eq!(owned.local_interface_type, Some(NwInterfaceType::Other));
+        assert_eq!(owned.local_interface_index, Some(14));
+        assert_eq!(owned.is_bound, Some(true));
+    }
+
+    #[test]
+    fn flow_meta_unknown_interface_type_decodes_to_none() {
+        // An out-of-range interface-type discriminant must fail safe to None
+        // rather than coerce into a valid variant.
+        assert!(interface_type_from_u8(2).is_some());
+        assert!(interface_type_from_u8(5).is_none());
+        assert!(interface_type_from_u8(255).is_none());
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/handler.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/handler.rs
@@ -38,6 +38,14 @@ where
     }
 }
 
+// `Intercept` is much larger than the unit variants (it carries the full
+// `TransparentProxyFlowMeta`), but this value is short-lived: it is produced per
+// flow by the matcher and consumed immediately. Boxing it would add a per-flow
+// heap allocation on the hot path for no real benefit, so allow the size skew.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "short-lived per-flow value; boxing would add a hot-path allocation"
+)]
 pub enum FlowAction<S> {
     Passthrough,
     Blocked,

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -4,6 +4,9 @@
 //!
 //! - [App proxy provider — Implement a VPN client for a flow-oriented, custom VPN protocol](https://developer.apple.com/documentation/NetworkExtension/app-proxy-provider)
 //! - [NETransparentProxyProvider](https://developer.apple.com/documentation/NetworkExtension/NETransparentProxyProvider)
+//! - [`handleNewFlow(_:)` — return `false` "indicates that the flow should be closed"](https://developer.apple.com/documentation/networkextension/neappproxyprovider/handlenewflow(_:))
+//! - [Apple DTS: returning `false` can fail the originating process; set up rules so you're not passed the flow (TCP)](https://developer.apple.com/forums/thread/716594)
+//! - [Apple DTS: transparent proxy UDP flows / not-handling a flow](https://developer.apple.com/forums/thread/690456)
 //!
 //! ## Re-entrant traffic deadlocks in flow handlers
 //!
@@ -73,6 +76,30 @@
 //! [`NwEgressParameters::allow_system_proxy`]. Scope is the
 //! SystemConfiguration proxy table only — other NE providers and VPN
 //! tunnels in the stack are unaffected.
+//!
+//! ## Declining a flow closes it — passthrough needs rule-exclusion or splicing
+//!
+//! Returning `false` from `handleNewFlow` / `handleNewUDPFlow` is **not** a
+//! clean hand-off to the default route. Apple documents it as "the flow should
+//! be closed" and DTS confirms it "can cause the flow's originating process to
+//! fail" — by the time the provider is asked, the flow is already diverted, and
+//! declining tears it down rather than re-injecting it. Whether the originating
+//! app survives is *not* deterministic: it depends on whether the system can
+//! re-home the flow on another path at that instant (e.g. a healthy VPN tunnel
+//! vs one mid-reassert after sleep/wake), which is why this bites intermittently
+//! on the same host/OS rather than always. Refs: the `handleNewFlow` docs +
+//! Apple DTS forum threads linked under *Tech Notes* above.
+//!
+//! There are therefore only two reliable ways to leave a flow untouched:
+//!
+//! - **`excludedNetworkRules`** — the flow is never diverted to the provider,
+//!   so it takes the default path with zero involvement. Correct for static,
+//!   remote-endpoint/CIDR-shaped exclusions (private ranges, known VPN infra).
+//! - **claim it and splice** — return `true`, open the flow, and forward bytes
+//!   verbatim to a direct egress connection (no MITM). The only option when the
+//!   decision is per-flow / per-app and can't be expressed as a static rule.
+//!
+//! Do **not** rely on returning `false` as a passthrough mechanism.
 //!
 //! [`HostWithPort`]: rama_net::address::HostWithPort
 //! [`NwEgressParameters::preserve_original_meta_data`]: types::NwEgressParameters::preserve_original_meta_data

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -2,7 +2,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use rama_core::extensions::Extension;
-use rama_net::address::{Host, HostWithPort};
+use rama_net::address::{
+    Host, HostWithPort,
+    ip::{IpScopes, ipnet::IpNet, scope_cidrs},
+};
 use rama_utils::{
     macros::generate_set_and_with,
     octets::kib,
@@ -523,6 +526,37 @@ impl TransparentProxyNetworkRule {
         self.exclude = true;
         self
     }
+
+    /// Set the remote network from a CIDR (IPv4 or IPv6), filling both the
+    /// network address and prefix length from a single [`IpNet`]. Host bits are
+    /// dropped — the rule matches the whole network.
+    #[must_use]
+    pub fn remote_net(mut self, net: impl Into<IpNet>) -> Self {
+        let net = net.into();
+        self.remote_network = Some(Host::from(net.network()));
+        self.remote_prefix = Some(net.prefix_len());
+        self
+    }
+
+    /// Build an "all traffic" rule restricted to the given remote CIDR.
+    #[must_use]
+    pub fn for_remote_net(net: impl Into<IpNet>) -> Self {
+        Self::any().remote_net(net)
+    }
+
+    /// One excluded rule per CIDR in the given [`IpScopes`] mask.
+    ///
+    /// Excluded rules are bypassed by the kernel and never reach the provider,
+    /// so the matching ranges take the default network path untouched. This is
+    /// the correct way to passthrough whole ranges: declining a flow in the
+    /// handler instead *closes* it (see the crate-level `tproxy` docs).
+    #[must_use]
+    pub fn excluded_for_ip_scopes(scopes: IpScopes) -> Vec<Self> {
+        scope_cidrs(scopes)
+            .into_iter()
+            .map(|net| Self::for_remote_net(net).excluded())
+            .collect()
+    }
 }
 
 /// Engine-level transparent proxy configuration.
@@ -606,6 +640,16 @@ impl TransparentProxyConfig {
         }
     }
 
+    /// Append excluded rules for every CIDR in `scopes`, so those ranges are
+    /// never diverted to the provider (true passthrough). See
+    /// [`TransparentProxyNetworkRule::excluded_for_ip_scopes`].
+    #[must_use]
+    pub fn exclude_ip_scopes(mut self, scopes: IpScopes) -> Self {
+        self.rules
+            .extend(TransparentProxyNetworkRule::excluded_for_ip_scopes(scopes));
+        self
+    }
+
     generate_set_and_with! {
         /// Set the per-flow TCP write-pump back-pressure cap.
         ///
@@ -685,6 +729,34 @@ mod transparent_proxy_config_tests {
             "TransparentProxyNetworkRule::any() must default to INCLUDED \
              (exclude=false). Flipping this default is a breaking change \
              that silently routes 0% of traffic through the proxy.",
+        );
+    }
+
+    #[test]
+    fn remote_net_sets_network_and_prefix() {
+        let net: IpNet = "10.1.2.3/8".parse().unwrap();
+        let r = TransparentProxyNetworkRule::for_remote_net(net);
+        // host bits dropped → network address
+        assert_eq!(
+            r.remote_network().map(ToString::to_string).as_deref(),
+            Some("10.0.0.0")
+        );
+        assert_eq!(r.remote_prefix(), Some(8));
+        assert!(!r.exclude());
+    }
+
+    #[test]
+    fn exclude_ip_scopes_appends_excluded_cidr_rules() {
+        let base = TransparentProxyConfig::new();
+        let base_len = base.rules().len();
+        let cfg = base.exclude_ip_scopes(IpScopes::LOCAL);
+        let added = &cfg.rules()[base_len..];
+        assert_eq!(added.len(), scope_cidrs(IpScopes::LOCAL).len());
+        assert!(
+            added
+                .iter()
+                .all(|r| r.exclude() && r.remote_prefix().is_some()),
+            "every scope-derived rule must be an excluded CIDR rule"
         );
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -767,6 +767,20 @@ pub struct TransparentProxyFlowMeta {
     pub source_app_audit_token: Option<AuditToken>,
     /// Process identifier resolved from the source-app audit token, if available.
     pub source_app_pid: Option<i32>,
+    /// Remote hostname the originating app connected to (DNS name, not the
+    /// resolved IP), if the OS exposed it for this flow.
+    pub remote_hostname: Option<Box<str>>,
+    /// Name of the network interface this flow egresses on (e.g. `en0`,
+    /// `utun4`), if known. The primary signal for detecting VPN/tunnel egress.
+    pub local_interface_name: Option<Box<str>>,
+    /// Type of the egress interface (wifi / wired / cellular / loopback /
+    /// other), if known.
+    pub local_interface_type: Option<NwInterfaceType>,
+    /// Index of the egress interface, if known.
+    pub local_interface_index: Option<u32>,
+    /// Whether the originating app bound this flow to a specific interface, if
+    /// known.
+    pub is_bound: Option<bool>,
 }
 
 impl TransparentProxyFlowMeta {
@@ -788,6 +802,11 @@ impl TransparentProxyFlowMeta {
             source_app_bundle_identifier: None,
             source_app_audit_token: None,
             source_app_pid: None,
+            remote_hostname: None,
+            local_interface_name: None,
+            local_interface_type: None,
+            local_interface_index: None,
+            is_bound: None,
         }
     }
 
@@ -841,6 +860,46 @@ impl TransparentProxyFlowMeta {
         /// Set source app pid.
         pub fn source_app_pid(mut self, value: Option<i32>) -> Self {
             self.source_app_pid = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the remote hostname the originating app connected to.
+        pub fn remote_hostname(mut self, value: Option<Box<str>>) -> Self {
+            self.remote_hostname = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the egress interface name.
+        pub fn local_interface_name(mut self, value: Option<Box<str>>) -> Self {
+            self.local_interface_name = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the egress interface type.
+        pub fn local_interface_type(mut self, value: Option<NwInterfaceType>) -> Self {
+            self.local_interface_type = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the egress interface index.
+        pub fn local_interface_index(mut self, value: Option<u32>) -> Self {
+            self.local_interface_index = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set whether the originating app bound this flow to a specific interface.
+        pub fn is_bound(mut self, value: Option<bool>) -> Self {
+            self.is_bound = value;
             self
         }
     }

--- a/rama-net-apple-networkextension/tests/promote_ffi_e2e.rs
+++ b/rama-net-apple-networkextension/tests/promote_ffi_e2e.rs
@@ -294,6 +294,16 @@ fn make_tcp_meta_pin() -> (RamaTransparentProxyFlowMeta, &'static [u8]) {
         source_app_audit_token_bytes_len: 0,
         source_app_pid: 4242,
         source_app_pid_is_set: true,
+        remote_hostname_utf8: std::ptr::null(),
+        remote_hostname_utf8_len: 0,
+        local_interface_name_utf8: std::ptr::null(),
+        local_interface_name_utf8_len: 0,
+        local_interface_index: 0,
+        local_interface_index_is_set: false,
+        local_interface_type: 0,
+        local_interface_type_is_set: false,
+        is_bound: false,
+        is_bound_is_set: false,
     };
     (meta, HOST)
 }

--- a/rama-net/Cargo.toml
+++ b/rama-net/Cargo.toml
@@ -48,6 +48,7 @@ dial9 = ["dep:dial9-tokio-telemetry", "dep:dial9-trace-format", "rama-core/dial9
 
 [dependencies]
 ahash = { workspace = true }
+bitflags = { workspace = true }
 const_format = { workspace = true }
 csv = { workspace = true }
 dial9-tokio-telemetry = { workspace = true, optional = true }

--- a/rama-net/src/address/ip/mod.rs
+++ b/rama-net/src/address/ip/mod.rs
@@ -17,6 +17,10 @@ pub mod ipnet {
 
 pub mod geo;
 pub mod private;
+pub mod scope;
+
+#[doc(inline)]
+pub use scope::{IpScopes, ip_scope, ipv4_scope, ipv6_scope, scope_cidrs};
 
 /// An IPv4 address with the address pointing to localhost: `127.0.0.1`
 pub const IPV4_LOCALHOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);

--- a/rama-net/src/address/ip/private.rs
+++ b/rama-net/src/address/ip/private.rs
@@ -65,19 +65,19 @@ pub fn is_private_ipv6(addr: Ipv6Addr) -> bool {
 // --- IPv4 Helpers ---
 
 #[inline(always)]
-fn is_ipv4_this_network(val: u32) -> bool {
+pub(super) fn is_ipv4_this_network(val: u32) -> bool {
     // RFC 791 / IANA "This network": 0.0.0.0/8.
     val & 0xFF00_0000 == 0x0000_0000
 }
 
 #[inline(always)]
-fn is_ipv4_shared(val: u32) -> bool {
+pub(super) fn is_ipv4_shared(val: u32) -> bool {
     // RFC 6598 shared address space: 100.64.0.0/10.
     val & 0xFFC0_0000 == 0x6440_0000
 }
 
 #[inline(always)]
-fn is_ipv4_protocol_assignments(val: u32) -> bool {
+pub(super) fn is_ipv4_protocol_assignments(val: u32) -> bool {
     // Conservatively cover only the clearly non-global allocations under
     // 192.0.0.0/24, leaving out the globally reachable anycast addresses
     // 192.0.0.9/32 and 192.0.0.10/32.
@@ -90,13 +90,13 @@ fn is_ipv4_protocol_assignments(val: u32) -> bool {
 }
 
 #[inline(always)]
-fn is_ipv4_benchmarking(val: u32) -> bool {
+pub(super) fn is_ipv4_benchmarking(val: u32) -> bool {
     // RFC 2544 benchmarking: 198.18.0.0/15.
     val & 0xFFFE_0000 == 0xC612_0000
 }
 
 #[inline(always)]
-fn is_ipv4_reserved(val: u32) -> bool {
+pub(super) fn is_ipv4_reserved(val: u32) -> bool {
     // IANA reserved/future-use block: 240.0.0.0/4.
     val & 0xF000_0000 == 0xF000_0000
 }
@@ -104,37 +104,37 @@ fn is_ipv4_reserved(val: u32) -> bool {
 // --- IPv6 Helpers ---
 
 #[inline(always)]
-fn is_ipv6_site_local(val: u128) -> bool {
+pub(super) fn is_ipv6_site_local(val: u128) -> bool {
     // fec0::/10 (Deprecated, but non-global)
     (val >> 118) == 0x03fb
 }
 
 #[inline(always)]
-fn is_ipv6_documentation(val: u128) -> bool {
+pub(super) fn is_ipv6_documentation(val: u128) -> bool {
     // 2001:db8::/32 (RFC 3849) or 3fff::/20 (RFC 9637)
     (val >> 96 == 0x2001_0db8) || (val >> 108 == 0x3fff0)
 }
 
 #[inline(always)]
-fn is_ipv6_benchmarking(val: u128) -> bool {
+pub(super) fn is_ipv6_benchmarking(val: u128) -> bool {
     // RFC 5180 benchmarking: 2001:2::/48.
     (val >> 80) == 0x2001_0002_0000
 }
 
 #[inline(always)]
-fn is_ipv6_discard_only(val: u128) -> bool {
+pub(super) fn is_ipv6_discard_only(val: u128) -> bool {
     // RFC 6666 discard-only prefix: 100::/64.
     (val >> 64) == 0x0100_0000_0000_0000
 }
 
 #[inline(always)]
-fn is_ipv6_dummy_prefix(val: u128) -> bool {
+pub(super) fn is_ipv6_dummy_prefix(val: u128) -> bool {
     // RFC 9780 dummy prefix: 100:0:0:1::/64.
     (val >> 64) == 0x0100_0000_0000_0001
 }
 
 #[inline(always)]
-fn is_ipv6_local_use_translation(val: u128) -> bool {
+pub(super) fn is_ipv6_local_use_translation(val: u128) -> bool {
     // RFC 8215 local-use translation prefix: 64:ff9b:1::/48.
     (val >> 80) == 0x0064_ff9b_0001
 }

--- a/rama-net/src/address/ip/scope.rs
+++ b/rama-net/src/address/ip/scope.rs
@@ -1,0 +1,358 @@
+//! Classify IP addresses into special-use [`IpScopes`] and enumerate the CIDR
+//! ranges that make up a scope.
+//!
+//! [`super::private::is_private_ip`] collapses every non-global range into a
+//! single bool. [`ip_scope`] keeps the categories apart, so callers can compose
+//! them with ordinary set algebra — the "a / b / a+b" question:
+//!
+//! ```
+//! use rama_net::address::ip::scope::{ip_scope, IpScopes};
+//!
+//! let ip = [127, 0, 0, 1];
+//! // loopback only
+//! assert_eq!(ip_scope(ip), IpScopes::LOOPBACK);
+//! // "private but not loopback" — PRIVATE and LOOPBACK are distinct bits
+//! assert!(!ip_scope(ip).contains(IpScopes::PRIVATE));
+//! // "private OR loopback"
+//! assert!(ip_scope(ip).intersects(IpScopes::PRIVATE | IpScopes::LOOPBACK));
+//! ```
+//!
+//! References:
+//! - <https://www.iana.org/assignments/iana-ipv4-special-registry/>
+//! - <https://www.iana.org/assignments/iana-ipv6-special-registry/>
+
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use super::ipnet::{IpNet, Ipv4Net, Ipv6Net};
+use super::private::{
+    is_ipv4_benchmarking, is_ipv4_protocol_assignments, is_ipv4_reserved, is_ipv4_shared,
+    is_ipv4_this_network, is_ipv6_benchmarking, is_ipv6_discard_only, is_ipv6_documentation,
+    is_ipv6_dummy_prefix, is_ipv6_local_use_translation, is_ipv6_site_local,
+};
+
+bitflags::bitflags! {
+    /// Special-use scope an IP address belongs to.
+    ///
+    /// [`ip_scope`] returns exactly one bit per address (the most specific
+    /// category, or [`IpScopes::GLOBAL`] for an ordinary public address). The
+    /// bits are meant to be combined into masks — see [`IpScopes::LOCAL`] and
+    /// [`IpScopes::NON_GLOBAL`] — so a caller can ask "is this in *any* of these
+    /// scopes?" with [`IpScopes::intersects`].
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct IpScopes: u16 {
+        /// Loopback: `127.0.0.0/8`, `::1`.
+        const LOOPBACK = 1 << 0;
+        /// RFC 1918 private (`10/8`, `172.16/12`, `192.168/16`) and IPv6
+        /// unique-local (`fc00::/7`).
+        const PRIVATE = 1 << 1;
+        /// Link-local: `169.254.0.0/16`, `fe80::/10`.
+        const LINK_LOCAL = 1 << 2;
+        /// RFC 6598 shared / CGNAT address space: `100.64.0.0/10`.
+        const SHARED = 1 << 3;
+        /// Unspecified / "this network": `0.0.0.0/8`, `::`.
+        const UNSPECIFIED = 1 << 4;
+        /// Multicast: `224.0.0.0/4`, `ff00::/8`.
+        const MULTICAST = 1 << 5;
+        /// Documentation ranges (e.g. `192.0.2.0/24`, `2001:db8::/32`).
+        const DOCUMENTATION = 1 << 6;
+        /// Benchmarking ranges (`198.18.0.0/15`, `2001:2::/48`).
+        const BENCHMARKING = 1 << 7;
+        /// Everything else that is non-global: reserved/future-use, broadcast,
+        /// protocol-assignment sub-ranges, deprecated site-local, and the v6
+        /// discard / dummy / local-use-translation prefixes.
+        const RESERVED = 1 << 8;
+        /// Ordinary, globally-routable public address (none of the above).
+        const GLOBAL = 1 << 15;
+    }
+}
+
+impl IpScopes {
+    /// Every scope except [`IpScopes::GLOBAL`] — i.e. exactly the set that
+    /// [`is_private_ip`](super::private::is_private_ip) treats as non-public.
+    pub const NON_GLOBAL: Self = Self::all().difference(Self::GLOBAL);
+
+    /// The local-network-ish scopes most commonly excluded from interception:
+    /// loopback, RFC 1918 private, link-local and CGNAT/shared.
+    pub const LOCAL: Self = Self::LOOPBACK
+        .union(Self::PRIVATE)
+        .union(Self::LINK_LOCAL)
+        .union(Self::SHARED);
+}
+
+/// Classify `addr` into the special-use [`IpScopes`] it belongs to.
+///
+/// Returns a single bit; [`IpScopes::GLOBAL`] for ordinary public addresses.
+#[inline]
+#[must_use]
+pub fn ip_scope(addr: impl Into<IpAddr>) -> IpScopes {
+    match addr.into() {
+        IpAddr::V4(addr) => ipv4_scope(addr),
+        IpAddr::V6(addr) => ipv6_scope(addr),
+    }
+}
+
+/// Classify an IPv4 address. See [`ip_scope`].
+#[must_use]
+pub fn ipv4_scope(addr: Ipv4Addr) -> IpScopes {
+    let val = u32::from(addr);
+
+    // Ordered most-specific first; the non-global ranges are disjoint except
+    // broadcast ⊂ reserved (both land in RESERVED), so order only affects which
+    // single bit is reported, never GLOBAL-vs-not.
+    if addr.is_loopback() {
+        IpScopes::LOOPBACK
+    } else if addr.is_private() {
+        IpScopes::PRIVATE
+    } else if is_ipv4_shared(val) {
+        IpScopes::SHARED
+    } else if addr.is_link_local() {
+        IpScopes::LINK_LOCAL
+    } else if is_ipv4_this_network(val) {
+        IpScopes::UNSPECIFIED
+    } else if is_ipv4_benchmarking(val) {
+        IpScopes::BENCHMARKING
+    } else if addr.is_documentation() {
+        IpScopes::DOCUMENTATION
+    } else if addr.is_multicast() {
+        IpScopes::MULTICAST
+    } else if is_ipv4_protocol_assignments(val) || addr.is_broadcast() || is_ipv4_reserved(val) {
+        IpScopes::RESERVED
+    } else {
+        IpScopes::GLOBAL
+    }
+}
+
+/// Classify an IPv6 address. See [`ip_scope`].
+#[must_use]
+pub fn ipv6_scope(addr: Ipv6Addr) -> IpScopes {
+    let val = u128::from(addr);
+
+    if addr.is_loopback() {
+        IpScopes::LOOPBACK
+    } else if addr.is_unspecified() {
+        IpScopes::UNSPECIFIED
+    } else if addr.is_multicast() {
+        IpScopes::MULTICAST
+    } else if addr.is_unicast_link_local() {
+        IpScopes::LINK_LOCAL
+    } else if addr.is_unique_local() {
+        IpScopes::PRIVATE
+    } else if is_ipv6_benchmarking(val) {
+        IpScopes::BENCHMARKING
+    } else if is_ipv6_documentation(val) {
+        IpScopes::DOCUMENTATION
+    } else if is_ipv6_site_local(val)
+        || is_ipv6_discard_only(val)
+        || is_ipv6_dummy_prefix(val)
+        || is_ipv6_local_use_translation(val)
+    {
+        IpScopes::RESERVED
+    } else {
+        IpScopes::GLOBAL
+    }
+}
+
+/// The CIDR ranges that make up the given `scopes` mask, across IPv4 and IPv6.
+///
+/// Intended for turning a scope mask into concrete network rules (e.g. excluding
+/// every local range from interception in one call). [`IpScopes::GLOBAL`] has no
+/// finite CIDR list and contributes nothing. Only the well-defined,
+/// rule-shaped ranges are emitted; partial/sparse sets (the v4
+/// protocol-assignment carve-outs) are intentionally omitted from
+/// [`IpScopes::RESERVED`] since they don't form a clean prefix.
+#[must_use]
+pub fn scope_cidrs(scopes: IpScopes) -> Vec<IpNet> {
+    // `new_assert` is infallible for the hardcoded, statically-valid prefixes
+    // below (and avoids the `unwrap`/`expect` clippy gate).
+    fn v4(a: [u8; 4], prefix: u8) -> IpNet {
+        IpNet::V4(Ipv4Net::new_assert(
+            Ipv4Addr::new(a[0], a[1], a[2], a[3]),
+            prefix,
+        ))
+    }
+    fn v6(addr: Ipv6Addr, prefix: u8) -> IpNet {
+        IpNet::V6(Ipv6Net::new_assert(addr, prefix))
+    }
+
+    let mut out = Vec::new();
+    if scopes.contains(IpScopes::LOOPBACK) {
+        out.push(v4([127, 0, 0, 0], 8));
+        out.push(v6(Ipv6Addr::LOCALHOST, 128));
+    }
+    if scopes.contains(IpScopes::PRIVATE) {
+        out.push(v4([10, 0, 0, 0], 8));
+        out.push(v4([172, 16, 0, 0], 12));
+        out.push(v4([192, 168, 0, 0], 16));
+        out.push(v6(Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0), 7)); // fc00::/7
+    }
+    if scopes.contains(IpScopes::LINK_LOCAL) {
+        out.push(v4([169, 254, 0, 0], 16));
+        out.push(v6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0), 10)); // fe80::/10
+    }
+    if scopes.contains(IpScopes::SHARED) {
+        out.push(v4([100, 64, 0, 0], 10));
+    }
+    if scopes.contains(IpScopes::UNSPECIFIED) {
+        out.push(v4([0, 0, 0, 0], 8));
+        out.push(v6(Ipv6Addr::UNSPECIFIED, 128));
+    }
+    if scopes.contains(IpScopes::MULTICAST) {
+        out.push(v4([224, 0, 0, 0], 4));
+        out.push(v6(Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0), 8)); // ff00::/8
+    }
+    if scopes.contains(IpScopes::DOCUMENTATION) {
+        out.push(v4([192, 0, 2, 0], 24));
+        out.push(v4([198, 51, 100, 0], 24));
+        out.push(v4([203, 0, 113, 0], 24));
+        out.push(v6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 0), 32)); // 2001:db8::/32
+    }
+    if scopes.contains(IpScopes::BENCHMARKING) {
+        out.push(v4([198, 18, 0, 0], 15));
+        out.push(v6(Ipv6Addr::new(0x2001, 0x2, 0, 0, 0, 0, 0, 0), 48)); // 2001:2::/48
+    }
+    if scopes.contains(IpScopes::RESERVED) {
+        out.push(v4([240, 0, 0, 0], 4));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::private::is_private_ip;
+    use super::*;
+
+    /// The scope classifier must agree with the existing `is_private_ip` bool:
+    /// non-global iff private. This pins `ip_scope` against the trusted
+    /// (heavily-tested) classifier without duplicating its case table.
+    #[test]
+    fn scope_non_global_matches_is_private_ip() {
+        let v4: &[[u8; 4]] = &[
+            [127, 0, 0, 1],
+            [10, 0, 0, 1],
+            [172, 16, 0, 1],
+            [192, 168, 1, 1],
+            [0, 1, 2, 3],
+            [100, 64, 0, 1],
+            [100, 63, 255, 255],
+            [169, 254, 1, 1],
+            [192, 0, 0, 8],
+            [192, 0, 0, 9],
+            [192, 0, 2, 1],
+            [198, 18, 0, 1],
+            [198, 51, 100, 1],
+            [224, 0, 0, 1],
+            [240, 0, 0, 1],
+            [255, 255, 255, 255],
+            [8, 8, 8, 8],
+            [1, 1, 1, 1],
+            [192, 88, 99, 1],
+        ];
+        for a in v4 {
+            let ip = IpAddr::from(*a);
+            assert_eq!(
+                ip_scope(ip).contains(IpScopes::GLOBAL),
+                !is_private_ip(ip),
+                "v4 {ip}: scope={:?}",
+                ip_scope(ip)
+            );
+            // exactly one bit is ever set
+            assert_eq!(
+                ip_scope(ip).bits().count_ones(),
+                1,
+                "v4 {ip} not single-bit"
+            );
+        }
+
+        let v6: &[&str] = &[
+            "::1",
+            "::",
+            "fc00::1",
+            "fe80::1",
+            "ff02::1",
+            "fec0::1",
+            "2001:db8::1",
+            "2001:2::1",
+            "100::1",
+            "64:ff9b:1::1",
+            "64:ff9b::1",
+            "2001:4860:4860::8888",
+            "2606:4700:4700::1111",
+        ];
+        for s in v6 {
+            let ip: IpAddr = s.parse().unwrap();
+            assert_eq!(
+                ip_scope(ip).contains(IpScopes::GLOBAL),
+                !is_private_ip(ip),
+                "v6 {ip}: scope={:?}",
+                ip_scope(ip)
+            );
+            assert_eq!(
+                ip_scope(ip).bits().count_ones(),
+                1,
+                "v6 {ip} not single-bit"
+            );
+        }
+    }
+
+    #[test]
+    fn scope_assigns_expected_categories() {
+        assert_eq!(ip_scope([127, 0, 0, 1]), IpScopes::LOOPBACK);
+        assert_eq!(ip_scope([10, 1, 2, 3]), IpScopes::PRIVATE);
+        assert_eq!(ip_scope([100, 64, 0, 1]), IpScopes::SHARED);
+        assert_eq!(ip_scope([169, 254, 0, 1]), IpScopes::LINK_LOCAL);
+        assert_eq!(ip_scope([224, 0, 0, 1]), IpScopes::MULTICAST);
+        assert_eq!(ip_scope([8, 8, 8, 8]), IpScopes::GLOBAL);
+        assert_eq!(
+            ip_scope("::1".parse::<IpAddr>().unwrap()),
+            IpScopes::LOOPBACK
+        );
+        assert_eq!(
+            ip_scope("fc00::1".parse::<IpAddr>().unwrap()),
+            IpScopes::PRIVATE
+        );
+        assert_eq!(
+            ip_scope("fe80::1".parse::<IpAddr>().unwrap()),
+            IpScopes::LINK_LOCAL
+        );
+    }
+
+    #[test]
+    fn masks_compose_as_expected() {
+        // "private but not loopback"
+        assert!(ip_scope([10, 0, 0, 1]).contains(IpScopes::PRIVATE));
+        assert!(!ip_scope([10, 0, 0, 1]).contains(IpScopes::LOOPBACK));
+        // LOCAL covers loopback/private/link-local/shared but not multicast/global
+        assert!(IpScopes::LOCAL.contains(ip_scope([127, 0, 0, 1])));
+        assert!(IpScopes::LOCAL.contains(ip_scope([100, 64, 0, 1])));
+        assert!(!IpScopes::LOCAL.intersects(ip_scope([224, 0, 0, 1])));
+        assert!(!IpScopes::LOCAL.intersects(ip_scope([8, 8, 8, 8])));
+        // NON_GLOBAL is the complement of GLOBAL
+        assert!(IpScopes::NON_GLOBAL.intersects(ip_scope([10, 0, 0, 1])));
+        assert!(!IpScopes::NON_GLOBAL.intersects(ip_scope([8, 8, 8, 8])));
+    }
+
+    #[test]
+    fn scope_cidrs_cover_their_members() {
+        let nets = scope_cidrs(IpScopes::LOCAL);
+        // every emitted CIDR must itself classify within LOCAL
+        for net in &nets {
+            assert!(
+                IpScopes::LOCAL.contains(ip_scope(net.network())),
+                "cidr {net} not LOCAL"
+            );
+        }
+        // a representative member of each LOCAL scope is contained by some cidr
+        for ip in [
+            IpAddr::from([10, 1, 2, 3]),
+            IpAddr::from([127, 0, 0, 5]),
+            IpAddr::from([169, 254, 9, 9]),
+            IpAddr::from([100, 100, 0, 1]),
+        ] {
+            assert!(
+                nets.iter().any(|n| n.contains(&ip)),
+                "no cidr contains {ip}"
+            );
+        }
+        assert!(scope_cidrs(IpScopes::GLOBAL).is_empty());
+    }
+}


### PR DESCRIPTION
Surfaces the egress interface (name/type/index + bound flag) and remote DNS hostname per flow across the NE FFI, and logs them in the transparent-proxy example.