### PR TITLE
uri: infallible PathPattern matcher + router rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ Package.resolved
 # internal docs
 docs/internal
 docs/audit
+
+# TNMT
+mutants.out/
+mutants.out.old/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,12 +2373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3796,7 +3790,6 @@ dependencies = [
  "iri-string",
  "itertools 0.15.0",
  "jiff",
- "matchit",
  "memchr",
  "mime_guess",
  "multer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,6 @@ jiff = { version = "0.2.29", features = ["serde"] }
 libc = "0.2"
 libfuzzer-sys = "0.4"
 loom = "0.7"
-matchit = "0.9"
 md5 = "0.8"
 memchr = "2.8"
 memmap2 = "0.9"

--- a/docs/book/src/gateway/fastcgi.md
+++ b/docs/book/src/gateway/fastcgi.md
@@ -127,7 +127,7 @@ embed it deep inside an otherwise normal HTTP service stack.
 Practical cases this unlocks:
 
 - **Hybrid server, FastCGI for one slice.** Run a regular rama HTTP server, but
-  route a subset of paths (e.g. `/admin/**` powered by PHP-FPM, or `/legacy/**`
+  route a subset of paths (e.g. `/admin/{*}` powered by PHP-FPM, or `/legacy/{*}`
   living behind an old FastCGI authorizer) into `FastCgiHttpClient` while the
   rest is served natively. Conditional [service branches](../intro/service_branches.md)
   on path or host make this a few extra lines.

--- a/examples/http_connect_proxy.rs
+++ b/examples/http_connect_proxy.rs
@@ -138,7 +138,7 @@ async fn main() {
                                     "lucky_number": path.number,
                                 }))
                             },
