### PR TITLE
Harden Apple NE passthrough and overload handling

### DIFF
--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -253,6 +253,25 @@ typedef struct {
     /// value the pump uses. Default is 256 KiB; there is no
     /// "0 means unset" path.
     size_t tcp_write_pump_max_pending_bytes;
+    /// Combined TCP+UDP live-flow soft cap that triggers the idle TCP
+    /// pressure reaper. 0 disables this established-flow reaper.
+    uint32_t flow_pressure_soft_cap;
+    /// Target combined live-flow count after a pressure reap.
+    uint32_t flow_pressure_low_water;
+    /// Minimum idle age before a TCP flow is eligible for pressure reaping.
+    uint32_t flow_pressure_idle_floor_ms;
+    /// Hard cap on pre-ready TCP egress starts. 0 disables hard refusal.
+    uint32_t tcp_start_in_flight_hard_cap;
+    /// Soft cap used with the start-latency breaker. 0 disables breaker refusal.
+    uint32_t tcp_start_in_flight_soft_cap;
+    /// p95 start-to-ready latency threshold that opens the breaker.
+    uint32_t tcp_start_latency_breaker_p95_ms;
+    /// p95 start-to-ready latency threshold that closes the breaker.
+    uint32_t tcp_start_latency_breaker_close_p95_ms;
+    /// Connect-timeout clamp once pre-ready pressure reaches the soft cap.
+    uint32_t tcp_pressure_connect_timeout_ms;
+    /// Connect-timeout clamp while the start-latency breaker is open.
+    uint32_t tcp_breaker_connect_timeout_ms;
 } RamaTransparentProxyConfig;
 
 /// Initialization config passed once before using engine APIs.