-                            HttpMatcher::get("/*") => async move |req: Request| {
+                            HttpMatcher::get("/{*}") => async move |req: Request| {
                                 Json(json!({
                                     "method": req.method().as_str(),
                                     "path": req.uri().path_or_root(),

--- a/examples/http_rate_limit.rs
+++ b/examples/http_rate_limit.rs
@@ -104,12 +104,12 @@ async fn main() {
                     ),
                     // you can also use options for the policy itself, in case you want to disable
                     // the limit for some
-                    (HttpMatcher::path("/admin/*"), None),
+                    (HttpMatcher::path("/admin/{*}"), None),
                     // test path so you can test also rate limiting on an http level
                     // > NOTE: as you can also make your own Matchers you can limit on w/e
                     // > property you want.
                     (
-                        HttpMatcher::path("/limit/*"),
+                        HttpMatcher::path("/limit/{*}"),
                         Some(Either::A(ConcurrentPolicy::max_with_backoff(
                             2,
                             Some(ExponentialBackoff::default()),
@@ -118,7 +118,7 @@ async fn main() {
                     // this one is the reason why we are using the (Vec<M, P>, P) approach from above,
                     // as we want to have a default policy for all other requests
                     (
-                        HttpMatcher::path("/api/*"),
+                        HttpMatcher::path("/api/{*}"),
                         Some(Either::B((
                             vec![
                                 (

--- a/examples/http_service_match.rs
+++ b/examples/http_service_match.rs
@@ -31,7 +31,7 @@ use rama::{
     http::{
         Request,
         layer::trace::TraceLayer,
-        matcher::{HttpMatcher, PathMatcher},
+        matcher::HttpMatcher,
         server::HttpServer,
         service::web::match_service,
         service::web::response::{Html, Json, Redirect},
@@ -72,7 +72,7 @@ async fn main() {
                 .into_layer(
                         match_service!{
                             HttpMatcher::get("/") => Html(r##"<h1>Home</h1><a href="/echo">Echo Request</a>"##.to_owned()),
-                            PathMatcher::new("/echo") => |req: Request| async move {
+                            HttpMatcher::path("/echo") => |req: Request| async move {
                                 Json(json!({
                                     "method": req.method().as_str(),
                                     "path": req.uri().path_or_root(),

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
@@ -1297,12 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
-
-[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,7 +2028,6 @@ dependencies = [
  "httpdate",
  "iri-string",
  "jiff",
- "matchit",
  "memchr",
  "mime_guess",
  "multer",

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -1439,12 +1439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8863b587001c1b9a8a4e36008cebc6b3612cb1226fe2de94858e06092687b608"
-
-[[package]]
 name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,7 +2357,6 @@ dependencies = [
  "httpdate",
  "iri-string",
  "jiff",
- "matchit",
  "memchr",
  "mime_guess",
  "multer",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -58,6 +58,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "path_matcher"
+path = "fuzz_targets/path_matcher.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "selector_parse"
 path = "fuzz_targets/selector_parse.rs"
 test = false

--- a/fuzz/fuzz_targets/path_matcher.rs
+++ b/fuzz/fuzz_targets/path_matcher.rs
@@ -49,7 +49,6 @@ fuzz_target!(|input: Input| {
             // to the first binding, so don't assert value equality here).
             assert!(caps.get(name).is_some());
         }
-        drop(caps.glob());
-        drop(caps.is_empty());
+        std::hint::black_box((caps.glob(), caps.is_empty()));
     }
 });

--- a/fuzz/fuzz_targets/path_matcher.rs
+++ b/fuzz/fuzz_targets/path_matcher.rs
@@ -1,0 +1,55 @@
+//! Fuzz target for [`rama_net::uri::PathPattern`].
+//!
+//! Goals: compilation and matching never panic on any pattern/path bytes
+//! (the matcher is infallible by contract), and the two match entry points
+//! stay consistent — `is_match` must agree with `captures().is_some()` for
+//! every input, since `is_match` takes an allocation-free fast path for
+//! capture-free patterns that must not diverge from the capturing path.
+//!
+//! Run with:
+//!     cargo +nightly fuzz run path_matcher
+#![no_main]
+
+use libfuzzer_sys::{
+    arbitrary::{self, Arbitrary},
+    fuzz_target,
+};
+use rama::net::uri::{PathMatchOptions, PathPattern, PathRef};
+
+#[derive(Arbitrary, Debug)]
+struct Input {
+    pattern: String,
+    path: String,
+    ignore_ascii_case: bool,
+    percent_decode: bool,
+}
+
+fuzz_target!(|input: Input| {
+    let opts = PathMatchOptions {
+        partial: false,
+        ignore_ascii_case: input.ignore_ascii_case,
+        percent_decode: input.percent_decode,
+    };
+    let pat = PathPattern::new_with_opts(input.pattern.as_str(), opts);
+    let path = PathRef::from_raw_str(&input.path);
+
+    let matched = pat.is_match(path);
+    let caps = pat.captures(path);
+    assert_eq!(
+        matched,
+        caps.is_some(),
+        "is_match vs captures disagree: pattern={:?} path={:?}",
+        input.pattern,
+        input.path,
+    );
+
+    if let Some(caps) = caps {
+        for (name, _value) in caps.iter() {
+            // Every iterated name must be resolvable (duplicate names resolve
+            // to the first binding, so don't assert value equality here).
+            assert!(caps.get(name).is_some());
+        }
+        drop(caps.glob());
+        drop(caps.is_empty());
+    }
+});

--- a/justfile
+++ b/justfile
@@ -14,6 +14,15 @@ export RUSTFLAGS := \
     } else { \
         "-D warnings --cfg tokio_unstable" \
     }
+# Mirror CI's doc job: rustdoc warnings (e.g. private intra-doc links) fail
+# locally too, unless ALLOW_WARNINGS=true. rustdoc reads RUSTDOCFLAGS, not
+# RUSTFLAGS, so it needs its own export.
+export RUSTDOCFLAGS := \
+    if env_var_or_default("ALLOW_WARNINGS", "false") == "true" { \
+        "" \
+    } else { \
+        "-D warnings" \
+    }
 export RUST_LOG := "debug"
 
 fmt *ARGS:

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -59,7 +59,6 @@ http-range-header = { workspace = true }
 httpdate = { workspace = true }
 iri-string = { workspace = true }
 jiff = { workspace = true }
-matchit = { workspace = true }
 memchr = { workspace = true, optional = true }
 mime_guess = { workspace = true, optional = true }
 multer = { workspace = true, optional = true }

--- a/rama-http/src/matcher/mod.rs
+++ b/rama-http/src/matcher/mod.rs
@@ -12,7 +12,6 @@ use rama_net::{
     stream::matcher::SocketMatcher,
     uri::PathPattern,
 };
-use rama_utils::str::arcstr::ArcStr;
 use rama_utils::thirdparty::{regex::Regex, wildcard::Wildcard};
 use std::fmt;
 use std::sync::Arc;
@@ -78,12 +77,6 @@ pub enum HttpMatcherKind<Body> {
     /// (`{name}` / `{*name}` captures, `{}` / `{*}` globs). Captures are
     /// recorded as [`UriParams`].
     Path(PathPattern),
-    /// Matches when the URI path begins with this prefix (segment-boundary,
-    /// case-insensitive).
-    PathPrefix(ArcStr),
-    /// Matches when the URI path equals this literal exactly (case-insensitive),
-    /// with metacharacters compared verbatim.
-    PathLiteral(ArcStr),
     /// [`DomainMatcher`], a matcher based on the (sub)domain of the request's URI.
     Domain(DomainMatcher),
     /// [`VersionMatcher`], a matcher based on the HTTP version of the request.
@@ -110,8 +103,6 @@ impl<Body> Clone for HttpMatcherKind<Body> {
             Self::All(inner) => Self::All(inner.clone()),
             Self::Method(inner) => Self::Method(*inner),
             Self::Path(inner) => Self::Path(inner.clone()),
-            Self::PathPrefix(inner) => Self::PathPrefix(inner.clone()),
-            Self::PathLiteral(inner) => Self::PathLiteral(inner.clone()),
             Self::Domain(inner) => Self::Domain(inner.clone()),
             Self::Version(inner) => Self::Version(*inner),
             Self::Any(inner) => Self::Any(inner.clone()),
@@ -130,8 +121,6 @@ impl<Body> fmt::Debug for HttpMatcherKind<Body> {
             Self::All(inner) => f.debug_tuple("All").field(inner).finish(),
             Self::Method(inner) => f.debug_tuple("Method").field(inner).finish(),
             Self::Path(inner) => f.debug_tuple("Path").field(inner).finish(),
-            Self::PathPrefix(inner) => f.debug_tuple("PathPrefix").field(inner).finish(),
-            Self::PathLiteral(inner) => f.debug_tuple("PathLiteral").field(inner).finish(),
             Self::Domain(inner) => f.debug_tuple("Domain").field(inner).finish(),
             Self::Version(inner) => f.debug_tuple("Version").field(inner).finish(),
             Self::Any(inner) => f.debug_tuple("Any").field(inner).finish(),
@@ -588,22 +577,14 @@ impl<Body> HttpMatcher<Body> {
         }
     }
 
-    /// Create a path matcher that matches a literal path exactly, with
-    /// brace tokens (`{name}`, …) compared verbatim rather than interpreted.
-    #[must_use]
-    pub fn path_literal(path: impl AsRef<str>) -> Self {
-        Self {
-            kind: HttpMatcherKind::PathLiteral(path::normalize(path.as_ref()).into()),
-            negate: false,
-        }
-    }
-
-    /// Create a path matcher that matches any path beginning with `path`
-    /// (matched at `/` segment boundaries, case-insensitive).
+    /// Create a path matcher that matches any path beginning with `path`,
+    /// matched at `/` segment boundaries (case-insensitive): `/api` matches
+    /// `/api` and `/api/users`, but not `/apixyz`. Compiles to a prefix-mode
+    /// [`PathPattern`], so `{name}` / `{*name}` captures are honored too.
     #[must_use]
     pub fn path_prefix(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpMatcherKind::PathPrefix(path::normalize(path.as_ref()).into()),
+            kind: HttpMatcherKind::Path(path::compile_prefix_pattern(path.as_ref())),
             negate: false,
         }
     }
@@ -983,8 +964,6 @@ where
             Self::All(all) => all.iter().matches_and(ext, req),
             Self::Method(method) => method.matches(ext, req),
             Self::Path(pattern) => path::match_pattern(pattern, ext, req.uri().path_or_root()),
-            Self::PathPrefix(prefix) => path::match_prefix(prefix, req.uri().path_or_root()),
-            Self::PathLiteral(literal) => path::match_literal(literal, req.uri().path_or_root()),
             Self::Domain(domain) => domain.matches(ext, req),
             Self::Version(version) => version.matches(ext, req),
             Self::Uri(uri) => uri.matches(ext, req),

--- a/rama-http/src/matcher/mod.rs
+++ b/rama-http/src/matcher/mod.rs
@@ -75,8 +75,8 @@ pub enum HttpMatcherKind<Body> {
     /// [`MethodMatcher`], a matcher that matches one or more HTTP methods.
     Method(MethodMatcher),
     /// A matcher based on the URI path, compiled from a [`PathPattern`]
-    /// (`:name` / `:name**` captures, `*` / `**` globs). Captures are recorded
-    /// as [`UriParams`].
+    /// (`{name}` / `{*name}` captures, `{}` / `{*}` globs). Captures are
+    /// recorded as [`UriParams`].
     Path(PathPattern),
     /// Matches when the URI path begins with this prefix (segment-boundary,
     /// case-insensitive).
@@ -578,20 +578,18 @@ impl<Body> HttpMatcher<Body> {
         self.or(Self::uri_wildcard(wc))
     }
 
-    /// Create a path matcher from a [`PathPattern`] (`:name` / `:name**`
-    /// captures, `*` / `**` globs; `{name}` / `{*name}` accepted as aliases).
+    /// Create a path matcher from a [`PathPattern`] (`{name}` / `{*name}`
+    /// captures, `{}` / `{*}` globs).
     #[must_use]
     pub fn path(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpMatcherKind::Path(path::compile_pattern(&path::translate_route_path(
-                path.as_ref(),
-            ))),
+            kind: HttpMatcherKind::Path(path::compile_pattern(path.as_ref())),
             negate: false,
         }
     }
 
     /// Create a path matcher that matches a literal path exactly, with
-    /// metacharacters (`*`, `:`, …) compared verbatim rather than interpreted.
+    /// brace tokens (`{name}`, …) compared verbatim rather than interpreted.
     #[must_use]
     pub fn path_literal(path: impl AsRef<str>) -> Self {
         Self {

--- a/rama-http/src/matcher/mod.rs
+++ b/rama-http/src/matcher/mod.rs
@@ -10,7 +10,9 @@ use rama_core::{extensions::Extensions, matcher::IteratorMatcherExt};
 use rama_net::{
     address::{AsDomainRef, Domain},
     stream::matcher::SocketMatcher,
+    uri::PathPattern,
 };
+use rama_utils::str::arcstr::ArcStr;
 use rama_utils::thirdparty::{regex::Regex, wildcard::Wildcard};
 use std::fmt;
 use std::sync::Arc;
@@ -30,9 +32,9 @@ mod version;
 #[doc(inline)]
 pub use version::VersionMatcher;
 
-mod path;
+pub(crate) mod path;
 #[doc(inline)]
-pub use path::{PathMatcher, UriParams, UriParamsDeserializeError};
+pub use path::{UriParams, UriParamsDeserializeError};
 
 mod header;
 #[doc(inline)]
@@ -72,8 +74,16 @@ pub enum HttpMatcherKind<Body> {
     All(Vec<HttpMatcher<Body>>),
     /// [`MethodMatcher`], a matcher that matches one or more HTTP methods.
     Method(MethodMatcher),
-    /// [`PathMatcher`], a matcher based on the URI path.
-    Path(PathMatcher),
+    /// A matcher based on the URI path, compiled from a [`PathPattern`]
+    /// (`:name` / `:name**` captures, `*` / `**` globs). Captures are recorded
+    /// as [`UriParams`].
+    Path(PathPattern),
+    /// Matches when the URI path begins with this prefix (segment-boundary,
+    /// case-insensitive).
+    PathPrefix(ArcStr),
+    /// Matches when the URI path equals this literal exactly (case-insensitive),
+    /// with metacharacters compared verbatim.
+    PathLiteral(ArcStr),
     /// [`DomainMatcher`], a matcher based on the (sub)domain of the request's URI.
     Domain(DomainMatcher),
     /// [`VersionMatcher`], a matcher based on the HTTP version of the request.
@@ -100,6 +110,8 @@ impl<Body> Clone for HttpMatcherKind<Body> {
             Self::All(inner) => Self::All(inner.clone()),
             Self::Method(inner) => Self::Method(*inner),
             Self::Path(inner) => Self::Path(inner.clone()),
+            Self::PathPrefix(inner) => Self::PathPrefix(inner.clone()),
+            Self::PathLiteral(inner) => Self::PathLiteral(inner.clone()),
             Self::Domain(inner) => Self::Domain(inner.clone()),
             Self::Version(inner) => Self::Version(*inner),
             Self::Any(inner) => Self::Any(inner.clone()),
@@ -118,6 +130,8 @@ impl<Body> fmt::Debug for HttpMatcherKind<Body> {
             Self::All(inner) => f.debug_tuple("All").field(inner).finish(),
             Self::Method(inner) => f.debug_tuple("Method").field(inner).finish(),
             Self::Path(inner) => f.debug_tuple("Path").field(inner).finish(),
+            Self::PathPrefix(inner) => f.debug_tuple("PathPrefix").field(inner).finish(),
+            Self::PathLiteral(inner) => f.debug_tuple("PathLiteral").field(inner).finish(),
             Self::Domain(inner) => f.debug_tuple("Domain").field(inner).finish(),
             Self::Version(inner) => f.debug_tuple("Version").field(inner).finish(),
             Self::Any(inner) => f.debug_tuple("Any").field(inner).finish(),
@@ -564,44 +578,45 @@ impl<Body> HttpMatcher<Body> {
         self.or(Self::uri_wildcard(wc))
     }
 
-    /// Create a [`PathMatcher`] matcher.
+    /// Create a path matcher from a [`PathPattern`] (`:name` / `:name**`
+    /// captures, `*` / `**` globs; `{name}` / `{*name}` accepted as aliases).
     #[must_use]
     pub fn path(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpMatcherKind::Path(PathMatcher::new(path)),
+            kind: HttpMatcherKind::Path(path::compile_pattern(&path::translate_route_path(
+                path.as_ref(),
+            ))),
             negate: false,
         }
     }
 
-    /// Create a [`PathMatcher`] matcher for literal.
+    /// Create a path matcher that matches a literal path exactly, with
+    /// metacharacters (`*`, `:`, …) compared verbatim rather than interpreted.
     #[must_use]
     pub fn path_literal(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpMatcherKind::Path(PathMatcher::new_literal(path)),
+            kind: HttpMatcherKind::PathLiteral(path::normalize(path.as_ref()).into()),
             negate: false,
         }
     }
 
-    /// Create a [`PathMatcher`] matcher for prefix.
+    /// Create a path matcher that matches any path beginning with `path`
+    /// (matched at `/` segment boundaries, case-insensitive).
     #[must_use]
     pub fn path_prefix(path: impl AsRef<str>) -> Self {
         Self {
-            kind: HttpMatcherKind::Path(PathMatcher::new_prefix(path)),
+            kind: HttpMatcherKind::PathPrefix(path::normalize(path.as_ref()).into()),
             negate: false,
         }
     }
 
-    /// Add a [`PathMatcher`] to match on top of the existing set of [`HttpMatcher`] matchers.
-    ///
-    /// See [`PathMatcher`] for more information.
+    /// Add a path matcher to match on top of the existing set of [`HttpMatcher`] matchers.
     #[must_use]
     pub fn and_path(self, path: impl AsRef<str>) -> Self {
         self.and(Self::path(path))
     }
 
-    /// Create a [`PathMatcher`] matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
-    ///
-    /// See [`PathMatcher`] for more information.
+    /// Create a path matcher to match as an alternative to the existing set of [`HttpMatcher`] matchers.
     #[must_use]
     pub fn or_path(self, path: impl AsRef<str>) -> Self {
         self.or(Self::path(path))
@@ -734,7 +749,7 @@ impl<Body> HttpMatcher<Body> {
         self.or(Self::socket(socket))
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a GET request.
+    /// Create a matcher to match for a GET request.
     #[must_use]
     pub fn get(path: impl AsRef<str>) -> Self {
         Self::method_get().and_path(path)
@@ -815,55 +830,55 @@ impl<Body> HttpMatcher<Body> {
         self.or(Self::any_subdomain(domains))
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a POST request.
+    /// Create a matcher to match for a POST request.
     #[must_use]
     pub fn post(path: impl AsRef<str>) -> Self {
         Self::method_post().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a PUT request.
+    /// Create a matcher to match for a PUT request.
     #[must_use]
     pub fn put(path: impl AsRef<str>) -> Self {
         Self::method_put().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a DELETE request.
+    /// Create a matcher to match for a DELETE request.
     #[must_use]
     pub fn delete(path: impl AsRef<str>) -> Self {
         Self::method_delete().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a PATCH request.
+    /// Create a matcher to match for a PATCH request.
     #[must_use]
     pub fn patch(path: impl AsRef<str>) -> Self {
         Self::method_patch().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a HEAD request.
+    /// Create a matcher to match for a HEAD request.
     #[must_use]
     pub fn head(path: impl AsRef<str>) -> Self {
         Self::method_head().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a OPTIONS request.
+    /// Create a matcher to match for a OPTIONS request.
     #[must_use]
     pub fn options(path: impl AsRef<str>) -> Self {
         Self::method_options().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a TRACE request.
+    /// Create a matcher to match for a TRACE request.
     #[must_use]
     pub fn trace(path: impl AsRef<str>) -> Self {
         Self::method_trace().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a CONNECT request.
+    /// Create a matcher to match for a CONNECT request.
     #[must_use]
     pub fn connect(path: impl AsRef<str>) -> Self {
         Self::method_connect().and_path(path)
     }
 
-    /// Create a [`PathMatcher`] matcher to match for a QUERY request.
+    /// Create a matcher to match for a QUERY request.
     #[must_use]
     pub fn query(path: impl AsRef<str>) -> Self {
         Self::method_query().and_path(path)
@@ -969,7 +984,9 @@ where
         match self {
             Self::All(all) => all.iter().matches_and(ext, req),
             Self::Method(method) => method.matches(ext, req),
-            Self::Path(path) => path.matches(ext, req),
+            Self::Path(pattern) => path::match_pattern(pattern, ext, req.uri().path_or_root()),
+            Self::PathPrefix(prefix) => path::match_prefix(prefix, req.uri().path_or_root()),
+            Self::PathLiteral(literal) => path::match_literal(literal, req.uri().path_or_root()),
             Self::Domain(domain) => domain.matches(ext, req),
             Self::Version(version) => version.matches(ext, req),
             Self::Uri(uri) => uri.matches(ext, req),

--- a/rama-http/src/matcher/path/mod.rs
+++ b/rama-http/src/matcher/path/mod.rs
@@ -1,26 +1,26 @@
-#![expect(
-    clippy::unreachable,
-    reason = "path-fragment branches gated on a `PathFragment::Literal` filter just above each unreachable arm"
-)]
+//! URI path parameters captured during routing, plus the helpers that bridge
+//! [`rama_net::uri::PathPattern`] matching into [`UriParams`].
+//!
+//! The matching engine itself lives in rama-net ([`PathPattern`]); this module
+//! owns the HTTP-routing glue: the `{name}` / `{*name}` syntax aliases, the
+//! case-insensitive match options, and turning [`PathCaptures`] into the
+//! [`UriParams`] extension the [`Path`](crate::service::web::extract::Path)
+//! extractor reads.
 
-use std::sync::Arc;
-
+use crate::StatusCode;
 use crate::service::web::response::IntoResponse;
-use crate::{Request, StatusCode};
 use ahash::{HashMap, HashMapExt as _};
 use rama_core::extensions::{Extension, Extensions};
-use rama_net::uri::util::percent_encoding;
-use rama_utils::collections::smallvec::SmallVec;
+use rama_net::uri::{PathCaptures, PathMatchOptions, PathPattern, PathRef};
 use rama_utils::str::arcstr::ArcStr;
-use rama_utils::str::smol_str::{StrExt as _, format_smolstr};
-use rama_utils::str::starts_with_ignore_ascii_case;
+use rama_utils::str::smol_str::format_smolstr;
 
 mod de;
 
 #[derive(Debug, Clone, Default, Extension)]
 #[extension(tags(http))]
 /// parameters that are inserted in the [`Extensions`],
-/// in case the [`PathMatcher`] found a match for the given [`Request`].
+/// in case a path matcher found a match for the given [`Request`](crate::Request).
 pub struct UriParams {
     params: Option<HashMap<ArcStr, ArcStr>>,
     glob: Option<ArcStr>,
@@ -99,6 +99,25 @@ impl UriParams {
             .into_iter()
             .flatten()
     }
+
+    /// Build [`UriParams`] from a successful [`PathPattern`] match: named
+    /// captures (incl. `:name**`) become params, the anonymous `**` glob (if
+    /// any) becomes the glob value.
+    pub(crate) fn from_captures(caps: &PathCaptures<'_, '_>) -> Self {
+        let mut params = Self::default();
+        for (name, value) in caps.iter() {
+            params.insert(ArcStr::from(name), ArcStr::from(value));
+        }
+        if let Some(glob) = caps.glob() {
+            params.append_glob(glob);
+        }
+        params
+    }
+
+    /// `true` when no named param and no glob were captured.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.glob.is_none() && self.params.as_ref().is_none_or(HashMap::is_empty)
+    }
 }
 
 impl<K, V> FromIterator<(K, V)> for UriParams
@@ -113,6 +132,88 @@ where
         }
         params
     }
+}
+
+/// Path-matching options used throughout HTTP routing: case-insensitive,
+/// percent-decoded, segment-boundary — mirrors the legacy matcher's behaviour.
+pub(crate) const HTTP_PATH_OPTS: PathMatchOptions = PathMatchOptions {
+    partial: false,
+    ignore_ascii_case: true,
+    percent_decode: true,
+};
+
+/// Compile `pattern` (in [`PathPattern`] syntax) with the HTTP routing options.
+pub(crate) fn compile_pattern(pattern: &str) -> PathPattern {
+    PathPattern::new_with_opts(pattern, HTTP_PATH_OPTS)
+}
+
+/// Translate router / [`HttpMatcher`](crate::matcher::HttpMatcher) path syntax
+/// into [`PathPattern`] syntax: `{name}` → `:name`, `{*name}` → `:name**`.
+/// Everything else — including native `:name`, `*`, `**`, and literals — passes
+/// through unchanged, so both spellings are accepted.
+pub(crate) fn translate_route_path(path: &str) -> String {
+    if !path.contains('{') {
+        return path.to_owned();
+    }
+    let mut out = String::with_capacity(path.len());
+    let mut rest = path;
+    while let Some(open) = rest.find('{') {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 1..];
+        if let Some(close) = after.find('}') {
+            let inner = &after[..close];
+            out.push(':');
+            if let Some(name) = inner.strip_prefix('*') {
+                out.push_str(name);
+                out.push_str("**");
+            } else {
+                out.push_str(inner);
+            }
+            rest = &after[close + 1..];
+        } else {
+            // Unbalanced `{` — keep it literal and move on.
+            out.push('{');
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Match `path` against a compiled [`PathPattern`], inserting the captured
+/// [`UriParams`] into `ext` on a successful match that bound anything.
+pub(crate) fn match_pattern(pattern: &PathPattern, ext: Option<&Extensions>, path: &str) -> bool {
+    match pattern.captures(PathRef::from_raw_str(path)) {
+        Some(caps) => {
+            if let Some(ext) = ext {
+                let params = UriParams::from_captures(&caps);
+                if !params.is_empty() {
+                    ext.insert(params);
+                }
+            }
+            true
+        }
+        None => false,
+    }
+}
+
+/// `true` when `path` begins with `prefix` at a segment boundary
+/// (case-insensitive, percent-decoded).
+pub(crate) fn match_prefix(prefix: &str, path: &str) -> bool {
+    PathRef::from_raw_str(path).has_prefix_with_opts(prefix, HTTP_PATH_OPTS)
+}
+
+/// `true` when `path` equals `literal` exactly (slashes trimmed,
+/// case-insensitive), with metacharacters compared verbatim.
+pub(crate) fn match_literal(literal: &str, path: &str) -> bool {
+    let path = path.trim().trim_matches('/');
+    literal.eq_ignore_ascii_case(path)
+}
+
+/// Normalise a path/prefix/literal the way the matchers store it: trimmed of
+/// surrounding whitespace and leading/trailing slashes.
+pub(crate) fn normalize(path: &str) -> &str {
+    path.trim().trim_matches('/')
 }
 
 #[derive(Debug)]
@@ -174,526 +275,49 @@ impl IntoResponse for UriParamsDeserializeError {
     }
 }
 
-#[derive(Debug, Clone)]
-enum PathFragment {
-    Literal(ArcStr),
-    Param(ArcStr),
-    Glob,
-}
-
-#[derive(Debug, Clone)]
-enum PathMatcherKind {
-    Prefix(ArcStr),
-    Literal(ArcStr),
-    FragmentList(std::sync::Arc<[PathFragment]>),
-}
-
-#[derive(Debug, Clone)]
-/// Matcher based on the URI path.
-pub struct PathMatcher {
-    kind: PathMatcherKind,
-}
-
-impl PathMatcher {
-    /// Create a new [`PathMatcher`] for the given path.
-    pub fn new(path: impl AsRef<str>) -> Self {
-        let path = path.as_ref();
-        let path = path.trim().trim_matches('/');
-
-        if !path.contains(['*', '{', '}']) {
-            return Self {
-                kind: PathMatcherKind::Literal(ArcStr::from(path)),
-            };
-        }
-
-        let path_parts: SmallVec<[_; 8]> = path.split('/').filter(|s| !s.is_empty()).collect();
-        let fragment_length = path_parts.len();
-        if fragment_length == 1 && path_parts[0].is_empty() {
-            return Self {
-                kind: PathMatcherKind::FragmentList(Arc::from([PathFragment::Glob])),
-            };
-        }
-
-        let fragments: SmallVec<[_; 8]> = path_parts
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, s)| {
-                if s.is_empty() {
-                    return None;
-                }
-                if s.starts_with(':') {
-                    Some(PathFragment::Param(ArcStr::from(
-                        s.trim_start_matches(':').to_lowercase_smolstr(),
-                    )))
-                } else if s.starts_with('{') && s.ends_with('}') && s.len() > 2 {
-                    let param_name = s[1..s.len() - 1].to_lowercase_smolstr();
-                    Some(PathFragment::Param(ArcStr::from(param_name)))
-                } else if s == "*" && index == fragment_length - 1 {
-                    Some(PathFragment::Glob)
-                } else {
-                    Some(PathFragment::Literal(ArcStr::from(
-                        s.to_lowercase_smolstr(),
-                    )))
-                }
-            })
-            .collect();
-
-        if fragments
-            .iter()
-            .all(|f| matches!(f, PathFragment::Literal(_)))
-        {
-            // optimization for pure literal paths..
-            return Self {
-                kind: PathMatcherKind::Literal(ArcStr::from(path)),
-            };
-        }
-
-        Self {
-            kind: PathMatcherKind::FragmentList(Arc::from(fragments.as_slice())),
-        }
-    }
-
-    /// Create a new [`PathMatcher`] for the given prefix.
-    pub fn new_prefix(path: impl AsRef<str>) -> Self {
-        let path = path.as_ref();
-        let path = path.trim().trim_matches('/');
-        Self {
-            kind: PathMatcherKind::Prefix(path.into()),
-        }
-    }
-
-    /// Create a new [`PathMatcher`] for the given literal.
-    ///
-    /// Useful constructor in case you want to create a literal
-    /// with special characters given [`Self::new`] would interpret
-    /// something like `/*` as a glob, while you might require a literal *...
-    pub fn new_literal(path: impl AsRef<str>) -> Self {
-        let path = path.as_ref();
-        let path = path.trim().trim_matches('/');
-        Self {
-            kind: PathMatcherKind::Literal(path.into()),
-        }
-    }
-
-    #[must_use]
-    pub fn fragment_count(&self) -> usize {
-        match &self.kind {
-            PathMatcherKind::Prefix(_) | PathMatcherKind::Literal(_) => 0,
-            PathMatcherKind::FragmentList(path_fragments) => path_fragments.len(),
-        }
-    }
-
-    /// Try to remove the literals that prefix other fragments. This can be useful
-    /// for routers which want to first match on a literal, and do the rest as a normal prefix.
-    ///
-    /// Err is returned with the original data in case it doesn't contain literal prefixes.
-    pub fn try_remove_literal_prefix(
-        self,
-        allow_glob: bool,
-    ) -> Result<(ArcStr, Option<Self>), Self> {
-        match self.kind {
-            PathMatcherKind::Literal(s) | PathMatcherKind::Prefix(s) => Ok((s, None)),
-            PathMatcherKind::FragmentList(fragments) => {
-                let mut pos = 0;
-                for fragment in fragments.iter() {
-                    if !matches!(fragment, PathFragment::Literal(_)) {
-                        break;
-                    }
-                    pos += 1;
-                }
-                if pos == 0 || pos == fragments.len() {
-                    return Err(Self {
-                        kind: PathMatcherKind::FragmentList(fragments),
-                    });
-                }
-                let (fragments, rem) = fragments.split_at(pos);
-
-                let mut output = String::with_capacity(
-                    fragments.len()
-                        + fragments
-                            .iter()
-                            .map(|f| match f {
-                                PathFragment::Literal(s) => s.len(),
-                                PathFragment::Param(_) | PathFragment::Glob => unreachable!(),
-                            })
-                            .sum::<usize>(),
-                );
-                for fragment in fragments {
-                    match fragment {
-                        PathFragment::Literal(s) => output.push_str(s.as_ref()),
-                        PathFragment::Param(_) | PathFragment::Glob => unreachable!(),
-                    }
-                }
-
-                Ok(if rem.is_empty() {
-                    (ArcStr::from(output), None)
-                } else if !allow_glob
-                    && rem
-                        .last()
-                        .map(|f| matches!(f, PathFragment::Glob))
-                        .unwrap_or_default()
-                {
-                    (
-                        ArcStr::from(output),
-                        Some(Self {
-                            kind: PathMatcherKind::FragmentList(Arc::from(&rem[..rem.len() - 1])),
-                        }),
-                    )
-                } else {
-                    (
-                        ArcStr::from(output),
-                        Some(Self {
-                            kind: PathMatcherKind::FragmentList(Arc::from(rem)),
-                        }),
-                    )
-                })
-            }
-        }
-    }
-
-    pub fn matches_path(&self, ext: Option<&Extensions>, path: impl AsRef<str>) -> bool {
-        match self.matches_path_inner(path) {
-            PathMatch::None => false,
-            PathMatch::Literal => true,
-            PathMatch::WithParams(params) => {
-                if let Some(ext) = ext {
-                    ext.insert(params);
-                }
-                true
-            }
-        }
-    }
-
-    fn matches_path_inner(&self, path: impl AsRef<str>) -> PathMatch {
-        let path = path.as_ref().trim().trim_matches('/');
-        match &self.kind {
-            PathMatcherKind::Prefix(prefix) => {
-                if prefix.is_empty() || starts_with_ignore_ascii_case(path, prefix) {
-                    PathMatch::Literal
-                } else {
-                    PathMatch::None
-                }
-            }
-            PathMatcherKind::Literal(literal) => {
-                if literal.eq_ignore_ascii_case(path) {
-                    PathMatch::Literal
-                } else {
-                    PathMatch::None
-                }
-            }
-            PathMatcherKind::FragmentList(fragments) => {
-                let fragments_iter = fragments.iter().map(Some).chain(std::iter::repeat(None));
-                let mut params = UriParams::default();
-                for (segment, fragment) in path
-                    .split('/')
-                    .map(Some)
-                    .chain(std::iter::repeat(None))
-                    .zip(fragments_iter)
-                {
-                    match (segment, fragment) {
-                        (Some(segment), Some(fragment)) => match fragment {
-                            PathFragment::Literal(literal) => {
-                                if !literal.eq_ignore_ascii_case(segment) {
-                                    return PathMatch::None;
-                                }
-                            }
-                            PathFragment::Param(name) => {
-                                if segment.is_empty() {
-                                    return PathMatch::None;
-                                }
-                                let segment = percent_encoding::percent_decode(segment.as_bytes())
-                                    .decode_utf8()
-                                    .map(Into::into)
-                                    .unwrap_or_else(|_| segment.into());
-                                params.insert(name.clone(), segment);
-                            }
-                            PathFragment::Glob => {
-                                params.append_glob(segment);
-                            }
-                        },
-                        (None, None) => {
-                            break;
-                        }
-                        (Some(segment), None) => {
-                            if params.glob().is_none() {
-                                return PathMatch::None;
-                            }
-                            params.append_glob(segment);
-                        }
-                        _ => {
-                            return PathMatch::None;
-                        }
-                    }
-                }
-
-                PathMatch::WithParams(params)
-            }
-        }
-    }
-}
-
-impl<Body> rama_core::matcher::Matcher<Request<Body>> for PathMatcher {
-    fn matches(&self, ext: Option<&Extensions>, req: &Request<Body>) -> bool {
-        self.matches_path(ext, req.uri().path_or_root())
-    }
-}
-
-#[derive(Debug, Clone)]
-enum PathMatch {
-    None,
-    Literal,
-    WithParams(UriParams),
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use rama_utils::str::arcstr::arcstr;
 
     #[test]
-    fn test_path_matcher_match_path() {
-        struct TestCase {
-            path: &'static str,
-            matcher_path: &'static str,
-            result: PathMatch,
-        }
-
-        impl TestCase {
-            fn some(
-                path: &'static str,
-                matcher_path: &'static str,
-                result: Option<UriParams>,
-            ) -> Self {
-                Self {
-                    path,
-                    matcher_path,
-                    result: result
-                        .map(PathMatch::WithParams)
-                        .unwrap_or(PathMatch::Literal),
-                }
-            }
-
-            fn none(path: &'static str, matcher_path: &'static str) -> Self {
-                Self {
-                    path,
-                    matcher_path,
-                    result: PathMatch::None,
-                }
-            }
-        }
-
-        let test_cases = vec![
-            TestCase::some("/", "/", None),
-            TestCase::some("", "/", None),
-            TestCase::some("/", "", None),
-            TestCase::some("", "", None),
-            TestCase::some("/foo", "/foo", None),
-            TestCase::some("/foo", "//foo//", None),
-            TestCase::some("/*foo", "/*foo", None),
-            TestCase::some("/foo/*bar/baz", "/foo/*bar/baz", None),
-            TestCase::none("/foo/*bar/baz", "/foo/*bar"),
-            TestCase::none("/", "/{foo}"),
-            TestCase::some(
-                "/",
-                "/*",
-                Some(UriParams {
-                    glob: Some(ArcStr::from("/")),
-                    ..UriParams::default()
-                }),
-            ),
-            TestCase::none("/", "//{foo}"),
-            TestCase::none("", "/{foo}"),
-            TestCase::none("/foo", "/bar"),
-            TestCase::some(
-                "/person/glen%20dc/age",
-                "/person/{name}/age",
-                Some(UriParams {
-                    params: Some({
-                        let mut params = HashMap::new();
-                        params.insert(arcstr!("name"), arcstr!("glen dc"));
-                        params
-                    }),
-                    ..UriParams::default()
-                }),
-            ),
-            TestCase::none("/foo", "/bar"),
-            TestCase::some("/foo", "foo", None),
-            TestCase::some("/foo/bar/", "foo/bar", None),
-            TestCase::none("/foo/bar/", "foo/baz"),
-            TestCase::some("/foo/bar/", "/foo/bar", None),
-            TestCase::some("/foo/bar", "/foo/bar", None),
-            TestCase::some("/foo/bar", "foo/bar", None),
-            TestCase::some("/book/oxford-dictionary/author", "/book/{title}/author", {
-                let mut params = UriParams::default();
-                params.insert(arcstr!("title"), arcstr!("oxford-dictionary"));
-                Some(params)
-            }),
-            TestCase::some("/book/oxford-dictionary/author", "/book/{title}/author", {
-                let mut params = UriParams::default();
-                params.insert(arcstr!("title"), arcstr!("oxford-dictionary"));
-                Some(params)
-            }),
-            TestCase::some(
-                "/book/oxford-dictionary/author/0",
-                "/book/{title}/author/{index}",
-                {
-                    let mut params = UriParams::default();
-                    params.insert(arcstr!("title"), arcstr!("oxford-dictionary"));
-                    params.insert(arcstr!("index"), arcstr!("0"));
-                    Some(params)
-                },
-            ),
-            TestCase::some(
-                "/book/oxford-dictionary/author/1",
-                "/book/{title}/author/{index}",
-                {
-                    let mut params = UriParams::default();
-                    params.insert(arcstr!("title"), arcstr!("oxford-dictionary"));
-                    params.insert(arcstr!("index"), arcstr!("1"));
-                    Some(params)
-                },
-            ),
-            TestCase::none("/book/oxford-dictionary", "/book/{title}/author"),
-            TestCase::none(
-                "/book/oxford-dictionary/author/birthdate",
-                "/book/{title}/author",
-            ),
-            TestCase::none("oxford-dictionary/author", "/book/{title}/author"),
-            TestCase::none("/foo", "/"),
-            TestCase::none("/foo", "/*f"),
-            TestCase::some(
-                "/foo",
-                "/*",
-                Some(UriParams {
-                    glob: Some("/foo".into()),
-                    ..UriParams::default()
-                }),
-            ),
-            TestCase::some(
-                "/assets/css/reset.css",
-                "/assets/*",
-                Some(UriParams {
-                    glob: Some("/css/reset.css".into()),
-                    ..UriParams::default()
-                }),
-            ),
-            TestCase::some("/assets/eu/css/reset.css", "/assets/{local}/*", {
-                let mut params = UriParams::default();
-                params.insert(arcstr!("local"), arcstr!("eu"));
-                params.glob = Some("/css/reset.css".into());
-                Some(params)
-            }),
-            TestCase::some("/assets/eu/css/reset.css", "/assets/:local/css/*", {
-                let mut params = UriParams::default();
-                params.insert(arcstr!("local"), arcstr!("eu"));
-                params.glob = Some("/reset.css".into());
-                Some(params)
-            }),
-        ];
-        for test_case in test_cases.into_iter() {
-            let matcher = PathMatcher::new(test_case.matcher_path);
-            let result = matcher.matches_path_inner(test_case.path);
-            match (result.clone(), test_case.result.clone()) {
-                (PathMatch::None, PathMatch::None) | (PathMatch::Literal, PathMatch::Literal) => (),
-                (PathMatch::WithParams(result), PathMatch::WithParams(expected_result)) => {
-                    assert_eq!(
-                        result.params,
-                        expected_result.params,
-                        "unexpected result params: ({:?})({}).matcher({}) => {:?} != {:?}",
-                        matcher,
-                        test_case.matcher_path,
-                        test_case.path,
-                        result.params,
-                        expected_result.params,
-                    );
-                    assert_eq!(
-                        result.glob,
-                        expected_result.glob,
-                        "unexpected result glob: ({:?})({}).matcher({}) => {:?} != {:?}",
-                        matcher,
-                        test_case.matcher_path,
-                        test_case.path,
-                        result.glob,
-                        expected_result.glob,
-                    );
-                }
-                _ => {
-                    panic!(
-                        "unexpected result: ({:?})({}).matcher({}) => {:?} != {:?}",
-                        matcher, test_case.matcher_path, test_case.path, result, test_case.result
-                    )
-                }
-            }
-        }
+    fn translate_route_syntax() {
+        assert_eq!(translate_route_path("/users/{id}"), "/users/:id");
+        assert_eq!(translate_route_path("/assets/{*path}"), "/assets/:path**");
+        assert_eq!(
+            translate_route_path("/users/{user_id}/orders/{order_id}"),
+            "/users/:user_id/orders/:order_id"
+        );
+        // Native syntax passes through.
+        assert_eq!(translate_route_path("/users/:id/x"), "/users/:id/x");
+        assert_eq!(translate_route_path("/a/**"), "/a/**");
     }
 
     #[test]
-    fn test_path_matcher_match_path_literal() {
-        for (prefix, path, is_match) in [
-            ("", "", true),
-            ("/", "/", true),
-            ("/", "", true),
-            ("", "/", true),
-            ("/foo", "/", false),
-            ("/foo", "", false),
-            ("/", "/foo", false),
-            ("", "/foo", false),
-            ("/foo", "/foo", true),
-            ("/*/foo", "/*/foo", true),
-            ("/*/foo", "/*/foo/", true),
-            ("/*/foo/", "/*/foo/", true),
-            ("/*/foo/", "/*/foo", true),
-            ("/*/foo/", "/bar/foo", false),
-            ("/bar/foo/", "/bar/foo/baz", false),
-            ("/bar/foo", "/bar/foo/baz", false),
-            ("/bar/foo*", "/bar/foo/baz", false),
-            ("/FoO/42", "/foo/42/1", false),
-            ("/FoO/42", "/foo/42/", true),
-        ] {
-            let matcher = PathMatcher::new_literal(prefix);
-            match (matcher.matches_path_inner(path), is_match) {
-                (PathMatch::Literal, true) | (PathMatch::None, false) => (),
-                (result, is_match) => {
-                    panic!(
-                        "unexpected result for path '{path}: {result:?} (is_match: {is_match}); matcher = {matcher:?}"
-                    );
-                }
-            }
-        }
+    fn pattern_captures_into_uri_params() {
+        let pat = compile_pattern(&translate_route_path("/users/{id}"));
+        let ext = Extensions::new();
+        assert!(match_pattern(&pat, Some(&ext), "/users/glen%20dc"));
+        let params = ext.get_ref::<UriParams>().unwrap();
+        assert_eq!(params.get("id"), Some("glen dc"));
+
+        // Named catch-all is read as a normal param.
+        let pat = compile_pattern(&translate_route_path("/assets/{*path}"));
+        let ext = Extensions::new();
+        assert!(match_pattern(&pat, Some(&ext), "/assets/css/app.css"));
+        assert_eq!(
+            ext.get_ref::<UriParams>().unwrap().get("path"),
+            Some("css/app.css")
+        );
     }
 
     #[test]
-    fn test_path_matcher_match_path_prefix() {
-        for (prefix, path, is_match) in [
-            ("", "", true),
-            ("/", "/", true),
-            ("/", "", true),
-            ("", "/", true),
-            ("/foo", "/", false),
-            ("/foo", "", false),
-            ("/", "/foo", true),
-            ("", "/foo", true),
-            ("/foo", "/foo", true),
-            ("/*/foo", "/*/foo", true),
-            ("/*/foo", "/*/foo/", true),
-            ("/*/foo/", "/*/foo/", true),
-            ("/*/foo/", "/*/foo", true),
-            ("/*/foo/", "/bar/foo", false),
-            ("/bar/foo/", "/bar/foo/baz", true),
-            ("/bar/foo", "/bar/foo/baz", true),
-            ("/bar/foo*", "/bar/foo/baz", false),
-            ("/FoO/42", "/foo/42/1", true),
-        ] {
-            let matcher = PathMatcher::new_prefix(prefix);
-            match (matcher.matches_path_inner(path), is_match) {
-                (PathMatch::Literal, true) | (PathMatch::None, false) => (),
-                (result, is_match) => {
-                    panic!(
-                        "unexpected result for path '{path}: {result:?} (is_match: {is_match}); matcher = {matcher:?}"
-                    );
-                }
-            }
-        }
+    fn prefix_and_literal() {
+        assert!(match_prefix("api", "/api/users"));
+        assert!(match_prefix("api", "/api"));
+        assert!(!match_prefix("api", "/apixyz"));
+        assert!(match_literal("foo/bar", "/foo/bar/"));
+        assert!(!match_literal("foo/bar", "/foo/baz"));
     }
 
     #[test]

--- a/rama-http/src/matcher/path/mod.rs
+++ b/rama-http/src/matcher/path/mod.rs
@@ -147,6 +147,13 @@ pub(crate) fn compile_pattern(pattern: &str) -> PathPattern {
     PathPattern::new_with_opts(pattern, HTTP_PATH_OPTS)
 }
 
+/// Compile a prefix matcher (in [`PathPattern`] syntax) with the HTTP routing
+/// options: matches a leading run of segments, ignoring trailing segments and
+/// the trailing slash. So `/api` matches `/api` and `/api/users`.
+pub(crate) fn compile_prefix_pattern(prefix: &str) -> PathPattern {
+    PathPattern::new_prefix_with_opts(normalize(prefix), HTTP_PATH_OPTS)
+}
+
 /// Match `path` against a compiled [`PathPattern`], inserting the captured
 /// [`UriParams`] into `ext` on a successful match that bound anything.
 pub(crate) fn match_pattern(pattern: &PathPattern, ext: Option<&Extensions>, path: &str) -> bool {
@@ -164,22 +171,9 @@ pub(crate) fn match_pattern(pattern: &PathPattern, ext: Option<&Extensions>, pat
     }
 }
 
-/// `true` when `path` begins with `prefix` at a segment boundary
-/// (case-insensitive, percent-decoded).
-pub(crate) fn match_prefix(prefix: &str, path: &str) -> bool {
-    PathRef::from_raw_str(path).has_prefix_with_opts(prefix, HTTP_PATH_OPTS)
-}
-
-/// `true` when `path` equals `literal` exactly (slashes trimmed,
-/// case-insensitive), with metacharacters compared verbatim.
-pub(crate) fn match_literal(literal: &str, path: &str) -> bool {
-    let path = path.trim().trim_matches('/');
-    literal.eq_ignore_ascii_case(path)
-}
-
-/// Normalise a path/prefix/literal the way the matchers store it: trimmed of
-/// surrounding whitespace and leading/trailing slashes.
-pub(crate) fn normalize(path: &str) -> &str {
+/// Normalise a prefix the way the matcher stores it: trimmed of surrounding
+/// whitespace and leading/trailing slashes.
+fn normalize(path: &str) -> &str {
     path.trim().trim_matches('/')
 }
 
@@ -266,12 +260,13 @@ mod test {
     }
 
     #[test]
-    fn prefix_and_literal() {
-        assert!(match_prefix("api", "/api/users"));
-        assert!(match_prefix("api", "/api"));
-        assert!(!match_prefix("api", "/apixyz"));
-        assert!(match_literal("foo/bar", "/foo/bar/"));
-        assert!(!match_literal("foo/bar", "/foo/baz"));
+    fn prefix_pattern_glue() {
+        let api = compile_prefix_pattern("/api");
+        assert!(api.is_match(PathRef::from_raw_str("/api")));
+        assert!(api.is_match(PathRef::from_raw_str("/api/users")));
+        assert!(!api.is_match(PathRef::from_raw_str("/apixyz")));
+        // case-insensitive via HTTP_PATH_OPTS
+        assert!(api.is_match(PathRef::from_raw_str("/API/users")));
     }
 
     #[test]

--- a/rama-http/src/matcher/path/mod.rs
+++ b/rama-http/src/matcher/path/mod.rs
@@ -1,11 +1,11 @@
 //! URI path parameters captured during routing, plus the helpers that bridge
 //! [`rama_net::uri::PathPattern`] matching into [`UriParams`].
 //!
-//! The matching engine itself lives in rama-net ([`PathPattern`]); this module
-//! owns the HTTP-routing glue: the `{name}` / `{*name}` syntax aliases, the
-//! case-insensitive match options, and turning [`PathCaptures`] into the
-//! [`UriParams`] extension the [`Path`](crate::service::web::extract::Path)
-//! extractor reads.
+//! The matching engine itself lives in rama-net ([`PathPattern`]), whose
+//! `{name}` / `{*name}` brace syntax is used directly by HTTP routing; this
+//! module owns the routing glue: the case-insensitive match options and
+//! turning [`PathCaptures`] into the [`UriParams`] extension the
+//! [`Path`](crate::service::web::extract::Path) extractor reads.
 
 use crate::StatusCode;
 use crate::service::web::response::IntoResponse;
@@ -101,7 +101,7 @@ impl UriParams {
     }
 
     /// Build [`UriParams`] from a successful [`PathPattern`] match: named
-    /// captures (incl. `:name**`) become params, the anonymous `**` glob (if
+    /// captures (incl. `{*name}`) become params, the anonymous `{*}` glob (if
     /// any) becomes the glob value.
     pub(crate) fn from_captures(caps: &PathCaptures<'_, '_>) -> Self {
         let mut params = Self::default();
@@ -145,39 +145,6 @@ pub(crate) const HTTP_PATH_OPTS: PathMatchOptions = PathMatchOptions {
 /// Compile `pattern` (in [`PathPattern`] syntax) with the HTTP routing options.
 pub(crate) fn compile_pattern(pattern: &str) -> PathPattern {
     PathPattern::new_with_opts(pattern, HTTP_PATH_OPTS)
-}
-
-/// Translate router / [`HttpMatcher`](crate::matcher::HttpMatcher) path syntax
-/// into [`PathPattern`] syntax: `{name}` → `:name`, `{*name}` → `:name**`.
-/// Everything else — including native `:name`, `*`, `**`, and literals — passes
-/// through unchanged, so both spellings are accepted.
-pub(crate) fn translate_route_path(path: &str) -> String {
-    if !path.contains('{') {
-        return path.to_owned();
-    }
-    let mut out = String::with_capacity(path.len());
-    let mut rest = path;
-    while let Some(open) = rest.find('{') {
-        out.push_str(&rest[..open]);
-        let after = &rest[open + 1..];
-        if let Some(close) = after.find('}') {
-            let inner = &after[..close];
-            out.push(':');
-            if let Some(name) = inner.strip_prefix('*') {
-                out.push_str(name);
-                out.push_str("**");
-            } else {
-                out.push_str(inner);
-            }
-            rest = &after[close + 1..];
-        } else {
-            // Unbalanced `{` — keep it literal and move on.
-            out.push('{');
-            rest = after;
-        }
-    }
-    out.push_str(rest);
-    out
 }
 
 /// Match `path` against a compiled [`PathPattern`], inserting the captured
@@ -281,28 +248,15 @@ mod test {
     use rama_utils::str::arcstr::arcstr;
 
     #[test]
-    fn translate_route_syntax() {
-        assert_eq!(translate_route_path("/users/{id}"), "/users/:id");
-        assert_eq!(translate_route_path("/assets/{*path}"), "/assets/:path**");
-        assert_eq!(
-            translate_route_path("/users/{user_id}/orders/{order_id}"),
-            "/users/:user_id/orders/:order_id"
-        );
-        // Native syntax passes through.
-        assert_eq!(translate_route_path("/users/:id/x"), "/users/:id/x");
-        assert_eq!(translate_route_path("/a/**"), "/a/**");
-    }
-
-    #[test]
     fn pattern_captures_into_uri_params() {
-        let pat = compile_pattern(&translate_route_path("/users/{id}"));
+        let pat = compile_pattern("/users/{id}");
         let ext = Extensions::new();
         assert!(match_pattern(&pat, Some(&ext), "/users/glen%20dc"));
         let params = ext.get_ref::<UriParams>().unwrap();
         assert_eq!(params.get("id"), Some("glen dc"));
 
         // Named catch-all is read as a normal param.
-        let pat = compile_pattern(&translate_route_path("/assets/{*path}"));
+        let pat = compile_pattern("/assets/{*path}");
         let ext = Extensions::new();
         assert!(match_pattern(&pat, Some(&ext), "/assets/css/app.css"));
         assert_eq!(

--- a/rama-http/src/service/web/endpoint/extract/path.rs
+++ b/rama-http/src/service/web/endpoint/extract/path.rs
@@ -81,7 +81,7 @@ mod tests {
         }
 
         let svc = WebService::default().with_get(
-            "/a/{foo}/{bar}/b/*",
+            "/a/{foo}/{bar}/b/{}",
             async |Path(params): Path<Params>| {
                 assert_eq!(params.foo, "hello");
                 assert_eq!(params.bar, 42);

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -18,7 +18,7 @@ use rama_http_types::Method;
 use rama_http_types::{
     Body, OriginalRouterUri, StatusCode, uri::try_to_strip_path_prefix_from_uri,
 };
-use rama_net::uri::PathPattern;
+use rama_net::uri::{PathPattern, PathPatternSegmentKind};
 use rama_utils::{
     collections::NonEmptySmallVec,
     str::smol_str::{StrExt as _, format_smolstr},
@@ -87,38 +87,20 @@ struct RouteEntry<O, E> {
     handlers: Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>,
 }
 
-/// `true` when `seg` is a whole-segment catch-all (`{*}` or `{*name}`). Mirrors
-/// the matcher's acceptance: a non-name body (`{*bad name}`) is a literal there,
-/// so it must not rank as a catch-all here.
-fn is_catch_all(seg: &str) -> bool {
-    seg.strip_prefix("{*")
-        .and_then(|s| s.strip_suffix('}'))
-        .is_some_and(|name| name.is_empty() || name.bytes().all(is_segment_name_byte))
-}
-
-/// Capture-name byte class of the `PathPattern` grammar: `ALPHA / DIGIT / "_" / "-"`.
-fn is_segment_name_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
-}
-
-/// Specificity rank of one pattern segment.
-fn segment_rank(seg: &str) -> u8 {
-    if is_catch_all(seg) {
-        0 // catch-all (variable length)
-    } else if seg.contains('{') {
-        1 // within-segment capture / wildcard
-    } else {
-        2 // literal
+/// Specificity rank of one segment kind: literal (2) beats within-segment
+/// dynamic (1) beats catch-all (0). Higher under `Vec`'s ordering = more specific.
+fn rank(kind: PathPatternSegmentKind) -> u8 {
+    match kind {
+        PathPatternSegmentKind::Literal => 2,
+        PathPatternSegmentKind::Dynamic => 1,
+        PathPatternSegmentKind::CatchAll => 0,
     }
 }
 
-/// Per-segment specificity key for a normalized pattern.
-fn path_specificity(pattern: &str) -> Vec<u8> {
-    pattern
-        .split('/')
-        .filter(|s| !s.is_empty())
-        .map(segment_rank)
-        .collect()
+/// Per-segment specificity key for a compiled pattern. The pattern itself is
+/// the authority on what each segment is — the router never parses the syntax.
+fn specificity_of(pattern: &PathPattern) -> Vec<u8> {
+    pattern.segment_kinds().map(rank).collect()
 }
 
 impl<S, L, O, E> std::fmt::Debug for Router<S, L, O, E> {
@@ -602,13 +584,14 @@ where
         if let Some(entry) = self.routes.iter_mut().find(|e| e.key == key) {
             entry.handlers.push((matcher, service));
         } else {
-            let specificity = path_specificity(path);
+            let pattern = compile_pattern(&pattern_str);
+            let specificity = specificity_of(&pattern);
             // keep `routes` most-specific-first; first match wins at lookup
             let pos = self.routes.partition_point(|e| e.specificity > specificity);
             self.routes.insert(
                 pos,
                 RouteEntry {
-                    pattern: compile_pattern(&pattern_str),
+                    pattern,
                     key,
                     specificity,
                     handlers: vec![(matcher, service)],
@@ -707,14 +690,34 @@ struct DynamicPrefix {
 /// Split a (normalized, lowercased) mount prefix into its leading literal run
 /// — the trie key — and any dynamic tail. A trailing catch-all (`{*}` or
 /// `{*name}`) is dropped: the nested service handles the remainder.
+///
+/// Segment classification comes from the compiled [`PathPattern`]
+/// ([`segment_kinds`](PathPattern::segment_kinds)); the router only splits on
+/// `/`, never on the pattern syntax itself.
 fn split_sub_prefix(prefix: &str) -> (String, Option<DynamicPrefix>) {
-    let mut segs: Vec<&str> = prefix.split('/').filter(|s| !s.is_empty()).collect();
-    if segs.last().is_some_and(|s| segment_rank(s) == 0) {
-        segs.pop();
+    if prefix.is_empty() {
+        return (String::new(), None);
     }
-    let lit_end = segs.iter().take_while(|s| segment_rank(s) == 2).count();
+    let kinds: Vec<_> = compile_pattern(prefix).segment_kinds().collect();
+    let segs: Vec<&str> = prefix.split('/').collect();
+    // The caller trimmed surrounding slashes, so `/`-splitting lines up 1:1
+    // with the compiled segments. If a degenerate prefix (e.g. trailing `/?`)
+    // breaks that, fall back to mounting under the whole literal.
+    if segs.len() != kinds.len() {
+        return (prefix.to_owned(), None);
+    }
+    // Drop a trailing catch-all; the nested service owns the remainder.
+    let end = if kinds.last() == Some(&PathPatternSegmentKind::CatchAll) {
+        segs.len() - 1
+    } else {
+        segs.len()
+    };
+    let lit_end = kinds[..end]
+        .iter()
+        .take_while(|k| **k == PathPatternSegmentKind::Literal)
+        .count();
     let literal = segs[..lit_end].join("/");
-    let dynamic = &segs[lit_end..];
+    let dynamic = &segs[lit_end..end];
     if dynamic.is_empty() {
         (literal, None)
     } else {
@@ -1198,27 +1201,15 @@ mod tests {
     }
 
     #[test]
-    fn segment_rank_and_catch_all_classification() {
-        assert_eq!(segment_rank("users"), 2); // literal
-        assert_eq!(segment_rank("{id}"), 1); // within-segment capture
-        assert_eq!(segment_rank("{}"), 1); // within-segment wildcard
-        assert_eq!(segment_rank("{pkg}.json"), 1); // affixed capture
-        assert!(is_catch_all("{*}"));
-        assert!(is_catch_all("{*rest}"));
-        assert_eq!(segment_rank("{*}"), 0);
-        assert_eq!(segment_rank("{*rest}"), 0);
-        // The matcher treats `{*bad name}` / `{*}}` as literals (non-name body),
-        // so they must NOT be ranked as low-priority catch-alls here.
-        assert!(!is_catch_all("{*bad name}"));
-        assert!(!is_catch_all("{*}}"));
-        assert_eq!(segment_rank("{*bad name}"), 1);
-    }
-
-    #[test]
-    fn path_specificity_orders_static_over_capture_over_catch_all() {
-        assert_eq!(path_specificity("/users/{id}"), vec![2, 1]);
-        assert_eq!(path_specificity("/assets/{*path}"), vec![2, 0]);
-        assert_eq!(path_specificity("/a/b/c"), vec![2, 2, 2]);
+    fn specificity_reflects_segment_kinds() {
+        let spec = |p: &str| specificity_of(&compile_pattern(p));
+        assert_eq!(spec("/a/b/c"), vec![2, 2, 2]); // all literal
+        assert_eq!(spec("/users/{id}"), vec![2, 1]); // literal + capture
+        assert_eq!(spec("/files/{}.json"), vec![2, 1]); // literal + affixed wildcard
+        assert_eq!(spec("/assets/{*path}"), vec![2, 0]); // literal + catch-all
+        // An invalid catch-all body is a literal in the matcher, so it ranks as
+        // a literal here too — the router no longer guesses, so no drift.
+        assert_eq!(spec("/api/{*bad name}"), vec![2, 2]);
     }
 
     #[test]

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -3,7 +3,7 @@
     reason = "macro-generated `#[allow]` attributes whose underlying lints fire only for some expansions"
 )]
 
-use std::{convert::Infallible, error::Error, fmt};
+use std::{cmp::Reverse, convert::Infallible, error::Error, fmt};
 
 use radix_trie::{Trie, TrieCommon as _};
 use rama_core::{
@@ -18,7 +18,7 @@ use rama_http_types::Method;
 use rama_http_types::{
     Body, OriginalRouterUri, StatusCode, uri::try_to_strip_path_prefix_from_uri,
 };
-use rama_net::uri::{PathPattern, PathPatternSegmentKind};
+use rama_net::uri::{PathPattern, PathPatternSegmentKind, PathPatternSegmentSpecificity};
 use rama_utils::{
     collections::NonEmptySmallVec,
     str::smol_str::{StrExt as _, format_smolstr},
@@ -83,24 +83,39 @@ struct RouteEntry<O, E> {
     key: String,
     /// Per-segment specificity ranks (static=2, capture=1, catch-all=0);
     /// higher under `Vec`'s ordering = more specific.
-    specificity: Vec<u8>,
+    specificity: Vec<SegmentSpecificityRank>,
     handlers: Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>,
 }
 
-/// Specificity rank of one segment kind: literal (2) beats within-segment
-/// dynamic (1) beats catch-all (0). Higher under `Vec`'s ordering = more specific.
-fn rank(kind: PathPatternSegmentKind) -> u8 {
-    match kind {
+/// Specificity rank of one segment. Literal beats dynamic beats catch-all; for
+/// two dynamic segments, more literal bytes and fewer wildcard/capture/optional
+/// parts wins (e.g. `{file}.json` beats `{file}`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct SegmentSpecificityRank {
+    kind: u8,
+    literal_bytes: usize,
+    fewer_dynamic_parts: Reverse<usize>,
+    fewer_optional_parts: Reverse<usize>,
+}
+
+fn rank(spec: PathPatternSegmentSpecificity) -> SegmentSpecificityRank {
+    let kind = match spec.kind {
         PathPatternSegmentKind::Literal => 2,
         PathPatternSegmentKind::Dynamic => 1,
         PathPatternSegmentKind::CatchAll => 0,
+    };
+    SegmentSpecificityRank {
+        kind,
+        literal_bytes: spec.literal_bytes,
+        fewer_dynamic_parts: Reverse(spec.dynamic_parts),
+        fewer_optional_parts: Reverse(spec.optional_parts),
     }
 }
 
 /// Per-segment specificity key for a compiled pattern. The pattern itself is
 /// the authority on what each segment is — the router never parses the syntax.
-fn specificity_of(pattern: &PathPattern) -> Vec<u8> {
-    pattern.segment_kinds().map(rank).collect()
+fn specificity_of(pattern: &PathPattern) -> Vec<SegmentSpecificityRank> {
+    pattern.segment_specificity().map(rank).collect()
 }
 
 impl<S, L, O, E> std::fmt::Debug for Router<S, L, O, E> {
@@ -587,7 +602,9 @@ where
             let pattern = compile_pattern(&pattern_str);
             let specificity = specificity_of(&pattern);
             // keep `routes` most-specific-first; first match wins at lookup
-            let pos = self.routes.partition_point(|e| e.specificity > specificity);
+            let pos = self
+                .routes
+                .partition_point(|e| e.specificity >= specificity);
             self.routes.insert(
                 pos,
                 RouteEntry {
@@ -1202,7 +1219,12 @@ mod tests {
 
     #[test]
     fn specificity_reflects_segment_kinds() {
-        let spec = |p: &str| specificity_of(&compile_pattern(p));
+        let spec = |p: &str| {
+            specificity_of(&compile_pattern(p))
+                .into_iter()
+                .map(|rank| rank.kind)
+                .collect::<Vec<_>>()
+        };
         assert_eq!(spec("/a/b/c"), vec![2, 2, 2]); // all literal
         assert_eq!(spec("/users/{id}"), vec![2, 1]); // literal + capture
         assert_eq!(spec("/files/{}.json"), vec![2, 1]); // literal + affixed wildcard
@@ -1210,6 +1232,16 @@ mod tests {
         // An invalid catch-all body is a literal in the matcher, so it ranks as
         // a literal here too — the router no longer guesses, so no drift.
         assert_eq!(spec("/api/{*bad name}"), vec![2, 2]);
+    }
+
+    #[test]
+    fn specificity_breaks_dynamic_ties_with_literal_weight() {
+        let plain = specificity_of(&compile_pattern("/files/{name}"));
+        let json = specificity_of(&compile_pattern("/files/{name}.json"));
+        let wildcard_json = specificity_of(&compile_pattern("/files/{}.json"));
+
+        assert!(json > plain);
+        assert!(wildcard_json > plain);
     }
 
     #[test]
@@ -1295,6 +1327,70 @@ mod tests {
         let res = router.serve(req).await.unwrap();
         let body = res.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(body, "rest:a/b");
+    }
+
+    #[tokio::test]
+    async fn test_router_affixed_dynamic_beats_plain_dynamic_either_order() {
+        fn plain_svc() -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(|req: Request| async move {
+                let p = req.extensions().get_ref::<UriParams>().unwrap();
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(format!("plain:{}", p.get("name").unwrap())))
+                    .unwrap())
+            })
+        }
+        fn json_svc() -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(|req: Request| async move {
+                let p = req.extensions().get_ref::<UriParams>().unwrap();
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(format!("json:{}", p.get("name").unwrap())))
+                    .unwrap())
+            })
+        }
+
+        let routers = [
+            Router::new()
+                .with_get("/files/{name}", plain_svc())
+                .with_get("/files/{name}.json", json_svc()),
+            Router::new()
+                .with_get("/files/{name}.json", json_svc())
+                .with_get("/files/{name}", plain_svc()),
+        ];
+        for router in routers {
+            let router = ErrorHandlerLayer::new().layer(router);
+            let req = Request::get("/files/readme.json")
+                .body(Body::empty())
+                .unwrap();
+            let res = router.serve(req).await.unwrap();
+            let body = res.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body, "json:readme");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_router_equal_specificity_preserves_registration_order() {
+        fn svc(
+            label: &'static str,
+        ) -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(move |_req: Request| async move {
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(label))
+                    .unwrap())
+            })
+        }
+
+        let router = ErrorHandlerLayer::new().layer(
+            Router::new()
+                .with_get("/files/{a}", svc("first"))
+                .with_get("/files/{b}", svc("second")),
+        );
+        let req = Request::get("/files/readme").body(Body::empty()).unwrap();
+        let res = router.serve(req).await.unwrap();
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body, "first");
     }
 
     #[tokio::test]

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -5,7 +5,6 @@
 
 use std::{convert::Infallible, error::Error, fmt};
 
-use matchit::Router as MatchitRouter;
 use radix_trie::{Trie, TrieCommon as _};
 use rama_core::{
     Layer,
@@ -19,6 +18,7 @@ use rama_http_types::Method;
 use rama_http_types::{
     Body, OriginalRouterUri, StatusCode, uri::try_to_strip_path_prefix_from_uri,
 };
+use rama_net::uri::PathPattern;
 use rama_utils::{
     collections::NonEmptySmallVec,
     str::smol_str::{StrExt as _, format_smolstr},
@@ -27,7 +27,8 @@ use rama_utils::{
 use crate::{
     Request, Response,
     headers::Allow,
-    matcher::{HttpMatcher, MethodMatcher, PathMatcher, UriParams},
+    matcher::path::{compile_pattern, match_pattern, translate_route_path},
+    matcher::{HttpMatcher, MethodMatcher, UriParams},
     service::web::{
         IntoEndpointService, IntoEndpointServiceWithState,
         response::{ErrorResponse, Headers, IntoResponse},
@@ -60,16 +61,50 @@ where
 
 /// A basic router that can be used to route requests to different services based on the request path.
 ///
-/// This router uses `matchit::Router` to efficiently match incoming requests
-/// to predefined routes. Each route is associated with an `HttpMatcher`
-/// and a corresponding service handler.
+/// Each route compiles to a [`PathPattern`]; on lookup the most-specific
+/// matching pattern wins (static segments beat captures beat catch-alls).
+/// Nested services are mounted under a prefix via a [`Trie`].
 #[allow(unused)]
 pub struct Router<State = (), Layer = DefaultEndpointLayer, O = Response, E = RouterError> {
-    routes: MatchitRouter<Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>>,
+    routes: Vec<RouteEntry<O, E>>,
     sub_services: Option<Trie<String, SubService<O, E>>>,
     not_found: Option<BoxService<Request, O, E>>,
     layer: Layer,
     state: State,
+}
+
+/// One registered route path: its compiled pattern, a specificity key (kept
+/// sorted most-specific-first across `routes`), and the per-method handlers
+/// sharing this path.
+struct RouteEntry<O, E> {
+    pattern: PathPattern,
+    /// Lowercased, translated pattern string — identity key for merging repeat
+    /// registrations of the same path under different methods.
+    key: String,
+    /// Per-segment specificity ranks (static=2, capture=1, catch-all=0);
+    /// higher under `Vec`'s ordering = more specific.
+    specificity: Vec<u8>,
+    handlers: Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>,
+}
+
+/// Specificity rank of one translated pattern segment.
+fn segment_rank(seg: &str) -> u8 {
+    if seg == "**" || (seg.starts_with(':') && seg.ends_with("**")) {
+        0 // catch-all (variable length)
+    } else if seg.contains(':') || seg.contains('*') {
+        1 // within-segment capture / wildcard
+    } else {
+        2 // literal
+    }
+}
+
+/// Per-segment specificity key for a translated, normalized pattern.
+fn path_specificity(translated: &str) -> Vec<u8> {
+    translated
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(segment_rank)
+        .collect()
 }
 
 impl<S, L, O, E> std::fmt::Debug for Router<S, L, O, E> {
@@ -94,7 +129,7 @@ where
     /// Create a new router with state
     pub fn new_with_state(state: State) -> Self {
         Self {
-            routes: MatchitRouter::new(),
+            routes: Vec::new(),
             sub_services: None,
             not_found: None,
             layer: Default::default(),
@@ -411,7 +446,7 @@ where
         Router<State, Layer, O, E>: Service<Request, Output = O, Error = E>,
     {
         let router = Self {
-            routes: MatchitRouter::new(),
+            routes: Vec::new(),
             sub_services: None,
             not_found: None,
             layer: self.layer.clone(),
@@ -500,39 +535,15 @@ where
         nested: BoxService<Request, O, E>,
     ) -> &mut Self {
         let prefix = prefix.as_ref().trim().trim_matches('/').to_lowercase();
+        let (literal, dynamic) = split_sub_prefix(&prefix);
         let trie = self.sub_services.get_or_insert_default();
-
-        if !prefix.contains(['*', '{', '}']) {
-            trie.insert(
-                prefix,
-                SubService {
-                    svc: nested,
-                    matcher: None,
-                },
-            );
-        } else {
-            const DISALLOW_GLOB: bool = false;
-            match PathMatcher::new(prefix).try_remove_literal_prefix(DISALLOW_GLOB) {
-                Ok((literal, maybe_matcher)) => {
-                    trie.insert(
-                        literal.to_string(),
-                        SubService {
-                            svc: nested,
-                            matcher: maybe_matcher,
-                        },
-                    );
-                }
-                Err(matcher) => {
-                    trie.insert(
-                        Default::default(),
-                        SubService {
-                            svc: nested,
-                            matcher: Some(matcher),
-                        },
-                    );
-                }
-            }
-        }
+        trie.insert(
+            literal,
+            SubService {
+                svc: nested,
+                dynamic,
+            },
+        );
 
         self
     }
@@ -554,9 +565,6 @@ where
         self
     }
 
-    // TODO: Make this fallible,
-    // and also do not allow empty path, instead folks should use `not_found` for that
-
     /// add a route to the router with it's matcher and service.
     pub fn set_match_route<I, T>(
         &mut self,
@@ -574,15 +582,25 @@ where
             .boxed();
 
         let path = path.as_ref().trim().trim_matches('/');
-        let path = format_smolstr!("/{path}").to_lowercase_smolstr();
+        let translated = translate_route_path(path);
+        let pattern_str = format_smolstr!("/{translated}");
+        let key = pattern_str.to_lowercase();
 
-        if let Ok(matched) = self.routes.at_mut(&path) {
-            matched.value.push((matcher, service));
+        if let Some(entry) = self.routes.iter_mut().find(|e| e.key == key) {
+            entry.handlers.push((matcher, service));
         } else {
-            #[allow(clippy::expect_used, reason = "TODO later")]
-            self.routes
-                .insert(path, vec![(matcher, service)])
-                .expect("add route");
+            let specificity = path_specificity(&translated);
+            // keep `routes` most-specific-first; first match wins at lookup
+            let pos = self.routes.partition_point(|e| e.specificity > specificity);
+            self.routes.insert(
+                pos,
+                RouteEntry {
+                    pattern: compile_pattern(&pattern_str),
+                    key,
+                    specificity,
+                    handlers: vec![(matcher, service)],
+                },
+            );
         }
 
         self
@@ -659,7 +677,51 @@ impl From<Infallible> for RouterError {
 
 struct SubService<O, E> {
     svc: BoxService<Request, O, E>,
-    matcher: Option<PathMatcher>,
+    /// `Some` when the mount prefix has dynamic segments after its literal head
+    /// (the trie key). Matches those segments right after the literal prefix.
+    dynamic: Option<DynamicPrefix>,
+}
+
+/// The dynamic tail of a sub-service mount prefix (the part after the leading
+/// literal segments that key the trie).
+struct DynamicPrefix {
+    /// Pattern matching exactly the dynamic segments (e.g. `/:user_id`).
+    pattern: PathPattern,
+    /// Number of dynamic segments to slice off after the literal prefix.
+    seg_count: usize,
+}
+
+/// Split a (normalized, lowercased) mount prefix into its leading literal run
+/// — the trie key — and any dynamic tail. A trailing catch-all (`*`, `**`,
+/// `{*name}`, `:name**`) is dropped: the nested service handles the remainder.
+fn split_sub_prefix(prefix: &str) -> (String, Option<DynamicPrefix>) {
+    let translated = translate_route_path(prefix);
+    let mut segs: Vec<&str> = translated.split('/').filter(|s| !s.is_empty()).collect();
+    if segs
+        .last()
+        .is_some_and(|s| segment_rank(s) == 0 || *s == "*")
+    {
+        segs.pop();
+    }
+    let lit_end = segs.iter().take_while(|s| segment_rank(s) == 2).count();
+    let literal = segs[..lit_end].join("/");
+    let dynamic = &segs[lit_end..];
+    if dynamic.is_empty() {
+        (literal, None)
+    } else {
+        let mut dyn_pattern = String::new();
+        for seg in dynamic {
+            dyn_pattern.push('/');
+            dyn_pattern.push_str(seg);
+        }
+        (
+            literal,
+            Some(DynamicPrefix {
+                pattern: compile_pattern(&dyn_pattern),
+                seg_count: dynamic.len(),
+            }),
+        )
+    }
 }
 
 impl<State, L, O, E> Service<Request> for Router<State, L, O, E>
@@ -673,42 +735,49 @@ where
     type Error = E;
 
     async fn serve(&self, req: Request) -> Result<Self::Output, Self::Error> {
-        let path = req.uri().path_or_root().to_lowercase_smolstr();
+        let path = req.uri().path_or_root().to_owned();
 
         // Collect allowed methods when a path matches but no method matches.
-        // Initialised here so it is visible after the if-let block and after
+        // Initialised here so it is visible after the route scan and after
         // sub_services, letting sub_services take priority over a 405.
         let mut allowed_methods: Option<MethodMatcher> = None;
 
-        if let Ok(matched) = self.routes.at(path.as_str()) {
-            let uri_params = matched.params.iter();
+        // most-specific-first: the first matching route owns the path
+        // (method mismatch -> 405, no fall-through to a vaguer route).
+        for entry in self.routes.iter() {
+            let ext = Extensions::new();
+            if !match_pattern(&entry.pattern, Some(&ext), &path) {
+                continue;
+            }
 
+            // merge with any existing (nested-router) UriParams
+            let captured = ext.get_ref::<UriParams>().cloned().unwrap_or_default();
             let params = match req.extensions().get_ref::<UriParams>() {
-                Some(params) => {
-                    let mut params = params.clone();
-                    params.extend(uri_params);
+                Some(existing) => {
+                    let mut params = existing.clone();
+                    params.extend(captured.iter());
                     params
                 }
-                None => uri_params.collect::<UriParams>(),
+                None => captured,
             };
-
             req.extensions().insert(params);
 
-            for (matcher, service) in matched.value.iter() {
-                let ext = Extensions::new();
-                if matcher.matches(Some(&ext), &req) {
-                    req.extensions().extend(&ext);
+            for (matcher, service) in entry.handlers.iter() {
+                let mext = Extensions::new();
+                if matcher.matches(Some(&mext), &req) {
+                    req.extensions().extend(&mext);
                     return service.serve(req).await;
                 }
             }
 
             // Path matched but no method matched — collect for a potential 405.
             // Do not return yet: a sub_service may still handle this request.
-            for (matcher, _) in matched.value.iter() {
+            for (matcher, _) in entry.handlers.iter() {
                 if let Some(m) = matcher.allowed_methods() {
                     allowed_methods = Some(allowed_methods.map_or(m, |acc| acc.or_method(m)));
                 }
             }
+            break;
         }
 
         let (mut parts, body) = req.into_parts();
@@ -723,17 +792,16 @@ where
                 .get_ancestor(norm_path.as_str())
                 .and_then(|sub_trie| sub_trie.key().zip(sub_trie.value()))
             {
-                if let Some(matcher) = sub_svc.matcher.as_ref() {
-                    let fragment_count = matcher.fragment_count();
+                if let Some(dynamic) = sub_svc.dynamic.as_ref() {
                     let mut pos = 0;
                     let mut fragment_index = 0;
                     let path = parts.uri.path_or_root().trim_matches('/');
 
                     let offset = prefix.len().min(path.len());
-                    let path = &path[offset..].trim_matches('/');
+                    let path = path[offset..].trim_matches('/');
 
                     for char in path.bytes() {
-                        if fragment_index >= fragment_count {
+                        if fragment_index >= dynamic.seg_count {
                             break;
                         }
                         pos += 1;
@@ -742,10 +810,12 @@ where
                         }
                     }
 
-                    let fragments_path = &path[..pos];
+                    // pattern is trailing-strict; drop the boundary `/`
+                    let fragments_path = path[..pos].trim_end_matches('/');
 
                     let ext = Extensions::new();
-                    if matcher.matches_path(Some(&ext), fragments_path) {
+                    let dynamic_path = format_smolstr!("/{fragments_path}");
+                    if match_pattern(&dynamic.pattern, Some(&ext), &dynamic_path) {
                         let full_prefix = format_smolstr!("{prefix}/{fragments_path}",);
                         let modified_uri = match try_to_strip_path_prefix_from_uri(
                             &parts.uri,

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -27,7 +27,7 @@ use rama_utils::{
 use crate::{
     Request, Response,
     headers::Allow,
-    matcher::path::{compile_pattern, match_pattern, translate_route_path},
+    matcher::path::{compile_pattern, match_pattern},
     matcher::{HttpMatcher, MethodMatcher, UriParams},
     service::web::{
         IntoEndpointService, IntoEndpointServiceWithState,
@@ -78,7 +78,7 @@ pub struct Router<State = (), Layer = DefaultEndpointLayer, O = Response, E = Ro
 /// sharing this path.
 struct RouteEntry<O, E> {
     pattern: PathPattern,
-    /// Lowercased, translated pattern string — identity key for merging repeat
+    /// Lowercased pattern string — identity key for merging repeat
     /// registrations of the same path under different methods.
     key: String,
     /// Per-segment specificity ranks (static=2, capture=1, catch-all=0);
@@ -87,20 +87,25 @@ struct RouteEntry<O, E> {
     handlers: Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>,
 }
 
-/// Specificity rank of one translated pattern segment.
+/// `true` when `seg` is a whole-segment catch-all (`{*}` or `{*name}`).
+fn is_catch_all(seg: &str) -> bool {
+    seg.starts_with("{*") && seg.ends_with('}')
+}
+
+/// Specificity rank of one pattern segment.
 fn segment_rank(seg: &str) -> u8 {
-    if seg == "**" || (seg.starts_with(':') && seg.ends_with("**")) {
+    if is_catch_all(seg) {
         0 // catch-all (variable length)
-    } else if seg.contains(':') || seg.contains('*') {
+    } else if seg.contains('{') {
         1 // within-segment capture / wildcard
     } else {
         2 // literal
     }
 }
 
-/// Per-segment specificity key for a translated, normalized pattern.
-fn path_specificity(translated: &str) -> Vec<u8> {
-    translated
+/// Per-segment specificity key for a normalized pattern.
+fn path_specificity(pattern: &str) -> Vec<u8> {
+    pattern
         .split('/')
         .filter(|s| !s.is_empty())
         .map(segment_rank)
@@ -582,14 +587,13 @@ where
             .boxed();
 
         let path = path.as_ref().trim().trim_matches('/');
-        let translated = translate_route_path(path);
-        let pattern_str = format_smolstr!("/{translated}");
+        let pattern_str = format_smolstr!("/{path}");
         let key = pattern_str.to_lowercase();
 
         if let Some(entry) = self.routes.iter_mut().find(|e| e.key == key) {
             entry.handlers.push((matcher, service));
         } else {
-            let specificity = path_specificity(&translated);
+            let specificity = path_specificity(path);
             // keep `routes` most-specific-first; first match wins at lookup
             let pos = self.routes.partition_point(|e| e.specificity > specificity);
             self.routes.insert(
@@ -692,15 +696,11 @@ struct DynamicPrefix {
 }
 
 /// Split a (normalized, lowercased) mount prefix into its leading literal run
-/// — the trie key — and any dynamic tail. A trailing catch-all (`*`, `**`,
-/// `{*name}`, `:name**`) is dropped: the nested service handles the remainder.
+/// — the trie key — and any dynamic tail. A trailing catch-all (`{*}` or
+/// `{*name}`) is dropped: the nested service handles the remainder.
 fn split_sub_prefix(prefix: &str) -> (String, Option<DynamicPrefix>) {
-    let translated = translate_route_path(prefix);
-    let mut segs: Vec<&str> = translated.split('/').filter(|s| !s.is_empty()).collect();
-    if segs
-        .last()
-        .is_some_and(|s| segment_rank(s) == 0 || *s == "*")
-    {
+    let mut segs: Vec<&str> = prefix.split('/').filter(|s| !s.is_empty()).collect();
+    if segs.last().is_some_and(|s| segment_rank(s) == 0) {
         segs.pop();
     }
     let lit_end = segs.iter().take_while(|s| segment_rank(s) == 2).count();
@@ -1231,7 +1231,7 @@ mod tests {
                 .with_post(format!("{prefix}users"), create_user_service())
                 .with_delete(format!("{prefix}users/{{user_id}}"), delete_user_service())
                 .with_sub_router_make_fn(
-                    format!("{prefix}users/{{user_id}}/*"), // glob should be dropped by nester
+                    format!("{prefix}users/{{user_id}}/{{*}}"), // glob should be dropped by nester
                     |router| {
                         router
                             .with_get(prefix, get_user_service())

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -1331,6 +1331,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_router_invalid_catch_all_mount_is_literal() {
+        // RAMA-PR1027-001: `{*bad name}` is an invalid catch-all body, so the
+        // matcher treats it as a literal segment. The mount must therefore NOT
+        // collapse to `/api`; `/api/users` must not reach the nested service.
+        let app = Router::new()
+            .with_sub_service(
+                "/api/{*bad name}",
+                Router::new().with_get("/", root_service()),
+            )
+            .with_not_found(not_found_service());
+        let app = ErrorHandlerLayer::new().layer(app);
+
+        let req = Request::get("/api/users").body(Body::empty()).unwrap();
+        let res = app.serve(req).await.unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::NOT_FOUND,
+            "invalid catch-all must not mount the sub-service at /api"
+        );
+    }
+
+    #[tokio::test]
     #[tracing_test::traced_test]
     async fn test_router_nest() {
         let cases = [

--- a/rama-http/src/service/web/router.rs
+++ b/rama-http/src/service/web/router.rs
@@ -87,9 +87,18 @@ struct RouteEntry<O, E> {
     handlers: Vec<(HttpMatcher<Body>, BoxService<Request, O, E>)>,
 }
 
-/// `true` when `seg` is a whole-segment catch-all (`{*}` or `{*name}`).
+/// `true` when `seg` is a whole-segment catch-all (`{*}` or `{*name}`). Mirrors
+/// the matcher's acceptance: a non-name body (`{*bad name}`) is a literal there,
+/// so it must not rank as a catch-all here.
 fn is_catch_all(seg: &str) -> bool {
-    seg.starts_with("{*") && seg.ends_with('}')
+    seg.strip_prefix("{*")
+        .and_then(|s| s.strip_suffix('}'))
+        .is_some_and(|name| name.is_empty() || name.bytes().all(is_segment_name_byte))
+}
+
+/// Capture-name byte class of the `PathPattern` grammar: `ALPHA / DIGIT / "_" / "-"`.
+fn is_segment_name_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
 }
 
 /// Specificity rank of one pattern segment.
@@ -689,7 +698,7 @@ struct SubService<O, E> {
 /// The dynamic tail of a sub-service mount prefix (the part after the leading
 /// literal segments that key the trie).
 struct DynamicPrefix {
-    /// Pattern matching exactly the dynamic segments (e.g. `/:user_id`).
+    /// Pattern matching exactly the dynamic segments (e.g. `/{user_id}`).
     pattern: PathPattern,
     /// Number of dynamic segments to slice off after the literal prefix.
     seg_count: usize,
@@ -1186,6 +1195,139 @@ mod tests {
         let res = router.serve(req).await.unwrap();
         assert_eq!(res.status(), StatusCode::NOT_FOUND);
         assert!(res.headers().get(header::ALLOW).is_none());
+    }
+
+    #[test]
+    fn segment_rank_and_catch_all_classification() {
+        assert_eq!(segment_rank("users"), 2); // literal
+        assert_eq!(segment_rank("{id}"), 1); // within-segment capture
+        assert_eq!(segment_rank("{}"), 1); // within-segment wildcard
+        assert_eq!(segment_rank("{pkg}.json"), 1); // affixed capture
+        assert!(is_catch_all("{*}"));
+        assert!(is_catch_all("{*rest}"));
+        assert_eq!(segment_rank("{*}"), 0);
+        assert_eq!(segment_rank("{*rest}"), 0);
+        // The matcher treats `{*bad name}` / `{*}}` as literals (non-name body),
+        // so they must NOT be ranked as low-priority catch-alls here.
+        assert!(!is_catch_all("{*bad name}"));
+        assert!(!is_catch_all("{*}}"));
+        assert_eq!(segment_rank("{*bad name}"), 1);
+    }
+
+    #[test]
+    fn path_specificity_orders_static_over_capture_over_catch_all() {
+        assert_eq!(path_specificity("/users/{id}"), vec![2, 1]);
+        assert_eq!(path_specificity("/assets/{*path}"), vec![2, 0]);
+        assert_eq!(path_specificity("/a/b/c"), vec![2, 2, 2]);
+    }
+
+    #[test]
+    fn split_sub_prefix_shapes() {
+        use rama_net::uri::PathRef;
+
+        // Trailing within-segment capture (no catch-all) is kept as the tail.
+        let (lit, dynamic) = split_sub_prefix("users/{user_id}");
+        assert_eq!(lit, "users");
+        let d = dynamic.unwrap();
+        assert_eq!(d.seg_count, 1);
+        assert!(d.pattern.is_match(PathRef::from_raw_str("/123")));
+
+        // A named catch-all is dropped just like anon `{*}`.
+        let (lit, dynamic) = split_sub_prefix("users/{user_id}/{*rest}");
+        assert_eq!(lit, "users");
+        assert_eq!(dynamic.unwrap().seg_count, 1);
+
+        // Anon catch-all dropped, pure-literal prefix -> no dynamic tail.
+        let (lit, dynamic) = split_sub_prefix("api/v1/{*}");
+        assert_eq!(lit, "api/v1");
+        assert!(dynamic.is_none());
+
+        // Dynamic segment in the middle: literal stops at the first non-literal.
+        let (lit, dynamic) = split_sub_prefix("a/{id}/b");
+        assert_eq!(lit, "a");
+        let d = dynamic.unwrap();
+        assert_eq!(d.seg_count, 2);
+        assert!(d.pattern.is_match(PathRef::from_raw_str("/x/b")));
+
+        // All-dynamic prefix: empty literal trie key.
+        let (lit, dynamic) = split_sub_prefix("{id}/rest");
+        assert_eq!(lit, "");
+        assert_eq!(dynamic.unwrap().seg_count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_router_capture_beats_catch_all_either_order() {
+        fn name_svc() -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(|req: Request| async move {
+                let p = req.extensions().get_ref::<UriParams>().unwrap();
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(format!("name:{}", p.get("name").unwrap())))
+                    .unwrap())
+            })
+        }
+        fn rest_svc() -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(|req: Request| async move {
+                let p = req.extensions().get_ref::<UriParams>().unwrap();
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(format!("rest:{}", p.get("rest").unwrap())))
+                    .unwrap())
+            })
+        }
+
+        // `{name}` (rank 1) must win over `{*rest}` (rank 0) on a single-segment
+        // path, independent of registration order.
+        let routers = [
+            Router::new()
+                .with_get("/files/{name}", name_svc())
+                .with_get("/files/{*rest}", rest_svc()),
+            Router::new()
+                .with_get("/files/{*rest}", rest_svc())
+                .with_get("/files/{name}", name_svc()),
+        ];
+        for router in routers {
+            let router = ErrorHandlerLayer::new().layer(router);
+            let req = Request::get("/files/x").body(Body::empty()).unwrap();
+            let res = router.serve(req).await.unwrap();
+            let body = res.into_body().collect().await.unwrap().to_bytes();
+            assert_eq!(body, "name:x");
+        }
+
+        // A multi-segment path no longer fits `{name}` and falls to the catch-all.
+        let router = ErrorHandlerLayer::new().layer(
+            Router::new()
+                .with_get("/files/{name}", name_svc())
+                .with_get("/files/{*rest}", rest_svc()),
+        );
+        let req = Request::get("/files/a/b").body(Body::empty()).unwrap();
+        let res = router.serve(req).await.unwrap();
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(body, "rest:a/b");
+    }
+
+    #[tokio::test]
+    async fn test_router_anonymous_glob_surfaces_via_uri_params() {
+        fn glob_svc() -> impl Service<Request, Output = Response, Error = Infallible> {
+            service_fn(|req: Request| async move {
+                let p = req.extensions().get_ref::<UriParams>().unwrap();
+                // anon `{*}` is the glob, not a named param
+                assert!(p.get("rest").is_none());
+                Ok(Response::builder()
+                    .status(200)
+                    .body(Body::from(format!("glob:{}", p.glob().unwrap())))
+                    .unwrap())
+            })
+        }
+        let router =
+            ErrorHandlerLayer::new().layer(Router::new().with_get("/assets/{*}", glob_svc()));
+        let req = Request::get("/assets/css/app.css")
+            .body(Body::empty())
+            .unwrap();
+        let res = router.serve(req).await.unwrap();
+        let body = res.into_body().collect().await.unwrap().to_bytes();
+        // glob() is path-style (leading `/`), unlike a named catch-all param.
+        assert_eq!(body, "glob:/css/app.css");
     }
 
     #[tokio::test]

--- a/rama-net/src/byte_sets.rs
+++ b/rama-net/src/byte_sets.rs
@@ -69,6 +69,11 @@ const IPVFUTURE_TAIL_BYTE_SET: [bool; 256] =
 /// records. Consumed by [`crate::address::domain`]'s label validator.
 const LABEL_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
 
+/// Path-pattern capture-name byte class: `ALPHA / DIGIT / "_" / "-"`. Scans the
+/// `:name` identifier in [`crate::uri::PathPattern`]. Same membership as a DNS
+/// label, kept separate so the two grammars can drift independently.
+const PATTERN_NAME_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
+
 // --- Predicates (single-load hot path) -------------------------------------
 
 #[inline(always)]
@@ -129,4 +134,9 @@ pub(crate) const fn is_ipvfuture_tail_byte(b: u8) -> bool {
 #[inline(always)]
 pub(crate) const fn is_label_byte(b: u8) -> bool {
     LABEL_BYTE_SET[b as usize]
+}
+
+#[inline(always)]
+pub(crate) const fn is_pattern_name_byte(b: u8) -> bool {
+    PATTERN_NAME_BYTE_SET[b as usize]
 }

--- a/rama-net/src/byte_sets.rs
+++ b/rama-net/src/byte_sets.rs
@@ -70,7 +70,7 @@ const IPVFUTURE_TAIL_BYTE_SET: [bool; 256] =
 const LABEL_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
 
 /// Path-pattern capture-name byte class: `ALPHA / DIGIT / "_" / "-"`. Scans the
-/// `:name` identifier in [`crate::uri::PathPattern`]. Same membership as a DNS
+/// `{name}` identifier in [`crate::uri::PathPattern`]. Same membership as a DNS
 /// label, kept separate so the two grammars can drift independently.
 const PATTERN_NAME_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
 

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -84,6 +84,10 @@ mod path_mut;
 #[doc(inline)]
 pub use path_mut::PathMut;
 
+mod path_matcher;
+#[doc(inline)]
+pub use path_matcher::{PathCaptures, PathPattern};
+
 mod query;
 #[doc(inline)]
 pub use query::{Query, QueryDeserializeError, QueryPair, QueryPairRef, QueryPairs, QueryRef};

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -86,7 +86,7 @@ pub use path_mut::PathMut;
 
 mod path_matcher;
 #[doc(inline)]
-pub use path_matcher::{PathCaptures, PathPattern};
+pub use path_matcher::{PathCaptures, PathPattern, PathPatternSegmentKind};
 
 mod query;
 #[doc(inline)]

--- a/rama-net/src/uri/mod.rs
+++ b/rama-net/src/uri/mod.rs
@@ -86,7 +86,9 @@ pub use path_mut::PathMut;
 
 mod path_matcher;
 #[doc(inline)]
-pub use path_matcher::{PathCaptures, PathPattern, PathPatternSegmentKind};
+pub use path_matcher::{
+    PathCaptures, PathPattern, PathPatternSegmentKind, PathPatternSegmentSpecificity,
+};
 
 mod query;
 #[doc(inline)]

--- a/rama-net/src/uri/parser/tests/accessors.rs
+++ b/rama-net/src/uri/parser/tests/accessors.rs
@@ -532,3 +532,50 @@ fn host_port_shortcuts_match_authority() {
         assert_eq!(u.port(), a.port(), "port mismatch on {s:?}");
     }
 }
+
+// ----------------------------------------------------------------------
+// path segment matching: contains_segments / PathSegment matchers
+// ----------------------------------------------------------------------
+
+#[test]
+fn contains_segments_matches_whole_segment_runs() {
+    let u = parse_graceful("/golang.org/x/mod/@v/list").unwrap();
+    let p = u.path().unwrap();
+    // present as whole segment(s), at any position
+    assert!(p.contains_segments("@v"));
+    assert!(p.contains_segments("mod/@v"));
+    assert!(p.contains_segments("x"));
+    // not a partial-segment match
+    assert!(!p.contains_segments("@version"));
+    assert!(!p.contains_segments("od/@v"));
+    // empty needle is trivially contained
+    assert!(p.contains_segments(""));
+}
+
+#[test]
+fn contains_segments_is_decode_aware() {
+    // `%2D` == `-`; the `/-/` registry marker must match decoded.
+    let u = parse_graceful("/npm/%2D/rev").unwrap();
+    assert!(u.path().unwrap().contains_segments("-"));
+}
+
+#[test]
+fn segment_suffix_prefix_and_matches() {
+    let u = parse_graceful("/dl/rails-7.1.0.gem").unwrap();
+    let seg = u.path().unwrap().last_segment().unwrap();
+    // only `.gem` is the real extension here
+    for ext in [".gem", ".tgz", ".zip", ".nupkg"] {
+        assert_eq!(seg.has_suffix(ext), ext == ".gem", "has_suffix({ext})");
+    }
+    assert!(seg.has_prefix("rails-"));
+    assert!(seg.matches("rails-7.1.0.gem"));
+    assert!(!seg.matches("rails-7.1.0.tgz"));
+}
+
+#[test]
+fn segment_has_suffix_is_decode_aware() {
+    // `%2E` == `.`; the suffix check decodes both sides.
+    let u = parse_graceful("/pkg/widget%2Etgz").unwrap();
+    let seg = u.path().unwrap().last_segment().unwrap();
+    assert!(seg.has_suffix(".tgz"));
+}

--- a/rama-net/src/uri/parser/tests/mod.rs
+++ b/rama-net/src/uri/parser/tests/mod.rs
@@ -51,6 +51,7 @@ pub(super) mod idna;
 pub(super) mod mutation;
 pub(super) mod non_http_schemes;
 pub(super) mod origin_form;
+pub(super) mod path_matcher;
 pub(super) mod path_mut;
 pub(super) mod path_segments;
 pub(super) mod query_collect;
@@ -180,8 +181,9 @@ const _: fn() = || {
         UserInfoRef,
     };
     use crate::uri::{
-        Fragment, FragmentRef, ParseError, PathRef, Query, QueryDeserializeError, QueryPair,
-        QueryPairRef, QueryRef, ResolveError, Uri, UriError, WireError,
+        Fragment, FragmentRef, ParseError, PathCaptures, PathPattern, PathRef, Query,
+        QueryDeserializeError, QueryPair, QueryPairRef, QueryRef, ResolveError, Uri, UriError,
+        WireError,
     };
 
     assert_send_sync::<Uri>();
@@ -198,6 +200,8 @@ const _: fn() = || {
     assert_send_sync::<Fragment>();
     assert_send_sync::<FragmentRef<'static>>();
     assert_send_sync::<PathRef<'static>>();
+    assert_send_sync::<PathPattern>();
+    assert_send_sync::<PathCaptures<'static, 'static>>();
 
     assert_send_sync::<Authority>();
     assert_send_sync::<AuthorityRef<'static>>();

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -598,3 +598,32 @@ fn segment_kinds_classify_each_segment() {
     assert_eq!(PathPattern::new("/").segment_kinds().len(), 0);
     assert_eq!(PathPattern::new("").segment_kinds().len(), 0);
 }
+
+#[test]
+fn prefix_matching() {
+    let api = PathPattern::new_prefix("/api");
+    assert!(api.is_match(p("/api"))); // bare prefix
+    assert!(api.is_match(p("/api/"))); // trailing slash ignored
+    assert!(api.is_match(p("/api/users")));
+    assert!(api.is_match(p("/api/users/42")));
+    assert!(!api.is_match(p("/apixyz"))); // segment-boundary, not substring
+    assert!(!api.is_match(p("/"))); // shorter than the prefix
+    assert!(!api.is_match(p("")));
+
+    // Multi-segment prefix.
+    let v2 = PathPattern::new_prefix("/api/v2");
+    assert!(v2.is_match(p("/api/v2")));
+    assert!(v2.is_match(p("/api/v2/users")));
+    assert!(!v2.is_match(p("/api"))); // path shorter than prefix
+    assert!(!v2.is_match(p("/api/v2x"))); // partial last segment
+
+    // Empty prefix matches everything.
+    let any = PathPattern::new_prefix("");
+    assert!(any.is_match(p("/anything/at/all")));
+    assert!(any.is_match(p("")));
+
+    // Captures still bind in prefix mode; the trailing run is ignored.
+    let cap = PathPattern::new_prefix("/users/{id}");
+    let caps = cap.captures(p("/users/42/orders/7")).unwrap();
+    assert_eq!(caps.get("id"), Some("42"));
+}

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -558,3 +558,21 @@ fn pathological_multi_catchall_is_polynomial_and_correct() {
     let g = ok.captures(p("/a/b/c/end")).expect("must match");
     assert_eq!(g.glob(), Some("a"));
 }
+
+#[test]
+fn brace_misuse_falls_back_to_literal() {
+    // Mid-segment `{*…}` is not a catch-all; the whole segment is literal.
+    let pat = PathPattern::new("/a{*}b");
+    assert!(pat.is_match(p("/a{*}b")));
+    assert!(!pat.is_match(p("/axb")));
+
+    // `{}}` = anonymous run `{}` then a literal `}`.
+    let pat = PathPattern::new("/{}}");
+    assert!(pat.is_match(p("/anything}")));
+    assert!(!pat.is_match(p("/anything")));
+
+    // Whole-segment `{*}}` has a non-name catch-all body -> literal segment.
+    let pat = PathPattern::new("/{*}}");
+    assert!(pat.is_match(p("/{*}}")));
+    assert!(!pat.is_match(p("/a/b")));
+}

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -1,10 +1,11 @@
 //! `PathPattern` — infallible path-pattern matching and captures.
 //!
 //! Pins the matcher contract: literal exactness, whole-segment and run
-//! captures, anonymous wildcards with literal affixes, catch-all (`**`, incl.
+//! captures, anonymous wildcards with literal affixes, catch-all (`{*}`, incl.
 //! mid-pattern), explicit trailing-slash policy, decode-aware and case-(in)
 //! sensitive comparison, the `?` optional element, polynomial backtracking, and
-//! that meta-char misuse / UTF-8 / percent-encoding never panic.
+//! that brace misuse / UTF-8 / percent-encoding never panic. `*`, `:`, `.` etc.
+//! are plain literals; only `{`, `}`, `?` are metacharacters.
 
 use crate::uri::{PathMatchOptions, PathPattern, PathRef};
 
@@ -27,7 +28,7 @@ fn caps(pattern: &str, path: &str) -> Option<Vec<(String, String)>> {
     })
 }
 
-/// The `**` glob value for `path` against `pattern`, if matched.
+/// The `{*}` glob value for `path` against `pattern`, if matched.
 fn glob_of(pattern: &str, path: &str) -> Option<String> {
     PathPattern::new(pattern)
         .captures(p(path))
@@ -49,25 +50,45 @@ fn literal_exact() {
 }
 
 #[test]
+fn old_metachars_are_now_literals() {
+    // `:` is a plain literal now (Google AIP custom-method style).
+    let colon = PathPattern::new("/books:archive");
+    assert!(colon.is_match(p("/books:archive")));
+    assert!(!colon.is_match(p("/books/archive")));
+    assert!(colon.captures(p("/books:archive")).unwrap().is_empty());
+
+    // `*` is a plain literal now, not a wildcard.
+    let star = PathPattern::new("/a*b");
+    assert!(star.is_match(p("/a*b")));
+    assert!(!star.is_match(p("/axb")));
+    assert!(!star.is_match(p("/ab")));
+
+    // `**` likewise: a literal segment, no longer a catch-all.
+    let dstar = PathPattern::new("/x/**");
+    assert!(dstar.is_match(p("/x/**")));
+    assert!(!dstar.is_match(p("/x/a/b")));
+}
+
+#[test]
 fn whole_segment_capture_trailing_required() {
     assert_eq!(
-        caps("/simple/:name/", "/simple/requests/"),
+        caps("/simple/{name}/", "/simple/requests/"),
         Some(vec![("name".to_owned(), "requests".to_owned())])
     );
-    assert!(caps("/simple/:name/", "/simple/requests").is_none());
+    assert!(caps("/simple/{name}/", "/simple/requests").is_none());
 }
 
 #[test]
 fn optional_trailing_slash() {
     let want = Some(vec![("name".to_owned(), "requests".to_owned())]);
-    assert_eq!(caps("/simple/:name/?", "/simple/requests"), want);
-    assert_eq!(caps("/simple/:name/?", "/simple/requests/"), want);
+    assert_eq!(caps("/simple/{name}/?", "/simple/requests"), want);
+    assert_eq!(caps("/simple/{name}/?", "/simple/requests/"), want);
 }
 
 #[test]
 fn capture_with_suffix() {
     assert_eq!(
-        caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget.json"),
+        caps("/p2/{vendor}/{pkg}.json", "/p2/acme/widget.json"),
         Some(vec![
             ("pkg".to_owned(), "widget".to_owned()),
             ("vendor".to_owned(), "acme".to_owned()),
@@ -75,18 +96,18 @@ fn capture_with_suffix() {
     );
     // `~` lands inside the captured run.
     assert_eq!(
-        caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget~dev.json"),
+        caps("/p2/{vendor}/{pkg}.json", "/p2/acme/widget~dev.json"),
         Some(vec![
             ("pkg".to_owned(), "widget~dev".to_owned()),
             ("vendor".to_owned(), "acme".to_owned()),
         ])
     );
-    assert!(caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget.txt").is_none());
+    assert!(caps("/p2/{vendor}/{pkg}.json", "/p2/acme/widget.txt").is_none());
 }
 
 #[test]
 fn anonymous_wildcard_suffix() {
-    let pat = PathPattern::new("/files/*.txt");
+    let pat = PathPattern::new("/files/{}.txt");
     assert!(pat.is_match(p("/files/readme.txt")));
     assert!(!pat.is_match(p("/files/readme.md")));
     assert!(pat.captures(p("/files/readme.txt")).unwrap().is_empty());
@@ -94,28 +115,28 @@ fn anonymous_wildcard_suffix() {
 
 #[test]
 fn catch_all_tail() {
-    assert_eq!(glob_of("/assets/**", "/assets/a"), Some("a".to_owned()));
+    assert_eq!(glob_of("/assets/{*}", "/assets/a"), Some("a".to_owned()));
     assert_eq!(
-        glob_of("/assets/**", "/assets/a/b/c"),
+        glob_of("/assets/{*}", "/assets/a/b/c"),
         Some("a/b/c".to_owned())
     );
-    // `**` requires 1+ segments.
+    // `{*}` requires 1+ segments.
     assert!(
-        PathPattern::new("/assets/**")
+        PathPattern::new("/assets/{*}")
             .captures(p("/assets"))
             .is_none()
     );
-    assert!(!PathPattern::new("/assets/**").is_match(p("/assets")));
+    assert!(!PathPattern::new("/assets/{*}").is_match(p("/assets")));
 }
 
 #[test]
 fn catch_all_middle() {
-    let pat = PathPattern::new("/p2/**/*.txt");
+    let pat = PathPattern::new("/p2/{*}/{}.txt");
     assert!(pat.is_match(p("/p2/a/b/c.txt")));
-    // `**` is 1+, so a single trailing segment leaves nothing for it.
+    // `{*}` is 1+, so a single trailing segment leaves nothing for it.
     assert!(!pat.is_match(p("/p2/x.txt")));
     assert_eq!(
-        glob_of("/p2/**/*.txt", "/p2/a/b/c.txt"),
+        glob_of("/p2/{*}/{}.txt", "/p2/a/b/c.txt"),
         Some("a/b".to_owned())
     );
 }
@@ -124,7 +145,7 @@ fn catch_all_middle() {
 fn decode_aware_capture() {
     // `%6d` decodes to `m`, so the encoded path still captures vendor=acme.
     assert_eq!(
-        caps("/p2/:vendor/:pkg*.json", "/p2/ac%6de/widget.json"),
+        caps("/p2/{vendor}/{pkg}.json", "/p2/ac%6de/widget.json"),
         Some(vec![
             ("pkg".to_owned(), "widget".to_owned()),
             ("vendor".to_owned(), "acme".to_owned()),
@@ -165,12 +186,12 @@ fn root_and_empty_edges() {
     assert!(PathPattern::new("/a").is_match(p("/a")));
 
     assert!(PathPattern::new("").is_match(p("")));
-    // `*` is 0+ within a segment and `/` is a single empty segment, so `/*`
+    // `{}` is 0+ within a segment and `/` is a single empty segment, so `/{}`
     // matches `/`.
-    assert!(PathPattern::new("/*").is_match(p("/")));
-    assert!(!PathPattern::new(":weird*?[]").is_match(p("/x")));
-    assert!(PathPattern::new("/*").is_match(p("/anything")));
-    assert_eq!(glob_of("/**", "/a/b"), Some("a/b".to_owned()));
+    assert!(PathPattern::new("/{}").is_match(p("/")));
+    assert!(!PathPattern::new("{weird}?[]").is_match(p("/x")));
+    assert!(PathPattern::new("/{}").is_match(p("/anything")));
+    assert_eq!(glob_of("/{*}", "/a/b"), Some("a/b".to_owned()));
 }
 
 #[test]
@@ -180,12 +201,12 @@ fn is_match_captures_parity() {
             "/backend-api/codex/responses",
             "/backend-api/codex/responses",
         ),
-        ("/files/*.txt", "/files/a.txt"),
-        ("/p2/:vendor/:pkg*.json", "/p2/acme/widget.json"),
-        ("/assets/**", "/assets/a/b"),
-        ("/simple/:name/?", "/simple/x/"),
+        ("/files/{}.txt", "/files/a.txt"),
+        ("/p2/{vendor}/{pkg}.json", "/p2/acme/widget.json"),
+        ("/assets/{*}", "/assets/a/b"),
+        ("/simple/{name}/?", "/simple/x/"),
         ("/api/v2", "/api/v3"),
-        ("/files/*.txt", "/files/a.md"),
+        ("/files/{}.txt", "/files/a.md"),
         ("/", "/"),
         ("/", "/a"),
     ];
@@ -205,7 +226,7 @@ fn is_match_captures_parity() {
 
 #[test]
 fn capture_accessors() {
-    let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
+    let pat = PathPattern::new("/p2/{vendor}/{pkg}.json");
     let caps = pat.captures(p("/p2/acme/widget.json")).unwrap();
     assert_eq!(caps.get("vendor"), Some("acme"));
     assert_eq!(caps.get("pkg"), Some("widget"));
@@ -220,9 +241,9 @@ fn capture_accessors() {
 
 #[test]
 fn capture_then_literal_without_star() {
-    // `:pkg.json` (no `*`) captures the greedy run before the `.json` literal —
-    // same result as `:pkg*.json`, with the literal matched intact.
-    let pat = PathPattern::new("/p2/:vendor/:pkg.json");
+    // `{pkg}.json` captures the greedy run before the `.json` literal, with the
+    // literal matched intact.
+    let pat = PathPattern::new("/p2/{vendor}/{pkg}.json");
     let caps = pat.captures(p("/p2/acme/widget.json")).unwrap();
     assert_eq!(caps.get("pkg"), Some("widget"));
     assert_eq!(caps.get("vendor"), Some("acme"));
@@ -231,7 +252,7 @@ fn capture_then_literal_without_star() {
 
 #[test]
 fn capture_names_with_underscore_and_dash() {
-    let pat = PathPattern::new("/:my_name/:other-id");
+    let pat = PathPattern::new("/{my_name}/{other-id}");
     let caps = pat.captures(p("/foo/bar")).unwrap();
     assert_eq!(caps.get("my_name"), Some("foo"));
     assert_eq!(caps.get("other-id"), Some("bar"));
@@ -254,26 +275,26 @@ fn capture_free_trailing_slash_fast_path() {
 
 #[test]
 fn backtracking_discards_stale_bindings() {
-    // `**` is shortest-first: take=1 ([a]) tentatively binds :x="b" then fails
+    // `{*}` is shortest-first: take=1 ([a]) tentatively binds x="b" then fails
     // on the leftover [c]; that binding must be discarded before take=2 binds
-    // :x="c". A leaked binding would surface as a stale `x` here.
+    // x="c". A leaked binding would surface as a stale `x` here.
     assert_eq!(
-        caps("/**/:x", "/a/b/c"),
+        caps("/{*}/{x}", "/a/b/c"),
         Some(vec![("x".to_owned(), "c".to_owned())])
     );
-    assert_eq!(glob_of("/**/:x", "/a/b/c"), Some("a/b".to_owned()));
+    assert_eq!(glob_of("/{*}/{x}", "/a/b/c"), Some("a/b".to_owned()));
 }
 
 #[test]
 fn anonymous_and_glob_excluded_from_named() {
-    // `:` with no following name is an uncaptured wildcard run.
-    let anon_pat = PathPattern::new("/p2/:/:real");
+    // `{}` is an uncaptured wildcard run.
+    let anon_pat = PathPattern::new("/p2/{}/{real}");
     let caps = anon_pat.captures(p("/p2/foo/bar")).unwrap();
     assert_eq!(caps.get("real"), Some("bar"));
     assert_eq!(caps.iter().collect::<Vec<_>>(), vec![("real", "bar")]);
 
-    // The `**` glob is reachable only via glob(), never get()/iter().
-    let glob_pat = PathPattern::new("/files/**/:name");
+    // The `{*}` glob is reachable only via glob(), never get()/iter().
+    let glob_pat = PathPattern::new("/files/{*}/{name}");
     let g = glob_pat.captures(p("/files/a/b/x")).unwrap();
     assert_eq!(g.get("name"), Some("x"));
     assert_eq!(g.glob(), Some("a/b"));
@@ -282,50 +303,50 @@ fn anonymous_and_glob_excluded_from_named() {
 
 #[test]
 fn named_catch_all() {
-    // `:name**` is a named catch-all: 1+ segments, '/'-joined and decoded,
+    // `{*name}` is a named catch-all: 1+ segments, '/'-joined and decoded,
     // read via get()/iter() — not glob().
     assert_eq!(
-        caps("/assets/:path**", "/assets/css/app.css"),
+        caps("/assets/{*path}", "/assets/css/app.css"),
         Some(vec![("path".to_owned(), "css/app.css".to_owned())])
     );
     assert_eq!(
-        caps("/assets/:path**", "/assets/a"),
+        caps("/assets/{*path}", "/assets/a"),
         Some(vec![("path".to_owned(), "a".to_owned())])
     );
     // It is a named binding, so glob() stays empty.
-    let pat = PathPattern::new("/assets/:path**");
+    let pat = PathPattern::new("/assets/{*path}");
     let c = pat.captures(p("/assets/a/b")).unwrap();
     assert_eq!(c.get("path"), Some("a/b"));
     assert_eq!(c.glob(), None);
 
-    // Like `**`, it needs 1+ segments: the bare prefix does not match.
+    // Like `{*}`, it needs 1+ segments: the bare prefix does not match.
     assert!(
-        PathPattern::new("/assets/:path**")
+        PathPattern::new("/assets/{*path}")
             .captures(p("/assets"))
             .is_none()
     );
 
     // Mid-pattern: the run stops before the trailing literal.
     assert_eq!(
-        caps("/a/:mid**/z", "/a/b/c/z"),
+        caps("/a/{*mid}/z", "/a/b/c/z"),
         Some(vec![("mid".to_owned(), "b/c".to_owned())])
     );
 
     // Decoded + joined across segments.
     assert_eq!(
-        caps("/d/:rest**", "/d/a%20b/c"),
+        caps("/d/{*rest}", "/d/a%20b/c"),
         Some(vec![("rest".to_owned(), "a b/c".to_owned())])
     );
 
-    // A single `*` stays within a segment (contrast): `:path*` captures one
-    // segment only, so a multi-segment path does not match.
+    // `{name}` stays within a segment (contrast): it captures one segment
+    // only, so a multi-segment path does not match.
     assert!(
-        PathPattern::new("/assets/:path*")
+        PathPattern::new("/assets/{path}")
             .captures(p("/assets/a/b"))
             .is_none()
     );
     assert_eq!(
-        caps("/assets/:path*", "/assets/a"),
+        caps("/assets/{path}", "/assets/a"),
         Some(vec![("path".to_owned(), "a".to_owned())])
     );
 }
@@ -338,21 +359,21 @@ fn utf8_literal_and_capture() {
 
     // Capture carries a multibyte value through intact.
     assert_eq!(
-        caps("/u/:name", "/u/naïve"),
+        caps("/u/{name}", "/u/naïve"),
         Some(vec![("name".to_owned(), "naïve".to_owned())])
     );
 
     // Percent-encoded UTF-8 decodes to the same value, both in a capture and
     // against a (decoded) literal segment.
     assert_eq!(
-        caps("/u/:name", "/u/caf%C3%A9"),
+        caps("/u/{name}", "/u/caf%C3%A9"),
         Some(vec![("name".to_owned(), "café".to_owned())])
     );
     assert!(PathPattern::new("/café").is_match(p("/caf%C3%A9")));
 
     // A multibyte run inside an affixed capture splits on the literal byte.
     assert_eq!(
-        caps("/d/:name*.md", "/d/naïve.md"),
+        caps("/d/{name}.md", "/d/naïve.md"),
         Some(vec![("name".to_owned(), "naïve".to_owned())])
     );
 }
@@ -362,18 +383,18 @@ fn pct_encoded_inside_segment_is_not_a_separator() {
     // `%2F` decodes to `/` but stays *within* the captured value — segmentation
     // happens on raw `/`, before decoding, so it must not split the segment.
     assert_eq!(
-        caps("/files/:name", "/files/a%2Fb"),
+        caps("/files/{name}", "/files/a%2Fb"),
         Some(vec![("name".to_owned(), "a/b".to_owned())])
     );
     assert_eq!(
-        caps("/person/:name/age", "/person/glen%20dc/age"),
+        caps("/person/{name}/age", "/person/glen%20dc/age"),
         Some(vec![("name".to_owned(), "glen dc".to_owned())])
     );
-    // A percent-encoded metacharacter decodes to a plain literal in the value
-    // (`%2A` == `*`); it is never re-interpreted as a wildcard.
+    // A percent-encoded brace decodes to a plain literal in the value
+    // (`%7B` == `{`); it is never re-interpreted as a token.
     assert_eq!(
-        caps("/x/:v", "/x/%2A"),
-        Some(vec![("v".to_owned(), "*".to_owned())])
+        caps("/x/{v}", "/x/%7Babc"),
+        Some(vec![("v".to_owned(), "{abc".to_owned())])
     );
 }
 
@@ -381,55 +402,61 @@ fn pct_encoded_inside_segment_is_not_a_separator() {
 fn invalid_utf8_decodes_lossy_without_panic() {
     // `%ff` decodes to byte 0xFF (not valid UTF-8): the capture is rendered
     // lossily (U+FFFD) rather than panicking or dropping the match.
-    let pat = PathPattern::new("/x/:v");
+    let pat = PathPattern::new("/x/{v}");
     let caps = pat.captures(p("/x/%ff")).unwrap();
     assert_eq!(caps.get("v"), Some("\u{FFFD}"));
-    // Same for the `**` glob join.
-    assert_eq!(glob_of("/g/**", "/g/a/%ff"), Some("a/\u{FFFD}".to_owned()));
+    // Same for the `{*}` glob join.
+    assert_eq!(glob_of("/g/{*}", "/g/a/%ff"), Some("a/\u{FFFD}".to_owned()));
 }
 
 #[test]
 fn misused_meta_chars_never_panic_and_stay_consistent() {
-    // Patterns that abuse the matching metacharacters (`*`, `:`, `?`, `**`)
-    // must compile (infallible) and match without panicking, and is_match must
-    // always agree with captures().is_some() — including on percent-encoded,
-    // empty, and double-slash paths.
+    // Patterns that abuse the brace metacharacters (`{`, `}`, `?`) or pile up
+    // the now-literal `*`/`:` must compile (infallible) and match without
+    // panicking, and is_match must always agree with captures().is_some() —
+    // including on percent-encoded, empty, and double-slash paths.
     let patterns = [
-        ":",
-        "::",
-        ":*",
-        "*:",
-        "*",
-        "**",
-        "***",
-        "/:",
-        "/::/",
-        "a**",
-        "**b",
-        ":?",
-        "?:",
+        "{",
+        "}",
+        "{}",
+        "{{}}",
+        "{}}",
+        "{{}",
+        "{name",
+        "name}",
+        "{bad name}",
+        "{na/me}",
+        "{*}",
+        "{**}",
+        "{*}}",
+        "{*bad name}",
+        "{*na/me}",
+        "a{*}",
+        "{*}b",
+        "{}?",
+        "{name}?",
+        "{?}",
+        "?{}",
         "??",
         "a?",
         "ab?c",
-        "*?",
-        "**?",
-        ":name?",
-        ":*name",
-        "[]{}",
-        "(){}",
-        ":weird*?[]",
+        "{weird}?[]",
+        ":",
+        "*",
+        "**",
+        "***",
         "/",
         "//",
         "///",
         "",
-        "::*::",
-        "/a/**/**/b",
-        ":a*:b*:c",
-        ":rest**",
-        ":**",
-        ":name***",
-        "x:name**",
-        "/a/:mid**/z",
+        "/a/{*}/{*}/b",
+        "{a}{b}{c}",
+        "{*rest}",
+        "x{*name}",
+        "{*name}}",
+        "/a/{*mid}/z",
+        "{}.{}",
+        "v{ver}-rc",
     ];
     let paths = [
         "", "/", "//", "/abc", "/a/b", "/a/b/c", "/a//b", "/x/", "/*", "/:", "/a?b", "/%2F",
@@ -466,10 +493,10 @@ fn misused_meta_chars_never_panic_and_stay_consistent() {
 fn pathological_multi_run_segment_is_polynomial_and_correct() {
     use std::time::{Duration, Instant};
 
-    // One segment, two literal-separated captures `[a*][b][b*][b]`: matching
+    // One segment, two literal-separated captures `[a][b][b][b]`: matching
     // "aaa…a" + "bb", greedy-longest binds a="aaa…a", literal `b`, then b=""
     // before the trailing literal `b`.
-    let pat = PathPattern::new("/:a*b:b*b");
+    let pat = PathPattern::new("/{a}b{b}b");
     let hay = "/".to_owned() + &"a".repeat(40) + "bb";
     let start = Instant::now();
     let caps = pat.captures(p(&hay)).expect("must match");
@@ -478,7 +505,7 @@ fn pathological_multi_run_segment_is_polynomial_and_correct() {
 
     // A failing match over a long run forces the matcher to prove no split
     // works — the exponential blowup case.
-    let fail_pat = PathPattern::new(":x*:y*:z*:w*:v*END");
+    let fail_pat = PathPattern::new("{x}{y}{z}{w}{v}END");
     let fail_hay = "/".to_owned() + &"q".repeat(60);
     assert!(!fail_pat.is_match(p(&fail_hay)));
     assert!(
@@ -514,9 +541,9 @@ fn pathological_many_optional_literals_is_polynomial() {
 fn pathological_multi_catchall_is_polynomial_and_correct() {
     use std::time::{Duration, Instant};
 
-    // Eight `**` plus a trailing literal that never appears: naive search is
+    // Eight `{*}` plus a trailing literal that never appears: naive search is
     // O(segments^8); the cross-segment memo keeps it polynomial.
-    let pat = PathPattern::new("/**/**/**/**/**/**/**/**/end");
+    let pat = PathPattern::new("/{*}/{*}/{*}/{*}/{*}/{*}/{*}/{*}/end");
     let hay = "/".to_owned() + &"x/".repeat(30) + "y";
     let start = Instant::now();
     assert!(!pat.is_match(p(&hay)));
@@ -525,9 +552,9 @@ fn pathological_multi_catchall_is_polynomial_and_correct() {
         "matching must stay polynomial"
     );
 
-    // Still matches + globs correctly when the tail lines up. `**` is
+    // Still matches + globs correctly when the tail lines up. `{*}` is
     // shortest-first, so the first takes one segment and the second the rest.
-    let ok = PathPattern::new("/**/**/end");
+    let ok = PathPattern::new("/{*}/{*}/end");
     let g = ok.captures(p("/a/b/c/end")).expect("must match");
     assert_eq!(g.glob(), Some("a"));
 }

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -576,3 +576,25 @@ fn brace_misuse_falls_back_to_literal() {
     assert!(pat.is_match(p("/{*}}")));
     assert!(!pat.is_match(p("/a/b")));
 }
+
+#[test]
+fn segment_kinds_classify_each_segment() {
+    use crate::uri::PathPatternSegmentKind as K;
+    let kinds = |pat: &str| PathPattern::new(pat).segment_kinds().collect::<Vec<_>>();
+
+    assert_eq!(kinds("/a/b"), [K::Literal, K::Literal]);
+    assert_eq!(kinds("/users/{id}"), [K::Literal, K::Dynamic]);
+    assert_eq!(kinds("/files/{}.json"), [K::Literal, K::Dynamic]);
+    assert_eq!(kinds("/p/{pkg}.json"), [K::Literal, K::Dynamic]);
+    assert_eq!(kinds("/assets/{*}"), [K::Literal, K::CatchAll]);
+    assert_eq!(kinds("/assets/{*rest}"), [K::Literal, K::CatchAll]);
+    // An optional element makes the segment non-fixed -> dynamic.
+    assert_eq!(kinds("/maybe/a?"), [K::Literal, K::Dynamic]);
+    // Invalid catch-all / brace junk is a literal, exactly as the matcher
+    // treats it (no router-side drift).
+    assert_eq!(kinds("/api/{*bad name}"), [K::Literal, K::Literal]);
+    assert_eq!(kinds("/x/{na.me}"), [K::Literal, K::Literal]);
+    // Bare root has no segments.
+    assert_eq!(PathPattern::new("/").segment_kinds().len(), 0);
+    assert_eq!(PathPattern::new("").segment_kinds().len(), 0);
+}

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -1,10 +1,10 @@
-//! `PathPattern` — infallible path-pattern matching + captures.
+//! `PathPattern` — infallible path-pattern matching and captures.
 //!
-//! These tests pin the matcher's contract: literal exactness, whole-segment
-//! and run captures, anonymous wildcards with literal affixes, catch-all
-//! (`**`, incl. mid-pattern), explicit trailing-slash policy, decode-aware
-//! comparison, case sensitivity, and the `?` optional element. Each `#[test]`
-//! covers one group of the spec matrix.
+//! Pins the matcher contract: literal exactness, whole-segment and run
+//! captures, anonymous wildcards with literal affixes, catch-all (`**`, incl.
+//! mid-pattern), explicit trailing-slash policy, decode-aware and case-(in)
+//! sensitive comparison, the `?` optional element, polynomial backtracking, and
+//! that meta-char misuse / UTF-8 / percent-encoding never panic.
 
 use crate::uri::{PathMatchOptions, PathPattern, PathRef};
 
@@ -34,19 +34,12 @@ fn glob_of(pattern: &str, path: &str) -> Option<String> {
         .and_then(|c| c.glob().map(str::to_owned))
 }
 
-// ======================================================================
-// 1. Literal exact
-// ======================================================================
-
 #[test]
 fn literal_exact() {
     let pat = PathPattern::new("/backend-api/codex/responses");
     assert!(pat.is_match(p("/backend-api/codex/responses")));
-    // No extra trailing segment, no missing segment.
     assert!(!pat.is_match(p("/backend-api/codex/responses/x")));
     assert!(!pat.is_match(p("/backend-api/codex")));
-    // Captures present (empty) exactly when is_match is true.
-    assert!(pat.captures(p("/backend-api/codex/responses")).is_some());
     assert!(
         pat.captures(p("/backend-api/codex/responses"))
             .unwrap()
@@ -55,36 +48,21 @@ fn literal_exact() {
     assert!(pat.captures(p("/backend-api/codex")).is_none());
 }
 
-// ======================================================================
-// 2. Whole-segment capture, trailing slash required
-// ======================================================================
-
 #[test]
 fn whole_segment_capture_trailing_required() {
-    // `/simple/:name/` requires the trailing slash.
     assert_eq!(
         caps("/simple/:name/", "/simple/requests/"),
         Some(vec![("name".to_owned(), "requests".to_owned())])
     );
-    // Without the trailing slash: no match.
     assert!(caps("/simple/:name/", "/simple/requests").is_none());
 }
 
-// ======================================================================
-// 3. Optional trailing slash
-// ======================================================================
-
 #[test]
 fn optional_trailing_slash() {
-    // `/simple/:name/?` matches both forms with name=requests.
     let want = Some(vec![("name".to_owned(), "requests".to_owned())]);
     assert_eq!(caps("/simple/:name/?", "/simple/requests"), want);
     assert_eq!(caps("/simple/:name/?", "/simple/requests/"), want);
 }
-
-// ======================================================================
-// 4. Capture + literal suffix (run capture)
-// ======================================================================
 
 #[test]
 fn capture_with_suffix() {
@@ -95,7 +73,7 @@ fn capture_with_suffix() {
             ("vendor".to_owned(), "acme".to_owned()),
         ])
     );
-    // `~` is inside the captured run.
+    // `~` lands inside the captured run.
     assert_eq!(
         caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget~dev.json"),
         Some(vec![
@@ -103,26 +81,16 @@ fn capture_with_suffix() {
             ("vendor".to_owned(), "acme".to_owned()),
         ])
     );
-    // Wrong suffix: no match.
     assert!(caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget.txt").is_none());
 }
-
-// ======================================================================
-// 5. Anonymous wildcard + literal suffix
-// ======================================================================
 
 #[test]
 fn anonymous_wildcard_suffix() {
     let pat = PathPattern::new("/files/*.txt");
     assert!(pat.is_match(p("/files/readme.txt")));
     assert!(!pat.is_match(p("/files/readme.md")));
-    // No captures recorded for the anonymous `*`.
     assert!(pat.captures(p("/files/readme.txt")).unwrap().is_empty());
 }
-
-// ======================================================================
-// 6. Catch-all (`**`)
-// ======================================================================
 
 #[test]
 fn catch_all_tail() {
@@ -131,7 +99,7 @@ fn catch_all_tail() {
         glob_of("/assets/**", "/assets/a/b/c"),
         Some("a/b/c".to_owned())
     );
-    // `**` requires 1+ segments: `/assets` alone does not match.
+    // `**` requires 1+ segments.
     assert!(
         PathPattern::new("/assets/**")
             .captures(p("/assets"))
@@ -140,26 +108,17 @@ fn catch_all_tail() {
     assert!(!PathPattern::new("/assets/**").is_match(p("/assets")));
 }
 
-// ======================================================================
-// 7. Catch-all in the middle
-// ======================================================================
-
 #[test]
 fn catch_all_middle() {
     let pat = PathPattern::new("/p2/**/*.txt");
     assert!(pat.is_match(p("/p2/a/b/c.txt")));
     // `**` is 1+, so a single trailing segment leaves nothing for it.
     assert!(!pat.is_match(p("/p2/x.txt")));
-    // The glob captures the middle run before the final `*.txt` segment.
     assert_eq!(
         glob_of("/p2/**/*.txt", "/p2/a/b/c.txt"),
         Some("a/b".to_owned())
     );
 }
-
-// ======================================================================
-// 8. Decode-aware capture
-// ======================================================================
 
 #[test]
 fn decode_aware_capture() {
@@ -173,18 +132,12 @@ fn decode_aware_capture() {
     );
 }
 
-// ======================================================================
-// 9. Case sensitivity (default vs ignore_ascii_case)
-// ======================================================================
-
 #[test]
 fn case_sensitivity() {
-    // Default: case-sensitive literal.
     let sensitive = PathPattern::new("/api/v2");
     assert!(sensitive.is_match(p("/api/v2")));
     assert!(!sensitive.is_match(p("/API/v2")));
 
-    // ignore_ascii_case opts into case-insensitive matching.
     let insensitive = PathPattern::new_with_opts(
         "/api/v2",
         PathMatchOptions {
@@ -196,10 +149,6 @@ fn case_sensitivity() {
     assert!(insensitive.is_match(p("/api/v2")));
 }
 
-// ======================================================================
-// 10. Char-optional `?`
-// ======================================================================
-
 #[test]
 fn char_optional() {
     // `ab?c` -> optional `b`.
@@ -209,34 +158,20 @@ fn char_optional() {
     assert!(!pat.is_match(p("/abdc")));
 }
 
-// ======================================================================
-// 11. Empty / root edge cases (no panics)
-// ======================================================================
-
 #[test]
 fn root_and_empty_edges() {
-    // Root pattern matches root path only.
     assert!(PathPattern::new("/").is_match(p("/")));
     assert!(!PathPattern::new("/a").is_match(p("/")));
     assert!(PathPattern::new("/a").is_match(p("/a")));
 
-    // No panics on empty path, bare `*`, or odd inputs (outcomes asserted so
-    // the calls aren't dropped, but the point is the absence of a panic).
     assert!(PathPattern::new("").is_match(p("")));
-    // `*` is 0+ within a segment, and `/` is a single empty segment, so `/*`
+    // `*` is 0+ within a segment and `/` is a single empty segment, so `/*`
     // matches `/`.
     assert!(PathPattern::new("/*").is_match(p("/")));
-    // Odd literal-laden pattern: just must not panic; it shouldn't match `/x`.
     assert!(!PathPattern::new(":weird*?[]").is_match(p("/x")));
-    // `/*` (anonymous 0+ within a segment) matches a single non-empty segment.
     assert!(PathPattern::new("/*").is_match(p("/anything")));
-    // `**` over a multi-segment path must not panic and joins the glob.
     assert_eq!(glob_of("/**", "/a/b"), Some("a/b".to_owned()));
 }
-
-// ======================================================================
-// is_match / captures parity + extra no-capture cases
-// ======================================================================
 
 #[test]
 fn is_match_captures_parity() {
@@ -256,26 +191,17 @@ fn is_match_captures_parity() {
     ];
     for (pattern, path) in cases {
         let pat = PathPattern::new(*pattern);
-        let m = pat.is_match(p(path));
-        let c = pat.captures(p(path));
         assert_eq!(
-            m,
-            c.is_some(),
+            pat.is_match(p(path)),
+            pat.captures(p(path)).is_some(),
             "is_match/captures disagree for pattern {pattern:?} path {path:?}"
         );
     }
 
-    // A pure-literal multi-segment pattern: captures Some+empty when matched.
     let pat = PathPattern::new("/a/b/c");
-    assert!(pat.is_match(p("/a/b/c")));
     assert!(pat.captures(p("/a/b/c")).unwrap().is_empty());
-    assert!(!pat.is_match(p("/a/b")));
     assert!(pat.captures(p("/a/b")).is_none());
 }
-
-// ======================================================================
-// get() / is_empty() accessors (direct — the helpers above only read iter/glob)
-// ======================================================================
 
 #[test]
 fn capture_accessors() {
@@ -292,25 +218,16 @@ fn capture_accessors() {
     assert_eq!(empty.get("anything"), None);
 }
 
-// ======================================================================
-// Capture directly followed by a literal (no `*`)
-// ======================================================================
-
 #[test]
 fn capture_then_literal_without_star() {
-    // `:pkg.json` (no `*`): the capture is the greedy run before the `.json`
-    // literal — same result as `:pkg*.json`. Pins that the literal after the
-    // name is matched intact (not having its first byte swallowed).
+    // `:pkg.json` (no `*`) captures the greedy run before the `.json` literal —
+    // same result as `:pkg*.json`, with the literal matched intact.
     let pat = PathPattern::new("/p2/:vendor/:pkg.json");
     let caps = pat.captures(p("/p2/acme/widget.json")).unwrap();
     assert_eq!(caps.get("pkg"), Some("widget"));
     assert_eq!(caps.get("vendor"), Some("acme"));
     assert!(pat.captures(p("/p2/acme/widget.txt")).is_none());
 }
-
-// ======================================================================
-// Capture names with `_` and `-`
-// ======================================================================
 
 #[test]
 fn capture_names_with_underscore_and_dash() {
@@ -319,10 +236,6 @@ fn capture_names_with_underscore_and_dash() {
     assert_eq!(caps.get("my_name"), Some("foo"));
     assert_eq!(caps.get("other-id"), Some("bar"));
 }
-
-// ======================================================================
-// Capture-free trailing-slash policy (exercises the alloc-free fast path)
-// ======================================================================
 
 #[test]
 fn capture_free_trailing_slash_fast_path() {
@@ -339,10 +252,6 @@ fn capture_free_trailing_slash_fast_path() {
     assert!(optional.is_match(p("/a/b/")));
 }
 
-// ======================================================================
-// Backtracking discards tentative bindings before re-binding
-// ======================================================================
-
 #[test]
 fn backtracking_discards_stale_bindings() {
     // `**` is shortest-first: take=1 ([a]) tentatively binds :x="b" then fails
@@ -354,10 +263,6 @@ fn backtracking_discards_stale_bindings() {
     );
     assert_eq!(glob_of("/**/:x", "/a/b/c"), Some("a/b".to_owned()));
 }
-
-// ======================================================================
-// Anonymous (`:` with no name) and glob bindings excluded from get()/iter()
-// ======================================================================
 
 #[test]
 fn anonymous_and_glob_excluded_from_named() {
@@ -375,23 +280,140 @@ fn anonymous_and_glob_excluded_from_named() {
     assert_eq!(g.iter().collect::<Vec<_>>(), vec![("name", "x")]);
 }
 
-// ======================================================================
-// Pathological shapes are polynomial AND still correct
-//
-// These shapes (many runs / many optionals in one segment, many `**` in a
-// pattern) would explode exponentially under naive backtracking; the memo
-// keeps them fast. The asserts pin both: a wall-clock budget that a 2^N
-// matcher blows through, and the exact match/capture result so the memo can't
-// "go fast by being wrong".
-// ======================================================================
+#[test]
+fn utf8_literal_and_capture() {
+    // Multibyte UTF-8 literal segment.
+    assert!(PathPattern::new("/café/menu").is_match(p("/café/menu")));
+    assert!(!PathPattern::new("/café/menu").is_match(p("/cafe/menu")));
+
+    // Capture carries a multibyte value through intact.
+    assert_eq!(
+        caps("/u/:name", "/u/naïve"),
+        Some(vec![("name".to_owned(), "naïve".to_owned())])
+    );
+
+    // Percent-encoded UTF-8 decodes to the same value, both in a capture and
+    // against a (decoded) literal segment.
+    assert_eq!(
+        caps("/u/:name", "/u/caf%C3%A9"),
+        Some(vec![("name".to_owned(), "café".to_owned())])
+    );
+    assert!(PathPattern::new("/café").is_match(p("/caf%C3%A9")));
+
+    // A multibyte run inside an affixed capture splits on the literal byte.
+    assert_eq!(
+        caps("/d/:name*.md", "/d/naïve.md"),
+        Some(vec![("name".to_owned(), "naïve".to_owned())])
+    );
+}
+
+#[test]
+fn pct_encoded_inside_segment_is_not_a_separator() {
+    // `%2F` decodes to `/` but stays *within* the captured value — segmentation
+    // happens on raw `/`, before decoding, so it must not split the segment.
+    assert_eq!(
+        caps("/files/:name", "/files/a%2Fb"),
+        Some(vec![("name".to_owned(), "a/b".to_owned())])
+    );
+    assert_eq!(
+        caps("/person/:name/age", "/person/glen%20dc/age"),
+        Some(vec![("name".to_owned(), "glen dc".to_owned())])
+    );
+    // A percent-encoded metacharacter decodes to a plain literal in the value
+    // (`%2A` == `*`); it is never re-interpreted as a wildcard.
+    assert_eq!(
+        caps("/x/:v", "/x/%2A"),
+        Some(vec![("v".to_owned(), "*".to_owned())])
+    );
+}
+
+#[test]
+fn invalid_utf8_decodes_lossy_without_panic() {
+    // `%ff` decodes to byte 0xFF (not valid UTF-8): the capture is rendered
+    // lossily (U+FFFD) rather than panicking or dropping the match.
+    let pat = PathPattern::new("/x/:v");
+    let caps = pat.captures(p("/x/%ff")).unwrap();
+    assert_eq!(caps.get("v"), Some("\u{FFFD}"));
+    // Same for the `**` glob join.
+    assert_eq!(glob_of("/g/**", "/g/a/%ff"), Some("a/\u{FFFD}".to_owned()));
+}
+
+#[test]
+fn misused_meta_chars_never_panic_and_stay_consistent() {
+    // Patterns that abuse the matching metacharacters (`*`, `:`, `?`, `**`)
+    // must compile (infallible) and match without panicking, and is_match must
+    // always agree with captures().is_some() — including on percent-encoded,
+    // empty, and double-slash paths.
+    let patterns = [
+        ":",
+        "::",
+        ":*",
+        "*:",
+        "*",
+        "**",
+        "***",
+        "/:",
+        "/::/",
+        "a**",
+        "**b",
+        ":?",
+        "?:",
+        "??",
+        "a?",
+        "ab?c",
+        "*?",
+        "**?",
+        ":name?",
+        ":*name",
+        "[]{}",
+        "(){}",
+        ":weird*?[]",
+        "/",
+        "//",
+        "///",
+        "",
+        "::*::",
+        "/a/**/**/b",
+        ":a*:b*:c",
+    ];
+    let paths = [
+        "", "/", "//", "/abc", "/a/b", "/a/b/c", "/a//b", "/x/", "/*", "/:", "/a?b", "/%2F",
+        "/%ff", "/café", "/a%2Fb/c",
+    ];
+    for pattern in patterns {
+        let pat = PathPattern::new(pattern);
+        for path in paths {
+            let pr = p(path);
+            assert_eq!(
+                pat.is_match(pr),
+                pat.captures(pr).is_some(),
+                "is_match/captures disagree: pattern={pattern:?} path={path:?}"
+            );
+            if let Some(c) = pat.captures(pr) {
+                // Accessors must not panic; a name yielded by iter() resolves
+                // via get() (duplicate names resolve to the first binding, so
+                // only presence is asserted, not value equality).
+                for (name, _value) in c.iter() {
+                    assert!(c.get(name).is_some());
+                }
+                std::hint::black_box((c.glob(), c.is_empty()));
+            }
+        }
+    }
+}
+
+// The shapes below explode exponentially under naive backtracking; the failure
+// memo keeps them polynomial. Each asserts both a wall-clock budget a 2^N
+// matcher blows through and the exact result, so the memo can't "go fast by
+// being wrong".
 
 #[test]
 fn pathological_multi_run_segment_is_polynomial_and_correct() {
     use std::time::{Duration, Instant};
 
     // One segment, two literal-separated captures `[a*][b][b*][b]`: matching
-    // "aaa…a" + "bb", greedy-longest binds a="aaa…a" then literal `b`, then
-    // b="" before the trailing literal `b`.
+    // "aaa…a" + "bb", greedy-longest binds a="aaa…a", literal `b`, then b=""
+    // before the trailing literal `b`.
     let pat = PathPattern::new("/:a*b:b*b");
     let hay = "/".to_owned() + &"a".repeat(40) + "bb";
     let start = Instant::now();
@@ -400,10 +422,9 @@ fn pathological_multi_run_segment_is_polynomial_and_correct() {
     assert_eq!(caps.get("b"), Some(""));
 
     // A failing match over a long run forces the matcher to prove no split
-    // works — the exponential blowup case. Many adjacent captures + literals.
+    // works — the exponential blowup case.
     let fail_pat = PathPattern::new(":x*:y*:z*:w*:v*END");
     let fail_hay = "/".to_owned() + &"q".repeat(60);
-    assert!(fail_pat.captures(p(&fail_hay)).is_none());
     assert!(!fail_pat.is_match(p(&fail_hay)));
     assert!(
         start.elapsed() < Duration::from_secs(2),
@@ -426,8 +447,7 @@ fn pathological_many_optional_literals_is_polynomial() {
     let hay = "/".to_owned() + &"a".repeat(30);
     let start = Instant::now();
     assert!(!pat.is_match(p(&hay)));
-    assert!(pat.captures(p(&hay)).is_none());
-    // All-optional prefix can still match when the literal lands.
+    // The all-optional prefix can still match when the literal lands.
     assert!(PathPattern::new(raw.as_str()).is_match(p("/Z")));
     assert!(
         start.elapsed() < Duration::from_secs(2),
@@ -440,22 +460,19 @@ fn pathological_multi_catchall_is_polynomial_and_correct() {
     use std::time::{Duration, Instant};
 
     // Eight `**` plus a trailing literal that never appears: naive search is
-    // O(segments^8); the cross-segment memo keeps it polynomial. (Two `**`
-    // alone are only O(n^2), too cheap to exercise the memo.)
+    // O(segments^8); the cross-segment memo keeps it polynomial.
     let pat = PathPattern::new("/**/**/**/**/**/**/**/**/end");
     let hay = "/".to_owned() + &"x/".repeat(30) + "y";
     let start = Instant::now();
     assert!(!pat.is_match(p(&hay)));
-    assert!(pat.captures(p(&hay)).is_none());
     assert!(
         start.elapsed() < Duration::from_secs(2),
         "matching must stay polynomial"
     );
 
-    // And it still matches + globs correctly when the tail lines up. `**` is
-    // shortest-first, so the first `**` takes one segment and the second the
-    // rest before `end`.
+    // Still matches + globs correctly when the tail lines up. `**` is
+    // shortest-first, so the first takes one segment and the second the rest.
     let ok = PathPattern::new("/**/**/end");
     let g = ok.captures(p("/a/b/c/end")).expect("must match");
-    assert_eq!(g.glob(), Some("a".to_owned()).as_deref());
+    assert_eq!(g.glob(), Some("a"));
 }

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -1,0 +1,461 @@
+//! `PathPattern` — infallible path-pattern matching + captures.
+//!
+//! These tests pin the matcher's contract: literal exactness, whole-segment
+//! and run captures, anonymous wildcards with literal affixes, catch-all
+//! (`**`, incl. mid-pattern), explicit trailing-slash policy, decode-aware
+//! comparison, case sensitivity, and the `?` optional element. Each `#[test]`
+//! covers one group of the spec matrix.
+
+use crate::uri::{PathMatchOptions, PathPattern, PathRef};
+
+/// Build a [`PathRef`] from a raw on-wire path string.
+fn p(s: &str) -> PathRef<'_> {
+    PathRef::from_raw_str(s)
+}
+
+/// Capture `path` against `pattern`, returning `(name, value)` pairs sorted
+/// by name for stable assertions (glob excluded — see [`glob_of`]).
+fn caps(pattern: &str, path: &str) -> Option<Vec<(String, String)>> {
+    let pat = PathPattern::new(pattern);
+    pat.captures(p(path)).map(|c| {
+        let mut v: Vec<(String, String)> = c
+            .iter()
+            .map(|(n, val)| (n.to_owned(), val.to_owned()))
+            .collect();
+        v.sort();
+        v
+    })
+}
+
+/// The `**` glob value for `path` against `pattern`, if matched.
+fn glob_of(pattern: &str, path: &str) -> Option<String> {
+    PathPattern::new(pattern)
+        .captures(p(path))
+        .and_then(|c| c.glob().map(str::to_owned))
+}
+
+// ======================================================================
+// 1. Literal exact
+// ======================================================================
+
+#[test]
+fn literal_exact() {
+    let pat = PathPattern::new("/backend-api/codex/responses");
+    assert!(pat.is_match(p("/backend-api/codex/responses")));
+    // No extra trailing segment, no missing segment.
+    assert!(!pat.is_match(p("/backend-api/codex/responses/x")));
+    assert!(!pat.is_match(p("/backend-api/codex")));
+    // Captures present (empty) exactly when is_match is true.
+    assert!(pat.captures(p("/backend-api/codex/responses")).is_some());
+    assert!(
+        pat.captures(p("/backend-api/codex/responses"))
+            .unwrap()
+            .is_empty()
+    );
+    assert!(pat.captures(p("/backend-api/codex")).is_none());
+}
+
+// ======================================================================
+// 2. Whole-segment capture, trailing slash required
+// ======================================================================
+
+#[test]
+fn whole_segment_capture_trailing_required() {
+    // `/simple/:name/` requires the trailing slash.
+    assert_eq!(
+        caps("/simple/:name/", "/simple/requests/"),
+        Some(vec![("name".to_owned(), "requests".to_owned())])
+    );
+    // Without the trailing slash: no match.
+    assert!(caps("/simple/:name/", "/simple/requests").is_none());
+}
+
+// ======================================================================
+// 3. Optional trailing slash
+// ======================================================================
+
+#[test]
+fn optional_trailing_slash() {
+    // `/simple/:name/?` matches both forms with name=requests.
+    let want = Some(vec![("name".to_owned(), "requests".to_owned())]);
+    assert_eq!(caps("/simple/:name/?", "/simple/requests"), want);
+    assert_eq!(caps("/simple/:name/?", "/simple/requests/"), want);
+}
+
+// ======================================================================
+// 4. Capture + literal suffix (run capture)
+// ======================================================================
+
+#[test]
+fn capture_with_suffix() {
+    assert_eq!(
+        caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget.json"),
+        Some(vec![
+            ("pkg".to_owned(), "widget".to_owned()),
+            ("vendor".to_owned(), "acme".to_owned()),
+        ])
+    );
+    // `~` is inside the captured run.
+    assert_eq!(
+        caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget~dev.json"),
+        Some(vec![
+            ("pkg".to_owned(), "widget~dev".to_owned()),
+            ("vendor".to_owned(), "acme".to_owned()),
+        ])
+    );
+    // Wrong suffix: no match.
+    assert!(caps("/p2/:vendor/:pkg*.json", "/p2/acme/widget.txt").is_none());
+}
+
+// ======================================================================
+// 5. Anonymous wildcard + literal suffix
+// ======================================================================
+
+#[test]
+fn anonymous_wildcard_suffix() {
+    let pat = PathPattern::new("/files/*.txt");
+    assert!(pat.is_match(p("/files/readme.txt")));
+    assert!(!pat.is_match(p("/files/readme.md")));
+    // No captures recorded for the anonymous `*`.
+    assert!(pat.captures(p("/files/readme.txt")).unwrap().is_empty());
+}
+
+// ======================================================================
+// 6. Catch-all (`**`)
+// ======================================================================
+
+#[test]
+fn catch_all_tail() {
+    assert_eq!(glob_of("/assets/**", "/assets/a"), Some("a".to_owned()));
+    assert_eq!(
+        glob_of("/assets/**", "/assets/a/b/c"),
+        Some("a/b/c".to_owned())
+    );
+    // `**` requires 1+ segments: `/assets` alone does not match.
+    assert!(
+        PathPattern::new("/assets/**")
+            .captures(p("/assets"))
+            .is_none()
+    );
+    assert!(!PathPattern::new("/assets/**").is_match(p("/assets")));
+}
+
+// ======================================================================
+// 7. Catch-all in the middle
+// ======================================================================
+
+#[test]
+fn catch_all_middle() {
+    let pat = PathPattern::new("/p2/**/*.txt");
+    assert!(pat.is_match(p("/p2/a/b/c.txt")));
+    // `**` is 1+, so a single trailing segment leaves nothing for it.
+    assert!(!pat.is_match(p("/p2/x.txt")));
+    // The glob captures the middle run before the final `*.txt` segment.
+    assert_eq!(
+        glob_of("/p2/**/*.txt", "/p2/a/b/c.txt"),
+        Some("a/b".to_owned())
+    );
+}
+
+// ======================================================================
+// 8. Decode-aware capture
+// ======================================================================
+
+#[test]
+fn decode_aware_capture() {
+    // `%6d` decodes to `m`, so the encoded path still captures vendor=acme.
+    assert_eq!(
+        caps("/p2/:vendor/:pkg*.json", "/p2/ac%6de/widget.json"),
+        Some(vec![
+            ("pkg".to_owned(), "widget".to_owned()),
+            ("vendor".to_owned(), "acme".to_owned()),
+        ])
+    );
+}
+
+// ======================================================================
+// 9. Case sensitivity (default vs ignore_ascii_case)
+// ======================================================================
+
+#[test]
+fn case_sensitivity() {
+    // Default: case-sensitive literal.
+    let sensitive = PathPattern::new("/api/v2");
+    assert!(sensitive.is_match(p("/api/v2")));
+    assert!(!sensitive.is_match(p("/API/v2")));
+
+    // ignore_ascii_case opts into case-insensitive matching.
+    let insensitive = PathPattern::new_with_opts(
+        "/api/v2",
+        PathMatchOptions {
+            ignore_ascii_case: true,
+            ..Default::default()
+        },
+    );
+    assert!(insensitive.is_match(p("/API/v2")));
+    assert!(insensitive.is_match(p("/api/v2")));
+}
+
+// ======================================================================
+// 10. Char-optional `?`
+// ======================================================================
+
+#[test]
+fn char_optional() {
+    // `ab?c` -> optional `b`.
+    let pat = PathPattern::new("/ab?c");
+    assert!(pat.is_match(p("/abc")));
+    assert!(pat.is_match(p("/ac")));
+    assert!(!pat.is_match(p("/abdc")));
+}
+
+// ======================================================================
+// 11. Empty / root edge cases (no panics)
+// ======================================================================
+
+#[test]
+fn root_and_empty_edges() {
+    // Root pattern matches root path only.
+    assert!(PathPattern::new("/").is_match(p("/")));
+    assert!(!PathPattern::new("/a").is_match(p("/")));
+    assert!(PathPattern::new("/a").is_match(p("/a")));
+
+    // No panics on empty path, bare `*`, or odd inputs (outcomes asserted so
+    // the calls aren't dropped, but the point is the absence of a panic).
+    assert!(PathPattern::new("").is_match(p("")));
+    // `*` is 0+ within a segment, and `/` is a single empty segment, so `/*`
+    // matches `/`.
+    assert!(PathPattern::new("/*").is_match(p("/")));
+    // Odd literal-laden pattern: just must not panic; it shouldn't match `/x`.
+    assert!(!PathPattern::new(":weird*?[]").is_match(p("/x")));
+    // `/*` (anonymous 0+ within a segment) matches a single non-empty segment.
+    assert!(PathPattern::new("/*").is_match(p("/anything")));
+    // `**` over a multi-segment path must not panic and joins the glob.
+    assert_eq!(glob_of("/**", "/a/b"), Some("a/b".to_owned()));
+}
+
+// ======================================================================
+// is_match / captures parity + extra no-capture cases
+// ======================================================================
+
+#[test]
+fn is_match_captures_parity() {
+    let cases: &[(&str, &str)] = &[
+        (
+            "/backend-api/codex/responses",
+            "/backend-api/codex/responses",
+        ),
+        ("/files/*.txt", "/files/a.txt"),
+        ("/p2/:vendor/:pkg*.json", "/p2/acme/widget.json"),
+        ("/assets/**", "/assets/a/b"),
+        ("/simple/:name/?", "/simple/x/"),
+        ("/api/v2", "/api/v3"),
+        ("/files/*.txt", "/files/a.md"),
+        ("/", "/"),
+        ("/", "/a"),
+    ];
+    for (pattern, path) in cases {
+        let pat = PathPattern::new(*pattern);
+        let m = pat.is_match(p(path));
+        let c = pat.captures(p(path));
+        assert_eq!(
+            m,
+            c.is_some(),
+            "is_match/captures disagree for pattern {pattern:?} path {path:?}"
+        );
+    }
+
+    // A pure-literal multi-segment pattern: captures Some+empty when matched.
+    let pat = PathPattern::new("/a/b/c");
+    assert!(pat.is_match(p("/a/b/c")));
+    assert!(pat.captures(p("/a/b/c")).unwrap().is_empty());
+    assert!(!pat.is_match(p("/a/b")));
+    assert!(pat.captures(p("/a/b")).is_none());
+}
+
+// ======================================================================
+// get() / is_empty() accessors (direct — the helpers above only read iter/glob)
+// ======================================================================
+
+#[test]
+fn capture_accessors() {
+    let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
+    let caps = pat.captures(p("/p2/acme/widget.json")).unwrap();
+    assert_eq!(caps.get("vendor"), Some("acme"));
+    assert_eq!(caps.get("pkg"), Some("widget"));
+    assert_eq!(caps.get("absent"), None);
+    assert!(!caps.is_empty());
+
+    let empty_pat = PathPattern::new("/x");
+    let empty = empty_pat.captures(p("/x")).unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(empty.get("anything"), None);
+}
+
+// ======================================================================
+// Capture directly followed by a literal (no `*`)
+// ======================================================================
+
+#[test]
+fn capture_then_literal_without_star() {
+    // `:pkg.json` (no `*`): the capture is the greedy run before the `.json`
+    // literal — same result as `:pkg*.json`. Pins that the literal after the
+    // name is matched intact (not having its first byte swallowed).
+    let pat = PathPattern::new("/p2/:vendor/:pkg.json");
+    let caps = pat.captures(p("/p2/acme/widget.json")).unwrap();
+    assert_eq!(caps.get("pkg"), Some("widget"));
+    assert_eq!(caps.get("vendor"), Some("acme"));
+    assert!(pat.captures(p("/p2/acme/widget.txt")).is_none());
+}
+
+// ======================================================================
+// Capture names with `_` and `-`
+// ======================================================================
+
+#[test]
+fn capture_names_with_underscore_and_dash() {
+    let pat = PathPattern::new("/:my_name/:other-id");
+    let caps = pat.captures(p("/foo/bar")).unwrap();
+    assert_eq!(caps.get("my_name"), Some("foo"));
+    assert_eq!(caps.get("other-id"), Some("bar"));
+}
+
+// ======================================================================
+// Capture-free trailing-slash policy (exercises the alloc-free fast path)
+// ======================================================================
+
+#[test]
+fn capture_free_trailing_slash_fast_path() {
+    let required = PathPattern::new("/a/b/");
+    assert!(required.is_match(p("/a/b/")));
+    assert!(!required.is_match(p("/a/b")));
+
+    let forbidden = PathPattern::new("/a/b");
+    assert!(forbidden.is_match(p("/a/b")));
+    assert!(!forbidden.is_match(p("/a/b/")));
+
+    let optional = PathPattern::new("/a/b/?");
+    assert!(optional.is_match(p("/a/b")));
+    assert!(optional.is_match(p("/a/b/")));
+}
+
+// ======================================================================
+// Backtracking discards tentative bindings before re-binding
+// ======================================================================
+
+#[test]
+fn backtracking_discards_stale_bindings() {
+    // `**` is shortest-first: take=1 ([a]) tentatively binds :x="b" then fails
+    // on the leftover [c]; that binding must be discarded before take=2 binds
+    // :x="c". A leaked binding would surface as a stale `x` here.
+    assert_eq!(
+        caps("/**/:x", "/a/b/c"),
+        Some(vec![("x".to_owned(), "c".to_owned())])
+    );
+    assert_eq!(glob_of("/**/:x", "/a/b/c"), Some("a/b".to_owned()));
+}
+
+// ======================================================================
+// Anonymous (`:` with no name) and glob bindings excluded from get()/iter()
+// ======================================================================
+
+#[test]
+fn anonymous_and_glob_excluded_from_named() {
+    // `:` with no following name is an uncaptured wildcard run.
+    let anon_pat = PathPattern::new("/p2/:/:real");
+    let caps = anon_pat.captures(p("/p2/foo/bar")).unwrap();
+    assert_eq!(caps.get("real"), Some("bar"));
+    assert_eq!(caps.iter().collect::<Vec<_>>(), vec![("real", "bar")]);
+
+    // The `**` glob is reachable only via glob(), never get()/iter().
+    let glob_pat = PathPattern::new("/files/**/:name");
+    let g = glob_pat.captures(p("/files/a/b/x")).unwrap();
+    assert_eq!(g.get("name"), Some("x"));
+    assert_eq!(g.glob(), Some("a/b"));
+    assert_eq!(g.iter().collect::<Vec<_>>(), vec![("name", "x")]);
+}
+
+// ======================================================================
+// Pathological shapes are polynomial AND still correct
+//
+// These shapes (many runs / many optionals in one segment, many `**` in a
+// pattern) would explode exponentially under naive backtracking; the memo
+// keeps them fast. The asserts pin both: a wall-clock budget that a 2^N
+// matcher blows through, and the exact match/capture result so the memo can't
+// "go fast by being wrong".
+// ======================================================================
+
+#[test]
+fn pathological_multi_run_segment_is_polynomial_and_correct() {
+    use std::time::{Duration, Instant};
+
+    // One segment, two literal-separated captures `[a*][b][b*][b]`: matching
+    // "aaa…a" + "bb", greedy-longest binds a="aaa…a" then literal `b`, then
+    // b="" before the trailing literal `b`.
+    let pat = PathPattern::new("/:a*b:b*b");
+    let hay = "/".to_owned() + &"a".repeat(40) + "bb";
+    let start = Instant::now();
+    let caps = pat.captures(p(&hay)).expect("must match");
+    assert_eq!(caps.get("a"), Some("a".repeat(40).as_str()));
+    assert_eq!(caps.get("b"), Some(""));
+
+    // A failing match over a long run forces the matcher to prove no split
+    // works — the exponential blowup case. Many adjacent captures + literals.
+    let fail_pat = PathPattern::new(":x*:y*:z*:w*:v*END");
+    let fail_hay = "/".to_owned() + &"q".repeat(60);
+    assert!(fail_pat.captures(p(&fail_hay)).is_none());
+    assert!(!fail_pat.is_match(p(&fail_hay)));
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "matching must stay polynomial"
+    );
+}
+
+#[test]
+fn pathological_many_optional_literals_is_polynomial() {
+    use std::time::{Duration, Instant};
+
+    // Thirty optional `a`s followed by a literal that can't match: the naive
+    // matcher forks 2^30 ways before failing.
+    let mut raw = String::from("/");
+    for _ in 0..30 {
+        raw.push_str("a?");
+    }
+    raw.push('Z');
+    let pat = PathPattern::new(raw.as_str());
+    let hay = "/".to_owned() + &"a".repeat(30);
+    let start = Instant::now();
+    assert!(!pat.is_match(p(&hay)));
+    assert!(pat.captures(p(&hay)).is_none());
+    // All-optional prefix can still match when the literal lands.
+    assert!(PathPattern::new(raw.as_str()).is_match(p("/Z")));
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "matching must stay polynomial"
+    );
+}
+
+#[test]
+fn pathological_multi_catchall_is_polynomial_and_correct() {
+    use std::time::{Duration, Instant};
+
+    // Eight `**` plus a trailing literal that never appears: naive search is
+    // O(segments^8); the cross-segment memo keeps it polynomial. (Two `**`
+    // alone are only O(n^2), too cheap to exercise the memo.)
+    let pat = PathPattern::new("/**/**/**/**/**/**/**/**/end");
+    let hay = "/".to_owned() + &"x/".repeat(30) + "y";
+    let start = Instant::now();
+    assert!(!pat.is_match(p(&hay)));
+    assert!(pat.captures(p(&hay)).is_none());
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "matching must stay polynomial"
+    );
+
+    // And it still matches + globs correctly when the tail lines up. `**` is
+    // shortest-first, so the first `**` takes one segment and the second the
+    // rest before `end`.
+    let ok = PathPattern::new("/**/**/end");
+    let g = ok.captures(p("/a/b/c/end")).expect("must match");
+    assert_eq!(g.glob(), Some("a".to_owned()).as_deref());
+}

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -600,6 +600,32 @@ fn segment_kinds_classify_each_segment() {
 }
 
 #[test]
+fn segment_specificity_reports_dynamic_tie_breakers() {
+    use crate::uri::PathPatternSegmentKind as K;
+    let specs: Vec<_> = PathPattern::new("/files/{name}.json")
+        .segment_specificity()
+        .collect();
+
+    assert_eq!(specs[0].kind, K::Literal);
+    assert_eq!(specs[0].literal_bytes, 5);
+    assert_eq!(specs[0].dynamic_parts, 0);
+    assert_eq!(specs[0].optional_parts, 0);
+
+    assert_eq!(specs[1].kind, K::Dynamic);
+    assert_eq!(specs[1].literal_bytes, 5);
+    assert_eq!(specs[1].dynamic_parts, 1);
+    assert_eq!(specs[1].optional_parts, 0);
+
+    let specs: Vec<_> = PathPattern::new("/maybe/a?")
+        .segment_specificity()
+        .collect();
+    assert_eq!(specs[1].kind, K::Dynamic);
+    assert_eq!(specs[1].literal_bytes, 1);
+    assert_eq!(specs[1].dynamic_parts, 0);
+    assert_eq!(specs[1].optional_parts, 1);
+}
+
+#[test]
 fn prefix_matching() {
     let api = PathPattern::new_prefix("/api");
     assert!(api.is_match(p("/api"))); // bare prefix

--- a/rama-net/src/uri/parser/tests/path_matcher.rs
+++ b/rama-net/src/uri/parser/tests/path_matcher.rs
@@ -281,6 +281,56 @@ fn anonymous_and_glob_excluded_from_named() {
 }
 
 #[test]
+fn named_catch_all() {
+    // `:name**` is a named catch-all: 1+ segments, '/'-joined and decoded,
+    // read via get()/iter() — not glob().
+    assert_eq!(
+        caps("/assets/:path**", "/assets/css/app.css"),
+        Some(vec![("path".to_owned(), "css/app.css".to_owned())])
+    );
+    assert_eq!(
+        caps("/assets/:path**", "/assets/a"),
+        Some(vec![("path".to_owned(), "a".to_owned())])
+    );
+    // It is a named binding, so glob() stays empty.
+    let pat = PathPattern::new("/assets/:path**");
+    let c = pat.captures(p("/assets/a/b")).unwrap();
+    assert_eq!(c.get("path"), Some("a/b"));
+    assert_eq!(c.glob(), None);
+
+    // Like `**`, it needs 1+ segments: the bare prefix does not match.
+    assert!(
+        PathPattern::new("/assets/:path**")
+            .captures(p("/assets"))
+            .is_none()
+    );
+
+    // Mid-pattern: the run stops before the trailing literal.
+    assert_eq!(
+        caps("/a/:mid**/z", "/a/b/c/z"),
+        Some(vec![("mid".to_owned(), "b/c".to_owned())])
+    );
+
+    // Decoded + joined across segments.
+    assert_eq!(
+        caps("/d/:rest**", "/d/a%20b/c"),
+        Some(vec![("rest".to_owned(), "a b/c".to_owned())])
+    );
+
+    // A single `*` stays within a segment (contrast): `:path*` captures one
+    // segment only, so a multi-segment path does not match.
+    assert!(
+        PathPattern::new("/assets/:path*")
+            .captures(p("/assets/a/b"))
+            .is_none()
+    );
+    assert_eq!(
+        caps("/assets/:path*", "/assets/a"),
+        Some(vec![("path".to_owned(), "a".to_owned())])
+    );
+}
+
+#[test]
 fn utf8_literal_and_capture() {
     // Multibyte UTF-8 literal segment.
     assert!(PathPattern::new("/café/menu").is_match(p("/café/menu")));
@@ -375,6 +425,11 @@ fn misused_meta_chars_never_panic_and_stay_consistent() {
         "::*::",
         "/a/**/**/b",
         ":a*:b*:c",
+        ":rest**",
+        ":**",
+        ":name***",
+        "x:name**",
+        "/a/:mid**/z",
     ];
     let paths = [
         "", "/", "//", "/abc", "/a/b", "/a/b/c", "/a//b", "/x/", "/*", "/:", "/a?b", "/%2F",

--- a/rama-net/src/uri/parser/tests/path_segments.rs
+++ b/rama-net/src/uri/parser/tests/path_segments.rs
@@ -253,3 +253,71 @@ fn iterator_count_matches() {
         );
     }
 }
+
+#[test]
+fn exact_size_len_and_size_hint() {
+    for (path, n) in [
+        ("/foo", 1usize),
+        ("/foo/bar", 2),
+        ("/foo/bar/baz", 3),
+        ("/", 1),
+        ("/foo/", 2),
+        ("/a//b", 3),
+    ] {
+        let u = parse_graceful(path).unwrap();
+        let it = u.path().unwrap().segments();
+        assert_eq!(it.len(), n, "len for {path:?}");
+        assert_eq!(it.size_hint(), (n, Some(n)), "size_hint for {path:?}");
+    }
+    // Empty path -> zero-length iterator.
+    let u = parse_graceful("http://example.com").unwrap();
+    assert_eq!(u.path().unwrap().segments().len(), 0);
+}
+
+#[test]
+fn len_tracks_remaining_as_it_advances() {
+    let u = parse_graceful("/a/b/c").unwrap();
+    let mut it = u.path().unwrap().segments();
+    assert_eq!(it.len(), 3);
+    it.next();
+    assert_eq!(it.len(), 2);
+    it.next();
+    assert_eq!(it.len(), 1);
+    it.next();
+    assert_eq!(it.len(), 0);
+    assert!(it.next().is_none());
+    assert_eq!(it.len(), 0);
+}
+
+// ----------------------------------------------------------------------
+// Positional accessors: nth/first/last_segment, segment_count
+// ----------------------------------------------------------------------
+
+#[test]
+fn positional_accessors() {
+    let u = parse_graceful("/v1/users/42").unwrap();
+    let p = u.path().unwrap();
+    assert_eq!(p.first_segment().unwrap().as_raw_str(), "v1");
+    assert_eq!(p.nth_segment(1).unwrap().as_raw_str(), "users");
+    assert_eq!(p.last_segment().unwrap().as_raw_str(), "42");
+    assert_eq!(p.nth_segment(3), None);
+    assert_eq!(p.segment_count(), 3);
+}
+
+#[test]
+fn last_segment_of_trailing_slash_is_empty() {
+    let u = parse_graceful("/foo/").unwrap();
+    let p = u.path().unwrap();
+    assert!(p.last_segment().unwrap().is_empty());
+    assert_eq!(p.segment_count(), 2);
+}
+
+#[test]
+fn accessors_on_empty_path() {
+    let u = parse_graceful("http://example.com").unwrap();
+    let p = u.path().unwrap();
+    assert_eq!(p.first_segment(), None);
+    assert_eq!(p.last_segment(), None);
+    assert_eq!(p.nth_segment(0), None);
+    assert_eq!(p.segment_count(), 0);
+}

--- a/rama-net/src/uri/path.rs
+++ b/rama-net/src/uri/path.rs
@@ -24,6 +24,19 @@ impl<'a> PathRef<'a> {
         Self { bytes }
     }
 
+    /// Borrow a raw on-the-wire path string as a [`PathRef`] — no allocation,
+    /// no `unsafe`.
+    ///
+    /// The input is treated as the already-encoded on-wire form (exactly like
+    /// the path of a parsed [`Uri`](super::Uri)). This is the cheap entry
+    /// point into the typed path API when you only hold a `&str`. Also
+    /// available as [`From<&str>`](#impl-From<%26str>-for-PathRef).
+    #[must_use]
+    #[inline]
+    pub const fn from_raw_str(path: &'a str) -> Self {
+        Self::new(path.as_bytes())
+    }
+
     /// Returns the raw on-the-wire path bytes.
     #[must_use]
     pub fn as_bytes(&self) -> &'a [u8] {
@@ -119,6 +132,82 @@ impl<'a> PathRef<'a> {
         let suffix = suffix.as_uri_component_bytes();
         match_suffix_in_body(strip_leading_slash(self.bytes), &suffix, opts).is_some()
     }
+
+    /// The `n`-th path segment (0-based), or `None` when the path has fewer
+    /// segments. See [`segments`](Self::segments) for the splitting rules.
+    #[must_use]
+    pub fn nth_segment(&self, n: usize) -> Option<PathSegment<'a>> {
+        self.segments().nth(n)
+    }
+
+    /// The first path segment, or `None` for an empty path.
+    #[must_use]
+    pub fn first_segment(&self) -> Option<PathSegment<'a>> {
+        self.segments().next()
+    }
+
+    /// The last path segment, or `None` for an empty path. A trailing `/`
+    /// yields a final empty segment, so `/foo/`'s last segment is `""`.
+    #[must_use]
+    pub fn last_segment(&self) -> Option<PathSegment<'a>> {
+        self.segments().last()
+    }
+
+    /// Number of path segments. `O(n)` in the path length — segment
+    /// splitting is lazy, so there is no cached count.
+    #[must_use]
+    pub fn segment_count(&self) -> usize {
+        self.segments().count()
+    }
+
+    /// `true` when `needle`'s segment(s) appear as a consecutive run of whole
+    /// path segments — matched at `/` boundaries with percent-decoded values
+    /// (default [`PathMatchOptions`]). E.g. `contains_segments("@v")` is true
+    /// for `/golang.org/x/mod/@v/list`, and false for `/x/@version/y`.
+    #[must_use]
+    pub fn contains_segments(&self, needle: impl IntoUriComponent) -> bool {
+        self.contains_segments_with_opts(needle, PathMatchOptions::default())
+    }
+
+    /// `true` when `needle`'s segment(s) appear as a consecutive run of whole
+    /// path segments under `opts`.
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling matchers; this impl only borrows the input"
+    )]
+    pub fn contains_segments_with_opts(
+        &self,
+        needle: impl IntoUriComponent,
+        opts: PathMatchOptions,
+    ) -> bool {
+        let needle = needle.as_uri_component_bytes();
+        if trim_ascii_slashes(&needle).is_empty() {
+            return true;
+        }
+        // Try the needle as a segment-prefix at each segment-aligned start
+        // of the path body (offset 0, and every byte just past a `/`).
+        let body = strip_leading_slash(self.bytes);
+        let mut start = 0;
+        loop {
+            if match_prefix_in_body(&body[start..], &needle, opts).is_some() {
+                return true;
+            }
+            match memchr::memchr(b'/', &body[start..]) {
+                Some(i) => start += i + 1,
+                None => return false,
+            }
+        }
+    }
+}
+
+impl<'a> From<&'a str> for PathRef<'a> {
+    /// Borrow a raw on-the-wire path string as a [`PathRef`]. See
+    /// [`PathRef::from_raw_str`].
+    #[inline]
+    fn from(path: &'a str) -> Self {
+        Self::from_raw_str(path)
+    }
 }
 
 impl std::fmt::Display for PathRef<'_> {
@@ -178,6 +267,77 @@ impl<'a> PathSegment<'a> {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.raw.is_empty()
+    }
+
+    /// `true` when this segment equals `other`, comparing percent-decoded
+    /// values (default [`PathMatchOptions`]). The typed alternative to
+    /// `seg.as_decoded_str() == other` that also handles `%`-case and the
+    /// invalid-UTF-8 pitfalls correctly.
+    #[must_use]
+    pub fn matches(&self, other: impl IntoUriComponent) -> bool {
+        self.matches_with_opts(other, PathMatchOptions::default())
+    }
+
+    /// `true` when this segment equals `other` under `opts` (the `partial`
+    /// flag is irrelevant within a single segment and is ignored here).
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling matchers; this impl only borrows the input"
+    )]
+    pub fn matches_with_opts(&self, other: impl IntoUriComponent, opts: PathMatchOptions) -> bool {
+        segment_eq(self.raw, &other.as_uri_component_bytes(), opts)
+    }
+
+    /// `true` when the (percent-decoded) segment value begins with `prefix`.
+    /// Byte-level *within* this one segment — for e.g. file-name prefixes.
+    #[must_use]
+    pub fn has_prefix(&self, prefix: impl IntoUriComponent) -> bool {
+        self.has_prefix_with_opts(prefix, PathMatchOptions::default())
+    }
+
+    /// `true` when the (percent-decoded) segment value begins with `prefix`
+    /// under `opts` (`partial` ignored — always byte-level within the segment).
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling matchers; this impl only borrows the input"
+    )]
+    pub fn has_prefix_with_opts(
+        &self,
+        prefix: impl IntoUriComponent,
+        opts: PathMatchOptions,
+    ) -> bool {
+        let pat = prefix.as_uri_component_bytes();
+        let seg = maybe_decode(self.raw, opts.percent_decode);
+        let pat = maybe_decode(&pat, opts.percent_decode);
+        byte_starts_with(&seg, &pat, opts.ignore_ascii_case)
+    }
+
+    /// `true` when the (percent-decoded) segment value ends with `suffix`.
+    /// Byte-level *within* this one segment — e.g. a file extension:
+    /// `seg.has_suffix(".tgz")`.
+    #[must_use]
+    pub fn has_suffix(&self, suffix: impl IntoUriComponent) -> bool {
+        self.has_suffix_with_opts(suffix, PathMatchOptions::default())
+    }
+
+    /// `true` when the (percent-decoded) segment value ends with `suffix`
+    /// under `opts` (`partial` ignored — always byte-level within the segment).
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling matchers; this impl only borrows the input"
+    )]
+    pub fn has_suffix_with_opts(
+        &self,
+        suffix: impl IntoUriComponent,
+        opts: PathMatchOptions,
+    ) -> bool {
+        let pat = suffix.as_uri_component_bytes();
+        let seg = maybe_decode(self.raw, opts.percent_decode);
+        let pat = maybe_decode(&pat, opts.percent_decode);
+        byte_ends_with(&seg, &pat, opts.ignore_ascii_case)
     }
 }
 
@@ -257,12 +417,12 @@ impl Default for PathMatchOptions {
 
 /// Drop a single leading `/`, yielding the path "body" used by the matchers.
 #[inline]
-fn strip_leading_slash(path: &[u8]) -> &[u8] {
+pub(super) fn strip_leading_slash(path: &[u8]) -> &[u8] {
     path.strip_prefix(b"/").unwrap_or(path)
 }
 
 /// Trim every leading and trailing `/` from a slice (pattern normalization).
-fn trim_ascii_slashes(mut bytes: &[u8]) -> &[u8] {
+pub(super) fn trim_ascii_slashes(mut bytes: &[u8]) -> &[u8] {
     while let Some(rest) = bytes.strip_prefix(b"/") {
         bytes = rest;
     }
@@ -272,8 +432,35 @@ fn trim_ascii_slashes(mut bytes: &[u8]) -> &[u8] {
     bytes
 }
 
+#[inline]
+pub(super) fn maybe_decode(bytes: &[u8], decode: bool) -> Cow<'_, [u8]> {
+    if decode {
+        percent_decode(bytes).into()
+    } else {
+        Cow::Borrowed(bytes)
+    }
+}
+
+#[inline]
+pub(super) fn byte_starts_with(hay: &[u8], needle: &[u8], ignore_case: bool) -> bool {
+    if ignore_case {
+        hay.len() >= needle.len() && hay[..needle.len()].eq_ignore_ascii_case(needle)
+    } else {
+        hay.starts_with(needle)
+    }
+}
+
+#[inline]
+pub(super) fn byte_ends_with(hay: &[u8], needle: &[u8], ignore_case: bool) -> bool {
+    if ignore_case {
+        hay.len() >= needle.len() && hay[hay.len() - needle.len()..].eq_ignore_ascii_case(needle)
+    } else {
+        hay.ends_with(needle)
+    }
+}
+
 /// Compare a single path segment against a pattern segment under `opts`.
-fn segment_eq(seg: &[u8], pat: &[u8], opts: PathMatchOptions) -> bool {
+pub(super) fn segment_eq(seg: &[u8], pat: &[u8], opts: PathMatchOptions) -> bool {
     if opts.percent_decode {
         // Compare decoded BYTES, not a lossy-UTF-8 rendering: lossy decoding
         // collapses every distinct invalid-UTF-8 byte to U+FFFD, which would

--- a/rama-net/src/uri/path.rs
+++ b/rama-net/src/uri/path.rs
@@ -153,11 +153,10 @@ impl<'a> PathRef<'a> {
         self.segments().last()
     }
 
-    /// Number of path segments. `O(n)` in the path length — segment
-    /// splitting is lazy, so there is no cached count.
+    /// Number of path segments. `O(n)` in the path length.
     #[must_use]
     pub fn segment_count(&self) -> usize {
-        self.segments().count()
+        self.segments().len()
     }
 
     /// `true` when `needle`'s segment(s) appear as a consecutive run of whole
@@ -381,9 +380,22 @@ impl<'a> Iterator for PathSegments<'a> {
             Some(PathSegment::new(seg))
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        // Each unyielded `/` precedes another segment, plus the final tail
+        // segment — exact, so this is also an `ExactSizeIterator`.
+        let n = if self.exhausted {
+            0
+        } else {
+            self.remaining.iter().filter(|&&b| b == b'/').count() + 1
+        };
+        (n, Some(n))
+    }
 }
 
 impl std::iter::FusedIterator for PathSegments<'_> {}
+
+impl ExactSizeIterator for PathSegments<'_> {}
 
 /// Options controlling path prefix/suffix matching and stripping
 /// ([`PathRef::has_prefix_with_opts`], [`super::PathMut::strip_prefix_with_opts`], …).

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -1,10 +1,11 @@
 //! Infallible path-pattern matching.
 //!
-//! [`PathPattern`] compiles a small glob/capture syntax and matches it against
-//! a [`PathRef`](super::PathRef) segment-by-segment, decode-aware and (by
-//! default) case-sensitive. Compilation never fails: anything that isn't a
-//! recognized meta token is treated as a literal. See [`PathPattern`] for the
-//! full syntax.
+//! [`PathPattern`] compiles a small brace-based glob/capture syntax and matches
+//! it against a [`PathRef`](super::PathRef) segment-by-segment, decode-aware and
+//! (by default) case-sensitive. Compilation never fails: anything that isn't a
+//! recognized brace token is treated as a literal. The only metacharacters are
+//! `{`, `}` and `?` — none of which is a valid unencoded URI path byte — so
+//! `*`, `:`, `.` etc. are all literals. See [`PathPattern`] for the full syntax.
 
 use std::borrow::Cow;
 
@@ -22,23 +23,29 @@ use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, str
 ///
 /// # Syntax
 ///
-/// A pattern is split on `/` into segments. Within a segment:
+/// A pattern is split on `/` into segments. The only metacharacters are `{`,
+/// `}` and `?`; everything else (`*`, `:`, `.`, …) is a literal. Within a
+/// segment:
 ///
 /// - **literal** text must equal the (decoded) path segment value;
-/// - `:name` captures a whole segment under `name`;
-/// - `:name*` captures a wildcard run within a segment, allowing literal
-///   prefix/suffix around it (`:pkg*.json` captures the part before `.json`).
-///   `:name` and `:name*` are equivalent when there is no surrounding literal;
-/// - `*` is an anonymous wildcard run (0+ chars), not captured;
+/// - `{name}` captures a run under `name`: a whole segment when alone
+///   (`{id}`), or the run bounded by surrounding literals when affixed
+///   (`{pkg}.json` captures the part before `.json`, `v{ver}-rc` the part
+///   between);
+/// - `{}` is an anonymous wildcard run (0+ chars), not captured (`{}.txt`);
 /// - `?` makes the immediately preceding element optional (zero-or-one):
-///   `a?` is an optional `a`, a trailing `/?` is an optional trailing slash;
-/// - `**`, as a *whole* segment, is an anonymous catch-all matching one or
+///   `a?` is an optional `a`, `{}?` an optional run, a trailing `/?` an
+///   optional trailing slash;
+/// - `{*}`, as a *whole* segment, is an anonymous catch-all matching one or
 ///   more path segments, available '/'-joined and decoded via
 ///   [`PathCaptures::glob`]. It may appear in the middle of a pattern;
-/// - `:name**`, as a *whole* segment, is the **named** catch-all: same 1+
-///   segment match as `**`, but the run is recorded under `name` (read back,
-///   '/'-joined and decoded, via [`PathCaptures::get`]). So a single `*`
-///   stays within a segment; a doubled `**` spans segments.
+/// - `{*name}`, as a *whole* segment, is the **named** catch-all: same 1+
+///   segment match as `{*}`, but the run is recorded under `name` (read back,
+///   '/'-joined and decoded, via [`PathCaptures::get`]). So `{name}` stays
+///   within a segment; `{*name}` spans segments.
+///
+/// An unclosed `{`, or a brace group whose body isn't a valid token, is taken
+/// literally. `{*}`/`{*name}` are catch-alls only as a *whole* segment.
 ///
 /// Trailing slash is explicit: `/a` matches only `/a`, `/a/` matches only
 /// `/a/`, and `/a/?` matches both.
@@ -46,18 +53,18 @@ use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, str
 /// ```
 /// use rama_net::uri::{PathPattern, PathRef};
 ///
-/// let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
+/// let pat = PathPattern::new("/p2/{vendor}/{pkg}.json");
 /// let caps = pat.captures(PathRef::from_raw_str("/p2/acme/widget.json")).unwrap();
 /// assert_eq!(caps.get("vendor"), Some("acme"));
 /// assert_eq!(caps.get("pkg"), Some("widget"));
 /// assert!(pat.captures(PathRef::from_raw_str("/p2/acme/widget.txt")).is_none());
 ///
-/// let assets = PathPattern::new("/assets/**");
+/// let assets = PathPattern::new("/assets/{*}");
 /// assert!(assets.is_match(PathRef::from_raw_str("/assets/css/app.css")));
 /// assert!(!assets.is_match(PathRef::from_raw_str("/assets")));
 ///
-/// // `:name**` is the named catch-all (read back via `get`).
-/// let files = PathPattern::new("/files/:rest**");
+/// // `{*name}` is the named catch-all (read back via `get`).
+/// let files = PathPattern::new("/files/{*rest}");
 /// let caps = files.captures(PathRef::from_raw_str("/files/a/b/c.txt")).unwrap();
 /// assert_eq!(caps.get("rest"), Some("a/b/c.txt"));
 /// ```
@@ -102,15 +109,15 @@ impl TrailingSlash {
 /// One `/`-delimited unit of a compiled pattern.
 #[derive(Debug, Clone)]
 enum PatternSegment {
-    /// `**` — matches one or more whole path segments (anonymous; read back
+    /// `{*}` — matches one or more whole path segments (anonymous; read back
     /// via [`PathCaptures::glob`]).
     CatchAll,
-    /// `:name**` — like [`CatchAll`](Self::CatchAll) but records the matched,
+    /// `{*name}` — like [`CatchAll`](Self::CatchAll) but records the matched,
     /// '/'-joined run under `name` (read back via [`PathCaptures::get`]).
     NamedCatchAll { name_start: usize, name_len: usize },
     /// A sequence of within-segment elements matched against a single path
     /// segment via greedy backtracking. Inline-sized for the common one- or
-    /// two-element segment (a bare literal, capture, or `:name*.ext` pair).
+    /// two-element segment (a bare literal, capture, or `{pkg}.ext` pair).
     Normal {
         elems: SmallVec<[Element; 2]>,
         /// Count of *ambiguity sources* in `elems`: wildcard runs
@@ -137,7 +144,7 @@ enum ElementKind {
     /// Literal bytes, compared against the decoded path-segment bytes. Boxed:
     /// fixed after compilation, so the `Vec` capacity word is dead weight.
     Literal(Box<[u8]>),
-    /// Anonymous wildcard run (0+ chars within the segment).
+    /// Anonymous wildcard run (`{}`, 0+ chars within the segment).
     Star,
     /// Named wildcard run that records what it matched. The name is the
     /// `name_bytes[start..start+len]` slice of the owning [`PathPattern`].
@@ -206,25 +213,23 @@ impl PathPattern {
         // exactly `/`.
         if !body.is_empty() {
             for seg in body.split(|&b| b == b'/') {
-                if seg == b"**" {
-                    capture_free = false;
-                    segments.push(PatternSegment::CatchAll);
-                    continue;
-                }
-                if let Some(name) = parse_named_catchall(seg) {
-                    capture_free = false;
-                    // `:**` (empty name) is just the anonymous catch-all.
-                    if name.is_empty() {
+                match parse_catchall(seg) {
+                    Some(CatchAll::Anon) => {
+                        capture_free = false;
                         segments.push(PatternSegment::CatchAll);
-                    } else {
+                        continue;
+                    }
+                    Some(CatchAll::Named(name)) => {
+                        capture_free = false;
                         let name_start = name_bytes.len();
                         name_bytes.extend_from_slice(name);
                         segments.push(PatternSegment::NamedCatchAll {
                             name_start,
                             name_len: name.len(),
                         });
+                        continue;
                     }
-                    continue;
+                    None => {}
                 }
                 let elements = parse_segment(seg, &mut name_bytes, &mut capture_free);
                 let ambiguity = elements
@@ -256,7 +261,7 @@ impl PathPattern {
     /// ```
     /// use rama_net::uri::{PathPattern, PathRef};
     ///
-    /// let pat = PathPattern::new("/files/*.txt");
+    /// let pat = PathPattern::new("/files/{}.txt");
     /// assert!(pat.is_match(PathRef::from_raw_str("/files/readme.txt")));
     /// assert!(!pat.is_match(PathRef::from_raw_str("/files/readme.md")));
     /// ```
@@ -270,7 +275,7 @@ impl PathPattern {
     }
 
     /// Allocation-free match for capture-free patterns. A capture-free
-    /// pattern has no `**`, so every pattern segment matches exactly one path
+    /// pattern has no catch-all, so every pattern segment matches exactly one path
     /// segment positionally — no backtracking across segments, no `Vec`, no
     /// captured-value strings.
     fn is_match_fast(&self, path: PathRef<'_>) -> bool {
@@ -320,7 +325,7 @@ impl PathPattern {
     /// ```
     /// use rama_net::uri::{PathPattern, PathRef};
     ///
-    /// let pat = PathPattern::new("/simple/:name/?");
+    /// let pat = PathPattern::new("/simple/{name}/?");
     /// let caps = pat.captures(PathRef::from_raw_str("/simple/requests")).unwrap();
     /// assert_eq!(caps.get("name"), Some("requests"));
     /// ```
@@ -374,7 +379,7 @@ struct Binding<'p> {
     name_start: usize,
     name_len: usize,
     value: Cow<'p, str>,
-    /// `true` for the `**` catch-all's joined value.
+    /// `true` for the `{*}` catch-all's joined value.
     is_glob: bool,
 }
 
@@ -416,7 +421,7 @@ impl<'p> Sink<'_, 'p> {
 /// ```
 /// use rama_net::uri::{PathPattern, PathRef};
 ///
-/// let pat = PathPattern::new("/p2/**/:file*.txt");
+/// let pat = PathPattern::new("/p2/{*}/{file}.txt");
 /// let caps = pat.captures(PathRef::from_raw_str("/p2/a/b/c.txt")).unwrap();
 /// assert_eq!(caps.glob(), Some("a/b"));
 /// assert_eq!(caps.get("file"), Some("c"));
@@ -436,7 +441,7 @@ impl<'a, 'p> PathCaptures<'a, 'p> {
     }
 
     /// The decoded value captured under `name`, or `None` if `name` was not
-    /// bound. The `**` catch-all is reachable via [`glob`](Self::glob), not
+    /// bound. The `{*}` catch-all is reachable via [`glob`](Self::glob), not
     /// here.
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&str> {
@@ -455,7 +460,7 @@ impl<'a, 'p> PathCaptures<'a, 'p> {
             .map(|b| (self.name_of(b), b.value.as_ref()))
     }
 
-    /// The `**` catch-all value, '/'-joined and decoded, or `None` when the
+    /// The `{*}` catch-all value, '/'-joined and decoded, or `None` when the
     /// pattern has no catch-all (or it didn't match).
     #[must_use]
     pub fn glob(&self) -> Option<&str> {
@@ -476,21 +481,35 @@ impl<'a, 'p> PathCaptures<'a, 'p> {
 // Compilation helpers
 // ----------------------------------------------------------------------
 
-/// If `seg` is a whole-segment named catch-all (`:name**`), return its name
-/// bytes (possibly empty for `:**`). Returns `None` for anything else — including
-/// within-segment `:name*` runs (single `*`) and names with non-identifier bytes,
-/// which fall through to [`parse_segment`].
-fn parse_named_catchall(seg: &[u8]) -> Option<&[u8]> {
-    let name = seg.strip_prefix(b":")?.strip_suffix(b"**")?;
-    name.iter()
+/// A whole-segment catch-all token.
+enum CatchAll<'a> {
+    /// `{*}`
+    Anon,
+    /// `{*name}` (name is non-empty, all [`is_pattern_name_byte`]).
+    Named(&'a [u8]),
+}
+
+/// If `seg` is a whole-segment catch-all (`{*}` or `{*name}`), classify it.
+/// Returns `None` for anything else — including mid-segment `{*…}` (handled as
+/// a literal by [`parse_segment`]) and `{*bad name}` — which fall through.
+fn parse_catchall(seg: &[u8]) -> Option<CatchAll<'_>> {
+    let inner = seg.strip_prefix(b"{*")?.strip_suffix(b"}")?;
+    if inner.is_empty() {
+        return Some(CatchAll::Anon);
+    }
+    inner
+        .iter()
         .all(|&b| is_pattern_name_byte(b))
-        .then_some(name)
+        .then_some(CatchAll::Named(inner))
 }
 
 /// Parse one (non catch-all) pattern segment into a sequence of elements.
 ///
-/// `name_bytes` accumulates capture-name bytes; element name indices point
-/// into it. `capture_free` is cleared whenever a named capture is seen.
+/// Scans for `{…}` brace groups (`{}` -> [`Star`](ElementKind::Star),
+/// `{name}` -> [`Capture`](ElementKind::Capture)); everything outside braces is
+/// literal. An unclosed `{`, or a group whose body isn't a valid token, is kept
+/// literal. `name_bytes` accumulates capture-name bytes; element name indices
+/// point into it. `capture_free` is cleared whenever a named capture is seen.
 fn parse_segment(
     seg: &[u8],
     name_bytes: &mut Vec<u8>,
@@ -514,37 +533,18 @@ fn parse_segment(
 
     while i < seg.len() {
         match seg[i] {
-            b'*' => {
-                flush_literal!();
-                elements.push(Element {
-                    kind: ElementKind::Star,
-                    optional: false,
-                });
-                i += 1;
-            }
-            b':' => {
-                flush_literal!();
-                // Capture name: identifier bytes until a meta char.
-                let start = i + 1;
-                let mut end = start;
-                while end < seg.len() && is_pattern_name_byte(seg[end]) {
-                    end += 1;
-                }
-                let name = &seg[start..end];
-                let name_start = name_bytes.len();
-                name_bytes.extend_from_slice(name);
-                *capture_free = false;
-                elements.push(Element {
-                    kind: ElementKind::Capture {
-                        name_start,
-                        name_len: name.len(),
-                    },
-                    optional: false,
-                });
-                i = end;
-                // `:name*` — the trailing `*` is part of the capture (run
-                // semantics) and adds no separate Star element.
-                if i < seg.len() && seg[i] == b'*' {
+            b'{' => {
+                // A `{…}` group is a token only when it closes and its body is
+                // a valid name (or empty); otherwise the `{` is a literal byte.
+                if let Some((kind, next)) = parse_brace(seg, i, name_bytes, capture_free) {
+                    flush_literal!();
+                    elements.push(Element {
+                        kind,
+                        optional: false,
+                    });
+                    i = next;
+                } else {
+                    literal.push(b'{');
                     i += 1;
                 }
             }
@@ -577,6 +577,39 @@ fn parse_segment(
     elements
 }
 
+/// Parse a within-segment `{…}` group starting at `seg[open] == '{'`. On a
+/// valid token returns its [`ElementKind`] and the index just past the closing
+/// `}`. `{}` -> Star, `{name}` -> Capture (name = non-empty
+/// [`is_pattern_name_byte`] run). Returns `None` (so the caller keeps `{`
+/// literal) for an unclosed brace or any non-name body — including `{*…}`,
+/// which is a catch-all only as a whole segment.
+fn parse_brace(
+    seg: &[u8],
+    open: usize,
+    name_bytes: &mut Vec<u8>,
+    capture_free: &mut bool,
+) -> Option<(ElementKind, usize)> {
+    let close = open + 1 + seg[open + 1..].iter().position(|&b| b == b'}')?;
+    let inner = &seg[open + 1..close];
+    let next = close + 1;
+    if inner.is_empty() {
+        return Some((ElementKind::Star, next));
+    }
+    if !inner.iter().all(|&b| is_pattern_name_byte(b)) {
+        return None;
+    }
+    let name_start = name_bytes.len();
+    name_bytes.extend_from_slice(inner);
+    *capture_free = false;
+    Some((
+        ElementKind::Capture {
+            name_start,
+            name_len: inner.len(),
+        },
+        next,
+    ))
+}
+
 // ----------------------------------------------------------------------
 // Matching
 // ----------------------------------------------------------------------
@@ -584,12 +617,12 @@ fn parse_segment(
 // Both match entry points share one greedy recursion. Without guards that
 // recursion is exponential: a wildcard run tries every split point and an
 // optional element forks, so a segment with many such *ambiguity sources*
-// (or a pattern with many `**`) revisits the same `(position)` state over and
+// (or a pattern with many `{*}`) revisits the same `(position)` state over and
 // over. Each level fixes that by memoizing *failed* states. Failure-only memo
 // is sound because capture recording happens solely on the unique success
 // path: a state proven unmatchable can never later succeed, so caching it
 // cannot drop or corrupt a binding. The memo grid is allocated only for the
-// pathological shapes (>= 2 ambiguity sources in a segment, >= 2 `**` in a
+// pathological shapes (>= 2 ambiguity sources in a segment, >= 2 `{*}` in a
 // pattern); simpler shapes recurse linearly with no allocation.
 
 /// Dense 2D failure set (`rows × cols`), one bit per `(row, col)` state packed
@@ -626,9 +659,9 @@ impl BitGrid {
     }
 }
 
-/// Failure memo for the cross-segment `**` search, keyed on the *remaining*
+/// Failure memo for the cross-segment catch-all search, keyed on the *remaining*
 /// `(pattern, path-segment)` counts. Only allocated when a pattern has two or
-/// more `**` (a single `**` can't revisit states).
+/// more catch-alls (a single one can't revisit states).
 enum SeqMemo {
     None,
     Grid {
@@ -687,7 +720,7 @@ impl SeqMemo {
 }
 
 /// Match a sequence of pattern segments against the path segments, with
-/// backtracking across `**` catch-alls. Returns `true` on full match.
+/// backtracking across `{*}` catch-alls. Returns `true` on full match.
 fn match_sequence<'p>(
     pats: &[PatternSegment],
     segs: &[&'p [u8]],
@@ -734,7 +767,7 @@ fn match_sequence<'p>(
     matched
 }
 
-/// Match a catch-all (`**` or `:name**`) against `segs`, then the remaining
+/// Match a catch-all (`{*}` or `{*name}`) against `segs`, then the remaining
 /// `rest` patterns against the tail. Consumes 1+ path segments, shortest first,
 /// growing until the tail matches. On success records the matched run, '/'-joined
 /// and decoded — as the anonymous glob when `name` is `None`, else a named binding.
@@ -860,7 +893,7 @@ fn match_elems<'p>(
     matched
 }
 
-/// Match a wildcard run (anonymous `*` or named capture) followed by `rest`.
+/// Match a wildcard run (anonymous `{}` or named capture) followed by `rest`.
 /// Greedy: try the longest run first, shrinking on backtrack. For a named
 /// capture, record the matched (decoded) substring as a binding.
 fn match_run<'p>(

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -1,55 +1,56 @@
 //! Infallible path-pattern matching.
 //!
-//! [`PathPattern`] compiles a small glob/capture syntax and matches it
-//! against a [`PathRef`](super::PathRef) segment-by-segment, decode-aware
-//! and (by default) case-sensitive. Compilation never fails: anything that
-//! isn't a recognized meta token is treated as a literal.
-//!
-//! # Syntax
-//!
-//! A pattern is split on `/` into segments. Within a segment:
-//!
-//! - **literal** text must equal the (decoded) path segment value;
-//! - `:name` captures a whole segment under `name`;
-//! - `:name*` captures a wildcard run within a segment, allowing literal
-//!   prefix/suffix around it (`:pkg*.json` captures the part before `.json`).
-//!   `:name` and `:name*` are equivalent when there is no surrounding literal;
-//! - `*` is an anonymous wildcard run (0+ chars), not captured;
-//! - `?` makes the immediately preceding element optional (zero-or-one):
-//!   `a?` is an optional `a`, a trailing `/?` is an optional trailing slash;
-//! - `**`, as a *whole* segment, is a catch-all matching one or more path
-//!   segments, available '/'-joined and decoded via [`PathCaptures::glob`].
-//!   It may appear in the middle of a pattern.
-//!
-//! Trailing slash is explicit: `/a` matches only `/a`, `/a/` matches only
-//! `/a/`, and `/a/?` matches both.
-//!
-//! ```
-//! use rama_net::uri::{PathPattern, PathRef};
-//!
-//! let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
-//! let caps = pat.captures(PathRef::from_raw_str("/p2/acme/widget.json")).unwrap();
-//! assert_eq!(caps.get("vendor"), Some("acme"));
-//! assert_eq!(caps.get("pkg"), Some("widget"));
-//! assert!(pat.captures(PathRef::from_raw_str("/p2/acme/widget.txt")).is_none());
-//! ```
+//! [`PathPattern`] compiles a small glob/capture syntax and matches it against
+//! a [`PathRef`](super::PathRef) segment-by-segment, decode-aware and (by
+//! default) case-sensitive. Compilation never fails: anything that isn't a
+//! recognized meta token is treated as a literal. See [`PathPattern`] for the
+//! full syntax.
 
 use std::borrow::Cow;
+
+use rama_utils::collections::smallvec::SmallVec;
+
+use crate::byte_sets::is_pattern_name_byte;
 
 use super::component_input::IntoUriComponent;
 use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, strip_leading_slash};
 
-/// A compiled path pattern — see the [module docs](self) for the syntax.
+/// A compiled path pattern.
 ///
 /// Construct via [`PathPattern::new`] / [`new_with_opts`](Self::new_with_opts)
 /// and test paths with [`is_match`](Self::is_match) / [`captures`](Self::captures).
 ///
+/// # Syntax
+///
+/// A pattern is split on `/` into segments. Within a segment:
+///
+/// - **literal** text must equal the (decoded) path segment value;
+/// - `:name` captures a whole segment under `name`;
+/// - `:name*` captures a wildcard run within a segment, allowing literal
+///   prefix/suffix around it (`:pkg*.json` captures the part before `.json`).
+///   `:name` and `:name*` are equivalent when there is no surrounding literal;
+/// - `*` is an anonymous wildcard run (0+ chars), not captured;
+/// - `?` makes the immediately preceding element optional (zero-or-one):
+///   `a?` is an optional `a`, a trailing `/?` is an optional trailing slash;
+/// - `**`, as a *whole* segment, is a catch-all matching one or more path
+///   segments, available '/'-joined and decoded via [`PathCaptures::glob`].
+///   It may appear in the middle of a pattern.
+///
+/// Trailing slash is explicit: `/a` matches only `/a`, `/a/` matches only
+/// `/a/`, and `/a/?` matches both.
+///
 /// ```
 /// use rama_net::uri::{PathPattern, PathRef};
 ///
-/// let pat = PathPattern::new("/assets/**");
-/// assert!(pat.is_match(PathRef::from_raw_str("/assets/css/app.css")));
-/// assert!(!pat.is_match(PathRef::from_raw_str("/assets")));
+/// let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
+/// let caps = pat.captures(PathRef::from_raw_str("/p2/acme/widget.json")).unwrap();
+/// assert_eq!(caps.get("vendor"), Some("acme"));
+/// assert_eq!(caps.get("pkg"), Some("widget"));
+/// assert!(pat.captures(PathRef::from_raw_str("/p2/acme/widget.txt")).is_none());
+///
+/// let assets = PathPattern::new("/assets/**");
+/// assert!(assets.is_match(PathRef::from_raw_str("/assets/css/app.css")));
+/// assert!(!assets.is_match(PathRef::from_raw_str("/assets")));
 /// ```
 #[derive(Debug, Clone)]
 pub struct PathPattern {
@@ -95,9 +96,10 @@ enum PatternSegment {
     /// `**` — matches one or more whole path segments.
     CatchAll,
     /// A sequence of within-segment elements matched against a single path
-    /// segment via greedy backtracking.
+    /// segment via greedy backtracking. Inline-sized for the common one- or
+    /// two-element segment (a bare literal, capture, or `:name*.ext` pair).
     Normal {
-        elems: Vec<Element>,
+        elems: SmallVec<[Element; 2]>,
         /// Count of *ambiguity sources* in `elems`: wildcard runs
         /// (`Star`/`Capture`) plus `optional` elements. Each is a backtrack
         /// point; with two or more of them the greedy recursion can revisit
@@ -119,8 +121,9 @@ struct Element {
 
 #[derive(Debug, Clone)]
 enum ElementKind {
-    /// Literal bytes, compared against the decoded path-segment bytes.
-    Literal(Vec<u8>),
+    /// Literal bytes, compared against the decoded path-segment bytes. Boxed:
+    /// fixed after compilation, so the `Vec` capacity word is dead weight.
+    Literal(Box<[u8]>),
     /// Anonymous wildcard run (0+ chars within the segment).
     Star,
     /// Named wildcard run that records what it matched. The name is the
@@ -293,7 +296,9 @@ impl PathPattern {
     /// ```
     #[must_use]
     pub fn captures<'p>(&self, path: PathRef<'p>) -> Option<PathCaptures<'_, 'p>> {
-        let segs: Vec<&'p [u8]> = path.segments().map(|s| s.as_bytes()).collect();
+        // Inline the segment list: most paths have a handful of segments, so
+        // this keeps the capturing path off the allocator in the common case.
+        let segs: SmallVec<[&'p [u8]; 8]> = path.segments().map(|s| s.as_bytes()).collect();
         let segs = self.check_trailing(&segs)?;
         let mut bindings: Vec<Binding<'p>> = Vec::new();
         let mut sink = Sink::Record(&mut bindings);
@@ -445,8 +450,12 @@ impl<'a, 'p> PathCaptures<'a, 'p> {
 ///
 /// `name_bytes` accumulates capture-name bytes; element name indices point
 /// into it. `capture_free` is cleared whenever a named capture is seen.
-fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) -> Vec<Element> {
-    let mut elements: Vec<Element> = Vec::new();
+fn parse_segment(
+    seg: &[u8],
+    name_bytes: &mut Vec<u8>,
+    capture_free: &mut bool,
+) -> SmallVec<[Element; 2]> {
+    let mut elements: SmallVec<[Element; 2]> = SmallVec::new();
     let mut literal: Vec<u8> = Vec::new();
     let mut i = 0;
 
@@ -455,7 +464,7 @@ fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) 
         () => {
             if !literal.is_empty() {
                 elements.push(Element {
-                    kind: ElementKind::Literal(std::mem::take(&mut literal)),
+                    kind: ElementKind::Literal(std::mem::take(&mut literal).into_boxed_slice()),
                     optional: false,
                 });
             }
@@ -477,7 +486,7 @@ fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) 
                 // Capture name: identifier bytes until a meta char.
                 let start = i + 1;
                 let mut end = start;
-                while end < seg.len() && is_name_byte(seg[end]) {
+                while end < seg.len() && is_pattern_name_byte(seg[end]) {
                     end += 1;
                 }
                 let name = &seg[start..end];
@@ -506,7 +515,7 @@ fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) 
                     // byte as its own optional literal element.
                     flush_literal!();
                     elements.push(Element {
-                        kind: ElementKind::Literal(vec![last]),
+                        kind: ElementKind::Literal(Box::from([last])),
                         optional: true,
                     });
                 } else if let Some(last) = elements.last_mut() {
@@ -527,11 +536,6 @@ fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) 
     elements
 }
 
-/// Bytes allowed in a `:name` identifier.
-fn is_name_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
-}
-
 // ----------------------------------------------------------------------
 // Matching
 // ----------------------------------------------------------------------
@@ -547,12 +551,50 @@ fn is_name_byte(b: u8) -> bool {
 // pathological shapes (>= 2 ambiguity sources in a segment, >= 2 `**` in a
 // pattern); simpler shapes recurse linearly with no allocation.
 
-/// Failure memo for the cross-segment `**` search, keyed on
-/// `(pattern_index, path_segment_index)`. Only allocated when a pattern has
-/// two or more `**` (a single `**` can't revisit states).
+/// Dense 2D failure set (`rows × cols`), one bit per `(row, col)` state packed
+/// into `u64` words — 8× tighter than a `bool` grid and fewer cache lines to
+/// touch during the recursion. Only built for the pathological shapes that need
+/// a memo; simpler patterns never allocate one.
+struct BitGrid {
+    words: Box<[u64]>,
+    cols: usize,
+}
+
+impl BitGrid {
+    fn new(rows: usize, cols: usize) -> Self {
+        let words = vec![0u64; (rows * cols).div_ceil(64)].into_boxed_slice();
+        Self { words, cols }
+    }
+
+    #[inline]
+    fn bit(&self, row: usize, col: usize) -> (usize, u64) {
+        let idx = row * self.cols + col;
+        (idx >> 6, 1u64 << (idx & 63))
+    }
+
+    #[inline]
+    fn get(&self, row: usize, col: usize) -> bool {
+        let (word, mask) = self.bit(row, col);
+        self.words[word] & mask != 0
+    }
+
+    #[inline]
+    fn set(&mut self, row: usize, col: usize) {
+        let (word, mask) = self.bit(row, col);
+        self.words[word] |= mask;
+    }
+}
+
+/// Failure memo for the cross-segment `**` search, keyed on the *remaining*
+/// `(pattern, path-segment)` counts. Only allocated when a pattern has two or
+/// more `**` (a single `**` can't revisit states).
 enum SeqMemo {
     None,
-    Grid { failed: Vec<bool>, stride: usize },
+    Grid {
+        grid: BitGrid,
+        base_pats: usize,
+        base_segs: usize,
+    },
 }
 
 impl SeqMemo {
@@ -562,28 +604,38 @@ impl SeqMemo {
             .filter(|p| matches!(p, PatternSegment::CatchAll))
             .count();
         if catch_alls >= 2 {
-            let rows = pats.len() + 1;
-            let stride = n_segs + 1;
             Self::Grid {
-                failed: vec![false; rows * stride],
-                stride,
+                grid: BitGrid::new(pats.len() + 1, n_segs + 1),
+                base_pats: pats.len(),
+                base_segs: n_segs,
             }
         } else {
             Self::None
         }
     }
 
-    /// `true` if `(pat_idx, seg_idx)` is already known to fail.
-    fn is_failed(&self, pat_idx: usize, seg_idx: usize) -> bool {
+    /// `true` if the state with `pats_left`/`segs_left` remaining is known to
+    /// fail. Both args are suffix lengths of the originals, so the advance from
+    /// the start (the grid row/col) is `base − left`.
+    fn is_failed(&self, pats_left: usize, segs_left: usize) -> bool {
         match self {
             Self::None => false,
-            Self::Grid { failed, stride } => failed[pat_idx * stride + seg_idx],
+            Self::Grid {
+                grid,
+                base_pats,
+                base_segs,
+            } => grid.get(base_pats - pats_left, base_segs - segs_left),
         }
     }
 
-    fn mark_failed(&mut self, pat_idx: usize, seg_idx: usize) {
-        if let Self::Grid { failed, stride } = self {
-            failed[pat_idx * *stride + seg_idx] = true;
+    fn mark_failed(&mut self, pats_left: usize, segs_left: usize) {
+        if let Self::Grid {
+            grid,
+            base_pats,
+            base_segs,
+        } = self
+        {
+            grid.set(*base_pats - pats_left, *base_segs - segs_left);
         }
     }
 }
@@ -597,11 +649,7 @@ fn match_sequence<'p>(
     sink: &mut Sink<'_, 'p>,
     memo: &mut SeqMemo,
 ) -> bool {
-    // State indices for the failure memo: how far we've advanced from the
-    // originals (both args are always suffixes of the originals).
-    let pat_idx = memo_pat_len(memo).saturating_sub(pats.len());
-    let seg_idx = memo_seg_len(memo).saturating_sub(segs.len());
-    if memo.is_failed(pat_idx, seg_idx) {
+    if memo.is_failed(pats.len(), segs.len()) {
         return false;
     }
 
@@ -651,26 +699,9 @@ fn match_sequence<'p>(
     };
 
     if !matched {
-        memo.mark_failed(pat_idx, seg_idx);
+        memo.mark_failed(pats.len(), segs.len());
     }
     matched
-}
-
-/// Original pattern length, recovered from the memo (only meaningful when a
-/// grid is present; otherwise indices are unused).
-fn memo_pat_len(memo: &SeqMemo) -> usize {
-    match memo {
-        SeqMemo::None => 0,
-        SeqMemo::Grid { failed, stride } => failed.len() / stride - 1,
-    }
-}
-
-/// Original path-segment count, recovered from the memo.
-fn memo_seg_len(memo: &SeqMemo) -> usize {
-    match memo {
-        SeqMemo::None => 0,
-        SeqMemo::Grid { stride, .. } => stride - 1,
-    }
 }
 
 /// Match one pattern segment's elements against one path segment's bytes.
@@ -688,43 +719,36 @@ fn match_segment<'p>(
 ) -> bool {
     let decoded = maybe_decode(raw_seg, opts.percent_decode);
     if ambiguity >= 2 {
-        // (element_index, hay_index) failure grid; rows are element positions
-        // 0..=elems.len(), columns hay positions 0..=hay.len().
-        let stride = decoded.len() + 1;
-        let mut failed = vec![false; (elems.len() + 1) * stride];
-        let mut memo = ElemMemo {
-            base_elems: elems.len(),
-            base_hay: decoded.len(),
-            failed: &mut failed,
-            stride,
-        };
+        let mut memo = ElemMemo::new(elems.len(), decoded.len());
         match_elems(elems, &decoded, opts, sink, &mut Some(&mut memo))
     } else {
         match_elems(elems, &decoded, opts, sink, &mut None)
     }
 }
 
-/// Failure memo for within-segment matching, keyed on
-/// `(element_index, hay_index)`.
-struct ElemMemo<'m> {
+/// Failure memo for within-segment matching, keyed on the *remaining*
+/// `(element, hay-byte)` counts.
+struct ElemMemo {
+    grid: BitGrid,
     base_elems: usize,
     base_hay: usize,
-    failed: &'m mut [bool],
-    stride: usize,
 }
 
-impl ElemMemo<'_> {
-    fn index(&self, elems_left: usize, hay_left: usize) -> usize {
-        let ei = self.base_elems - elems_left;
-        let hi = self.base_hay - hay_left;
-        ei * self.stride + hi
+impl ElemMemo {
+    fn new(n_elems: usize, n_hay: usize) -> Self {
+        Self {
+            grid: BitGrid::new(n_elems + 1, n_hay + 1),
+            base_elems: n_elems,
+            base_hay: n_hay,
+        }
     }
     fn is_failed(&self, elems_left: usize, hay_left: usize) -> bool {
-        self.failed[self.index(elems_left, hay_left)]
+        self.grid
+            .get(self.base_elems - elems_left, self.base_hay - hay_left)
     }
     fn mark_failed(&mut self, elems_left: usize, hay_left: usize) {
-        let i = self.index(elems_left, hay_left);
-        self.failed[i] = true;
+        self.grid
+            .set(self.base_elems - elems_left, self.base_hay - hay_left);
     }
 }
 
@@ -736,7 +760,7 @@ fn match_elems<'p>(
     hay: &[u8],
     opts: PathMatchOptions,
     sink: &mut Sink<'_, 'p>,
-    memo: &mut Option<&mut ElemMemo<'_>>,
+    memo: &mut Option<&mut ElemMemo>,
 ) -> bool {
     if let Some(m) = memo
         && m.is_failed(elems.len(), hay.len())
@@ -778,15 +802,14 @@ fn match_run<'p>(
     hay: &[u8],
     opts: PathMatchOptions,
     sink: &mut Sink<'_, 'p>,
-    memo: &mut Option<&mut ElemMemo<'_>>,
+    memo: &mut Option<&mut ElemMemo>,
 ) -> bool {
     // Try every split point, longest run first (greedy).
     for take in (0..=hay.len()).rev() {
         let mark = sink.len();
         if match_elems(rest, &hay[take..], opts, sink, memo) {
             if let Some((name_start, name_len)) = name {
-                // `hay` is already decoded; render the run lossily (invalid
-                // UTF-8 in the decoded bytes is vanishingly rare).
+                // `hay` is already decoded; just own the slice.
                 let value = decoded_owned(&hay[..take]);
                 // Insert before whatever `rest` recorded so order stays L-to-R.
                 sink.insert_at(
@@ -806,17 +829,23 @@ fn match_run<'p>(
     false
 }
 
-/// '/'-join decoded segment values into an owned string.
+/// '/'-join decoded segment values into an owned string, in a single pass
+/// (no intermediate `Vec<String>`).
 fn join_decoded<'p>(segs: &[&'p [u8]], decode: bool) -> Cow<'p, str> {
-    let parts: Vec<String> = segs
-        .iter()
-        .map(|s| String::from_utf8_lossy(&maybe_decode(s, decode)).into_owned())
-        .collect();
-    Cow::Owned(parts.join("/"))
+    // Decoded length ≤ raw length; pre-size for raw bytes plus separators.
+    let cap = segs.iter().map(|s| s.len()).sum::<usize>() + segs.len();
+    let mut out = String::with_capacity(cap);
+    for (i, s) in segs.iter().enumerate() {
+        if i > 0 {
+            out.push('/');
+        }
+        out.push_str(&String::from_utf8_lossy(&maybe_decode(s, decode)));
+    }
+    Cow::Owned(out)
 }
 
-/// Render an already-decoded byte slice to an owned `Cow` string (lossy on
-/// the rare invalid-UTF-8 decode).
+/// Own an already-decoded byte slice as a string, replacing invalid UTF-8
+/// (reachable: a decoded `%ff` is byte `0xFF`) with U+FFFD.
 fn decoded_owned<'p>(bytes: &[u8]) -> Cow<'p, str> {
     Cow::Owned(String::from_utf8_lossy(bytes).into_owned())
 }

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -100,6 +100,24 @@ pub enum PathPatternSegmentKind {
     CatchAll,
 }
 
+/// Specificity metadata for one compiled [`PathPattern`] segment.
+///
+/// This lets callers rank overlapping patterns without re-parsing the pattern
+/// syntax. The broad [`kind`](Self::kind) preserves the usual ordering
+/// (literal > dynamic > catch-all), while the counters let a router break ties
+/// between dynamic segments such as `{name}` and `{name}.json`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PathPatternSegmentSpecificity {
+    /// Coarse segment kind.
+    pub kind: PathPatternSegmentKind,
+    /// Number of fixed literal bytes inside the segment.
+    pub literal_bytes: usize,
+    /// Number of wildcard/capture runs inside the segment.
+    pub dynamic_parts: usize,
+    /// Number of optional elements inside the segment.
+    pub optional_parts: usize,
+}
+
 /// Policy for a path's trailing slash, derived from the pattern's own
 /// trailing form (explicit, never inferred).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -318,14 +336,62 @@ impl PathPattern {
     /// assert_eq!(kinds, [K::Literal, K::Literal]);
     /// ```
     pub fn segment_kinds(&self) -> impl ExactSizeIterator<Item = PathPatternSegmentKind> + '_ {
+        self.segment_specificity().map(|spec| spec.kind)
+    }
+
+    /// Specificity metadata for each `/`-delimited pattern segment, in order.
+    /// This is a richer version of [`segment_kinds`](Self::segment_kinds) for
+    /// callers that need stable precedence among overlapping dynamic patterns.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathPatternSegmentKind as K};
+    ///
+    /// let specs: Vec<_> = PathPattern::new("/files/{name}.json")
+    ///     .segment_specificity()
+    ///     .collect();
+    /// assert_eq!(specs[0].kind, K::Literal);
+    /// assert_eq!(specs[1].kind, K::Dynamic);
+    /// assert_eq!(specs[1].literal_bytes, 5);
+    /// assert_eq!(specs[1].dynamic_parts, 1);
+    /// ```
+    pub fn segment_specificity(
+        &self,
+    ) -> impl ExactSizeIterator<Item = PathPatternSegmentSpecificity> + '_ {
         self.segments.iter().map(|seg| match seg {
             PatternSegment::CatchAll | PatternSegment::NamedCatchAll { .. } => {
-                PathPatternSegmentKind::CatchAll
+                PathPatternSegmentSpecificity {
+                    kind: PathPatternSegmentKind::CatchAll,
+                    literal_bytes: 0,
+                    dynamic_parts: 1,
+                    optional_parts: 0,
+                }
             }
-            // `ambiguity == 0` means no wildcard/capture/optional element — the
-            // segment is a fixed string.
-            PatternSegment::Normal { ambiguity: 0, .. } => PathPatternSegmentKind::Literal,
-            PatternSegment::Normal { .. } => PathPatternSegmentKind::Dynamic,
+            PatternSegment::Normal { elems, ambiguity } => {
+                let literal_bytes = elems
+                    .iter()
+                    .map(|el| match &el.kind {
+                        ElementKind::Literal(lit) => lit.len(),
+                        ElementKind::Star | ElementKind::Capture { .. } => 0,
+                    })
+                    .sum();
+                let dynamic_parts = elems
+                    .iter()
+                    .filter(|el| matches!(el.kind, ElementKind::Star | ElementKind::Capture { .. }))
+                    .count();
+                let optional_parts = elems.iter().filter(|el| el.optional).count();
+                PathPatternSegmentSpecificity {
+                    // `ambiguity == 0` means no wildcard/capture/optional
+                    // element, so the segment is a fixed string.
+                    kind: if *ambiguity == 0 {
+                        PathPatternSegmentKind::Literal
+                    } else {
+                        PathPatternSegmentKind::Dynamic
+                    },
+                    literal_bytes,
+                    dynamic_parts,
+                    optional_parts,
+                }
+            }
         })
     }
 

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -32,9 +32,13 @@ use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, str
 /// - `*` is an anonymous wildcard run (0+ chars), not captured;
 /// - `?` makes the immediately preceding element optional (zero-or-one):
 ///   `a?` is an optional `a`, a trailing `/?` is an optional trailing slash;
-/// - `**`, as a *whole* segment, is a catch-all matching one or more path
-///   segments, available '/'-joined and decoded via [`PathCaptures::glob`].
-///   It may appear in the middle of a pattern.
+/// - `**`, as a *whole* segment, is an anonymous catch-all matching one or
+///   more path segments, available '/'-joined and decoded via
+///   [`PathCaptures::glob`]. It may appear in the middle of a pattern;
+/// - `:name**`, as a *whole* segment, is the **named** catch-all: same 1+
+///   segment match as `**`, but the run is recorded under `name` (read back,
+///   '/'-joined and decoded, via [`PathCaptures::get`]). So a single `*`
+///   stays within a segment; a doubled `**` spans segments.
 ///
 /// Trailing slash is explicit: `/a` matches only `/a`, `/a/` matches only
 /// `/a/`, and `/a/?` matches both.
@@ -51,6 +55,11 @@ use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, str
 /// let assets = PathPattern::new("/assets/**");
 /// assert!(assets.is_match(PathRef::from_raw_str("/assets/css/app.css")));
 /// assert!(!assets.is_match(PathRef::from_raw_str("/assets")));
+///
+/// // `:name**` is the named catch-all (read back via `get`).
+/// let files = PathPattern::new("/files/:rest**");
+/// let caps = files.captures(PathRef::from_raw_str("/files/a/b/c.txt")).unwrap();
+/// assert_eq!(caps.get("rest"), Some("a/b/c.txt"));
 /// ```
 #[derive(Debug, Clone)]
 pub struct PathPattern {
@@ -93,8 +102,12 @@ impl TrailingSlash {
 /// One `/`-delimited unit of a compiled pattern.
 #[derive(Debug, Clone)]
 enum PatternSegment {
-    /// `**` — matches one or more whole path segments.
+    /// `**` — matches one or more whole path segments (anonymous; read back
+    /// via [`PathCaptures::glob`]).
     CatchAll,
+    /// `:name**` — like [`CatchAll`](Self::CatchAll) but records the matched,
+    /// '/'-joined run under `name` (read back via [`PathCaptures::get`]).
+    NamedCatchAll { name_start: usize, name_len: usize },
     /// A sequence of within-segment elements matched against a single path
     /// segment via greedy backtracking. Inline-sized for the common one- or
     /// two-element segment (a bare literal, capture, or `:name*.ext` pair).
@@ -198,6 +211,21 @@ impl PathPattern {
                     segments.push(PatternSegment::CatchAll);
                     continue;
                 }
+                if let Some(name) = parse_named_catchall(seg) {
+                    capture_free = false;
+                    // `:**` (empty name) is just the anonymous catch-all.
+                    if name.is_empty() {
+                        segments.push(PatternSegment::CatchAll);
+                    } else {
+                        let name_start = name_bytes.len();
+                        name_bytes.extend_from_slice(name);
+                        segments.push(PatternSegment::NamedCatchAll {
+                            name_start,
+                            name_len: name.len(),
+                        });
+                    }
+                    continue;
+                }
                 let elements = parse_segment(seg, &mut name_bytes, &mut capture_free);
                 let ambiguity = elements
                     .iter()
@@ -272,9 +300,11 @@ impl PathPattern {
                     }
                 }
                 // Either the pattern ran out of segments (path has a real one
-                // left) or a `**` snuck in — impossible for a capture-free
+                // left) or a catch-all snuck in — impossible for a capture-free
                 // pattern, but a defensive miss either way.
-                None | Some(PatternSegment::CatchAll) => return false,
+                None | Some(PatternSegment::CatchAll | PatternSegment::NamedCatchAll { .. }) => {
+                    return false;
+                }
             }
             content_count += 1;
         };
@@ -446,7 +476,18 @@ impl<'a, 'p> PathCaptures<'a, 'p> {
 // Compilation helpers
 // ----------------------------------------------------------------------
 
-/// Parse one (non-`**`) pattern segment into a sequence of elements.
+/// If `seg` is a whole-segment named catch-all (`:name**`), return its name
+/// bytes (possibly empty for `:**`). Returns `None` for anything else — including
+/// within-segment `:name*` runs (single `*`) and names with non-identifier bytes,
+/// which fall through to [`parse_segment`].
+fn parse_named_catchall(seg: &[u8]) -> Option<&[u8]> {
+    let name = seg.strip_prefix(b":")?.strip_suffix(b"**")?;
+    name.iter()
+        .all(|&b| is_pattern_name_byte(b))
+        .then_some(name)
+}
+
+/// Parse one (non catch-all) pattern segment into a sequence of elements.
 ///
 /// `name_bytes` accumulates capture-name bytes; element name indices point
 /// into it. `capture_free` is cleared whenever a named capture is seen.
@@ -601,7 +642,12 @@ impl SeqMemo {
     fn new(pats: &[PatternSegment], n_segs: usize) -> Self {
         let catch_alls = pats
             .iter()
-            .filter(|p| matches!(p, PatternSegment::CatchAll))
+            .filter(|p| {
+                matches!(
+                    p,
+                    PatternSegment::CatchAll | PatternSegment::NamedCatchAll { .. }
+                )
+            })
             .count();
         if catch_alls >= 2 {
             Self::Grid {
@@ -656,31 +702,15 @@ fn match_sequence<'p>(
     let matched = match pats.split_first() {
         None => segs.is_empty(),
         Some((PatternSegment::CatchAll, rest)) => {
-            // `**` consumes 1+ path segments; try the shortest first, growing
-            // until the remaining patterns can match the tail.
-            let mut ok = false;
-            for take in 1..=segs.len() {
-                let mark = sink.len();
-                if match_sequence(rest, &segs[take..], opts, sink, memo) {
-                    // Record the glob (joined, decoded) only once the tail
-                    // matched, so discarded attempts cost nothing.
-                    let value = join_decoded(&segs[..take], opts.percent_decode);
-                    sink.insert_at(
-                        mark,
-                        Binding {
-                            name_start: 0,
-                            name_len: 0,
-                            value,
-                            is_glob: true,
-                        },
-                    );
-                    ok = true;
-                    break;
-                }
-                sink.truncate(mark);
-            }
-            ok
+            match_catch_all(None, rest, segs, opts, sink, memo)
         }
+        Some((
+            PatternSegment::NamedCatchAll {
+                name_start,
+                name_len,
+            },
+            rest,
+        )) => match_catch_all(Some((*name_start, *name_len)), rest, segs, opts, sink, memo),
         Some((PatternSegment::Normal { elems, ambiguity }, rest)) => {
             if let Some((seg, segs_rest)) = segs.split_first() {
                 let mark = sink.len();
@@ -702,6 +732,43 @@ fn match_sequence<'p>(
         memo.mark_failed(pats.len(), segs.len());
     }
     matched
+}
+
+/// Match a catch-all (`**` or `:name**`) against `segs`, then the remaining
+/// `rest` patterns against the tail. Consumes 1+ path segments, shortest first,
+/// growing until the tail matches. On success records the matched run, '/'-joined
+/// and decoded — as the anonymous glob when `name` is `None`, else a named binding.
+fn match_catch_all<'p>(
+    name: Option<(usize, usize)>,
+    rest: &[PatternSegment],
+    segs: &[&'p [u8]],
+    opts: PathMatchOptions,
+    sink: &mut Sink<'_, 'p>,
+    memo: &mut SeqMemo,
+) -> bool {
+    for take in 1..=segs.len() {
+        let mark = sink.len();
+        if match_sequence(rest, &segs[take..], opts, sink, memo) {
+            // Record only once the tail matched, so discarded attempts cost nothing.
+            let value = join_decoded(&segs[..take], opts.percent_decode);
+            let (name_start, name_len, is_glob) = match name {
+                Some((start, len)) => (start, len, false),
+                None => (0, 0, true),
+            };
+            sink.insert_at(
+                mark,
+                Binding {
+                    name_start,
+                    name_len,
+                    value,
+                    is_glob,
+                },
+            );
+            return true;
+        }
+        sink.truncate(mark);
+    }
+    false
 }
 
 /// Match one pattern segment's elements against one path segment's bytes.

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -1,0 +1,822 @@
+//! Infallible path-pattern matching.
+//!
+//! [`PathPattern`] compiles a small glob/capture syntax and matches it
+//! against a [`PathRef`](super::PathRef) segment-by-segment, decode-aware
+//! and (by default) case-sensitive. Compilation never fails: anything that
+//! isn't a recognized meta token is treated as a literal.
+//!
+//! # Syntax
+//!
+//! A pattern is split on `/` into segments. Within a segment:
+//!
+//! - **literal** text must equal the (decoded) path segment value;
+//! - `:name` captures a whole segment under `name`;
+//! - `:name*` captures a wildcard run within a segment, allowing literal
+//!   prefix/suffix around it (`:pkg*.json` captures the part before `.json`).
+//!   `:name` and `:name*` are equivalent when there is no surrounding literal;
+//! - `*` is an anonymous wildcard run (0+ chars), not captured;
+//! - `?` makes the immediately preceding element optional (zero-or-one):
+//!   `a?` is an optional `a`, a trailing `/?` is an optional trailing slash;
+//! - `**`, as a *whole* segment, is a catch-all matching one or more path
+//!   segments, available '/'-joined and decoded via [`PathCaptures::glob`].
+//!   It may appear in the middle of a pattern.
+//!
+//! Trailing slash is explicit: `/a` matches only `/a`, `/a/` matches only
+//! `/a/`, and `/a/?` matches both.
+//!
+//! ```
+//! use rama_net::uri::{PathPattern, PathRef};
+//!
+//! let pat = PathPattern::new("/p2/:vendor/:pkg*.json");
+//! let caps = pat.captures(PathRef::from_raw_str("/p2/acme/widget.json")).unwrap();
+//! assert_eq!(caps.get("vendor"), Some("acme"));
+//! assert_eq!(caps.get("pkg"), Some("widget"));
+//! assert!(pat.captures(PathRef::from_raw_str("/p2/acme/widget.txt")).is_none());
+//! ```
+
+use std::borrow::Cow;
+
+use super::component_input::IntoUriComponent;
+use super::path::{PathMatchOptions, PathRef, byte_starts_with, maybe_decode, strip_leading_slash};
+
+/// A compiled path pattern — see the [module docs](self) for the syntax.
+///
+/// Construct via [`PathPattern::new`] / [`new_with_opts`](Self::new_with_opts)
+/// and test paths with [`is_match`](Self::is_match) / [`captures`](Self::captures).
+///
+/// ```
+/// use rama_net::uri::{PathPattern, PathRef};
+///
+/// let pat = PathPattern::new("/assets/**");
+/// assert!(pat.is_match(PathRef::from_raw_str("/assets/css/app.css")));
+/// assert!(!pat.is_match(PathRef::from_raw_str("/assets")));
+/// ```
+#[derive(Debug, Clone)]
+pub struct PathPattern {
+    segments: Vec<PatternSegment>,
+    /// Capture names are appended here at compile time; [`Element`] capture
+    /// kinds index into it. Owning the names here is what lets
+    /// [`PathCaptures`] borrow them for `'a`.
+    name_bytes: Vec<u8>,
+    trailing: TrailingSlash,
+    opts: PathMatchOptions,
+    /// `true` when no segment binds a name and there is no catch-all — the
+    /// alloc-free [`is_match`](PathPattern::is_match) fast path applies.
+    capture_free: bool,
+}
+
+/// Policy for a path's trailing slash, derived from the pattern's own
+/// trailing form (explicit, never inferred).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrailingSlash {
+    /// Pattern has no trailing `/`: the path must not either.
+    Forbidden,
+    /// Pattern ends in `/`: the path must too.
+    Required,
+    /// Pattern ends in `/?`: both forms accepted.
+    Optional,
+}
+
+impl TrailingSlash {
+    /// Does this policy accept a path that does (`true`) / doesn't (`false`)
+    /// carry a trailing slash?
+    fn accepts(self, path_has_slash: bool) -> bool {
+        match self {
+            Self::Forbidden => !path_has_slash,
+            Self::Required => path_has_slash,
+            Self::Optional => true,
+        }
+    }
+}
+
+/// One `/`-delimited unit of a compiled pattern.
+#[derive(Debug, Clone)]
+enum PatternSegment {
+    /// `**` — matches one or more whole path segments.
+    CatchAll,
+    /// A sequence of within-segment elements matched against a single path
+    /// segment via greedy backtracking.
+    Normal {
+        elems: Vec<Element>,
+        /// Count of *ambiguity sources* in `elems`: wildcard runs
+        /// (`Star`/`Capture`) plus `optional` elements. Each is a backtrack
+        /// point; with two or more of them the greedy recursion can revisit
+        /// the same `(element, hay)` state exponentially, so we memoize
+        /// failures. With at most one source the recursion is linear, so we
+        /// skip the memo (and its allocation) entirely. Precomputed here so
+        /// the hot path doesn't rescan the element list per match.
+        ambiguity: usize,
+    },
+}
+
+/// A within-segment matching element.
+#[derive(Debug, Clone)]
+struct Element {
+    kind: ElementKind,
+    /// `?` suffix: the element may match zero occurrences.
+    optional: bool,
+}
+
+#[derive(Debug, Clone)]
+enum ElementKind {
+    /// Literal bytes, compared against the decoded path-segment bytes.
+    Literal(Vec<u8>),
+    /// Anonymous wildcard run (0+ chars within the segment).
+    Star,
+    /// Named wildcard run that records what it matched. The name is the
+    /// `name_bytes[start..start+len]` slice of the owning [`PathPattern`].
+    Capture { name_start: usize, name_len: usize },
+}
+
+impl PathPattern {
+    /// Compile a path pattern. Infallible: anything not a recognized meta
+    /// token is a literal.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathRef};
+    ///
+    /// let pat = PathPattern::new("/backend-api/codex/responses");
+    /// assert!(pat.is_match(PathRef::from_raw_str("/backend-api/codex/responses")));
+    /// assert!(!pat.is_match(PathRef::from_raw_str("/backend-api/codex")));
+    /// ```
+    #[must_use]
+    pub fn new(pattern: impl IntoUriComponent) -> Self {
+        Self::new_with_opts(pattern, PathMatchOptions::default())
+    }
+
+    /// [`new`](Self::new) with explicit [`PathMatchOptions`]. The matcher
+    /// honors `ignore_ascii_case` and `percent_decode`; `partial` is
+    /// irrelevant and ignored.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathMatchOptions, PathPattern, PathRef};
+    ///
+    /// let opts = PathMatchOptions {
+    ///     ignore_ascii_case: true,
+    ///     ..Default::default()
+    /// };
+    /// let pat = PathPattern::new_with_opts("/api/v2", opts);
+    /// assert!(pat.is_match(PathRef::from_raw_str("/API/v2")));
+    /// ```
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling APIs; this impl only borrows the input"
+    )]
+    pub fn new_with_opts(pattern: impl IntoUriComponent, opts: PathMatchOptions) -> Self {
+        let raw = pattern.as_uri_component_bytes();
+        Self::compile(&raw, opts)
+    }
+
+    fn compile(raw: &[u8], opts: PathMatchOptions) -> Self {
+        // Trailing-slash policy is read off the raw pattern *before* the
+        // leading slash is stripped, so the bare-root `/` (which becomes empty
+        // after stripping) still registers as a required trailing slash.
+        let (raw, trailing) = if let Some(rest) = raw.strip_suffix(b"/?") {
+            (rest, TrailingSlash::Optional)
+        } else if let Some(rest) = raw.strip_suffix(b"/") {
+            (rest, TrailingSlash::Required)
+        } else {
+            (raw, TrailingSlash::Forbidden)
+        };
+        let body = strip_leading_slash(raw);
+
+        let mut name_bytes: Vec<u8> = Vec::new();
+        let mut segments = Vec::new();
+        let mut capture_free = true;
+
+        // Split on `/`. An empty `body` (root pattern `/`) yields no
+        // segments, which together with `TrailingSlash::Required` matches
+        // exactly `/`.
+        if !body.is_empty() {
+            for seg in body.split(|&b| b == b'/') {
+                if seg == b"**" {
+                    capture_free = false;
+                    segments.push(PatternSegment::CatchAll);
+                    continue;
+                }
+                let elements = parse_segment(seg, &mut name_bytes, &mut capture_free);
+                let ambiguity = elements
+                    .iter()
+                    .filter(|e| {
+                        e.optional
+                            || matches!(e.kind, ElementKind::Star | ElementKind::Capture { .. })
+                    })
+                    .count();
+                segments.push(PatternSegment::Normal {
+                    elems: elements,
+                    ambiguity,
+                });
+            }
+        }
+
+        Self {
+            segments,
+            name_bytes,
+            trailing,
+            opts,
+            capture_free,
+        }
+    }
+
+    /// `true` when `path` matches. Allocation-free when the pattern has no
+    /// captures and no catch-all.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathRef};
+    ///
+    /// let pat = PathPattern::new("/files/*.txt");
+    /// assert!(pat.is_match(PathRef::from_raw_str("/files/readme.txt")));
+    /// assert!(!pat.is_match(PathRef::from_raw_str("/files/readme.md")));
+    /// ```
+    #[must_use]
+    pub fn is_match(&self, path: PathRef<'_>) -> bool {
+        if self.capture_free {
+            self.is_match_fast(path)
+        } else {
+            self.captures(path).is_some()
+        }
+    }
+
+    /// Allocation-free match for capture-free patterns. A capture-free
+    /// pattern has no `**`, so every pattern segment matches exactly one path
+    /// segment positionally — no backtracking across segments, no `Vec`, no
+    /// captured-value strings.
+    fn is_match_fast(&self, path: PathRef<'_>) -> bool {
+        // Walk the path segments with one-segment lookahead so the trailing-`/`
+        // marker can be classified without materializing the list.
+        let mut path_iter = path.segments().peekable();
+        let mut pat_iter = self.segments.iter();
+        let mut content_count = 0usize;
+        let mut ignore = Sink::Ignore;
+
+        let trailing = loop {
+            let Some(seg) = path_iter.next() else {
+                // No (more) segments: no trailing slash.
+                break false;
+            };
+            let is_last = path_iter.peek().is_none();
+            // The root path `/` is a lone empty segment: it carries the root
+            // slash but no content. A final empty segment after real content is
+            // the trailing-`/` marker. Either way it is not matched as content.
+            if seg.is_empty() && is_last && (content_count >= 1 || self.segments.is_empty()) {
+                break true;
+            }
+            match pat_iter.next() {
+                Some(PatternSegment::Normal { elems, ambiguity }) => {
+                    if !match_segment(elems, *ambiguity, seg.as_bytes(), self.opts, &mut ignore) {
+                        return false;
+                    }
+                }
+                // Either the pattern ran out of segments (path has a real one
+                // left) or a `**` snuck in — impossible for a capture-free
+                // pattern, but a defensive miss either way.
+                None | Some(PatternSegment::CatchAll) => return false,
+            }
+            content_count += 1;
+        };
+
+        // All path content consumed: the pattern must be exhausted and the
+        // observed trailing slash must satisfy the policy.
+        pat_iter.next().is_none() && self.trailing.accepts(trailing)
+    }
+
+    /// Match and return captured values, or `None` when `path` doesn't
+    /// match. May allocate a small `Vec` for the bindings.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathRef};
+    ///
+    /// let pat = PathPattern::new("/simple/:name/?");
+    /// let caps = pat.captures(PathRef::from_raw_str("/simple/requests")).unwrap();
+    /// assert_eq!(caps.get("name"), Some("requests"));
+    /// ```
+    #[must_use]
+    pub fn captures<'p>(&self, path: PathRef<'p>) -> Option<PathCaptures<'_, 'p>> {
+        let segs: Vec<&'p [u8]> = path.segments().map(|s| s.as_bytes()).collect();
+        let segs = self.check_trailing(&segs)?;
+        let mut bindings: Vec<Binding<'p>> = Vec::new();
+        let mut sink = Sink::Record(&mut bindings);
+        let mut seq_memo = SeqMemo::new(&self.segments, segs.len());
+        if match_sequence(&self.segments, segs, self.opts, &mut sink, &mut seq_memo) {
+            Some(PathCaptures {
+                name_bytes: &self.name_bytes,
+                bindings,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Validate the trailing-slash policy and return the content segments
+    /// (with any trailing-`/` empty marker removed), or `None` if the policy
+    /// rejects the path.
+    ///
+    /// `PathRef::segments()` yields a trailing empty segment for a trailing
+    /// `/` (so `/a/` -> ["a", ""]); we consume that here rather than letting
+    /// it leak into element matching. The bare root `/` is a lone empty
+    /// segment that carries the root slash but no content.
+    fn check_trailing<'s, 'p>(&self, segs: &'s [&'p [u8]]) -> Option<&'s [&'p [u8]]> {
+        // Root `/` (lone empty segment) carries the slash but no content; a
+        // final empty segment after real content is the trailing-`/` marker.
+        let last_empty = segs.last().is_some_and(|s| s.is_empty());
+        let is_root = segs.len() == 1 && last_empty && self.segments.is_empty();
+        let (content, has_slash) = if is_root {
+            (&segs[..0], true)
+        } else if last_empty && segs.len() >= 2 {
+            (&segs[..segs.len() - 1], true)
+        } else {
+            (segs, false)
+        };
+        self.trailing.accepts(has_slash).then_some(content)
+    }
+}
+
+/// A recorded capture: name slice into the pattern's `name_bytes`
+/// (`name_len == 0` for the anonymous glob), plus the matched, decoded value.
+#[derive(Debug, Clone)]
+struct Binding<'p> {
+    name_start: usize,
+    name_len: usize,
+    value: Cow<'p, str>,
+    /// `true` for the `**` catch-all's joined value.
+    is_glob: bool,
+}
+
+/// Where matched capture values go. The `is_match` fast path discards them
+/// without allocating; `captures` records them.
+enum Sink<'b, 'p> {
+    Ignore,
+    Record(&'b mut Vec<Binding<'p>>),
+}
+
+impl<'p> Sink<'_, 'p> {
+    /// Insert a binding at index `idx`, preserving left-to-right order when a
+    /// run records itself after its tail already pushed bindings.
+    fn insert_at(&mut self, idx: usize, b: Binding<'p>) {
+        if let Sink::Record(v) = self {
+            v.insert(idx, b);
+        }
+    }
+    fn len(&self) -> usize {
+        match self {
+            Sink::Ignore => 0,
+            Sink::Record(v) => v.len(),
+        }
+    }
+    fn truncate(&mut self, n: usize) {
+        if let Sink::Record(v) = self {
+            v.truncate(n);
+        }
+    }
+}
+
+/// Captured values from a successful [`PathPattern::captures`] match.
+///
+/// Capture names borrow from the compiled pattern (`'a`). Values are always
+/// percent-decoded (per the pattern's options); the `'p` value lifetime ties
+/// them to the matched path so a future zero-copy fast path can borrow,
+/// though today every value is owned.
+///
+/// ```
+/// use rama_net::uri::{PathPattern, PathRef};
+///
+/// let pat = PathPattern::new("/p2/**/:file*.txt");
+/// let caps = pat.captures(PathRef::from_raw_str("/p2/a/b/c.txt")).unwrap();
+/// assert_eq!(caps.glob(), Some("a/b"));
+/// assert_eq!(caps.get("file"), Some("c"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct PathCaptures<'a, 'p> {
+    name_bytes: &'a [u8],
+    bindings: Vec<Binding<'p>>,
+}
+
+impl<'a, 'p> PathCaptures<'a, 'p> {
+    fn name_of(&self, b: &Binding<'p>) -> &'a str {
+        let raw = &self.name_bytes[b.name_start..b.name_start + b.name_len];
+        // Safety: capture names are pattern bytes copied verbatim; the
+        // accepted name bytes are all ASCII (see `is_name_byte`).
+        unsafe { std::str::from_utf8_unchecked(raw) }
+    }
+
+    /// The decoded value captured under `name`, or `None` if `name` was not
+    /// bound. The `**` catch-all is reachable via [`glob`](Self::glob), not
+    /// here.
+    #[must_use]
+    pub fn get(&self, name: &str) -> Option<&str> {
+        self.bindings
+            .iter()
+            .find(|b| !b.is_glob && b.name_len != 0 && self.name_of(b) == name)
+            .map(|b| b.value.as_ref())
+    }
+
+    /// Iterator over `(name, decoded value)` for every named (non-glob)
+    /// capture, in match order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.bindings
+            .iter()
+            .filter(|b| !b.is_glob && b.name_len != 0)
+            .map(|b| (self.name_of(b), b.value.as_ref()))
+    }
+
+    /// The `**` catch-all value, '/'-joined and decoded, or `None` when the
+    /// pattern has no catch-all (or it didn't match).
+    #[must_use]
+    pub fn glob(&self) -> Option<&str> {
+        self.bindings
+            .iter()
+            .find(|b| b.is_glob)
+            .map(|b| b.value.as_ref())
+    }
+
+    /// `true` when there are no captures and no catch-all value.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+}
+
+// ----------------------------------------------------------------------
+// Compilation helpers
+// ----------------------------------------------------------------------
+
+/// Parse one (non-`**`) pattern segment into a sequence of elements.
+///
+/// `name_bytes` accumulates capture-name bytes; element name indices point
+/// into it. `capture_free` is cleared whenever a named capture is seen.
+fn parse_segment(seg: &[u8], name_bytes: &mut Vec<u8>, capture_free: &mut bool) -> Vec<Element> {
+    let mut elements: Vec<Element> = Vec::new();
+    let mut literal: Vec<u8> = Vec::new();
+    let mut i = 0;
+
+    // Flush any pending literal run into an element.
+    macro_rules! flush_literal {
+        () => {
+            if !literal.is_empty() {
+                elements.push(Element {
+                    kind: ElementKind::Literal(std::mem::take(&mut literal)),
+                    optional: false,
+                });
+            }
+        };
+    }
+
+    while i < seg.len() {
+        match seg[i] {
+            b'*' => {
+                flush_literal!();
+                elements.push(Element {
+                    kind: ElementKind::Star,
+                    optional: false,
+                });
+                i += 1;
+            }
+            b':' => {
+                flush_literal!();
+                // Capture name: identifier bytes until a meta char.
+                let start = i + 1;
+                let mut end = start;
+                while end < seg.len() && is_name_byte(seg[end]) {
+                    end += 1;
+                }
+                let name = &seg[start..end];
+                let name_start = name_bytes.len();
+                name_bytes.extend_from_slice(name);
+                *capture_free = false;
+                elements.push(Element {
+                    kind: ElementKind::Capture {
+                        name_start,
+                        name_len: name.len(),
+                    },
+                    optional: false,
+                });
+                i = end;
+                // `:name*` — the trailing `*` is part of the capture (run
+                // semantics) and adds no separate Star element.
+                if i < seg.len() && seg[i] == b'*' {
+                    i += 1;
+                }
+            }
+            b'?' => {
+                // `?` makes the immediately preceding element optional.
+                if let Some(last) = literal.pop() {
+                    // A pending literal run takes precedence: `?` binds only its
+                    // final byte. Flush the head literal, then push the final
+                    // byte as its own optional literal element.
+                    flush_literal!();
+                    elements.push(Element {
+                        kind: ElementKind::Literal(vec![last]),
+                        optional: true,
+                    });
+                } else if let Some(last) = elements.last_mut() {
+                    last.optional = true;
+                } else {
+                    // Leading `?` with nothing before it is a literal `?`.
+                    literal.push(b'?');
+                }
+                i += 1;
+            }
+            other => {
+                literal.push(other);
+                i += 1;
+            }
+        }
+    }
+    flush_literal!();
+    elements
+}
+
+/// Bytes allowed in a `:name` identifier.
+fn is_name_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-'
+}
+
+// ----------------------------------------------------------------------
+// Matching
+// ----------------------------------------------------------------------
+//
+// Both match entry points share one greedy recursion. Without guards that
+// recursion is exponential: a wildcard run tries every split point and an
+// optional element forks, so a segment with many such *ambiguity sources*
+// (or a pattern with many `**`) revisits the same `(position)` state over and
+// over. Each level fixes that by memoizing *failed* states. Failure-only memo
+// is sound because capture recording happens solely on the unique success
+// path: a state proven unmatchable can never later succeed, so caching it
+// cannot drop or corrupt a binding. The memo grid is allocated only for the
+// pathological shapes (>= 2 ambiguity sources in a segment, >= 2 `**` in a
+// pattern); simpler shapes recurse linearly with no allocation.
+
+/// Failure memo for the cross-segment `**` search, keyed on
+/// `(pattern_index, path_segment_index)`. Only allocated when a pattern has
+/// two or more `**` (a single `**` can't revisit states).
+enum SeqMemo {
+    None,
+    Grid { failed: Vec<bool>, stride: usize },
+}
+
+impl SeqMemo {
+    fn new(pats: &[PatternSegment], n_segs: usize) -> Self {
+        let catch_alls = pats
+            .iter()
+            .filter(|p| matches!(p, PatternSegment::CatchAll))
+            .count();
+        if catch_alls >= 2 {
+            let rows = pats.len() + 1;
+            let stride = n_segs + 1;
+            Self::Grid {
+                failed: vec![false; rows * stride],
+                stride,
+            }
+        } else {
+            Self::None
+        }
+    }
+
+    /// `true` if `(pat_idx, seg_idx)` is already known to fail.
+    fn is_failed(&self, pat_idx: usize, seg_idx: usize) -> bool {
+        match self {
+            Self::None => false,
+            Self::Grid { failed, stride } => failed[pat_idx * stride + seg_idx],
+        }
+    }
+
+    fn mark_failed(&mut self, pat_idx: usize, seg_idx: usize) {
+        if let Self::Grid { failed, stride } = self {
+            failed[pat_idx * *stride + seg_idx] = true;
+        }
+    }
+}
+
+/// Match a sequence of pattern segments against the path segments, with
+/// backtracking across `**` catch-alls. Returns `true` on full match.
+fn match_sequence<'p>(
+    pats: &[PatternSegment],
+    segs: &[&'p [u8]],
+    opts: PathMatchOptions,
+    sink: &mut Sink<'_, 'p>,
+    memo: &mut SeqMemo,
+) -> bool {
+    // State indices for the failure memo: how far we've advanced from the
+    // originals (both args are always suffixes of the originals).
+    let pat_idx = memo_pat_len(memo).saturating_sub(pats.len());
+    let seg_idx = memo_seg_len(memo).saturating_sub(segs.len());
+    if memo.is_failed(pat_idx, seg_idx) {
+        return false;
+    }
+
+    let matched = match pats.split_first() {
+        None => segs.is_empty(),
+        Some((PatternSegment::CatchAll, rest)) => {
+            // `**` consumes 1+ path segments; try the shortest first, growing
+            // until the remaining patterns can match the tail.
+            let mut ok = false;
+            for take in 1..=segs.len() {
+                let mark = sink.len();
+                if match_sequence(rest, &segs[take..], opts, sink, memo) {
+                    // Record the glob (joined, decoded) only once the tail
+                    // matched, so discarded attempts cost nothing.
+                    let value = join_decoded(&segs[..take], opts.percent_decode);
+                    sink.insert_at(
+                        mark,
+                        Binding {
+                            name_start: 0,
+                            name_len: 0,
+                            value,
+                            is_glob: true,
+                        },
+                    );
+                    ok = true;
+                    break;
+                }
+                sink.truncate(mark);
+            }
+            ok
+        }
+        Some((PatternSegment::Normal { elems, ambiguity }, rest)) => {
+            if let Some((seg, segs_rest)) = segs.split_first() {
+                let mark = sink.len();
+                if match_segment(elems, *ambiguity, seg, opts, sink)
+                    && match_sequence(rest, segs_rest, opts, sink, memo)
+                {
+                    true
+                } else {
+                    sink.truncate(mark);
+                    false
+                }
+            } else {
+                false
+            }
+        }
+    };
+
+    if !matched {
+        memo.mark_failed(pat_idx, seg_idx);
+    }
+    matched
+}
+
+/// Original pattern length, recovered from the memo (only meaningful when a
+/// grid is present; otherwise indices are unused).
+fn memo_pat_len(memo: &SeqMemo) -> usize {
+    match memo {
+        SeqMemo::None => 0,
+        SeqMemo::Grid { failed, stride } => failed.len() / stride - 1,
+    }
+}
+
+/// Original path-segment count, recovered from the memo.
+fn memo_seg_len(memo: &SeqMemo) -> usize {
+    match memo {
+        SeqMemo::None => 0,
+        SeqMemo::Grid { stride, .. } => stride - 1,
+    }
+}
+
+/// Match one pattern segment's elements against one path segment's bytes.
+///
+/// The path segment is decoded once (per `percent_decode`) up front, then
+/// elements are matched against the decoded bytes via greedy backtracking.
+/// `ambiguity` is the segment's precomputed backtrack-source count; >= 2
+/// switches on failure memoization.
+fn match_segment<'p>(
+    elems: &[Element],
+    ambiguity: usize,
+    raw_seg: &'p [u8],
+    opts: PathMatchOptions,
+    sink: &mut Sink<'_, 'p>,
+) -> bool {
+    let decoded = maybe_decode(raw_seg, opts.percent_decode);
+    if ambiguity >= 2 {
+        // (element_index, hay_index) failure grid; rows are element positions
+        // 0..=elems.len(), columns hay positions 0..=hay.len().
+        let stride = decoded.len() + 1;
+        let mut failed = vec![false; (elems.len() + 1) * stride];
+        let mut memo = ElemMemo {
+            base_elems: elems.len(),
+            base_hay: decoded.len(),
+            failed: &mut failed,
+            stride,
+        };
+        match_elems(elems, &decoded, opts, sink, &mut Some(&mut memo))
+    } else {
+        match_elems(elems, &decoded, opts, sink, &mut None)
+    }
+}
+
+/// Failure memo for within-segment matching, keyed on
+/// `(element_index, hay_index)`.
+struct ElemMemo<'m> {
+    base_elems: usize,
+    base_hay: usize,
+    failed: &'m mut [bool],
+    stride: usize,
+}
+
+impl ElemMemo<'_> {
+    fn index(&self, elems_left: usize, hay_left: usize) -> usize {
+        let ei = self.base_elems - elems_left;
+        let hi = self.base_hay - hay_left;
+        ei * self.stride + hi
+    }
+    fn is_failed(&self, elems_left: usize, hay_left: usize) -> bool {
+        self.failed[self.index(elems_left, hay_left)]
+    }
+    fn mark_failed(&mut self, elems_left: usize, hay_left: usize) {
+        let i = self.index(elems_left, hay_left);
+        self.failed[i] = true;
+    }
+}
+
+/// Greedy-with-backtracking match of `elems` against the (already decoded)
+/// `hay` bytes. Captures record decoded substrings. `memo`, when present,
+/// caches failed `(elems, hay)` states so the recursion stays polynomial.
+fn match_elems<'p>(
+    elems: &[Element],
+    hay: &[u8],
+    opts: PathMatchOptions,
+    sink: &mut Sink<'_, 'p>,
+    memo: &mut Option<&mut ElemMemo<'_>>,
+) -> bool {
+    if let Some(m) = memo
+        && m.is_failed(elems.len(), hay.len())
+    {
+        return false;
+    }
+
+    let matched = match elems.split_first() {
+        None => hay.is_empty(),
+        Some((el, rest)) => match &el.kind {
+            ElementKind::Literal(lit) => {
+                (byte_starts_with(hay, lit, opts.ignore_ascii_case)
+                    && match_elems(rest, &hay[lit.len()..], opts, sink, memo))
+                    // Optional literal: skip it entirely.
+                    || (el.optional && match_elems(rest, hay, opts, sink, memo))
+            }
+            // A run already matches zero bytes (the take == 0 split), so its
+            // `?` flag is a no-op — handled identically to a non-optional run.
+            ElementKind::Star => match_run(None, rest, hay, opts, sink, memo),
+            ElementKind::Capture {
+                name_start,
+                name_len,
+            } => match_run(Some((*name_start, *name_len)), rest, hay, opts, sink, memo),
+        },
+    };
+
+    if !matched && let Some(m) = memo {
+        m.mark_failed(elems.len(), hay.len());
+    }
+    matched
+}
+
+/// Match a wildcard run (anonymous `*` or named capture) followed by `rest`.
+/// Greedy: try the longest run first, shrinking on backtrack. For a named
+/// capture, record the matched (decoded) substring as a binding.
+fn match_run<'p>(
+    name: Option<(usize, usize)>,
+    rest: &[Element],
+    hay: &[u8],
+    opts: PathMatchOptions,
+    sink: &mut Sink<'_, 'p>,
+    memo: &mut Option<&mut ElemMemo<'_>>,
+) -> bool {
+    // Try every split point, longest run first (greedy).
+    for take in (0..=hay.len()).rev() {
+        let mark = sink.len();
+        if match_elems(rest, &hay[take..], opts, sink, memo) {
+            if let Some((name_start, name_len)) = name {
+                // `hay` is already decoded; render the run lossily (invalid
+                // UTF-8 in the decoded bytes is vanishingly rare).
+                let value = decoded_owned(&hay[..take]);
+                // Insert before whatever `rest` recorded so order stays L-to-R.
+                sink.insert_at(
+                    mark,
+                    Binding {
+                        name_start,
+                        name_len,
+                        value,
+                        is_glob: false,
+                    },
+                );
+            }
+            return true;
+        }
+        sink.truncate(mark);
+    }
+    false
+}
+
+/// '/'-join decoded segment values into an owned string.
+fn join_decoded<'p>(segs: &[&'p [u8]], decode: bool) -> Cow<'p, str> {
+    let parts: Vec<String> = segs
+        .iter()
+        .map(|s| String::from_utf8_lossy(&maybe_decode(s, decode)).into_owned())
+        .collect();
+    Cow::Owned(parts.join("/"))
+}
+
+/// Render an already-decoded byte slice to an owned `Cow` string (lossy on
+/// the rare invalid-UTF-8 decode).
+fn decoded_owned<'p>(bytes: &[u8]) -> Cow<'p, str> {
+    Cow::Owned(String::from_utf8_lossy(bytes).into_owned())
+}

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -80,6 +80,10 @@ pub struct PathPattern {
     /// `true` when no segment binds a name and there is no catch-all — the
     /// alloc-free [`is_match`](PathPattern::is_match) fast path applies.
     capture_free: bool,
+    /// `true` for a prefix matcher ([`new_prefix`](PathPattern::new_prefix)):
+    /// the pattern must match a *leading* run of the path's segments, and any
+    /// trailing segments and trailing-slash are ignored.
+    prefix: bool,
 }
 
 /// Coarse classification of a compiled [`PathPattern`] segment, exposed via
@@ -202,10 +206,39 @@ impl PathPattern {
     )]
     pub fn new_with_opts(pattern: impl IntoUriComponent, opts: PathMatchOptions) -> Self {
         let raw = pattern.as_uri_component_bytes();
-        Self::compile(&raw, opts)
+        Self::compile(&raw, opts, false)
     }
 
-    fn compile(raw: &[u8], opts: PathMatchOptions) -> Self {
+    /// Compile a **prefix** matcher: the pattern must match a leading run of the
+    /// path's segments; any trailing segments and the path's trailing slash are
+    /// ignored. So `/api` matches `/api`, `/api/`, and `/api/users` — but not
+    /// `/apixyz` (segments are matched whole).
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathRef};
+    ///
+    /// let api = PathPattern::new_prefix("/api");
+    /// assert!(api.is_match(PathRef::from_raw_str("/api")));
+    /// assert!(api.is_match(PathRef::from_raw_str("/api/users/42")));
+    /// assert!(!api.is_match(PathRef::from_raw_str("/apixyz")));
+    /// ```
+    #[must_use]
+    pub fn new_prefix(pattern: impl IntoUriComponent) -> Self {
+        Self::new_prefix_with_opts(pattern, PathMatchOptions::default())
+    }
+
+    /// [`new_prefix`](Self::new_prefix) with explicit [`PathMatchOptions`].
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "by-value matches IntoUriComponent's signature on sibling APIs; this impl only borrows the input"
+    )]
+    pub fn new_prefix_with_opts(pattern: impl IntoUriComponent, opts: PathMatchOptions) -> Self {
+        let raw = pattern.as_uri_component_bytes();
+        Self::compile(&raw, opts, true)
+    }
+
+    fn compile(raw: &[u8], opts: PathMatchOptions, prefix: bool) -> Self {
         // Trailing-slash policy is read off the raw pattern *before* the
         // leading slash is stripped, so the bare-root `/` (which becomes empty
         // after stripping) still registers as a required trailing slash.
@@ -266,6 +299,7 @@ impl PathPattern {
             trailing,
             opts,
             capture_free,
+            prefix,
         }
     }
 
@@ -307,7 +341,9 @@ impl PathPattern {
     /// ```
     #[must_use]
     pub fn is_match(&self, path: PathRef<'_>) -> bool {
-        if self.capture_free {
+        // The fast path assumes a full, both-ends-anchored match; prefix matching
+        // needs the segment-sequence engine, so route it through `captures`.
+        if self.capture_free && !self.prefix {
             self.is_match_fast(path)
         } else {
             self.captures(path).is_some()
@@ -373,12 +409,26 @@ impl PathPattern {
     pub fn captures<'p>(&self, path: PathRef<'p>) -> Option<PathCaptures<'_, 'p>> {
         // Inline the segment list: most paths have a handful of segments, so
         // this keeps the capturing path off the allocator in the common case.
-        let segs: SmallVec<[&'p [u8]; 8]> = path.segments().map(|s| s.as_bytes()).collect();
-        let segs = self.check_trailing(&segs)?;
+        let all: SmallVec<[&'p [u8]; 8]> = path.segments().map(|s| s.as_bytes()).collect();
+        // A prefix match ignores trailing segments + trailing-slash policy, so
+        // it matches against all segments; a full match trims the trailing-`/`
+        // marker and enforces the policy.
+        let segs: &[&'p [u8]] = if self.prefix {
+            &all
+        } else {
+            self.check_trailing(&all)?
+        };
         let mut bindings: Vec<Binding<'p>> = Vec::new();
         let mut sink = Sink::Record(&mut bindings);
         let mut seq_memo = SeqMemo::new(&self.segments, segs.len());
-        if match_sequence(&self.segments, segs, self.opts, &mut sink, &mut seq_memo) {
+        if match_sequence(
+            &self.segments,
+            segs,
+            self.opts,
+            &mut sink,
+            &mut seq_memo,
+            self.prefix,
+        ) {
             Some(PathCaptures {
                 name_bytes: &self.name_bytes,
                 bindings,
@@ -760,22 +810,25 @@ impl SeqMemo {
 }
 
 /// Match a sequence of pattern segments against the path segments, with
-/// backtracking across `{*}` catch-alls. Returns `true` on full match.
+/// backtracking across `{*}` catch-alls. Returns `true` on a match. When
+/// `prefix` is set, a path tail left over after the pattern is exhausted is
+/// accepted (leading-run match) instead of requiring full consumption.
 fn match_sequence<'p>(
     pats: &[PatternSegment],
     segs: &[&'p [u8]],
     opts: PathMatchOptions,
     sink: &mut Sink<'_, 'p>,
     memo: &mut SeqMemo,
+    prefix: bool,
 ) -> bool {
     if memo.is_failed(pats.len(), segs.len()) {
         return false;
     }
 
     let matched = match pats.split_first() {
-        None => segs.is_empty(),
+        None => prefix || segs.is_empty(),
         Some((PatternSegment::CatchAll, rest)) => {
-            match_catch_all(None, rest, segs, opts, sink, memo)
+            match_catch_all(None, rest, segs, opts, sink, memo, prefix)
         }
         Some((
             PatternSegment::NamedCatchAll {
@@ -783,12 +836,20 @@ fn match_sequence<'p>(
                 name_len,
             },
             rest,
-        )) => match_catch_all(Some((*name_start, *name_len)), rest, segs, opts, sink, memo),
+        )) => match_catch_all(
+            Some((*name_start, *name_len)),
+            rest,
+            segs,
+            opts,
+            sink,
+            memo,
+            prefix,
+        ),
         Some((PatternSegment::Normal { elems, ambiguity }, rest)) => {
             if let Some((seg, segs_rest)) = segs.split_first() {
                 let mark = sink.len();
                 if match_segment(elems, *ambiguity, seg, opts, sink)
-                    && match_sequence(rest, segs_rest, opts, sink, memo)
+                    && match_sequence(rest, segs_rest, opts, sink, memo, prefix)
                 {
                     true
                 } else {
@@ -818,10 +879,11 @@ fn match_catch_all<'p>(
     opts: PathMatchOptions,
     sink: &mut Sink<'_, 'p>,
     memo: &mut SeqMemo,
+    prefix: bool,
 ) -> bool {
     for take in 1..=segs.len() {
         let mark = sink.len();
-        if match_sequence(rest, &segs[take..], opts, sink, memo) {
+        if match_sequence(rest, &segs[take..], opts, sink, memo, prefix) {
             // Record only once the tail matched, so discarded attempts cost nothing.
             let value = join_decoded(&segs[..take], opts.percent_decode);
             let (name_start, name_len, is_glob) = match name {

--- a/rama-net/src/uri/path_matcher.rs
+++ b/rama-net/src/uri/path_matcher.rs
@@ -82,6 +82,20 @@ pub struct PathPattern {
     capture_free: bool,
 }
 
+/// Coarse classification of a compiled [`PathPattern`] segment, exposed via
+/// [`PathPattern::segment_kinds`] so callers (e.g. a router) can reason about
+/// route specificity without re-parsing the pattern syntax themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PathPatternSegmentKind {
+    /// A fixed string: the segment matches exactly one literal value.
+    Literal,
+    /// Within-segment dynamic (a capture/wildcard or optional element) still
+    /// bound to exactly one path segment.
+    Dynamic,
+    /// A whole-segment catch-all (`{*}` / `{*name}`) spanning 1+ segments.
+    CatchAll,
+}
+
 /// Policy for a path's trailing slash, derived from the pattern's own
 /// trailing form (explicit, never inferred).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -253,6 +267,32 @@ impl PathPattern {
             opts,
             capture_free,
         }
+    }
+
+    /// The [kind](PathPatternSegmentKind) of each `/`-delimited pattern segment,
+    /// in order — so callers can classify segments (literal vs dynamic vs
+    /// catch-all) straight from the compiled pattern instead of re-parsing the
+    /// syntax. A bare-root pattern (`/`) yields an empty iterator.
+    ///
+    /// ```
+    /// use rama_net::uri::{PathPattern, PathPatternSegmentKind as K};
+    ///
+    /// let kinds: Vec<_> = PathPattern::new("/users/{id}/{*rest}").segment_kinds().collect();
+    /// assert_eq!(kinds, [K::Literal, K::Dynamic, K::CatchAll]);
+    /// // An invalid catch-all body is a literal, exactly as the matcher treats it.
+    /// let kinds: Vec<_> = PathPattern::new("/api/{*bad name}").segment_kinds().collect();
+    /// assert_eq!(kinds, [K::Literal, K::Literal]);
+    /// ```
+    pub fn segment_kinds(&self) -> impl ExactSizeIterator<Item = PathPatternSegmentKind> + '_ {
+        self.segments.iter().map(|seg| match seg {
+            PatternSegment::CatchAll | PatternSegment::NamedCatchAll { .. } => {
+                PathPatternSegmentKind::CatchAll
+            }
+            // `ambiguity == 0` means no wildcard/capture/optional element — the
+            // segment is a fixed string.
+            PatternSegment::Normal { ambiguity: 0, .. } => PathPatternSegmentKind::Literal,
+            PatternSegment::Normal { .. } => PathPatternSegmentKind::Dynamic,
+        })
     }
 
     /// `true` when `path` matches. Allocation-free when the pattern has no


### PR DESCRIPTION
Infallible brace-syntax `PathPattern` matcher in `rama-net::uri`, with the web router rebuilt on it (drops the `matchit` dependency).