@@ -287,7 +306,9 @@ _Static_assert(offsetof(RamaTransparentProxyFlowMeta, is_bound) == 151, "RamaTra
 _Static_assert(sizeof(RamaTransparentProxyNetworkRule) == 56, "RamaTransparentProxyNetworkRule ABI drift");
 _Static_assert(offsetof(RamaTransparentProxyNetworkRule, local_network_utf8) == 24, "RamaTransparentProxyNetworkRule.local_network_utf8 offset drift");
 _Static_assert(offsetof(RamaTransparentProxyNetworkRule, protocol) == 44, "RamaTransparentProxyNetworkRule.protocol offset drift");
-_Static_assert(sizeof(RamaTransparentProxyConfig) == 40, "RamaTransparentProxyConfig ABI drift");
+_Static_assert(sizeof(RamaTransparentProxyConfig) == 80, "RamaTransparentProxyConfig ABI drift");
+_Static_assert(offsetof(RamaTransparentProxyConfig, flow_pressure_soft_cap) == 40, "RamaTransparentProxyConfig.flow_pressure_soft_cap offset drift");
+_Static_assert(offsetof(RamaTransparentProxyConfig, tcp_breaker_connect_timeout_ms) == 72, "RamaTransparentProxyConfig.tcp_breaker_connect_timeout_ms offset drift");
 _Static_assert(sizeof(RamaTransparentProxyInitConfig) == 32, "RamaTransparentProxyInitConfig ABI drift");
 #endif
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -43,6 +43,15 @@ struct RamaTransparentProxyConfigBridge {
     /// non-zero default via its builder, so the Swift-side initial
     /// value is never consulted in practice.
     var tcpWritePumpMaxPendingBytes: Int
+    var flowPressureSoftCap: UInt32
+    var flowPressureLowWater: UInt32
+    var flowPressureIdleFloorMs: UInt32
+    var tcpStartInFlightHardCap: UInt32
+    var tcpStartInFlightSoftCap: UInt32
+    var tcpStartLatencyBreakerP95Ms: UInt32
+    var tcpStartLatencyBreakerCloseP95Ms: UInt32
+    var tcpPressureConnectTimeoutMs: UInt32
+    var tcpBreakerConnectTimeoutMs: UInt32
 }
 
 enum RamaTransparentProxyFlowActionBridge: UInt32 {
@@ -459,40 +468,95 @@ private let ramaReleaseRetainedNSData: @convention(c) (UnsafeMutableRawPointer?)
     Unmanaged<NSData>.fromOpaque(context).release()
 }
 
-final class RamaTransparentProxyEngineHandle {
-    // Serialises `enginePtr` access so `stop()` can't free the engine
-    // while another thread is mid-FFI call. The session handles already
-    // use this exact pattern; mirror it here. Apple's
-    // `handleAppMessage(_:completionHandler:)` runs on the provider's
-    // dispatch queue, but a swift caller can still race a stop() against
-    // an in-flight message — without the lock, `enginePtr` is a non-
-    // atomic Swift property and the access is a data race.
-    private let lock = NSLock()
+/// Reader/writer lifetime guard for the Rust engine pointer.
+///
+/// FFI calls that only need a live engine enter as readers and may overlap.
+/// `stop()` is the writer: it first publishes `nil` so new readers decline,
+/// then waits for already-entered readers to leave before freeing/stopping the
+/// Rust engine. This keeps the UAF protection the old `NSLock` provided
+/// without serialising every admission decision behind one global mutex.
+private final class EngineLifetimeGate {
+    private let condition = NSCondition()
     private var enginePtr: OpaquePointer?
+    private var readers = 0
+
+    init(_ enginePtr: OpaquePointer) {
+        self.enginePtr = enginePtr
+    }
+
+    func withEngine<R>(default defaultValue: @autoclosure () -> R, _ body: (OpaquePointer) -> R)
+        -> R
+    {
+        condition.lock()
+        guard let p = enginePtr else {
+            condition.unlock()
+            return defaultValue()
+        }
+        readers += 1
+        condition.unlock()
+
+        defer {
+            condition.lock()
+            readers -= 1
+            if readers == 0 { condition.broadcast() }
+            condition.unlock()
+        }
+        return body(p)
+    }
+
+    func stop(reason: Int32) {
+        condition.lock()
+        let p = enginePtr
+        enginePtr = nil
+        while readers > 0 {
+            condition.wait()
+        }
+        condition.unlock()
+
+        if let p {
+            rama_transparent_proxy_engine_stop(p, reason)
+        }
+    }
+
+    func freeIfStillOwned() {
+        condition.lock()
+        let p = enginePtr
+        enginePtr = nil
+        while readers > 0 {
+            condition.wait()
+        }
+        condition.unlock()
+
+        if let p {
+            rama_transparent_proxy_engine_free(p)
+        }
+    }
+}
+
+final class RamaTransparentProxyEngineHandle {
+    private let lifetime: EngineLifetimeGate
 
     init?(engineConfigJson: Data? = nil) {
+        let ptr: OpaquePointer?
         if let engineConfigJson, !engineConfigJson.isEmpty {
-            self.enginePtr = engineConfigJson.withUnsafeBytes { raw in
+            ptr = engineConfigJson.withUnsafeBytes { raw in
                 let ptr = raw.bindMemory(to: UInt8.self).baseAddress
                 return rama_transparent_proxy_engine_new_with_config(
                     RamaBytesView(ptr: ptr, len: raw.count)
                 )
             }
         } else {
-            self.enginePtr = rama_transparent_proxy_engine_new()
+            ptr = rama_transparent_proxy_engine_new()
         }
 
-        if enginePtr == nil {
+        guard let ptr else {
             return nil
         }
+        self.lifetime = EngineLifetimeGate(ptr)
     }
 
     deinit {
-        // No lock: Swift's deinit only fires when no strong references
-        // exist, so there is no concurrent caller to race against.
-        if let p = enginePtr {
-            rama_transparent_proxy_engine_free(p)
-        }
+        lifetime.freeIfStillOwned()
     }
 
     static func initialize(storageDir: String?, appGroupDir: String?) -> Bool {
@@ -512,78 +576,78 @@ final class RamaTransparentProxyEngineHandle {
     }
 
     func config() -> RamaTransparentProxyConfigBridge? {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return nil }
-        guard let outPtr = rama_transparent_proxy_get_config(p) else { return nil }
-        defer { rama_transparent_proxy_config_free(outPtr) }
-        let out = outPtr.pointee
-        guard
-            let tunnelRemoteAddress = stringFromUtf8(
-                out.tunnel_remote_address_utf8,
-                Int(out.tunnel_remote_address_utf8_len)
-            )
-        else {
-            return nil
-        }
-
-        var rules: [RamaTransparentProxyRuleBridge] = []
-        if let ptr = out.rules, out.rules_len > 0 {
-            let buffer: UnsafeBufferPointer<RamaTransparentProxyNetworkRule> =
-                UnsafeBufferPointer(start: ptr, count: Int(out.rules_len))
-            for cRule in buffer {
-                rules.append(
-                    RamaTransparentProxyRuleBridge(
-                        remoteNetwork: stringFromUtf8(
-                            cRule.remote_network_utf8,
-                            Int(cRule.remote_network_utf8_len)
-                        ),
-                        remotePrefix: cRule.remote_prefix_is_set ? cRule.remote_prefix : nil,
-                        remotePort: cRule.remote_port_is_set ? cRule.remote_port : nil,
-                        localNetwork: stringFromUtf8(
-                            cRule.local_network_utf8,
-                            Int(cRule.local_network_utf8_len)
-                        ),
-                        localPrefix: cRule.local_prefix_is_set ? cRule.local_prefix : nil,
-                        protocolRaw: cRule.protocol,
-                        exclude: cRule.exclude
-                    )
+        lifetime.withEngine(default: nil) { p in
+            guard let outPtr = rama_transparent_proxy_get_config(p) else { return nil }
+            defer { rama_transparent_proxy_config_free(outPtr) }
+            let out = outPtr.pointee
+            guard
+                let tunnelRemoteAddress = stringFromUtf8(
+                    out.tunnel_remote_address_utf8,
+                    Int(out.tunnel_remote_address_utf8_len)
                 )
+            else {
+                return nil
             }
-        }
 
-        return RamaTransparentProxyConfigBridge(
-            tunnelRemoteAddress: tunnelRemoteAddress,
-            rules: rules,
-            tcpWritePumpMaxPendingBytes: Int(out.tcp_write_pump_max_pending_bytes)
-        )
+            var rules: [RamaTransparentProxyRuleBridge] = []
+            if let ptr = out.rules, out.rules_len > 0 {
+                let buffer: UnsafeBufferPointer<RamaTransparentProxyNetworkRule> =
+                    UnsafeBufferPointer(start: ptr, count: Int(out.rules_len))
+                for cRule in buffer {
+                    rules.append(
+                        RamaTransparentProxyRuleBridge(
+                            remoteNetwork: stringFromUtf8(
+                                cRule.remote_network_utf8,
+                                Int(cRule.remote_network_utf8_len)
+                            ),
+                            remotePrefix: cRule.remote_prefix_is_set ? cRule.remote_prefix : nil,
+                            remotePort: cRule.remote_port_is_set ? cRule.remote_port : nil,
+                            localNetwork: stringFromUtf8(
+                                cRule.local_network_utf8,
+                                Int(cRule.local_network_utf8_len)
+                            ),
+                            localPrefix: cRule.local_prefix_is_set ? cRule.local_prefix : nil,
+                            protocolRaw: cRule.protocol,
+                            exclude: cRule.exclude
+                        )
+                    )
+                }
+            }
+
+            return RamaTransparentProxyConfigBridge(
+                tunnelRemoteAddress: tunnelRemoteAddress,
+                rules: rules,
+                tcpWritePumpMaxPendingBytes: Int(out.tcp_write_pump_max_pending_bytes),
+                flowPressureSoftCap: out.flow_pressure_soft_cap,
+                flowPressureLowWater: out.flow_pressure_low_water,
+                flowPressureIdleFloorMs: out.flow_pressure_idle_floor_ms,
+                tcpStartInFlightHardCap: out.tcp_start_in_flight_hard_cap,
+                tcpStartInFlightSoftCap: out.tcp_start_in_flight_soft_cap,
+                tcpStartLatencyBreakerP95Ms: out.tcp_start_latency_breaker_p95_ms,
+                tcpStartLatencyBreakerCloseP95Ms: out.tcp_start_latency_breaker_close_p95_ms,
+                tcpPressureConnectTimeoutMs: out.tcp_pressure_connect_timeout_ms,
+                tcpBreakerConnectTimeoutMs: out.tcp_breaker_connect_timeout_ms
+            )
+        }
     }
 
     func stop(reason: Int32) {
-        lock.lock()
-        let p = enginePtr
-        enginePtr = nil
-        lock.unlock()
-        if let p {
-            rama_transparent_proxy_engine_stop(p, reason)
-        }
+        lifetime.stop(reason: reason)
     }
 
     /// Notify the Rust handler that the system is going to sleep.
     /// Fire-and-forget: Rust drives the handler on its runtime.
     func notifySystemSleep() {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return }
-        rama_transparent_proxy_engine_notify_system_sleep(p)
+        lifetime.withEngine(default: ()) { p in
+            rama_transparent_proxy_engine_notify_system_sleep(p)
+        }
     }
 
     /// Symmetric to [`notifySystemSleep`].
     func notifySystemWake() {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return }
-        rama_transparent_proxy_engine_notify_system_wake(p)
+        lifetime.withEngine(default: ()) { p in
+            rama_transparent_proxy_engine_notify_system_wake(p)
+        }
     }
 
     /// Forward a provider message into Rust and return the reply (or `nil` for
@@ -594,23 +658,18 @@ final class RamaTransparentProxyEngineHandle {
     /// from "no reply" — we surface both as `nil`. Rust handlers that want a
     /// distinguishable ack must return a non-empty payload.
     func handleAppMessage(_ message: Data) -> Data? {
-        // Hold the lock across the FFI call so a concurrent stop() can't
-        // free the engine while we're using it. stop() takes the same
-        // lock to swap enginePtr to nil before freeing.
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return nil }
+        lifetime.withEngine(default: nil) { p in
+            let ownedReply = message.withUnsafeBytes { raw in
+                let ptr = raw.bindMemory(to: UInt8.self).baseAddress
+                return rama_transparent_proxy_engine_handle_app_message(
+                    p,
+                    RamaBytesView(ptr: ptr, len: raw.count)
+                )
+            }
 
-        let ownedReply = message.withUnsafeBytes { raw in
-            let ptr = raw.bindMemory(to: UInt8.self).baseAddress
-            return rama_transparent_proxy_engine_handle_app_message(
-                p,
-                RamaBytesView(ptr: ptr, len: raw.count)
-            )
+            let reply = dataFromOwnedBytes(ownedReply)
+            return reply.isEmpty ? nil : reply
         }
-
-        let reply = dataFromOwnedBytes(ownedReply)
-        return reply.isEmpty ? nil : reply
     }
 
     func newTcpSession(
@@ -619,55 +678,52 @@ final class RamaTransparentProxyEngineHandle {
         onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) -> RamaTransparentProxyTcpSessionDecision {
-        // NOTE (lock held across the blocking decision): the FFI call
-        // below blocks until Rust decides (≤ decision_deadline, 3s), so
-        // a slow handler can stall stop()/sleep behind this lock. Fine
-        // today — the lock is a lifetime guard (stop() frees enginePtr
-        // under it) and Apple delivers handleNewFlow serially, so TCP
-        // decisions don't contend. If a slow decision ever stalls
-        // sleep/stop in practice, reconsider an RwLock (readers = FFI
-        // calls, writer = stop) to drop the cross-path blocking.
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return .passthrough }
-
-        let callbackBox = Unmanaged.passRetained(
-            TcpSessionCallbackBox(
-                onServerBytes: onServerBytes,
-                onClientReadDemand: onClientReadDemand,
-                onServerClosed: onServerClosed
-            ))
-        let callbacks = RamaTransparentProxyTcpSessionCallbacks(
-            context: callbackBox.toOpaque(),
-            on_server_bytes: ramaTcpOnServerBytesCallback,
-            on_server_closed: ramaTcpOnServerClosedCallback,
-            on_client_read_demand: ramaTcpOnClientReadDemandCallback
-        )
-
-        let result = withFlowMeta(meta) { metaPtr in
-            rama_transparent_proxy_engine_new_tcp_session(p, metaPtr, callbacks)
-        }
-        let action =
-            RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
-            ?? .passthrough
-        if action == .intercept, result.session == nil {
-            NSLog(
-                "RamaFFI: ffi returned tcp intercept without a session pointer; coercing decision to passthrough"
+        lifetime.withEngine(default: .passthrough) { p in
+            let callbackBox = Unmanaged.passRetained(
+                TcpSessionCallbackBox(
+                    onServerBytes: onServerBytes,
+                    onClientReadDemand: onClientReadDemand,
+                    onServerClosed: onServerClosed
+                ))
+            let callbacks = RamaTransparentProxyTcpSessionCallbacks(
+                context: callbackBox.toOpaque(),
+                on_server_bytes: ramaTcpOnServerBytesCallback,
+                on_server_closed: ramaTcpOnServerClosedCallback,
+                on_client_read_demand: ramaTcpOnClientReadDemandCallback
             )
-            callbackBox.release()
-            return .passthrough
-        }
-        guard action == .intercept, let sessionPtr = result.session else {
-            callbackBox.release()
-            switch action {
-            case .intercept, .passthrough:
-                return .passthrough
-            case .blocked:
+
+            let result = withFlowMeta(meta) { metaPtr in
+                rama_transparent_proxy_engine_new_tcp_session(p, metaPtr, callbacks)
+            }
+            guard let action = RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
+            else {
+                NSLog(
+                    "RamaFFI: ffi returned unknown tcp flow action \(result.action.rawValue); blocking flow"
+                )
+                callbackBox.release()
                 return .blocked
             }
-        }
+            if action == .intercept, result.session == nil {
+                NSLog(
+                    "RamaFFI: ffi returned tcp intercept without a session pointer; blocking flow"
+                )
+                callbackBox.release()
+                return .blocked
+            }
+            guard action == .intercept, let sessionPtr = result.session else {
+                callbackBox.release()
+                switch action {
+                case .passthrough:
+                    return .passthrough
+                case .intercept:
+                    return .blocked
+                case .blocked:
+                    return .blocked
+                }
+            }
 
-        return .intercept(RamaTcpSessionHandle(sessionPtr: sessionPtr, callbackBox: callbackBox))
+            return .intercept(RamaTcpSessionHandle(sessionPtr: sessionPtr, callbackBox: callbackBox))
+        }
     }
 
     func newUdpSession(
@@ -676,47 +732,52 @@ final class RamaTransparentProxyEngineHandle {
         onClientReadDemand: @escaping () -> Void,
         onServerClosed: @escaping () -> Void
     ) -> RamaTransparentProxyUdpSessionDecision {
-        lock.lock()
-        defer { lock.unlock() }
-        guard let p = enginePtr else { return .passthrough }
-
-        let callbackBox = Unmanaged.passRetained(
-            UdpSessionCallbackBox(
-                onServerDatagram: onServerDatagram,
-                onClientReadDemand: onClientReadDemand,
-                onServerClosed: onServerClosed
-            ))
-        let callbacks = RamaTransparentProxyUdpSessionCallbacks(
-            context: callbackBox.toOpaque(),
-            on_server_datagram: ramaUdpOnServerDatagramCallback,
-            on_client_read_demand: ramaUdpOnClientReadDemandCallback,
-            on_server_closed: ramaUdpOnServerClosedCallback
-        )
-
-        let result = withFlowMeta(meta) { metaPtr in
-            rama_transparent_proxy_engine_new_udp_session(p, metaPtr, callbacks)
-        }
-        let action =
-            RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
-            ?? .passthrough
-        if action == .intercept, result.session == nil {
-            NSLog(
-                "RamaFFI: ffi returned udp intercept without a session pointer; coercing decision to passthrough"
+        lifetime.withEngine(default: .passthrough) { p in
+            let callbackBox = Unmanaged.passRetained(
+                UdpSessionCallbackBox(
+                    onServerDatagram: onServerDatagram,
+                    onClientReadDemand: onClientReadDemand,
+                    onServerClosed: onServerClosed
+                ))
+            let callbacks = RamaTransparentProxyUdpSessionCallbacks(
+                context: callbackBox.toOpaque(),
+                on_server_datagram: ramaUdpOnServerDatagramCallback,
+                on_client_read_demand: ramaUdpOnClientReadDemandCallback,
+                on_server_closed: ramaUdpOnServerClosedCallback
             )
-            callbackBox.release()
-            return .passthrough
-        }
-        guard action == .intercept, let sessionPtr = result.session else {
-            callbackBox.release()
-            switch action {
-            case .intercept, .passthrough:
-                return .passthrough
-            case .blocked:
+
+            let result = withFlowMeta(meta) { metaPtr in
+                rama_transparent_proxy_engine_new_udp_session(p, metaPtr, callbacks)
+            }
+            guard let action = RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
+            else {
+                NSLog(
+                    "RamaFFI: ffi returned unknown udp flow action \(result.action.rawValue); blocking flow"
+                )
+                callbackBox.release()
                 return .blocked
             }
-        }
+            if action == .intercept, result.session == nil {
+                NSLog(
+                    "RamaFFI: ffi returned udp intercept without a session pointer; blocking flow"
+                )
+                callbackBox.release()
+                return .blocked
+            }
+            guard action == .intercept, let sessionPtr = result.session else {
+                callbackBox.release()
+                switch action {
+                case .passthrough:
+                    return .passthrough
+                case .intercept:
+                    return .blocked
+                case .blocked:
+                    return .blocked
+                }
+            }
 
-        return .intercept(RamaUdpSessionHandle(sessionPtr: sessionPtr, callbackBox: callbackBox))
+            return .intercept(RamaUdpSessionHandle(sessionPtr: sessionPtr, callbackBox: callbackBox))
+        }
     }
 }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Context/TcpFlowContext.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Context/TcpFlowContext.swift
@@ -157,6 +157,11 @@ final class TcpFlowContext: @unchecked Sendable {
     weak var core: TransparentProxyCore?
     /// Registry key, so the teardown methods can remove themselves.
     var flowId: ObjectIdentifier?
+    /// Admission token for a pre-ready egress start. Set before
+    /// `NWConnection.start`, cleared when the start reaches `.ready` or any
+    /// pre-open cleanup path fires. Lets the core maintain an exact in-flight
+    /// start gauge and start-to-ready latency window.
+    var admissionToken: TcpAdmissionToken?
     /// Sticky one-shot teardown guard. Mutated and read only on
     /// `flowQueue` (single-threaded by construction), so it needs no lock.
     private(set) var isDone = false
@@ -202,6 +207,10 @@ final class TcpFlowContext: @unchecked Sendable {
     private func applyPreOpenCleanup() {
         guard !isDone else { return }
         isDone = true
+        if let token = admissionToken {
+            core?.finishTcpStart(token, outcome: .failed)
+            admissionToken = nil
+        }
         let err = tcpUpstreamUnavailableError()
         flow?.closeReadWithError(err)
         flow?.closeWriteWithError(err)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionReadPump.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionReadPump.swift
@@ -76,6 +76,14 @@ final class NwTcpConnectionReadPump {
         onComplete: @escaping () -> Void
     ) {
         queue.async {
+            // Disarm the EOF-grace backstop BEFORE the `.closed` early
+            // return: an armed timer always implies `.closed` (every arm
+            // site sets it in the same block), and a stale timer would
+            // force-cancel the connection under the new forwarder's feet.
+            // The forwarder rediscovers a pre-existing EOF with one benign
+            // direct `receive`.
+            self.eofWork?.cancel()
+            self.eofWork = nil
             guard self.phase != .closed else {
                 onComplete()
                 return
@@ -86,10 +94,6 @@ final class NwTcpConnectionReadPump {
             }
             let hadInFlightRead = (self.phase == .reading)
             self.phase = .closed
-            // External cancel pre-empts the EOF backstop — same
-            // rationale as the existing `cancel()` path.
-            self.eofWork?.cancel()
-            self.eofWork = nil
             if hadInFlightRead {
                 self.onPromoteCarryover = { payload in
                     onCarryover(payload)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionWritePump.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionWritePump.swift
@@ -28,6 +28,16 @@ final class NwTcpConnectionWritePump: @unchecked Sendable {
     /// when the connection closes naturally before the deadline (or
     /// when the pump is externally cancelled).
     private var lingerWork: DispatchWorkItem?
+    /// Milliseconds since the flow last moved a byte, read on `core.queue`.
+    /// The linger watchdog consults this before force-cancelling: a FIN with
+    /// the read direction still streaming is a legitimate half-close, so it
+    /// re-arms while activity is recent and only cancels a quiet connection.
+    /// Default `.max` (always idle) keeps the plain bounded linger for
+    /// callers without a flow-activity clock.
+    private let readSideIdleMs: () -> UInt64
+    /// `lingerCloseDeadline` in milliseconds, for comparison against
+    /// `readSideIdleMs()`.
+    private let lingerCloseMs: UInt64
     /// Pending callback installed by
     /// `closeWhenDrained(_:)` — fires exactly once when the FIN
     /// completes (success or local error), or from `deinit` as
@@ -42,10 +52,13 @@ final class NwTcpConnectionWritePump: @unchecked Sendable {
         lingerCloseDeadline: DispatchTimeInterval,
         onDrained: @escaping () -> Void,
         onTerminal: @escaping (Error) -> Void = { _ in },
-        onActivity: @escaping () -> Void = {}
+        onActivity: @escaping () -> Void = {},
+        readSideIdleMs: @escaping () -> UInt64 = { .max }
     ) {
         self.connection = connection
         self.lingerCloseDeadline = lingerCloseDeadline
+        self.lingerCloseMs = Self.millis(from: lingerCloseDeadline)
+        self.readSideIdleMs = readSideIdleMs
         self.onTerminal = onTerminal
         let core = TcpWritePumpCore(
             queue: queue,
@@ -260,17 +273,46 @@ extension NwTcpConnectionWritePump: TcpWritePumpCoreDelegate {
         // The FIN is queued. Schedule the linger watchdog so the
         // NWConnection registration is released even if the peer
         // never replies with its own FIN. `cancel()` is idempotent.
-        //
-        // Capture `connection` strongly: a promote teardown can
-        // drop the per-flow ctx (and us with it) right after the
-        // FIN send completes, well before the linger deadline —
-        // `[weak self]` would no-op and leak the NWConnection.
+        armLingerCancel(afterMs: lingerCloseMs)
+    }
+
+    /// Arm (or re-arm) the linger force-cancel `afterMs` from now. At fire
+    /// time it re-arms while `readSideIdleMs()` shows recent activity (a
+    /// live half-close) and cancels only a quiet connection.
+    ///
+    /// Capture `connection` strongly: a promote teardown can drop the
+    /// per-flow ctx (and us with it) right after the FIN send completes —
+    /// `[weak self]` alone would no-op and leak the NWConnection. A gone
+    /// pump means the whole per-flow graph is gone and nothing can move
+    /// more bytes, so the cancel then proceeds unconditionally.
+    private func armLingerCancel(afterMs: UInt64) {
+        guard afterMs != .max else { return }  // `.never` deadline: no watchdog
         let conn = connection
         let work = DispatchWorkItem { [weak self] in
-            conn.cancelAndDetach()
-            self?.lingerWork = nil
+            guard let self else {
+                conn.cancelAndDetach()
+                return
+            }
+            let idle = self.readSideIdleMs()
+            if idle < self.lingerCloseMs {
+                self.armLingerCancel(afterMs: max(self.lingerCloseMs - idle, 50))
+            } else {
+                conn.cancelAndDetach()
+                self.lingerWork = nil
+            }
         }
         lingerWork = work
-        core.queue.asyncAfter(deadline: .now() + lingerCloseDeadline, execute: work)
+        core.queue.asyncAfter(deadline: .now() + .milliseconds(Int(afterMs)), execute: work)
+    }
+
+    private static func millis(from interval: DispatchTimeInterval) -> UInt64 {
+        switch interval {
+        case .seconds(let s): return s <= 0 ? 0 : UInt64(s) * 1_000
+        case .milliseconds(let ms): return ms <= 0 ? 0 : UInt64(ms)
+        case .microseconds(let us): return us <= 0 ? 0 : UInt64(us) / 1_000
+        case .nanoseconds(let ns): return ns <= 0 ? 0 : UInt64(ns) / 1_000_000
+        case .never: return .max
+        @unknown default: return UInt64(defaultLingerCloseMs)
+        }
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -416,13 +416,16 @@ nonisolated(unsafe) var defaultPromotedIdleTimeoutMs: UInt32 = 900_000
 // steady-state population bounded, but a fast BURST of connections can approach
 // the ceiling faster than those act. This is the burst backstop.
 //
-// Policy (deliberately conservative — see the constraints it honours below):
+// Established-flow pressure policy (deliberately conservative — see the
+// constraints it honours below):
 //   * Triggered when the COMBINED live flow count (TCP + UDP — the nexus ceiling
 //     is global across the flowswitch) crosses `…SoftCap` at admission time, on
 //     BOTH TCP and UDP admission (a UDP burst can approach the ceiling too).
-//   * NEVER refuses or delays a new flow: the new flow is always admitted; the
-//     reap (async, off the delivery thread) frees room for SUBSEQUENT flows.
+//   * This reaper never refuses or delays a new flow: the new flow is admitted;
+//     the reap (async, off the delivery thread) frees room for SUBSEQUENT flows.
 //     A burst of triggers is coalesced (`pressureReapInFlight`) into one scan.
+//     Separate TCP start admission caps below may still reject pre-ready egress
+//     starts before another expensive `NWConnection.start` is added.
 //   * NEVER touches an active or recently-active flow: only flows idle past
 //     `…IdleFloorMs` are eligible, evicted oldest-idle first (LRU) down to
 //     `…LowWater` for hysteresis. There is intentionally NO activity-blind
@@ -448,6 +451,41 @@ nonisolated(unsafe) var defaultPromotedIdleTimeoutMs: UInt32 = 900_000
 nonisolated(unsafe) var defaultFlowPressureSoftCap: UInt32 = 450
 nonisolated(unsafe) var defaultFlowPressureLowWater: UInt32 = 350
 nonisolated(unsafe) var defaultFlowPressureIdleFloorMs: UInt32 = 120_000
+
+/// Hard cap on egress `NWConnection.start` calls that have not reached
+/// `.ready` yet. This is the admission-side circuit breaker: every pre-ready
+/// egress connection is exactly the expensive NECP handler population that
+/// makes the next `nw_connection_start` slower, so once this cap is full we
+/// fail newly-claimed intercepted flows fast instead of adding another stalled
+/// start. `0` disables hard admission refusal.
+nonisolated(unsafe) var defaultTcpStartInFlightHardCap: UInt32 = 128
+
+/// Softer pre-ready pressure level used by the latency breaker. A slow
+/// start-to-ready window opens the breaker, but admission refusal only begins
+/// once there is also real pre-ready pressure at/above this cap. That avoids
+/// treating one slow cellular/VPN connect as global overload. `0` disables
+/// latency-breaker admission refusal (the hard cap above still applies).
+nonisolated(unsafe) var defaultTcpStartInFlightSoftCap: UInt32 = 64
+
+/// Start-to-ready latency threshold for the breaker, in milliseconds. The core
+/// tracks a rolling window of recent egress starts; if p95 crosses this
+/// threshold while pre-ready pressure is present, it opens the breaker and
+/// begins shedding new intercepted starts at the soft cap.
+nonisolated(unsafe) var defaultTcpStartLatencyBreakerP95Ms: UInt32 = 1_500
+
+/// Close threshold for the start-latency breaker. Once p95 drops below this
+/// and in-flight starts are below the soft cap, admission returns to normal.
+nonisolated(unsafe) var defaultTcpStartLatencyBreakerCloseP95Ms: UInt32 = 500
+
+/// Connect-timeout clamp once pre-ready pressure reaches the soft cap. The
+/// normal Rust-provided/default timeout is useful at low load, but under an
+/// overload spiral long pre-ready waits keep expensive NECP handlers alive and
+/// make every subsequent start slower. This clamp bounds that residency while
+/// still allowing a few seconds for transient path recovery.
+nonisolated(unsafe) var defaultTcpPressureConnectTimeoutMs: UInt32 = 5_000
+
+/// Stricter connect-timeout clamp while the latency breaker is open.
+nonisolated(unsafe) var defaultTcpBreakerConnectTimeoutMs: UInt32 = 3_000
 
 // ── Per-pump lifecycle / state enums ─────────────────────────────────────────
 
@@ -821,15 +859,9 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             return
         }
 
-        // The engine's value is authoritative — the previous "0 means
-        // unset" path was dead code (the default is non-zero), so the
-        // Swift initial value of `writePumpMaxPendingBytes` was never
-        // used in practice and the documented per-flow cap silently
-        // drifted from what the comments described.
-        writePumpMaxPendingBytes = startup.tcpWritePumpMaxPendingBytes
-        writePumpHwmLogThresholdBytes = writePumpMaxPendingBytes / 2
-        core.logLifecycle(
-            "tcp write pump cap set to \(writePumpMaxPendingBytes) bytes from engine config")
+        Self.applyRuntimeConfig(from: startup) { [core] msg in
+            core.logLifecycle(msg)
+        }
 
         let settings = Self.buildNetworkSettings(
             from: startup,
@@ -950,6 +982,36 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
             "network rules: included=\(includedRules.count) excluded=\(excludedRules.count)"
         )
         return settings
+    }
+
+    /// Apply engine-provided runtime knobs that live outside Apple's
+    /// `NETransparentProxyNetworkSettings`.
+    ///
+    /// Rust's `TransparentProxyConfig` is authoritative for these values; the
+    /// Swift globals are fallbacks for tests and startup failure paths only.
+    internal static func applyRuntimeConfig(
+        from startup: RamaTransparentProxyConfigBridge,
+        logLifecycle: (String) -> Void = { _ in }
+    ) {
+        writePumpMaxPendingBytes = startup.tcpWritePumpMaxPendingBytes
+        writePumpHwmLogThresholdBytes = writePumpMaxPendingBytes / 2
+        defaultFlowPressureSoftCap = startup.flowPressureSoftCap
+        defaultFlowPressureLowWater = startup.flowPressureLowWater
+        defaultFlowPressureIdleFloorMs = startup.flowPressureIdleFloorMs
+        defaultTcpStartInFlightHardCap = startup.tcpStartInFlightHardCap
+        defaultTcpStartInFlightSoftCap = startup.tcpStartInFlightSoftCap
+        defaultTcpStartLatencyBreakerP95Ms = startup.tcpStartLatencyBreakerP95Ms
+        defaultTcpStartLatencyBreakerCloseP95Ms = startup.tcpStartLatencyBreakerCloseP95Ms
+        defaultTcpPressureConnectTimeoutMs = startup.tcpPressureConnectTimeoutMs
+        defaultTcpBreakerConnectTimeoutMs = startup.tcpBreakerConnectTimeoutMs
+
+        logLifecycle("tcp write pump cap set to \(writePumpMaxPendingBytes) bytes from engine config")
+        logLifecycle(
+            "tcp overload config hardCap=\(defaultTcpStartInFlightHardCap) softCap=\(defaultTcpStartInFlightSoftCap) openP95Ms=\(defaultTcpStartLatencyBreakerP95Ms) closeP95Ms=\(defaultTcpStartLatencyBreakerCloseP95Ms) pressureTimeoutMs=\(defaultTcpPressureConnectTimeoutMs) breakerTimeoutMs=\(defaultTcpBreakerConnectTimeoutMs)"
+        )
+        logLifecycle(
+            "flow pressure config softCap=\(defaultFlowPressureSoftCap) lowWater=\(defaultFlowPressureLowWater) idleFloorMs=\(defaultFlowPressureIdleFloorMs)"
+        )
     }
 
     /// Translate one Rust-side rule into one or more

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -40,11 +40,6 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
     // Late-bound: only set once the engine decision is .intercept.
     var sessionHandle: RamaTcpSessionHandle?
 
-    // Set when the engine decided `.passthrough` up front: instead of closing
-    // the flow (returning false — which Apple terminates), we claim it and
-    // splice it directly to egress with no Rust hop. See `handleBornSplicedReady`.
-    var bornSpliced = false
-
     // Configured by `start`; defaults applied here so phase methods
     // can run in tests without going through the engine decision.
     var lingerCloseMs: UInt32 = defaultLingerCloseMs
@@ -123,22 +118,21 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             }
             return admitted
         case .passthrough:
-            // Up-front passthrough: do NOT return false (Apple closes the flow
-            // — it is not a hand-off to the default route). Claim it and splice
-            // it directly, no Rust hop. Register so the idle/wedge reaper +
-            // detachEngine see it (the reaper keys on `ctx.mode == .promoted`).
-            core?.logDebug("handleNewFlow tcp up-front passthrough -> born-spliced")
-            bornSpliced = true
-            // Mirror the intercept path: admit unconditionally, but if this
-            // registration reached the soft cap, nudge the idle reaper so a
-            // born-splice-heavy workload can't pile up slots past the cap
-            // without the pressure reaper ever running.
-            let occupancy = core?.registerTcpFlow(flowId, anchor: self) ?? 0
-            let admitted = startEgressConnection(session: nil)
-            if defaultFlowPressureSoftCap > 0, occupancy >= Int(defaultFlowPressureSoftCap) {
-                core?.reapIdleUnderPressure()
-            }
-            return admitted
+            // Up-front passthrough: return false so the kernel routes the flow
+            // directly, at zero per-flow cost to the extension. For
+            // `NETransparentProxyProvider` (unlike the `NEAppProxyProvider`
+            // base class, whose docs say a declined flow is closed) this is
+            // the documented hand-off: "Returning NO from handleNewFlow(_:)
+            // causes the flow to proceed to communicate directly with the
+            // flow's ultimate destination, instead of closing the flow with a
+            // 'Connection Refused' error." Claiming these flows instead (the
+            // 2026-07 "born-splice" experiment) gave every passthrough flow an
+            // in-extension egress NWConnection; under a SASE re-originator
+            // (Zscaler) that meant one NWConnection per machine-wide flow and
+            // an O(N) NECP path-update walk per connection start — a 100%-CPU
+            // collapse. UDP takes the identical return-false path.
+            core?.logDebug("handleNewFlow tcp bypassed by rust flow policy")
+            return false
         case .blocked:
             core?.logLifecycle("handleNewFlow tcp blocked by rust flow policy")
             let error = blockedFlowError()
@@ -213,7 +207,7 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
 
     // MARK: - Phase: egress connection
 
-    func startEgressConnection(session: RamaTcpSessionHandle?) -> Bool {
+    func startEgressConnection(session: RamaTcpSessionHandle) -> Bool {
         guard let remoteHost = meta.remoteHost, meta.remotePort > 0 else {
             core?.logDebug("handleTcpFlow: missing remote endpoint; rejecting flow")
             // Reject (close the claimed flow) rather than strand the app's
@@ -222,8 +216,7 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             return true
         }
 
-        // Born-spliced flows have no Rust session; fall back to defaults.
-        let egressOpts = session?.getEgressConnectOptions()
+        let egressOpts = session.getEgressConnectOptions()
         let connectTimeoutMs = egressOpts?.connectTimeoutMs ?? 10_000
         lingerCloseMs = egressOpts?.lingerCloseMs ?? defaultLingerCloseMs
         egressEofGraceMs = egressOpts?.egressEofGraceMs ?? defaultEgressEofGraceMs
@@ -386,13 +379,6 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         // when the path is viable or the feature is disabled.
         if !ctx.lastPathViable { core?.handleEgressViabilityLoss(ctx) }
 
-        if bornSpliced {
-            // Up-front passthrough: splice directly to egress. No Rust session,
-            // no session-bound read pumps, no promote callback — the forwarder
-            // owns both read directions from birth.
-            handleBornSplicedReady(connection: connection)
-            return
-        }
         guard let session = sessionHandle else { return }
 
         let writePump = buildEgressWritePump(connection: connection)
@@ -437,46 +423,6 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         )
 
         openKernelFlow(connection: connection, readPump: readPump, session: session)
-    }
-
-    /// Egress reached `.ready` for an up-front passthrough (born-spliced) flow.
-    /// Build the egress write pump, open the kernel flow, then hand both
-    /// directions to the direct splice forwarder. No Rust session and no
-    /// session-bound read pumps (`TcpClientReadPump` / `NwTcpConnectionReadPump`
-    /// require a session) — `beginBornSplicedCutover` starts the forwarder's own
-    /// `flow.readData` / `connection.receive` loops. Teardown is the same
-    /// hardened promoted path (`applyPromotedTerminal` + linger watchdog).
-    func handleBornSplicedReady(connection: any NwConnectionLike) {
-        _ = buildEgressWritePump(connection: connection)  // stored on `ctx`
-        flow.open(withLocalEndpoint: nil) { [weak self] error in
-            self?.flowQueue.async { [weak self] in
-                guard let self else { return }
-                if let error {
-                    self.core?.logDebug("born-splice flow.open error: \(error)")
-                    self.ctx.applyFlowOpenFailure(error)
-                    return
-                }
-                // Teardown may have raced ahead while flow.open was in flight;
-                // `ctx.connection == nil` is the canonical signal.
-                guard let conn = self.ctx.connection,
-                    let clientWritePump = self.ctx.clientWritePump,
-                    let egressWritePump = self.ctx.egressWritePump
-                else {
-                    self.core?.logTrace("born-splice flow.open observed teardown; dropping")
-                    return
-                }
-                self.core?.logTrace("flow.open ok (tcp, born-spliced)")
-                self.ctx.clientWritePump?.markOpened()
-                self.core?.beginBornSplicedCutover(
-                    ctx: self.ctx,
-                    flow: self.flow,
-                    connection: conn,
-                    clientWritePump: clientWritePump,
-                    egressWritePump: egressWritePump,
-                    flowQueue: self.flowQueue
-                )
-            }
-        }
     }
 
     func handleEgressFailed(_ error: NWError?) {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -118,19 +118,11 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             }
             return admitted
         case .passthrough:
-            // Up-front passthrough: return false so the kernel routes the flow
-            // directly, at zero per-flow cost to the extension. For
-            // `NETransparentProxyProvider` (unlike the `NEAppProxyProvider`
-            // base class, whose docs say a declined flow is closed) this is
-            // the documented hand-off: "Returning NO from handleNewFlow(_:)
-            // causes the flow to proceed to communicate directly with the
-            // flow's ultimate destination, instead of closing the flow with a
-            // 'Connection Refused' error." Claiming these flows instead (the
-            // 2026-07 "born-splice" experiment) gave every passthrough flow an
-            // in-extension egress NWConnection; under a SASE re-originator
-            // (Zscaler) that meant one NWConnection per machine-wide flow and
-            // an O(N) NECP path-update walk per connection start — a 100%-CPU
-            // collapse. UDP takes the identical return-false path.
+            // Declining hands the flow to the direct route (documented for
+            // NETransparentProxyProvider; only the NEAppProxyProvider base
+            // class closes declined flows). Never claim passthrough flows:
+            // each claimed flow costs an egress NWConnection, and NECP makes
+            // every connection start pay for all live ones.
             core?.logDebug("handleNewFlow tcp bypassed by rust flow policy")
             return false
         case .blocked:
@@ -276,28 +268,40 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
     /// `NWConnection` leak permanently (they outlive even the 15-min Rust
     /// idle timeout, whose drop re-enters this same wedged drain).
     ///
-    /// Once a terminal signal is observed the flow IS ending, so bound
-    /// the wait: force a full teardown if the graceful close hasn't
-    /// completed within `lingerCloseMs`. Idempotent — `applyFullTeardown`'s
-    /// sticky `done` flag makes this a no-op when the graceful path won,
-    /// and the nil-guard arms the timer at most once. Cost is one timer
-    /// per flow close (no hot-path impact), mirroring
-    /// `installConnectTimeout`. Setting `terminalSignalled` lets the
-    /// on-`stateQueue` maintenance watchdog reap the same wedge even when
-    /// this flow's own queue is starved (the failure mode that watchdog
-    /// exists for) — see `TransparentProxyCore.collectMaintenanceKicksLocked`.
+    /// Bound the close by progress, not wall clock: `onCloseEgress` fires at
+    /// every ordinary client half-close while the opposite direction may
+    /// still stream for a long time, so a blind deadline would truncate live
+    /// transfers. The work item re-checks the flow's activity clock and
+    /// re-arms while bytes still move; only a quiet close (the wedged drain
+    /// this backstop exists for) is force-torn-down. Idempotent via the
+    /// sticky `done` flag. Setting `terminalSignalled` lets the maintenance
+    /// watchdog reap the same wedge if this queue starves; it applies the
+    /// same idle gate, so the two reapers agree.
     func armTerminalDrainBackstop() {
         ctx.terminalSignalled = true
         guard terminalDrainBackstop == nil, ctx.isDone != true else { return }
+        scheduleDrainBackstopCheck(afterMs: UInt64(lingerCloseMs))
+    }
+
+    private func scheduleDrainBackstopCheck(afterMs: UInt64) {
         let work = DispatchWorkItem { [weak self] in
             guard let self, self.ctx.isDone == false else { return }
+            let idleMs =
+                (DispatchTime.now().uptimeNanoseconds
+                    &- self.ctx.lastActivityAt.uptimeNanoseconds) / 1_000_000
+            if idleMs < UInt64(self.lingerCloseMs) {
+                // Still moving bytes (live half-close) — check again once the
+                // current linger window could have elapsed quietly.
+                self.scheduleDrainBackstopCheck(
+                    afterMs: max(UInt64(self.lingerCloseMs) - idleMs, 50))
+                return
+            }
             self.core?.logDebug(
                 "tcp flow drain backstop fired; forcing teardown (peer not draining)")
             self.ctx.applyDrainBackstop()
         }
         terminalDrainBackstop = work
-        flowQueue.asyncAfter(
-            deadline: .now() + .milliseconds(Int(lingerCloseMs)), execute: work)
+        flowQueue.asyncAfter(deadline: .now() + .milliseconds(Int(afterMs)), execute: work)
     }
 
     func installEgressStateHandler(connection: any NwConnectionLike) {
@@ -552,7 +556,15 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
                 self.ctx.directForwarder?.cancel()
             },
             // C→S byte progress on `flowQueue` — see `buildClientWritePump`.
-            onActivity: { [weak self] in self?.ctx.lastActivityAt = .now() }
+            onActivity: { [weak self] in self?.ctx.lastActivityAt = .now() },
+            // Post-FIN the only activity bumps come from the still-open
+            // read direction, so the linger can tell a live half-close
+            // from a quiet connection. A gone ctx reads as fully idle.
+            readSideIdleMs: { [weak ctx] in
+                guard let ctx else { return .max }
+                return (DispatchTime.now().uptimeNanoseconds
+                    &- ctx.lastActivityAt.uptimeNanoseconds) / 1_000_000
+            }
         )
         ctx.egressWritePump = pump
         return pump

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -107,14 +107,30 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         case .intercept(let session):
             sessionHandle = session
             ctx.session = session
-            let occupancy = core?.registerTcpFlow(flowId, anchor: self) ?? 0
-            // Admit unconditionally — the flow-pressure backstop NEVER refuses
-            // or delays a new flow. If admitting this one reached the soft cap,
-            // ask the core to reap idle promoted flows asynchronously (off this
-            // delivery thread) to free slots for SUBSEQUENT flows.
+            guard let core else {
+                ctx.applyPreReadyFailure()
+                return true
+            }
+            let admission = core.admitTcpStart(flowId: flowId, meta: meta)
+            guard case .admit(let token) = admission else {
+                if case .reject(let reason) = admission {
+                    core.logLifecycle("tcp admission rejected: \(reason)")
+                }
+                let error = tcpUpstreamUnavailableError()
+                flow.closeReadWithError(error)
+                flow.closeWriteWithError(error)
+                session.cancel()
+                return true
+            }
+            ctx.admissionToken = token
+            let occupancy = core.registerTcpFlow(flowId, anchor: self, appId: token.appId)
+            // Admission is bounded by the start gauge above. The flow-pressure
+            // backstop still reaps idle established flows asynchronously to free
+            // room for subsequent flows as total live occupancy approaches the
+            // kernel nexus ceiling.
             let admitted = startEgressConnection(session: session)
             if defaultFlowPressureSoftCap > 0, occupancy >= Int(defaultFlowPressureSoftCap) {
-                core?.reapIdleUnderPressure()
+                core.reapIdleUnderPressure()
             }
             return admitted
         case .passthrough:
@@ -123,6 +139,7 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             // class closes declined flows). Never claim passthrough flows:
             // each claimed flow costs an egress NWConnection, and NECP makes
             // every connection start pay for all live ones.
+            core?.recordTcpPassthroughDecision(meta: meta)
             core?.logDebug("handleNewFlow tcp bypassed by rust flow policy")
             return false
         case .blocked:
@@ -209,7 +226,9 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         }
 
         let egressOpts = session.getEgressConnectOptions()
-        let connectTimeoutMs = egressOpts?.connectTimeoutMs ?? 10_000
+        let requestedConnectTimeoutMs = egressOpts?.connectTimeoutMs ?? 10_000
+        let connectTimeoutMs =
+            core?.tcpConnectTimeoutMs(base: requestedConnectTimeoutMs) ?? requestedConnectTimeoutMs
         lingerCloseMs = egressOpts?.lingerCloseMs ?? defaultLingerCloseMs
         egressEofGraceMs = egressOpts?.egressEofGraceMs ?? defaultEgressEofGraceMs
         // Mirror the linger budget onto the ctx so a later promote
@@ -249,6 +268,10 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             self.core?.logDebug(
                 "egress NWConnection timed out for tcp flow remote=\(remoteHost):\(self.meta.remotePort)"
             )
+            if let token = self.ctx.admissionToken {
+                self.core?.finishTcpStart(token, outcome: .timeout)
+                self.ctx.admissionToken = nil
+            }
             self.ctx.applyConnectTimeout()
         }
         timeoutWork = work
@@ -368,6 +391,10 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         }
         egressReady = true
         ctx.egressReady = true
+        if let token = ctx.admissionToken {
+            core?.finishTcpStart(token, outcome: .ready)
+            ctx.admissionToken = nil
+        }
         timeoutWork?.cancel()
         timeoutWork = nil
         // Cancel any pre-ready waiting budget so it can't tear a

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/UdpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/UdpFlowSession.swift
@@ -111,22 +111,24 @@ final class UdpFlowSession<F: UdpFlowLike>: UdpFlowSessionAnchor, @unchecked Sen
     // MARK: - Phases
 
     func installTerminate() {
-        // Capture only what the closure needs — flow / queue / flowId
-        // strong, ctx / core / session weak. The `removeUdpFlow`
-        // call at the end is what drops the session from the core's
-        // map; with no other strong ref, the session (and the
-        // `ctx`/`writer`/closure graph hanging off it, including
-        // this closure once it returns) deallocates. No
-        // `lifetimeAnchor` to nil — there is no cycle.
+        // The stored capture stays weak (no permanent cycle), but the
+        // dispatched block holds ctx strongly: `detachEngine` drops the
+        // registry anchors right after dispatching, and a weak capture in
+        // the block would dealloc ctx mid-flight and skip the kernel-flow
+        // close and the Rust `onClientClose`. The one-shot block releases
+        // its captures on return. Mirrors the TCP walk.
         let flow = self.flow
         let flowQueue = self.flowQueue
         let flowId = self.flowId
         ctx.terminate = { [weak ctx, weak core = self.core, weak self] error in
-            flowQueue.async { [weak ctx, weak core, weak self] in
-                guard let ctx, ctx.readState != .closed else { return }
+            guard let ctx else { return }
+            let core = core
+            let session = self
+            flowQueue.async {
+                guard ctx.readState != .closed else { return }
                 ctx.readState = .closed
-                self?.idleWork?.cancel()
-                self?.idleWork = nil
+                session?.idleWork?.cancel()
+                session?.idleWork = nil
                 ctx.writer?.close()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct TcpAdmissionToken: Sendable {
+    let flowId: ObjectIdentifier
+    let startedAt: DispatchTime
+    let appId: String
+}
+
+enum TcpAdmissionDecision {
+    case admit(TcpAdmissionToken)
+    case reject(String)
+}
+
+enum TcpStartOutcome {
+    case ready
+    case timeout
+    case failed
+}
+
+struct TcpOverloadSnapshot {
+    var admissionRate: Double
+    var timeoutRate: Double
+    var shedRate: Double
+    var startsInFlight: Int
+    var p50StartMs: UInt64
+    var p95StartMs: UInt64
+    var p99StartMs: UInt64
+    var breakerOpen: Bool
+}
+
+struct TcpOverloadState {
+    var startsInFlight: [ObjectIdentifier: TcpAdmissionToken] = [:]
+    var flowApps: [ObjectIdentifier: String] = [:]
+    var perAppFlowCounts: [String: Int] = [:]
+    var startLatencyMsWindow: [UInt64] = []
+    var admissionsSinceTick = 0
+    var timeoutsSinceTick = 0
+    var shedsSinceTick = 0
+    var breakerOpen = false
+
+    mutating func appId(for meta: RamaTransparentProxyFlowMetaBridge) -> String {
+        meta.sourceAppBundleIdentifier
+            ?? meta.sourceAppSigningIdentifier
+            ?? meta.sourceAppPid.map { "pid:\($0)" }
+            ?? "pid:unknown"
+    }
+
+    mutating func insertLatency(_ latencyMs: UInt64) {
+        startLatencyMsWindow.append(latencyMs)
+        if startLatencyMsWindow.count > 128 {
+            startLatencyMsWindow.removeFirst(startLatencyMsWindow.count - 128)
+        }
+    }
+
+    func percentile(_ percentile: Double) -> UInt64 {
+        guard !startLatencyMsWindow.isEmpty else { return 0 }
+        let sorted = startLatencyMsWindow.sorted()
+        let rawIndex = Int((Double(sorted.count - 1) * percentile).rounded(.up))
+        return sorted[min(max(rawIndex, 0), sorted.count - 1)]
+    }
+
+    func topAppSummary(limit: Int = 3) -> String {
+        perAppFlowCounts
+            .filter { $0.value > 0 }
+            .sorted { lhs, rhs in
+                if lhs.value == rhs.value { return lhs.key < rhs.key }
+                return lhs.value > rhs.value
+            }
+            .prefix(limit)
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
+    }
+
+    mutating func snapshotAndResetRates(intervalSeconds: Double) -> TcpOverloadSnapshot {
+        let seconds = max(intervalSeconds, 1.0)
+        let snapshot = TcpOverloadSnapshot(
+            admissionRate: Double(admissionsSinceTick) / seconds,
+            timeoutRate: Double(timeoutsSinceTick) / seconds,
+            shedRate: Double(shedsSinceTick) / seconds,
+            startsInFlight: startsInFlight.count,
+            p50StartMs: percentile(0.50),
+            p95StartMs: percentile(0.95),
+            p99StartMs: percentile(0.99),
+            breakerOpen: breakerOpen
+        )
+        admissionsSinceTick = 0
+        timeoutsSinceTick = 0
+        shedsSinceTick = 0
+        return snapshot
+    }
+}

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpDirectForwarder.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpDirectForwarder.swift
@@ -74,6 +74,14 @@ final class TcpDirectForwarder: @unchecked Sendable {
     /// promoted-flow idle reaper only drops flows that have genuinely gone
     /// quiet — never an actively-transferring one.
     private let onActivity: () -> Void
+    /// Closes the kernel flow's write half once S→C finished draining, so
+    /// the client app sees the server's EOF (the `flow` type here has no
+    /// close surface, hence the injected hook). Without it a client that
+    /// waits for server EOF never closes, no FIN is ever sent, and the
+    /// egress socket parks in CLOSE_WAIT until a watchdog reaps it. Called
+    /// with the S→C terminal error (nil for clean EOF) after the drain,
+    /// before the direction is marked `.finished`.
+    private let closeClientWrite: (Error?) -> Void
 
     // Existing per-flow write pumps. We do NOT take ownership —
     // tests can also hand in standalone pumps. The forwarder
@@ -125,6 +133,10 @@ final class TcpDirectForwarder: @unchecked Sendable {
     /// `finishing` after draining the buffer.
     private var c2sEofBuffered: Bool = false
     private var s2cEofBuffered: Bool = false
+    /// The S→C receive error that accompanied EOF, if any — forwarded to
+    /// `closeClientWrite` so a torn egress isn't presented to the client
+    /// app as a clean server EOF.
+    private var s2cTerminalError: Error?
 
     /// Set by `markClientReadDrained` / `markEgressReadDrained`
     /// after the cancelled-for-promote read pump has fired its
@@ -181,6 +193,7 @@ final class TcpDirectForwarder: @unchecked Sendable {
         onClosing: @escaping () -> Void = {},
         onDrainStall: @escaping () -> Void = {},
         onActivity: @escaping () -> Void = {},
+        closeClientWrite: @escaping (Error?) -> Void = { _ in },
         onTerminal: @escaping () -> Void
     ) {
         self.flow = flow
@@ -193,6 +206,7 @@ final class TcpDirectForwarder: @unchecked Sendable {
         self.onClosing = onClosing
         self.onDrainStall = onDrainStall
         self.onActivity = onActivity
+        self.closeClientWrite = closeClientWrite
         self.onTerminal = onTerminal
     }
 
@@ -259,12 +273,15 @@ final class TcpDirectForwarder: @unchecked Sendable {
                     self.s2cBuffer.pushBack(data)
                 } else {
                     self.s2cEofBuffered = true
+                    // EOF-observed closing signal, as in the receive loop.
+                    self.signalClosingLocked()
                 }
             case .active:
                 if let data = payload, !data.isEmpty {
                     self.writeS2CLocked(data)
                 } else {
                     self.s2cEofBuffered = true
+                    self.signalClosingLocked()
                     if self.s2cBuffer.isEmpty && !self.s2cWritePaused {
                         self.finishS2CLocked()
                     }
@@ -507,6 +524,13 @@ final class TcpDirectForwarder: @unchecked Sendable {
                     // drains. If the buffer is empty and we're
                     // not paused, finish now.
                     self.s2cEofBuffered = true
+                    if let error { self.s2cTerminalError = error }
+                    // Signal closing at EOF-observed time: a client that
+                    // stops reading strands the buffered tail, `.finishing`
+                    // is never entered, and the closing-stuck watchdog
+                    // would otherwise not see the flow at all. Its idle
+                    // gate still spares a drain that is making progress.
+                    self.signalClosingLocked()
                     if self.s2cBuffer.isEmpty && !self.s2cWritePaused {
                         self.finishS2CLocked()
                     }
@@ -571,6 +595,11 @@ final class TcpDirectForwarder: @unchecked Sendable {
                 guard let self else { return }
                 self.s2cBackstop?.cancel()
                 self.s2cBackstop = nil
+                // Every S->C byte has drained: surface the server's EOF to
+                // the client app. Write half only, so a continuing upload
+                // is untouched; the later duplicate close in
+                // `applyPromotedTerminal` is an idempotent no-op.
+                self.closeClientWrite(self.s2cTerminalError)
                 self.s2cPhase = .finished
                 self.maybeFireTerminalLocked()
             }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -310,6 +310,7 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// sit in the registry, while long enough that the resulting log
     /// volume is negligible.
     private static let periodicMaintenanceInterval: DispatchTimeInterval = .seconds(60)
+    private static let periodicMaintenanceIntervalSeconds: Double = 60.0
 
     /// TCP flow IDs observed pre-`egressReady` on the previous
     /// maintenance tick. On the NEXT tick, any flow still in this set
@@ -360,6 +361,10 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// low-water — would otherwise emit a persisted os_log on EVERY admission.
     /// Only mutated on `stateQueue`.
     private var pressureNoHeadroomLogged = false
+
+    /// Admission / overload counters for TCP egress starts. Only touched on
+    /// `stateQueue`, alongside the flow registries it summarizes.
+    private var overload = TcpOverloadState()
 
     /// Per-tick teardown work split by disposition: pre-ready flows get
     /// `applyConnectTimeout`, wedged-closing flows get `applyDrainBackstop`,
@@ -593,6 +598,7 @@ final class TransparentProxyCore: @unchecked Sendable {
         stateQueue.sync {
             self.stuckPreReadyFlowIds.removeAll(keepingCapacity: false)
             self.stuckClosingFlowIds.removeAll(keepingCapacity: false)
+            self.overload = TcpOverloadState()
         }
     }
 
@@ -613,9 +619,26 @@ final class TransparentProxyCore: @unchecked Sendable {
         if total > self.flowCountHighWater { self.flowCountHighWater = total }
         // Combined total is what matters for the kernel nexus ceiling (global
         // across the flowswitch). `cap`/`peak` make pressure visible in soak.
-        self.logDebug(
+        let overloadSnapshot = self.overload.snapshotAndResetRates(
+            intervalSeconds: Self.periodicMaintenanceIntervalSeconds)
+        let topApps = self.overload.topAppSummary()
+        let admissionRate = String(format: "%.2f", overloadSnapshot.admissionRate)
+        let timeoutRate = String(format: "%.2f", overloadSnapshot.timeoutRate)
+        let shedRate = String(format: "%.2f", overloadSnapshot.shedRate)
+        let breaker = overloadSnapshot.breakerOpen ? "open" : "closed"
+        let appSummary = topApps.isEmpty ? "-" : topApps
+        let latencySummary =
+            "p50=\(overloadSnapshot.p50StartMs),p95=\(overloadSnapshot.p95StartMs),"
+            + "p99=\(overloadSnapshot.p99StartMs)"
+        let countSummary =
             "tproxy live-flow counts tcp=\(tcp) udp=\(udp) total=\(total) "
-                + "peak=\(self.flowCountHighWater) softCap=\(defaultFlowPressureSoftCap)")
+            + "peak=\(self.flowCountHighWater) softCap=\(defaultFlowPressureSoftCap)"
+        let overloadSummary =
+            "tcpStartsInFlight=\(overloadSnapshot.startsInFlight) "
+            + "admissionRate=\(admissionRate)/s timeoutRate=\(timeoutRate)/s "
+            + "shedRate=\(shedRate)/s startLatencyMs[\(latencySummary)] "
+            + "breaker=\(breaker) topApps=\(appSummary)"
+        self.logLifecycle("\(countSummary) \(overloadSummary)")
 
         // Track two cross-tick "stuck" sets. An ID present in both the
         // previous AND the current set has been stuck for ≥ one tick
@@ -817,9 +840,13 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// read inside the register sync that already happens). Combined because
     /// the kernel nexus ceiling is global across the flowswitch, not per-proto.
     @discardableResult
-    func registerTcpFlow(_ flowId: ObjectIdentifier, anchor: TcpFlowSessionAnchor) -> Int {
+    func registerTcpFlow(_ flowId: ObjectIdentifier, anchor: TcpFlowSessionAnchor, appId: String? = nil) -> Int {
         stateQueue.sync {
             self.tcpSessions[flowId] = anchor
+            if let appId {
+                self.overload.flowApps[flowId] = appId
+                self.overload.perAppFlowCounts[appId, default: 0] += 1
+            }
             return self.tcpSessions.count + self.udpSessions.count
         }
     }
@@ -859,6 +886,15 @@ final class TransparentProxyCore: @unchecked Sendable {
         // guard below.
         stateQueue.async {
             self.tcpSessions.removeValue(forKey: flowId)
+            if let appId = self.overload.flowApps.removeValue(forKey: flowId),
+                let count = self.overload.perAppFlowCounts[appId]
+            {
+                if count <= 1 {
+                    self.overload.perAppFlowCounts.removeValue(forKey: appId)
+                } else {
+                    self.overload.perAppFlowCounts[appId] = count - 1
+                }
+            }
             // Belt-and-suspenders against `ObjectIdentifier` reuse:
             // if a torn-down flow's pointer is recycled for a new ctx
             // within one maintenance tick, the new ctx would inherit
@@ -867,6 +903,90 @@ final class TransparentProxyCore: @unchecked Sendable {
             // tracking set in lockstep with the registry.
             self.stuckPreReadyFlowIds.remove(flowId)
             self.stuckClosingFlowIds.remove(flowId)
+        }
+    }
+
+    // MARK: - TCP overload admission
+
+    func admitTcpStart(
+        flowId: ObjectIdentifier, meta: RamaTransparentProxyFlowMetaBridge
+    ) -> TcpAdmissionDecision {
+        stateQueue.sync {
+            let appId = self.overload.appId(for: meta)
+            let hardCap = Int(defaultTcpStartInFlightHardCap)
+            let softCap = Int(defaultTcpStartInFlightSoftCap)
+            let inFlight = self.overload.startsInFlight.count
+            if hardCap > 0, inFlight >= hardCap {
+                self.overload.shedsSinceTick += 1
+                return .reject(
+                    "hard start cap reached inFlight=\(inFlight) hardCap=\(hardCap) app=\(appId)")
+            }
+            if self.overload.breakerOpen, softCap > 0, inFlight >= softCap {
+                self.overload.shedsSinceTick += 1
+                return .reject(
+                    "latency breaker open inFlight=\(inFlight) softCap=\(softCap) app=\(appId)")
+            }
+            let token = TcpAdmissionToken(flowId: flowId, startedAt: .now(), appId: appId)
+            self.overload.startsInFlight[flowId] = token
+            self.overload.admissionsSinceTick += 1
+            return .admit(token)
+        }
+    }
+
+    func finishTcpStart(_ token: TcpAdmissionToken, outcome: TcpStartOutcome) {
+        stateQueue.async {
+            guard self.overload.startsInFlight.removeValue(forKey: token.flowId) != nil else {
+                return
+            }
+            let latencyMs =
+                (DispatchTime.now().uptimeNanoseconds &- token.startedAt.uptimeNanoseconds)
+                / 1_000_000
+            self.overload.insertLatency(latencyMs)
+            if outcome == .timeout {
+                self.overload.timeoutsSinceTick += 1
+            }
+            self.updateTcpAdmissionBreakerLocked()
+        }
+    }
+
+    func recordTcpPassthroughDecision(meta: RamaTransparentProxyFlowMetaBridge) {
+        stateQueue.async {
+            guard self.overload.breakerOpen else { return }
+            self.overload.shedsSinceTick += 1
+            let appId = self.overload.appId(for: meta)
+            self.logLifecycle("tcp overload: shedding passthrough decision app=\(appId)")
+        }
+    }
+
+    func tcpConnectTimeoutMs(base: UInt32) -> UInt32 {
+        stateQueue.sync {
+            let inFlight = self.overload.startsInFlight.count
+            let softCap = Int(defaultTcpStartInFlightSoftCap)
+            if self.overload.breakerOpen, defaultTcpBreakerConnectTimeoutMs > 0 {
+                return min(base, defaultTcpBreakerConnectTimeoutMs)
+            }
+            if softCap > 0, inFlight >= softCap, defaultTcpPressureConnectTimeoutMs > 0 {
+                return min(base, defaultTcpPressureConnectTimeoutMs)
+            }
+            return base
+        }
+    }
+
+    private func updateTcpAdmissionBreakerLocked() {
+        let p95 = self.overload.percentile(0.95)
+        let inFlight = self.overload.startsInFlight.count
+        let softCap = Int(defaultTcpStartInFlightSoftCap)
+        let openThreshold = UInt64(defaultTcpStartLatencyBreakerP95Ms)
+        let closeThreshold = UInt64(defaultTcpStartLatencyBreakerCloseP95Ms)
+        guard softCap > 0, openThreshold > 0 else { return }
+        if !self.overload.breakerOpen, inFlight >= softCap, p95 >= openThreshold {
+            self.overload.breakerOpen = true
+            self.logLifecycle(
+                "tcp overload breaker open: p95StartMs=\(p95) inFlight=\(inFlight) softCap=\(softCap)")
+        } else if self.overload.breakerOpen, inFlight < softCap, p95 <= closeThreshold {
+            self.overload.breakerOpen = false
+            self.logLifecycle(
+                "tcp overload breaker closed: p95StartMs=\(p95) inFlight=\(inFlight) softCap=\(softCap)")
         }
     }
 
@@ -916,6 +1036,28 @@ final class TransparentProxyCore: @unchecked Sendable {
             stateQueue.sync {
                 self.tcpSessions[flowId] = _TestTcpFlowSessionAnchor(ctx: ctx)
             }
+        }
+
+        func testAdmitTcpStart(
+            flowId: ObjectIdentifier, meta: RamaTransparentProxyFlowMetaBridge
+        ) -> TcpAdmissionDecision {
+            admitTcpStart(flowId: flowId, meta: meta)
+        }
+
+        func testFinishTcpStart(_ token: TcpAdmissionToken, outcome: TcpStartOutcome) {
+            finishTcpStart(token, outcome: outcome)
+        }
+
+        var testTcpStartsInFlight: Int {
+            stateQueue.sync { self.overload.startsInFlight.count }
+        }
+
+        var testTcpOverloadBreakerOpen: Bool {
+            stateQueue.sync { self.overload.breakerOpen }
+        }
+
+        func testTcpConnectTimeoutMs(base: UInt32) -> UInt32 {
+            tcpConnectTimeoutMs(base: base)
         }
 
         /// Symmetric for UDP. Wraps the bare ctx in a stub

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -406,23 +406,19 @@ final class TransparentProxyCore: @unchecked Sendable {
     ///
     /// Discriminator (race-free — uses ONLY already-`flowQueue`-relaxed fields,
     /// no forwarder-phase read which would widen the off-queue read surface):
-    ///   * `viaRust` (`mode != .promoted`): no forwarder — `terminalSignalled`
-    ///     IS the wedge indicator (graceful drain signalled but the flow never
-    ///     left the registry; its per-flow backstop must have been starved), as
-    ///     before.
-    ///   * `.promoted`: genuinely wedged only if it has ALSO stopped making byte
-    ///     progress past its linger budget. A live half-close keeps bumping
-    ///     `lastActivityAt` (the shared per-flow activity signal) on its still-
-    ///     active direction → not wedged → spared; if it later goes quiet it is
-    ///     reaped here (or by the idle reaper). A stalled FIN (peer stopped
-    ///     reading) makes no progress → quiet past the budget → wedged.
+    /// wedged means closing AND no byte progress past the linger budget, in
+    /// both modes. A live half-close keeps bumping `lastActivityAt` on its
+    /// still-active direction and is spared; `terminalSignalled` is sticky
+    /// and fires at every ordinary half-close, so it can never count as a
+    /// wedge on its own. Both write pumps bump the activity clock on the
+    /// flow's queue, so it is accurate in `viaRust` too.
+    ///
     /// The cross-tick "stuck for ≥1 tick" set adds ~one maintenance interval of
     /// hysteresis on top, so a merely bursty-but-alive flow is never selected.
     /// Read off `flowQueue` from the maintenance tick (same relaxation as
     /// `egressReady`); re-checked on `flowQueue` before the teardown fires.
     private static func flowIsDrainWedged(_ ctx: TcpFlowContext) -> Bool {
         guard ctx.terminalSignalled else { return false }
-        guard ctx.mode == .promoted else { return true }
         return flowIdleMs(ctx) > UInt64(ctx.lingerCloseMs)
     }
 
@@ -509,7 +505,13 @@ final class TransparentProxyCore: @unchecked Sendable {
                 // `lastActivityAt` (bumped on the shared write-pump flowQueue
                 // hop), so an actively-transferring flow of either mode is
                 // excluded here and never selected.
-                $0.ctx.egressReady && !$0.ctx.terminalSignalled
+                //
+                // Closing flows are eligible once genuinely drain-wedged:
+                // dead weight holding a nexus slot is the first thing to
+                // sacrifice under pressure. The wedge test's idle gate keeps
+                // a live half-close unreapable.
+                $0.ctx.egressReady
+                    && (!$0.ctx.terminalSignalled || Self.flowIsDrainWedged($0.ctx))
                     && (nowNs &- $0.lastNs) / 1_000_000 > floorMs
             }
             .sorted { $0.lastNs < $1.lastNs }
@@ -548,7 +550,8 @@ final class TransparentProxyCore: @unchecked Sendable {
         let floorMs = UInt64(defaultFlowPressureIdleFloorMs)
         for ctx in victims {
             runFlowTeardown(ctx) {
-                guard ctx.egressReady, !ctx.isDone, !ctx.terminalSignalled,
+                guard ctx.egressReady, !ctx.isDone,
+                    !ctx.terminalSignalled || Self.flowIsDrainWedged(ctx),
                     Self.flowIdleMs(ctx) > floorMs
                 else { return }
                 ctx.applyPressureEvicted()
@@ -1134,6 +1137,11 @@ final class TransparentProxyCore: @unchecked Sendable {
             onDrainStall: { [weak ctx] in ctx?.applyDrainBackstop() },
             // Bump the promoted-idle reaper clock on every byte moved.
             onActivity: { [weak ctx] in ctx?.lastActivityAt = .now() },
+            // The forwarder's flow type has no close surface; hand it the
+            // write-half close so the client app sees server EOF.
+            closeClientWrite: { [weak flow] error in
+                flow?.closeWriteWithError(error)
+            },
             // Both directions done. Route through the shared teardown so the
             // close marks `done` and detaches handlers — WITHOUT cancelling the
             // egress NWConnection, whose FIN/linger the egress write pump owns.

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -1104,12 +1104,10 @@ final class TransparentProxyCore: @unchecked Sendable {
         session.confirmPromoted(.ok)
     }
 
-    /// Build the direct kernel↔egress forwarder shared by the `viaRust`→promote
-    /// cutover and the born-spliced (up-front passthrough) path. Wires the same
-    /// lifecycle callbacks onto `ctx` and stores it as `ctx.directForwarder`.
-    /// The caller drives the cutover sequencing (read-pump carryover for the
-    /// promote path; the immediate Rust-done/read-drained signals for
-    /// born-spliced).
+    /// Build the direct kernel↔egress forwarder for the `viaRust`→promote
+    /// cutover. Wires the lifecycle callbacks onto `ctx` and stores it as
+    /// `ctx.directForwarder`. The caller drives the cutover sequencing
+    /// (read-pump carryover, then the Rust-done/read-drained signals).
     func makePromotedForwarder<F: TcpFlowLike>(
         ctx: TcpFlowContext,
         flow: F,
@@ -1143,45 +1141,6 @@ final class TransparentProxyCore: @unchecked Sendable {
         )
         ctx.directForwarder = forwarder
         return forwarder
-    }
-
-    /// Born-spliced cutover: a flow decided up-front as passthrough was claimed
-    /// (returning `true` so the kernel does NOT close it) but never routed
-    /// through Rust. It goes straight to the direct splice. Unlike
-    /// `beginPromoteCutover` there is no Rust service to unwind — no session,
-    /// no session-bound read pumps to cancel-with-carryover, no
-    /// `confirmPromoted`. Build the forwarder over the (empty) write pumps +
-    /// live connection and fire all four cutover signals immediately: with no
-    /// Rust bytes pending and no in-flight read to drain, both directions go
-    /// straight to `.active` and start their direct `flow.readData` /
-    /// `connection.receive` loops. The teardown path is identical to the
-    /// promote path (`applyPromotedTerminal` + the linger watchdog), so the
-    /// hardened, leak-fixed close is reused verbatim.
-    func beginBornSplicedCutover<F: TcpFlowLike>(
-        ctx: TcpFlowContext,
-        flow: F,
-        connection: any NwConnectionLike,
-        clientWritePump: TcpClientWritePump,
-        egressWritePump: NwTcpConnectionWritePump,
-        flowQueue: DispatchQueue
-    ) {
-        logTrace("born-splice: cutover begin")
-        let forwarder = makePromotedForwarder(
-            ctx: ctx,
-            flow: flow,
-            connection: connection,
-            clientWritePump: clientWritePump,
-            egressWritePump: egressWritePump,
-            flowQueue: flowQueue
-        )
-        ctx.mode = .promoted
-        ctx.lastActivityAt = .now()
-        // Order is irrelevant — whichever signal lands second per direction
-        // kicks off that direction's read loop (over empty carryover buffers).
-        forwarder.markClientReadDrained()
-        forwarder.markEgressReadDrained()
-        forwarder.markRustC2SDone()
-        forwarder.markRustS2CDone()
     }
 
     // MARK: - Per-flow handling (UDP)

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/DrainBackstopTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/DrainBackstopTests.swift
@@ -118,6 +118,13 @@ final class DrainBackstopTests: XCTestCase {
             self.ctx.flow = flow
             self.ctx.core = core
             self.ctx.flowId = flowId
+            // The watchdog's wedge test is idle-gated in BOTH modes (a
+            // closing flow still moving bytes is a live half-close and must
+            // be spared). These fixtures model a QUIET wedge, so age the
+            // activity clock past the linger budget.
+            self.ctx.lingerCloseMs = 0
+            self.ctx.lastActivityAt = DispatchTime(
+                uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds &- 1_000_000_000)
         }
 
         var wasTornDown: Bool { ctx.isDone }
@@ -203,5 +210,25 @@ final class DrainBackstopTests: XCTestCase {
         core.testRunPeriodicMaintenance()  // tick 3: kick
         XCTAssertTrue(fx.wasTornDown)
         XCTAssertEqual(fx.conn.cancelCount, 1)
+    }
+
+    /// A closing (`terminalSignalled`) flow still moving bytes is a live
+    /// half-close (e.g. upload EOF while the download keeps streaming) and
+    /// the watchdog must not reset it, however many ticks pass.
+    func testWatchdogSparesActivelyDrainingClosingFlow() {
+        let core = TransparentProxyCore()
+        let fx = WatchdogFx(core: core, ready: true, closing: true)
+        fx.ctx.lingerCloseMs = 5_000
+        core.testInsertTcpContext(fx.flowId, fx.ctx)
+
+        for _ in 0..<3 {
+            fx.ctx.lastActivityAt = .now()  // bytes keep moving
+            core.testRunPeriodicMaintenance()
+        }
+
+        XCTAssertFalse(
+            fx.wasTornDown,
+            "closing flow still moving bytes is a live half-close, not a wedge")
+        XCTAssertEqual(fx.conn.cancelCount, 0)
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
@@ -21,7 +21,7 @@ final class FFIAbiLayoutTests: XCTestCase {
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyFlowMeta>.alignment, 8)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyNetworkRule>.size, 56)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyNetworkRule>.alignment, 8)
-        XCTAssertEqual(MemoryLayout<RamaTransparentProxyConfig>.size, 40)
+        XCTAssertEqual(MemoryLayout<RamaTransparentProxyConfig>.size, 80)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyConfig>.alignment, 8)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyInitConfig>.size, 32)
         XCTAssertEqual(MemoryLayout<RamaTransparentProxyInitConfig>.alignment, 8)

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
@@ -208,23 +208,48 @@ final class FlowPressureReaperTests: XCTestCase {
             "actively-transferring viaRust flows must never be pressure-evicted")
     }
 
-    // MARK: - Closing flows excluded
+    // MARK: - Closing flows
 
-    func testAlreadyClosingFlowNotSelected() {
+    /// A closing flow whose drain is still making progress (idle past the
+    /// pressure floor but within its linger budget) is winding down
+    /// GRACEFULLY — the reaper must not double-tear it.
+    func testActivelyClosingFlowNotSelected() {
         defaultFlowPressureSoftCap = 2
         defaultFlowPressureLowWater = 1
         defaultFlowPressureIdleFloorMs = 5_000
         let core = makeCore()
         let closing = Fx(core: core, idleSeconds: 30)
-        closing.ctx.terminalSignalled = true  // already winding down
+        closing.ctx.terminalSignalled = true  // winding down…
+        closing.ctx.lingerCloseMs = 60_000  // …within its linger budget
         let idle = Fx(core: core, idleSeconds: 30)
         insert(core, [closing, idle])
 
         core.testReapIdleUnderPressure()
 
         XCTAssertFalse(
-            closing.wasTornDown, "a flow already closing is not double-torn by the backstop")
+            closing.wasTornDown,
+            "a gracefully-closing flow (not drain-wedged) is not double-torn by the backstop")
         XCTAssertTrue(idle.wasTornDown)
+    }
+
+    /// A closing flow quiet past its linger budget has a wedged drain: dead
+    /// weight holding a nexus slot. Under cap pressure it is eligible, not
+    /// shielded by `terminalSignalled`.
+    func testWedgedClosingFlowIsPressureEvicted() {
+        defaultFlowPressureSoftCap = 2
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 5_000
+        let core = makeCore()
+        let wedged = Fx(core: core, idleSeconds: 30)
+        wedged.ctx.terminalSignalled = true  // closing…
+        wedged.ctx.lingerCloseMs = 5_000  // …and quiet past the linger budget
+        insert(core, [wedged, Fx(core: core, idleSeconds: 1), Fx(core: core, idleSeconds: 1)])
+
+        core.testReapIdleUnderPressure()
+
+        XCTAssertTrue(
+            wedged.wasTornDown,
+            "a drain-wedged closing flow is reapable under pressure")
     }
 
     // MARK: - Below cap / disabled

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/NwTcpConnectionWritePumpLingerTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/NwTcpConnectionWritePumpLingerTests.swift
@@ -279,4 +279,45 @@ final class NwTcpConnectionWritePumpLingerTests: XCTestCase {
             "non-ready drain must force-cancel the connection so it can't leak"
         )
     }
+
+    /// The linger watchdog defers while the flow still moves bytes (a live
+    /// half-close) and only force-cancels once the connection has been
+    /// quiet for a full linger window.
+    func testLingerDefersWhileReadSideActive() {
+        final class IdleClock: @unchecked Sendable {
+            private let lock = NSLock()
+            private var ms: UInt64 = 0
+            var value: UInt64 {
+                get { lock.lock(); defer { lock.unlock() }; return ms }
+                set { lock.lock(); defer { lock.unlock() }; ms = newValue }
+            }
+        }
+        let mock = MockNwConnection()
+        mock.transition(to: .ready)
+        let queue = makeQueue()
+        let idle = IdleClock()  // starts at 0ms = actively moving bytes
+        let pump = NwTcpConnectionWritePump(
+            connection: mock,
+            queue: queue,
+            lingerCloseDeadline: .milliseconds(120),
+            onDrained: {},
+            readSideIdleMs: { idle.value }
+        )
+
+        pump.closeWhenDrained()
+        waitForQueueDrain(queue)
+        XCTAssertEqual(mock.sentChunks.count, 1, "the FIN itself is unaffected")
+
+        // Well past the linger deadline the connection must still be alive:
+        // every expiry observed recent activity and re-armed.
+        Thread.sleep(forTimeInterval: 0.4)
+        waitForQueueDrain(queue)
+        XCTAssertEqual(
+            mock.cancelCount, 0,
+            "linger must defer while the read side is still streaming")
+
+        // The flow goes quiet; the next re-armed check force-cancels.
+        idle.value = 10_000
+        pollUntil("linger watchdog cancels once the flow is quiet") { mock.cancelCount == 1 }
+    }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
@@ -237,7 +237,16 @@ final class ProviderStaticHelperTests: XCTestCase {
         RamaTransparentProxyConfigBridge(
             tunnelRemoteAddress: tunnel,
             rules: rules,
-            tcpWritePumpMaxPendingBytes: 1_048_576)
+            tcpWritePumpMaxPendingBytes: 1_048_576,
+            flowPressureSoftCap: defaultFlowPressureSoftCap,
+            flowPressureLowWater: defaultFlowPressureLowWater,
+            flowPressureIdleFloorMs: defaultFlowPressureIdleFloorMs,
+            tcpStartInFlightHardCap: defaultTcpStartInFlightHardCap,
+            tcpStartInFlightSoftCap: defaultTcpStartInFlightSoftCap,
+            tcpStartLatencyBreakerP95Ms: defaultTcpStartLatencyBreakerP95Ms,
+            tcpStartLatencyBreakerCloseP95Ms: defaultTcpStartLatencyBreakerCloseP95Ms,
+            tcpPressureConnectTimeoutMs: defaultTcpPressureConnectTimeoutMs,
+            tcpBreakerConnectTimeoutMs: defaultTcpBreakerConnectTimeoutMs)
     }
 
     func testBuildNetworkSettingsEmptyRules() {
@@ -247,6 +256,63 @@ final class ProviderStaticHelperTests: XCTestCase {
         XCTAssertNil(
             settings.excludedNetworkRules,
             "no excludes → property is nil, not an empty array")
+    }
+
+    func testApplyRuntimeConfigOverridesSwiftDefaults() {
+        let savedWriteCap = writePumpMaxPendingBytes
+        let savedWriteHwm = writePumpHwmLogThresholdBytes
+        let savedFlowSoftCap = defaultFlowPressureSoftCap
+        let savedFlowLowWater = defaultFlowPressureLowWater
+        let savedFlowIdleFloor = defaultFlowPressureIdleFloorMs
+        let savedHardCap = defaultTcpStartInFlightHardCap
+        let savedSoftCap = defaultTcpStartInFlightSoftCap
+        let savedOpenP95 = defaultTcpStartLatencyBreakerP95Ms
+        let savedCloseP95 = defaultTcpStartLatencyBreakerCloseP95Ms
+        let savedPressureTimeout = defaultTcpPressureConnectTimeoutMs
+        let savedBreakerTimeout = defaultTcpBreakerConnectTimeoutMs
+        defer {
+            writePumpMaxPendingBytes = savedWriteCap
+            writePumpHwmLogThresholdBytes = savedWriteHwm
+            defaultFlowPressureSoftCap = savedFlowSoftCap
+            defaultFlowPressureLowWater = savedFlowLowWater
+            defaultFlowPressureIdleFloorMs = savedFlowIdleFloor
+            defaultTcpStartInFlightHardCap = savedHardCap
+            defaultTcpStartInFlightSoftCap = savedSoftCap
+            defaultTcpStartLatencyBreakerP95Ms = savedOpenP95
+            defaultTcpStartLatencyBreakerCloseP95Ms = savedCloseP95
+            defaultTcpPressureConnectTimeoutMs = savedPressureTimeout
+            defaultTcpBreakerConnectTimeoutMs = savedBreakerTimeout
+        }
+
+        let startup = RamaTransparentProxyConfigBridge(
+            tunnelRemoteAddress: "240.0.0.1",
+            rules: [],
+            tcpWritePumpMaxPendingBytes: 10_000,
+            flowPressureSoftCap: 11,
+            flowPressureLowWater: 12,
+            flowPressureIdleFloorMs: 13,
+            tcpStartInFlightHardCap: 14,
+            tcpStartInFlightSoftCap: 15,
+            tcpStartLatencyBreakerP95Ms: 16,
+            tcpStartLatencyBreakerCloseP95Ms: 17,
+            tcpPressureConnectTimeoutMs: 18,
+            tcpBreakerConnectTimeoutMs: 19)
+
+        var logs: [String] = []
+        RamaTransparentProxyProvider.applyRuntimeConfig(from: startup) { logs.append($0) }
+
+        XCTAssertEqual(writePumpMaxPendingBytes, 10_000)
+        XCTAssertEqual(writePumpHwmLogThresholdBytes, 5_000)
+        XCTAssertEqual(defaultFlowPressureSoftCap, 11)
+        XCTAssertEqual(defaultFlowPressureLowWater, 12)
+        XCTAssertEqual(defaultFlowPressureIdleFloorMs, 13)
+        XCTAssertEqual(defaultTcpStartInFlightHardCap, 14)
+        XCTAssertEqual(defaultTcpStartInFlightSoftCap, 15)
+        XCTAssertEqual(defaultTcpStartLatencyBreakerP95Ms, 16)
+        XCTAssertEqual(defaultTcpStartLatencyBreakerCloseP95Ms, 17)
+        XCTAssertEqual(defaultTcpPressureConnectTimeoutMs, 18)
+        XCTAssertEqual(defaultTcpBreakerConnectTimeoutMs, 19)
+        XCTAssertEqual(logs.count, 3)
     }
 
     func testBuildNetworkSettingsRoutesIncludesAndExcludes() {

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpEgressPumpInteractionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpEgressPumpInteractionTests.swift
@@ -292,4 +292,45 @@ final class TcpEgressPumpInteractionTests: XCTestCase {
         XCTAssertNil(weakWritePump, "write pump retained past watchdog fire — watchdog work item leak")
         XCTAssertNil(weakReadPump, "read pump retained past watchdog fire — watchdog work item leak")
     }
+
+    /// Peer EOF arms the read pump's EOF-grace force-cancel; a promote
+    /// cutover landing inside that grace window must disarm it, or the stale
+    /// timer cancels the connection under the new forwarder's feet.
+    func testCancelForPromoteDisarmsArmedEofGraceBackstop() {
+        let engine = makeEngine()
+        defer { engine.stop(reason: 0) }
+        let session = makeInterceptedSession(engine)
+        let queue = makeQueue("promote-disarms-eof-grace")
+        let mock = MockNwConnection()
+        mock.transition(to: .ready)
+
+        let readPump = NwTcpConnectionReadPump(
+            connection: mock,
+            session: session,
+            queue: queue,
+            eofGraceDeadline: .milliseconds(150)
+        )
+
+        readPump.start()
+        // Let the pump's async start actually ISSUE the receive before
+        // completing it, or the EOF is silently dropped and the pump never
+        // reaches `.closed`.
+        waitForQueueDrain(queue)
+        // Peer EOF: phase → .closed, EOF-grace backstop armed.
+        mock.completePendingReceive(isComplete: true)
+        waitForQueueDrain(queue)
+
+        // Promote lands within the grace window.
+        let done = expectation(description: "cancelForPromote completed")
+        readPump.cancelForPromote(onCarryover: { _ in }, onComplete: { done.fulfill() })
+        wait(for: [done], timeout: 1.0)
+
+        // Well past the grace deadline the connection must still be alive:
+        // it now belongs to the promoted forwarder.
+        Thread.sleep(forTimeInterval: 0.45)
+        waitForQueueDrain(queue)
+        XCTAssertEqual(
+            mock.cancelCount, 0,
+            "stale EOF-grace timer must not cancel a promoted connection")
+    }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionTests.swift
@@ -88,69 +88,6 @@ final class TcpFlowSessionTests: XCTestCase {
         XCTAssertNotNil(fx.session.ctx.clientWritePump)
     }
 
-    // MARK: - born-spliced (up-front passthrough → claim + direct splice)
-
-    private func poll(_ timeout: TimeInterval = 2.0, _ cond: () -> Bool) {
-        let deadline = Date().addingTimeInterval(timeout)
-        while !cond() && Date() < deadline { Thread.sleep(forTimeInterval: 0.002) }
-    }
-
-    private func pollOnFlowQueue(
-        _ session: TcpFlowSession<MockTcpFlow>,
-        timeout: TimeInterval = 2.0,
-        _ cond: @escaping (TcpFlowContext) -> Bool
-    ) {
-        poll(timeout) {
-            session.flowQueue.sync {
-                cond(session.ctx)
-            }
-        }
-    }
-
-    /// An up-front passthrough decision must NOT close the flow. The
-    /// born-spliced path claims it, builds the direct forwarder, and flips
-    /// `ctx.mode` to `.promoted` — no Rust session and no session-bound read
-    /// pumps. Drives the phase methods directly (no engine).
-    func testBornSplicedReadyBuildsForwarderAndPromotes() {
-        let fx = Fixture()
-        fx.session.buildClientWritePump()  // `start()` does this for every path
-        fx.session.bornSpliced = true
-        XCTAssertEqual(fx.session.ctx.mode, .viaRust, "mode is viaRust until the splice")
-
-        fx.session.handleBornSplicedReady(connection: fx.conn)
-        poll { fx.flow.openWasInvoked }
-        XCTAssertTrue(fx.flow.completeOpen(error: nil), "flow.open should be pending")
-
-        pollOnFlowQueue(fx.session) { ctx in
-            ctx.mode == .promoted && ctx.directForwarder != nil && ctx.egressWritePump != nil
-        }
-        fx.session.flowQueue.sync {
-            XCTAssertEqual(
-                fx.session.ctx.mode, .promoted,
-                "born-spliced flow must promote to the direct splice, not close")
-            XCTAssertNotNil(fx.session.ctx.directForwarder, "the direct forwarder must be built")
-            XCTAssertNotNil(fx.session.ctx.egressWritePump, "the egress write pump must be built")
-        }
-    }
-
-    /// Born-spliced teardown routes through the SAME hardened promoted close
-    /// as the via-Rust→promote path (`applyPromotedTerminal`): cancelling the
-    /// forwarder marks the flow done (the shared, leak-fixed teardown).
-    func testBornSplicedForwarderCancelMarksDone() {
-        let fx = Fixture()
-        fx.session.buildClientWritePump()
-        fx.session.bornSpliced = true
-        fx.session.handleBornSplicedReady(connection: fx.conn)
-        poll { fx.flow.openWasInvoked }
-        XCTAssertTrue(fx.flow.completeOpen(error: nil))
-        poll { fx.session.ctx.directForwarder != nil }
-        XCTAssertNotNil(fx.session.ctx.directForwarder)
-
-        fx.session.ctx.directForwarder?.cancel()
-        poll { fx.session.ctx.isDone == true }
-        XCTAssertEqual(fx.session.ctx.isDone, true, "promoted teardown marks the flow done")
-    }
-
     // MARK: - viability handler wiring
 
     /// The wired `viabilityUpdateHandler` MUST update `ctx.lastPathViable`

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
@@ -1,0 +1,202 @@
+import Foundation
+import XCTest
+
+@testable import RamaAppleNetworkExtension
+
+final class TcpOverloadAdmissionTests: XCTestCase {
+    private var savedHardCap: UInt32 = 0
+    private var savedSoftCap: UInt32 = 0
+    private var savedOpenP95: UInt32 = 0
+    private var savedCloseP95: UInt32 = 0
+    private var savedPressureTimeout: UInt32 = 0
+    private var savedBreakerTimeout: UInt32 = 0
+
+    override func setUp() {
+        super.setUp()
+        savedHardCap = defaultTcpStartInFlightHardCap
+        savedSoftCap = defaultTcpStartInFlightSoftCap
+        savedOpenP95 = defaultTcpStartLatencyBreakerP95Ms
+        savedCloseP95 = defaultTcpStartLatencyBreakerCloseP95Ms
+        savedPressureTimeout = defaultTcpPressureConnectTimeoutMs
+        savedBreakerTimeout = defaultTcpBreakerConnectTimeoutMs
+    }
+
+    override func tearDown() {
+        LifecycleLog.noticeOverride = nil
+        defaultTcpStartInFlightHardCap = savedHardCap
+        defaultTcpStartInFlightSoftCap = savedSoftCap
+        defaultTcpStartLatencyBreakerP95Ms = savedOpenP95
+        defaultTcpStartLatencyBreakerCloseP95Ms = savedCloseP95
+        defaultTcpPressureConnectTimeoutMs = savedPressureTimeout
+        defaultTcpBreakerConnectTimeoutMs = savedBreakerTimeout
+        super.tearDown()
+    }
+
+    func testHardStartCapRejectsBeforeAddingAnotherInFlightStart() {
+        defaultTcpStartInFlightHardCap = 1
+        let core = TransparentProxyCore()
+        let first = NSObject()
+        let second = NSObject()
+
+        guard case .admit = core.testAdmitTcpStart(flowId: ObjectIdentifier(first), meta: meta())
+        else {
+            XCTFail("first start should be admitted")
+            return
+        }
+
+        guard case .reject(let reason) = core.testAdmitTcpStart(
+            flowId: ObjectIdentifier(second), meta: meta())
+        else {
+            XCTFail("second start should be rejected at hard cap")
+            return
+        }
+
+        XCTAssertTrue(reason.contains("hard start cap reached"))
+        XCTAssertEqual(core.testTcpStartsInFlight, 1)
+    }
+
+    func testStartCompletionDecrementsInFlightGaugeForReadyAndTimeout() {
+        defaultTcpStartInFlightHardCap = 10
+        let core = TransparentProxyCore()
+        let readyFlow = NSObject()
+        let timeoutFlow = NSObject()
+
+        let readyToken = admittedToken(core, readyFlow)
+        let timeoutToken = admittedToken(core, timeoutFlow)
+        XCTAssertEqual(core.testTcpStartsInFlight, 2)
+
+        core.testFinishTcpStart(readyToken, outcome: .ready)
+        core.testFinishTcpStart(timeoutToken, outcome: .timeout)
+
+        waitFor("in-flight gauge drains") { core.testTcpStartsInFlight == 0 }
+    }
+
+    func testLatencyBreakerRejectsAtSoftCapAfterSlowStart() {
+        defaultTcpStartInFlightHardCap = 10
+        defaultTcpStartInFlightSoftCap = 1
+        defaultTcpStartLatencyBreakerP95Ms = 1
+        let core = TransparentProxyCore()
+        let first = NSObject()
+        let second = NSObject()
+        let third = NSObject()
+
+        let firstToken = admittedToken(core, first)
+        _ = admittedToken(core, second)
+        Thread.sleep(forTimeInterval: 0.005)
+        core.testFinishTcpStart(firstToken, outcome: .ready)
+
+        waitFor("breaker opens") { core.testTcpOverloadBreakerOpen }
+
+        guard case .reject(let reason) = core.testAdmitTcpStart(
+            flowId: ObjectIdentifier(third), meta: meta(bundleId: "com.example.third"))
+        else {
+            XCTFail("breaker should reject while in-flight starts are still at the soft cap")
+            return
+        }
+        XCTAssertTrue(reason.contains("latency breaker open"))
+    }
+
+    func testMaintenanceTelemetryIsPersistedAndIncludesOverloadFields() {
+        defaultTcpStartInFlightHardCap = 10
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+
+        let token = admittedToken(core, NSObject(), bundleId: "com.example.browser")
+        core.testFinishTcpStart(token, outcome: .timeout)
+        waitFor("in-flight gauge drains before telemetry") { core.testTcpStartsInFlight == 0 }
+
+        core.testRunPeriodicMaintenance()
+
+        let joined = captured.values.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("tproxy live-flow counts"))
+        XCTAssertTrue(joined.contains("admissionRate="))
+        XCTAssertTrue(joined.contains("timeoutRate="))
+        XCTAssertTrue(joined.contains("startLatencyMs["))
+        XCTAssertTrue(joined.contains("breaker="))
+    }
+
+    func testConnectTimeoutClampsUnderPressureAndBreaker() {
+        defaultTcpStartInFlightHardCap = 10
+        defaultTcpStartInFlightSoftCap = 1
+        defaultTcpPressureConnectTimeoutMs = 5_000
+        defaultTcpBreakerConnectTimeoutMs = 3_000
+        defaultTcpStartLatencyBreakerP95Ms = 1
+        let core = TransparentProxyCore()
+        let first = NSObject()
+        let second = NSObject()
+
+        XCTAssertEqual(core.testTcpConnectTimeoutMs(base: 10_000), 10_000)
+
+        let firstToken = admittedToken(core, first)
+        XCTAssertEqual(
+            core.testTcpConnectTimeoutMs(base: 10_000), 5_000,
+            "soft-cap pressure clamps long connect timeouts")
+
+        _ = admittedToken(core, second)
+        Thread.sleep(forTimeInterval: 0.005)
+        core.testFinishTcpStart(firstToken, outcome: .ready)
+        waitFor("breaker opens") { core.testTcpOverloadBreakerOpen }
+
+        XCTAssertEqual(
+            core.testTcpConnectTimeoutMs(base: 10_000), 3_000,
+            "open breaker uses the stricter timeout clamp")
+        XCTAssertEqual(
+            core.testTcpConnectTimeoutMs(base: 1_000), 1_000,
+            "adaptive timeout never raises an already-short explicit timeout")
+    }
+
+    private func admittedToken(
+        _ core: TransparentProxyCore, _ object: NSObject, bundleId: String = "com.example.app"
+    ) -> TcpAdmissionToken {
+        let decision = core.testAdmitTcpStart(
+            flowId: ObjectIdentifier(object), meta: meta(bundleId: bundleId))
+        guard case .admit(let token) = decision else {
+            XCTFail("expected admission, got \(decision)")
+            return TcpAdmissionToken(
+                flowId: ObjectIdentifier(object), startedAt: .now(), appId: bundleId)
+        }
+        return token
+    }
+
+    private func meta(bundleId: String = "com.example.app") -> RamaTransparentProxyFlowMetaBridge {
+        RamaTransparentProxyFlowMetaBridge(
+            protocolRaw: 1,
+            remoteHost: "example.com",
+            remotePort: 443,
+            localHost: nil,
+            localPort: 0,
+            sourceAppSigningIdentifier: nil,
+            sourceAppBundleIdentifier: bundleId,
+            sourceAppAuditToken: nil,
+            sourceAppPid: 4242
+        )
+    }
+
+    private func waitFor(
+        _ description: String, timeout: TimeInterval = 2.0, _ condition: () -> Bool
+    ) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition(), Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.002)
+        }
+        XCTAssertTrue(condition(), description)
+    }
+}
+
+private final class CapturedNotices: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    func append(_ message: String) {
+        lock.lock()
+        messages.append(message)
+        lock.unlock()
+    }
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return messages
+    }
+}

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "rama"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "base64",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "rama-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "asynk-strim",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "rama-crypto"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "base64",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "rama-dns"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -2271,11 +2271,11 @@ dependencies = [
 
 [[package]]
 name = "rama-error"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "rama-fastcgi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rama-core",
  "rama-http-types",
@@ -2287,7 +2287,7 @@ dependencies = [
 
 [[package]]
 name = "rama-grpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "rama-grpc-build"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "prettyplease",
  "proc-macro-crate",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "async-compression",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-backend"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "parking_lot",
  "pin-project-lite",
@@ -2386,7 +2386,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "atomic-waker",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-headers"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "base64",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-hyperium"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "http-body",
@@ -2441,7 +2441,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "rama-http-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "const_format",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "rama-json"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "itoa",
  "rama-utils",
@@ -2492,7 +2492,7 @@ dependencies = [
 
 [[package]]
 name = "rama-macros"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2502,7 +2502,7 @@ dependencies = [
 
 [[package]]
 name = "rama-net"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "bitflags 2.13.0",
@@ -2534,7 +2534,7 @@ dependencies = [
 
 [[package]]
 name = "rama-net-apple-networkextension"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "atomic-waker",
  "bindgen",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "rama-net-apple-xpc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "bindgen",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "rama-socks5"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "byteorder",
  "dial9-tokio-telemetry",
@@ -2585,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "rama-tcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "rama-tls"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "bytes",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "rama-tls-boring"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "brotli",
  "dial9-tokio-telemetry",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "rama-tls-rustls"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "dial9-tokio-telemetry",
  "dial9-trace-format",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "rama-tower"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "http-body",
@@ -2679,7 +2679,7 @@ dependencies = [
 
 [[package]]
 name = "rama-ua"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ahash",
  "itertools 0.15.0",
@@ -2696,7 +2696,7 @@ dependencies = [
 
 [[package]]
 name = "rama-udp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rama-core",
  "rama-net",
@@ -2707,7 +2707,7 @@ dependencies = [
 
 [[package]]
 name = "rama-unix"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
  "pin-project-lite",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "rama-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "const_format",
  "memchr",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "rama-ws"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "flate2",
  "rama-core",

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -50,13 +50,14 @@ fn init(config: Option<&apple_ne::ffi::tproxy::TransparentProxyInitConfig>) -> b
     init_status
 }
 
-/// Domains spliced *up-front* (born-spliced: claim + direct Swift splice, no
-/// Rust hop), keyed on the OS-provided destination hostname (`remote_hostname`,
-/// available before any TLS peek). Distinct from `exclude_domains`, which
-/// promote *after* the peek. A few common, easy-to-drive names here let a soak
-/// run exercise the born-spliced TCP path on demand — just
-/// `curl https://example.com/` in a loop.
-const BORN_SPLICE_DOMAINS: &[&str] = &["example.com", "example.org", "example.net", "neverssl.com"];
+/// Domains passed through *up-front* (declined in `handleNewFlow` — the
+/// documented transparent-provider hand-off to the direct route), keyed on the
+/// OS-provided destination hostname (`remote_hostname`, available before any
+/// TLS peek). Distinct from `exclude_domains`, which promote *after* the peek.
+/// A few common, easy-to-drive names here let a soak run exercise the up-front
+/// decline path on demand — just `curl https://example.com/` in a loop.
+const UPFRONT_PASSTHROUGH_DOMAINS: &[&str] =
+    &["example.com", "example.org", "example.net", "neverssl.com"];
 
 /// `true` if `host` equals or is a subdomain of any suffix in `suffixes`.
 fn host_matches_suffix(host: &str, suffixes: &[&str]) -> bool {
@@ -66,17 +67,13 @@ fn host_matches_suffix(host: &str, suffixes: &[&str]) -> bool {
 }
 
 #[inline(always)]
-fn flow_action_for_flow(
-    meta: &TransparentProxyFlowMeta,
-    allow_born_splice: bool,
-) -> TransparentProxyFlowAction {
-    // Up-front born-splice by destination hostname (OS-provided, no TLS peek).
-    // TCP-ONLY: for TCP, `Passthrough` means claim + direct splice (born-spliced).
-    // For UDP, `Passthrough` is still a `return false` that Apple CLOSES, so the
-    // hostname trigger must NOT apply there — it would kill UDP/QUIC flows.
-    if allow_born_splice
-        && let Some(host) = meta.remote_hostname.as_deref()
-        && host_matches_suffix(host, BORN_SPLICE_DOMAINS)
+fn flow_action_for_flow(meta: &TransparentProxyFlowMeta) -> TransparentProxyFlowAction {
+    // Up-front passthrough by destination hostname (OS-provided, no TLS peek).
+    // `Passthrough` declines the flow (`handleNewFlow` returns false), which
+    // for `NETransparentProxyProvider` hands it to the direct route — same
+    // contract for TCP and UDP.
+    if let Some(host) = meta.remote_hostname.as_deref()
+        && host_matches_suffix(host, UPFRONT_PASSTHROUGH_DOMAINS)
     {
         return TransparentProxyFlowAction::Passthrough;
     }
@@ -273,7 +270,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
     > + Send
     + '_ {
         log_new_flow("tcp", &meta);
-        let action = flow_action_for_flow(&meta, true); // TCP can born-splice
+        let action = flow_action_for_flow(&meta);
         let concurrency_limiter = self.concurrency_limiter.clone();
         let tcp_mitm_service = self.tcp_mitm_service.clone();
         std::future::ready(match action {
@@ -322,9 +319,7 @@ impl TransparentProxyHandler for DemoTransparentProxyHandler {
         if meta.remote_endpoint.as_ref().map(|e| e.port) == Some(53) {
             return std::future::ready(FlowAction::Passthrough);
         }
-        // UDP cannot born-splice (no UDP splice path) — never trigger the
-        // hostname born-splice here, or UDP `Passthrough` would close the flow.
-        let action = flow_action_for_flow(&meta, false);
+        let action = flow_action_for_flow(&meta);
         let udp_service = self.udp_service.clone();
         std::future::ready(match action {
             TransparentProxyFlowAction::Intercept => FlowAction::Intercept {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -173,9 +173,10 @@ impl DemoTransparentProxyHandler {
             ])
             // Exclude non-loopback private/local ranges (RFC1918, link-local,
             // CGNAT) at the kernel level: they take the default route untouched
-            // and are never diverted to the provider. This is the *correct*
-            // way to passthrough whole ranges — declining a flow in the handler
-            // closes it instead. Loopback is intentionally left handled.
+            // and are never diverted to the provider. Prefer this zero-cost
+            // tier for whole destination ranges; per-flow decisions decline in
+            // the handler and use the transparent-provider passthrough contract.
+            // Loopback is intentionally left handled.
             .with_exclude_ip_scopes(IpScopes::LOCAL.difference(IpScopes::LOOPBACK));
 
         let concurrency_limiter =

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -226,6 +226,24 @@ pub struct TransparentProxyConfig {
     /// uses. See
     /// [`tproxy::TransparentProxyConfig::tcp_write_pump_max_pending_bytes`].
     pub tcp_write_pump_max_pending_bytes: usize,
+    /// See [`tproxy::TransparentProxyConfig::flow_pressure_soft_cap`].
+    pub flow_pressure_soft_cap: u32,
+    /// See [`tproxy::TransparentProxyConfig::flow_pressure_low_water`].
+    pub flow_pressure_low_water: u32,
+    /// See [`tproxy::TransparentProxyConfig::flow_pressure_idle_floor_ms`].
+    pub flow_pressure_idle_floor_ms: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_start_in_flight_hard_cap`].
+    pub tcp_start_in_flight_hard_cap: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_start_in_flight_soft_cap`].
+    pub tcp_start_in_flight_soft_cap: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_start_latency_breaker_p95_ms`].
+    pub tcp_start_latency_breaker_p95_ms: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_start_latency_breaker_close_p95_ms`].
+    pub tcp_start_latency_breaker_close_p95_ms: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_pressure_connect_timeout_ms`].
+    pub tcp_pressure_connect_timeout_ms: u32,
+    /// See [`tproxy::TransparentProxyConfig::tcp_breaker_connect_timeout_ms`].
+    pub tcp_breaker_connect_timeout_ms: u32,
 }
 
 #[repr(C)]
@@ -298,6 +316,15 @@ impl TransparentProxyConfig {
             rules,
             rules_len,
             tcp_write_pump_max_pending_bytes: config.tcp_write_pump_max_pending_bytes(),
+            flow_pressure_soft_cap: config.flow_pressure_soft_cap(),
+            flow_pressure_low_water: config.flow_pressure_low_water(),
+            flow_pressure_idle_floor_ms: config.flow_pressure_idle_floor_ms(),
+            tcp_start_in_flight_hard_cap: config.tcp_start_in_flight_hard_cap(),
+            tcp_start_in_flight_soft_cap: config.tcp_start_in_flight_soft_cap(),
+            tcp_start_latency_breaker_p95_ms: config.tcp_start_latency_breaker_p95_ms(),
+            tcp_start_latency_breaker_close_p95_ms: config.tcp_start_latency_breaker_close_p95_ms(),
+            tcp_pressure_connect_timeout_ms: config.tcp_pressure_connect_timeout_ms(),
+            tcp_breaker_connect_timeout_ms: config.tcp_breaker_connect_timeout_ms(),
         }
     }
 
@@ -792,6 +819,15 @@ mod tests {
     fn ffi_config_round_trip_freed_under_lsan() {
         let config = tproxy::TransparentProxyConfig::default()
             .with_tunnel_remote_address(rama_utils::str::arcstr::ArcStr::from("198.51.100.1:443"))
+            .with_flow_pressure_soft_cap(10)
+            .with_flow_pressure_low_water(9)
+            .with_flow_pressure_idle_floor_ms(8)
+            .with_tcp_start_in_flight_hard_cap(7)
+            .with_tcp_start_in_flight_soft_cap(6)
+            .with_tcp_start_latency_breaker_p95_ms(5)
+            .with_tcp_start_latency_breaker_close_p95_ms(4)
+            .with_tcp_pressure_connect_timeout_ms(3)
+            .with_tcp_breaker_connect_timeout_ms(2)
             .with_rules(vec![
                 TransparentProxyNetworkRule::any()
                     .with_remote_network(
@@ -885,11 +921,19 @@ mod tests {
         assert_eq!(offset_of!(FfiTransparentProxyNetworkRule, protocol), 44);
         assert_eq!(offset_of!(FfiTransparentProxyNetworkRule, exclude), 48);
 
-        assert_eq!(size_of::<TransparentProxyConfig>(), 40);
+        assert_eq!(size_of::<TransparentProxyConfig>(), 80);
         assert_eq!(offset_of!(TransparentProxyConfig, rules), 16);
         assert_eq!(
             offset_of!(TransparentProxyConfig, tcp_write_pump_max_pending_bytes),
             32
+        );
+        assert_eq!(
+            offset_of!(TransparentProxyConfig, flow_pressure_soft_cap),
+            40
+        );
+        assert_eq!(
+            offset_of!(TransparentProxyConfig, tcp_breaker_connect_timeout_ms),
+            72
         );
 
         assert_eq!(size_of::<FfiTransparentProxyInitConfig>(), 32);
@@ -923,6 +967,33 @@ mod tests {
         assert!(!slice[2].exclude, "rule 2: default = included");
         assert!(slice[3].exclude, "rule 3: `.with_exclude(true)` → excluded");
         // SAFETY: same alloc as above.
+        unsafe { ffi.free() };
+    }
+
+    #[test]
+    fn ffi_config_overload_fields_round_trip() {
+        let config = tproxy::TransparentProxyConfig::default()
+            .with_flow_pressure_soft_cap(11)
+            .with_flow_pressure_low_water(12)
+            .with_flow_pressure_idle_floor_ms(13)
+            .with_tcp_start_in_flight_hard_cap(14)
+            .with_tcp_start_in_flight_soft_cap(15)
+            .with_tcp_start_latency_breaker_p95_ms(16)
+            .with_tcp_start_latency_breaker_close_p95_ms(17)
+            .with_tcp_pressure_connect_timeout_ms(18)
+            .with_tcp_breaker_connect_timeout_ms(19);
+
+        let ffi = TransparentProxyConfig::from_rust_type(&config);
+        assert_eq!(ffi.flow_pressure_soft_cap, 11);
+        assert_eq!(ffi.flow_pressure_low_water, 12);
+        assert_eq!(ffi.flow_pressure_idle_floor_ms, 13);
+        assert_eq!(ffi.tcp_start_in_flight_hard_cap, 14);
+        assert_eq!(ffi.tcp_start_in_flight_soft_cap, 15);
+        assert_eq!(ffi.tcp_start_latency_breaker_p95_ms, 16);
+        assert_eq!(ffi.tcp_start_latency_breaker_close_p95_ms, 17);
+        assert_eq!(ffi.tcp_pressure_connect_timeout_ms, 18);
+        assert_eq!(ffi.tcp_breaker_connect_timeout_ms, 19);
+        // SAFETY: `ffi` was just created by `from_rust_type` and not freed yet.
         unsafe { ffi.free() };
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -79,30 +79,21 @@
 //!
 //! ## Declining a flow (`return false`) IS the per-flow passthrough mechanism
 //!
-//! For **`NETransparentProxyProvider`** — which is what this crate's provider
-//! subclasses — Apple documents the decline explicitly as a hand-off, not a
-//! close: "Returning `NO` from `handleNewFlow(_:)` and
+//! For `NETransparentProxyProvider` — which is what this crate's provider
+//! subclasses — Apple documents the decline as a hand-off, not a close:
+//! "Returning `NO` from `handleNewFlow(_:)` and
 //! `handleNewUDPFlow(_:initialRemoteEndpoint:)` causes the flow to proceed to
 //! communicate directly with the flow's ultimate destination, instead of
-//! closing the flow with a 'Connection Refused' error." The oft-quoted "the
-//! flow should be closed" text belongs to `NEAppProxyProvider`, the **base
-//! class** (per-app proxies with app rules), whose semantics the transparent
-//! subclass deliberately overrides; DTS reports of declined flows killing the
-//! originating process concern that base-class behavior. Fleet-scale
-//! production of this crate (all UDP passthrough since inception, and all TCP
-//! passthrough until 2026-06) confirms the transparent-provider hand-off on
-//! the supported macOS range.
+//! closing the flow with a 'Connection Refused' error." The often-quoted "the
+//! flow should be closed" text belongs to `NEAppProxyProvider`, the base
+//! class, whose semantics the transparent subclass overrides.
 //!
-//! History: between 2026-06-24 and 2026-07-07 this crate instead *claimed*
-//! up-front-passthrough TCP flows and spliced them in-provider
-//! ("born-splice"), on the belief that declining closes them. That gave every
-//! passthrough flow an in-provider egress `NWConnection`; each
-//! `nw_connection_start` pays an NECP path-update walk over every registered
-//! endpoint handler in the process (O(N), serialized on one workloop), so
-//! under a SASE re-originator (Zscaler Client Connector re-emits ~all machine
-//! traffic from one process, matched passthrough by policy) the provider
-//! collapsed at 100% CPU and took the host's connectivity with it. Do **not**
-//! reintroduce claim-and-splice as a passthrough mechanism.
+//! Do not claim-and-splice passthrough flows instead: every claimed flow
+//! costs an in-provider egress `NWConnection`, and NECP makes each
+//! connection start pay a path-update walk over all registered handlers in
+//! the process, serialized on one workloop. A process that re-originates
+//! all machine traffic (SASE clients) then drives the provider to a
+//! CPU-bound collapse.
 //!
 //! The two passthrough tiers, by decision shape:
 //!

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -77,29 +77,42 @@
 //! SystemConfiguration proxy table only — other NE providers and VPN
 //! tunnels in the stack are unaffected.
 //!
-//! ## Declining a flow closes it — passthrough needs rule-exclusion or splicing
+//! ## Declining a flow (`return false`) IS the per-flow passthrough mechanism
 //!
-//! Returning `false` from `handleNewFlow` / `handleNewUDPFlow` is **not** a
-//! clean hand-off to the default route. Apple documents it as "the flow should
-//! be closed" and DTS confirms it "can cause the flow's originating process to
-//! fail" — by the time the provider is asked, the flow is already diverted, and
-//! declining tears it down rather than re-injecting it. Whether the originating
-//! app survives is *not* deterministic: it depends on whether the system can
-//! re-home the flow on another path at that instant (e.g. a healthy VPN tunnel
-//! vs one mid-reassert after sleep/wake), which is why this bites intermittently
-//! on the same host/OS rather than always. Refs: the `handleNewFlow` docs +
-//! Apple DTS forum threads linked under *Tech Notes* above.
+//! For **`NETransparentProxyProvider`** — which is what this crate's provider
+//! subclasses — Apple documents the decline explicitly as a hand-off, not a
+//! close: "Returning `NO` from `handleNewFlow(_:)` and
+//! `handleNewUDPFlow(_:initialRemoteEndpoint:)` causes the flow to proceed to
+//! communicate directly with the flow's ultimate destination, instead of
+//! closing the flow with a 'Connection Refused' error." The oft-quoted "the
+//! flow should be closed" text belongs to `NEAppProxyProvider`, the **base
+//! class** (per-app proxies with app rules), whose semantics the transparent
+//! subclass deliberately overrides; DTS reports of declined flows killing the
+//! originating process concern that base-class behavior. Fleet-scale
+//! production of this crate (all UDP passthrough since inception, and all TCP
+//! passthrough until 2026-06) confirms the transparent-provider hand-off on
+//! the supported macOS range.
 //!
-//! There are therefore only two reliable ways to leave a flow untouched:
+//! History: between 2026-06-24 and 2026-07-07 this crate instead *claimed*
+//! up-front-passthrough TCP flows and spliced them in-provider
+//! ("born-splice"), on the belief that declining closes them. That gave every
+//! passthrough flow an in-provider egress `NWConnection`; each
+//! `nw_connection_start` pays an NECP path-update walk over every registered
+//! endpoint handler in the process (O(N), serialized on one workloop), so
+//! under a SASE re-originator (Zscaler Client Connector re-emits ~all machine
+//! traffic from one process, matched passthrough by policy) the provider
+//! collapsed at 100% CPU and took the host's connectivity with it. Do **not**
+//! reintroduce claim-and-splice as a passthrough mechanism.
+//!
+//! The two passthrough tiers, by decision shape:
 //!
 //! - **`excludedNetworkRules`** — the flow is never diverted to the provider,
 //!   so it takes the default path with zero involvement. Correct for static,
 //!   remote-endpoint/CIDR-shaped exclusions (private ranges, known VPN infra).
-//! - **claim it and splice** — return `true`, open the flow, and forward bytes
-//!   verbatim to a direct egress connection (no MITM). The only option when the
-//!   decision is per-flow / per-app and can't be expressed as a static rule.
-//!
-//! Do **not** rely on returning `false` as a passthrough mechanism.
+//! - **decline in the handler (`return false`)** — per-flow / per-app
+//!   decisions that can't be expressed as a static rule. The flow proceeds
+//!   directly per the transparent-provider contract above, at zero further
+//!   cost to the provider.
 //!
 //! [`HostWithPort`]: rama_net::address::HostWithPort
 //! [`NwEgressParameters::preserve_original_meta_data`]: types::NwEgressParameters::preserve_original_meta_data

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -131,10 +131,14 @@ pub use self::{
         log_engine_build_error,
     },
     types::{
-        NwAttribution, NwEgressParameters, NwInterfaceType, NwMultipathServiceType, NwServiceClass,
-        NwTcpConnectOptions, TransparentProxyConfig, TransparentProxyFlowAction,
-        TransparentProxyFlowMeta, TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
-        TransparentProxyRuleProtocol,
+        DEFAULT_FLOW_PRESSURE_IDLE_FLOOR_MS, DEFAULT_FLOW_PRESSURE_LOW_WATER,
+        DEFAULT_FLOW_PRESSURE_SOFT_CAP, DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS,
+        DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS, DEFAULT_TCP_START_IN_FLIGHT_HARD_CAP,
+        DEFAULT_TCP_START_IN_FLIGHT_SOFT_CAP, DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS,
+        DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS, NwAttribution, NwEgressParameters,
+        NwInterfaceType, NwMultipathServiceType, NwServiceClass, NwTcpConnectOptions,
+        TransparentProxyConfig, TransparentProxyFlowAction, TransparentProxyFlowMeta,
+        TransparentProxyFlowProtocol, TransparentProxyNetworkRule, TransparentProxyRuleProtocol,
     },
 };
 pub use crate::process::AuditToken;

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -23,6 +23,26 @@ const MIN_TCP_WRITE_PUMP_MAX_PENDING_BYTES: usize = 1;
 /// 16 MiB per flow while still leaving room for bursty protocols.
 const MAX_TCP_WRITE_PUMP_MAX_PENDING_BYTES: usize = kib(8192);
 
+/// Default combined TCP+UDP live-flow soft cap that triggers the Swift-side
+/// idle TCP pressure reaper.
+pub const DEFAULT_FLOW_PRESSURE_SOFT_CAP: u32 = 450;
+/// Default target live-flow count after a pressure reap.
+pub const DEFAULT_FLOW_PRESSURE_LOW_WATER: u32 = 350;
+/// Default minimum idle age before a TCP flow is eligible for pressure reaping.
+pub const DEFAULT_FLOW_PRESSURE_IDLE_FLOOR_MS: u32 = 120_000;
+/// Default hard cap on pre-ready TCP egress `NWConnection.start` calls.
+pub const DEFAULT_TCP_START_IN_FLIGHT_HARD_CAP: u32 = 128;
+/// Default soft cap used with the TCP start-latency breaker.
+pub const DEFAULT_TCP_START_IN_FLIGHT_SOFT_CAP: u32 = 64;
+/// Default p95 start-to-ready latency that opens the TCP start breaker.
+pub const DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS: u32 = 1_500;
+/// Default p95 start-to-ready latency that closes the TCP start breaker.
+pub const DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS: u32 = 500;
+/// Default connect-timeout clamp under pre-ready TCP start pressure.
+pub const DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS: u32 = 5_000;
+/// Default connect-timeout clamp while the TCP start breaker is open.
+pub const DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS: u32 = 3_000;
+
 /// Monotonic per-process counter used to generate [`TransparentProxyFlowMeta`]
 /// `flow_id` values. Starts at 1; 0 is reserved as "unset / unknown."
 ///
@@ -587,6 +607,27 @@ pub struct TransparentProxyConfig {
     /// "0 means unset" path. The value the engine emits is the value the
     /// pump uses.
     tcp_write_pump_max_pending_bytes: usize,
+    /// Combined TCP+UDP live-flow soft cap that triggers Swift's idle TCP
+    /// pressure reaper. `0` disables this established-flow pressure reaper.
+    flow_pressure_soft_cap: u32,
+    /// Target combined live-flow count after a pressure reap.
+    flow_pressure_low_water: u32,
+    /// Minimum idle age before a TCP flow is eligible for pressure reaping.
+    flow_pressure_idle_floor_ms: u32,
+    /// Hard cap on pre-ready TCP egress `NWConnection.start` calls. `0`
+    /// disables hard start admission refusal.
+    tcp_start_in_flight_hard_cap: u32,
+    /// Soft cap used with the latency breaker. `0` disables latency-breaker
+    /// admission refusal.
+    tcp_start_in_flight_soft_cap: u32,
+    /// p95 start-to-ready latency threshold that opens the breaker.
+    tcp_start_latency_breaker_p95_ms: u32,
+    /// p95 start-to-ready latency threshold that closes the breaker.
+    tcp_start_latency_breaker_close_p95_ms: u32,
+    /// Connect-timeout clamp once pre-ready start pressure reaches the soft cap.
+    tcp_pressure_connect_timeout_ms: u32,
+    /// Connect-timeout clamp while the start-latency breaker is open.
+    tcp_breaker_connect_timeout_ms: u32,
 }
 
 impl TransparentProxyConfig {
@@ -601,6 +642,15 @@ impl TransparentProxyConfig {
             // isn't dead code and the documented per-flow cap is what's
             // actually applied at runtime.
             tcp_write_pump_max_pending_bytes: kib(256),
+            flow_pressure_soft_cap: DEFAULT_FLOW_PRESSURE_SOFT_CAP,
+            flow_pressure_low_water: DEFAULT_FLOW_PRESSURE_LOW_WATER,
+            flow_pressure_idle_floor_ms: DEFAULT_FLOW_PRESSURE_IDLE_FLOOR_MS,
+            tcp_start_in_flight_hard_cap: DEFAULT_TCP_START_IN_FLIGHT_HARD_CAP,
+            tcp_start_in_flight_soft_cap: DEFAULT_TCP_START_IN_FLIGHT_SOFT_CAP,
+            tcp_start_latency_breaker_p95_ms: DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS,
+            tcp_start_latency_breaker_close_p95_ms: DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS,
+            tcp_pressure_connect_timeout_ms: DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS,
+            tcp_breaker_connect_timeout_ms: DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS,
         }
     }
 
@@ -627,6 +677,63 @@ impl TransparentProxyConfig {
     #[must_use]
     pub fn tcp_write_pump_max_pending_bytes(&self) -> usize {
         self.tcp_write_pump_max_pending_bytes
+    }
+
+    /// Combined TCP+UDP live-flow soft cap that triggers Swift's idle TCP
+    /// pressure reaper. `0` disables this established-flow pressure reaper.
+    #[must_use]
+    pub fn flow_pressure_soft_cap(&self) -> u32 {
+        self.flow_pressure_soft_cap
+    }
+
+    /// Target combined live-flow count after a pressure reap.
+    #[must_use]
+    pub fn flow_pressure_low_water(&self) -> u32 {
+        self.flow_pressure_low_water
+    }
+
+    /// Minimum idle age before a TCP flow is eligible for pressure reaping.
+    #[must_use]
+    pub fn flow_pressure_idle_floor_ms(&self) -> u32 {
+        self.flow_pressure_idle_floor_ms
+    }
+
+    /// Hard cap on pre-ready TCP egress `NWConnection.start` calls. `0`
+    /// disables hard start admission refusal.
+    #[must_use]
+    pub fn tcp_start_in_flight_hard_cap(&self) -> u32 {
+        self.tcp_start_in_flight_hard_cap
+    }
+
+    /// Soft cap used with the latency breaker. `0` disables latency-breaker
+    /// admission refusal.
+    #[must_use]
+    pub fn tcp_start_in_flight_soft_cap(&self) -> u32 {
+        self.tcp_start_in_flight_soft_cap
+    }
+
+    /// p95 start-to-ready latency threshold that opens the breaker.
+    #[must_use]
+    pub fn tcp_start_latency_breaker_p95_ms(&self) -> u32 {
+        self.tcp_start_latency_breaker_p95_ms
+    }
+
+    /// p95 start-to-ready latency threshold that closes the breaker.
+    #[must_use]
+    pub fn tcp_start_latency_breaker_close_p95_ms(&self) -> u32 {
+        self.tcp_start_latency_breaker_close_p95_ms
+    }
+
+    /// Connect-timeout clamp once pre-ready start pressure reaches the soft cap.
+    #[must_use]
+    pub fn tcp_pressure_connect_timeout_ms(&self) -> u32 {
+        self.tcp_pressure_connect_timeout_ms
+    }
+
+    /// Connect-timeout clamp while the start-latency breaker is open.
+    #[must_use]
+    pub fn tcp_breaker_connect_timeout_ms(&self) -> u32 {
+        self.tcp_breaker_connect_timeout_ms
     }
 
     generate_set_and_with! {
@@ -669,6 +776,83 @@ impl TransparentProxyConfig {
                 MIN_TCP_WRITE_PUMP_MAX_PENDING_BYTES,
                 MAX_TCP_WRITE_PUMP_MAX_PENDING_BYTES,
             );
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the combined TCP+UDP live-flow soft cap that triggers Swift's
+        /// idle TCP pressure reaper. `0` disables this established-flow reaper.
+        pub fn flow_pressure_soft_cap(mut self, value: u32) -> Self {
+            self.flow_pressure_soft_cap = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the target combined live-flow count after a pressure reap.
+        pub fn flow_pressure_low_water(mut self, value: u32) -> Self {
+            self.flow_pressure_low_water = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the minimum idle age before a TCP flow is eligible for pressure
+        /// reaping, in milliseconds.
+        pub fn flow_pressure_idle_floor_ms(mut self, value: u32) -> Self {
+            self.flow_pressure_idle_floor_ms = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the hard cap on pre-ready TCP egress `NWConnection.start` calls.
+        /// `0` disables hard start admission refusal.
+        pub fn tcp_start_in_flight_hard_cap(mut self, value: u32) -> Self {
+            self.tcp_start_in_flight_hard_cap = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the soft cap used with the TCP start-latency breaker. `0`
+        /// disables latency-breaker admission refusal.
+        pub fn tcp_start_in_flight_soft_cap(mut self, value: u32) -> Self {
+            self.tcp_start_in_flight_soft_cap = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the p95 start-to-ready latency threshold that opens the breaker.
+        pub fn tcp_start_latency_breaker_p95_ms(mut self, value: u32) -> Self {
+            self.tcp_start_latency_breaker_p95_ms = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the p95 start-to-ready latency threshold that closes the breaker.
+        pub fn tcp_start_latency_breaker_close_p95_ms(mut self, value: u32) -> Self {
+            self.tcp_start_latency_breaker_close_p95_ms = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the connect-timeout clamp used once pre-ready start pressure
+        /// reaches the soft cap.
+        pub fn tcp_pressure_connect_timeout_ms(mut self, value: u32) -> Self {
+            self.tcp_pressure_connect_timeout_ms = value;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Set the connect-timeout clamp while the start-latency breaker is open.
+        pub fn tcp_breaker_connect_timeout_ms(mut self, value: u32) -> Self {
+            self.tcp_breaker_connect_timeout_ms = value;
             self
         }
     }
@@ -723,6 +907,68 @@ mod transparent_proxy_config_tests {
             MAX_TCP_WRITE_PUMP_MAX_PENDING_BYTES,
             "unbounded per-flow buffering must not cross the FFI boundary"
         );
+    }
+
+    #[test]
+    fn overload_defaults_match_swift_fallbacks() {
+        let cfg = TransparentProxyConfig::new();
+        assert_eq!(cfg.flow_pressure_soft_cap(), DEFAULT_FLOW_PRESSURE_SOFT_CAP);
+        assert_eq!(
+            cfg.flow_pressure_low_water(),
+            DEFAULT_FLOW_PRESSURE_LOW_WATER
+        );
+        assert_eq!(
+            cfg.flow_pressure_idle_floor_ms(),
+            DEFAULT_FLOW_PRESSURE_IDLE_FLOOR_MS
+        );
+        assert_eq!(
+            cfg.tcp_start_in_flight_hard_cap(),
+            DEFAULT_TCP_START_IN_FLIGHT_HARD_CAP
+        );
+        assert_eq!(
+            cfg.tcp_start_in_flight_soft_cap(),
+            DEFAULT_TCP_START_IN_FLIGHT_SOFT_CAP
+        );
+        assert_eq!(
+            cfg.tcp_start_latency_breaker_p95_ms(),
+            DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS
+        );
+        assert_eq!(
+            cfg.tcp_start_latency_breaker_close_p95_ms(),
+            DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS
+        );
+        assert_eq!(
+            cfg.tcp_pressure_connect_timeout_ms(),
+            DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS
+        );
+        assert_eq!(
+            cfg.tcp_breaker_connect_timeout_ms(),
+            DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS
+        );
+    }
+
+    #[test]
+    fn overload_knobs_round_trip() {
+        let cfg = TransparentProxyConfig::new()
+            .with_flow_pressure_soft_cap(1)
+            .with_flow_pressure_low_water(2)
+            .with_flow_pressure_idle_floor_ms(3)
+            .with_tcp_start_in_flight_hard_cap(4)
+            .with_tcp_start_in_flight_soft_cap(5)
+            .with_tcp_start_latency_breaker_p95_ms(6)
+            .with_tcp_start_latency_breaker_close_p95_ms(7)
+            .with_tcp_pressure_connect_timeout_ms(8)
+            .with_tcp_breaker_connect_timeout_ms(9);
+
+        assert_eq!(cfg.flow_pressure_soft_cap(), 1);
+        assert_eq!(cfg.flow_pressure_low_water(), 2);
+        assert_eq!(cfg.flow_pressure_idle_floor_ms(), 3);
+        assert_eq!(cfg.tcp_start_in_flight_hard_cap(), 4);
+        assert_eq!(cfg.tcp_start_in_flight_soft_cap(), 5);
+        assert_eq!(cfg.tcp_start_latency_breaker_p95_ms(), 6);
+        assert_eq!(cfg.tcp_start_latency_breaker_close_p95_ms(), 7);
+        assert_eq!(cfg.tcp_pressure_connect_timeout_ms(), 8);
+        assert_eq!(cfg.tcp_breaker_connect_timeout_ms(), 9);
     }
 
     /// Pin the default for the `exclude` flag — flipping the

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -547,9 +547,14 @@ impl TransparentProxyNetworkRule {
     /// One excluded rule per CIDR in the given [`IpScopes`] mask.
     ///
     /// Excluded rules are bypassed by the kernel and never reach the provider,
-    /// so the matching ranges take the default network path untouched. This is
-    /// the correct way to passthrough whole ranges: declining a flow in the
-    /// handler instead *closes* it (see the crate-level `tproxy` docs).
+    /// so the matching ranges take the default network path with zero per-flow
+    /// cost. Prefer this tier for static, destination-shaped exclusions;
+    /// per-flow / per-app decisions decline in the handler instead (a
+    /// documented direct hand-off for transparent providers — see the
+    /// crate-level `tproxy` docs). Note these rules match the flow's REMOTE
+    /// endpoint only: traffic *from* a tunnel-local source (e.g. a SASE client
+    /// re-originating on its utun) to a public destination is not excludable
+    /// here.
     #[must_use]
     pub fn excluded_for_ip_scopes(scopes: IpScopes) -> Vec<Self> {
         scope_cidrs(scopes)


### PR DESCRIPTION
Restores transparent-provider passthrough decline semantics and fixes Apple NE close-path retention.
Adds TCP overload admission controls, persisted overload telemetry, and configurable hardening knobs.