### PR TITLE
Harden Apple FFI stack (NE/XPC/SE) + fix dist spec & docs

### DIFF
--- a/docs/book/src/xpc.md
+++ b/docs/book/src/xpc.md
@@ -165,9 +165,9 @@ with `NSXPCConnection` services out of the box.
 
 **This crate does not yet expose the full Apple XPC surface.** It currently focuses on
 the raw-XPC pieces needed for structured message passing, endpoint handoff, request-reply,
-peer verification, and a first Rama-native server adapter. It does not yet provide:
+peer verification, typed serde codecs (`xpc_serde`), a selector-based
+`XpcMessageRouter`, and a Rama-native server adapter. It does not yet provide:
 
-- typed request/response codecs or higher-level XPC routing helpers on top of `XpcServer<S>`
 - launchd/plist-driven end-to-end examples in this book
 - compatibility with Foundation `NSXPCConnection`
 - wrappers for every newer Apple XPC API family beyond the current raw connection/endpoint model
@@ -226,5 +226,8 @@ Source: [`examples/xpc_ca_exchange.rs`](https://github.com/plabayo/rama/blob/mai
 
 For a practical Apple FFI usage of that pattern, see the transparent proxy demo at
 [`ffi/apple/examples/transparent_proxy`](https://github.com/plabayo/rama/tree/main/ffi/apple/examples/transparent_proxy),
-where the Network Extension receives the CA certificate in startup config but requests the
-private key from the host app over local XPC during startup.
+where the direction is the reverse of a naive "extension asks host for keys" design: the
+Network Extension **hosts** the XPC server and owns the MITM CA (generated and stored in the
+System Keychain), while the container app is the **client** — it drives settings updates and
+requests the CA certificate over XPC to install/rotate admin trust. The private key never
+leaves the extension.

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -358,6 +358,10 @@ typedef void (*RamaTcpClientReadDemandFn)(void* context);
 ///   * Callbacks may be invoked from any thread (Rust async runtime worker
 ///     threads). The Swift side is responsible for any synchronization the
 ///     pointee requires.
+///   * A callback body MUST NOT synchronously call back into this session
+///     (`_cancel`, `_free`, `_on_client_close`, `_signal_*_drain`, …): the
+///     engine holds a non-reentrant lock across the dispatch, so re-entry
+///     deadlocks. Dispatch such work to another queue and return.
 ///   * `bytes` passed to `on_server_bytes` is borrowed for the duration of the
 ///     call; the receiver MUST copy any data it needs to retain.
 typedef struct {
@@ -368,11 +372,11 @@ typedef struct {
     /// Called when Rust closes server-side TCP direction.
     RamaTcpServerClosedFn on_server_closed;
     /// Called when the Rust ingress channel has space again after
-    /// `rama_transparent_proxy_tcp_session_on_client_bytes` returned `false`.
-    /// Swift MUST keep `flow.readData` paused between the `false` return and
-    /// this callback firing — otherwise bytes pile up in Apple's per-flow NE
-    /// kernel buffer and eventually abort the shared NEAppProxyProvider
-    /// director.
+    /// `rama_transparent_proxy_tcp_session_on_client_bytes` returned
+    /// `RAMA_TCP_DELIVER_PAUSED`. Swift MUST keep `flow.readData` paused between
+    /// that return and this callback firing — otherwise bytes pile up in Apple's
+    /// per-flow NE kernel buffer and eventually abort the shared
+    /// NEAppProxyProvider director.
     RamaTcpClientReadDemandFn on_client_read_demand;
 } RamaTransparentProxyTcpSessionCallbacks;
 
@@ -389,10 +393,9 @@ typedef struct {
 /// `scope_id` carries the IPv6 zone identifier (interface index, as
 /// returned by `if_nametoindex(3)`) for link-local addresses like
 /// `fe80::1%en0`. `0` means "no scope". The textual `host_utf8` MUST
-/// NOT carry the `%zone` suffix — Swift converts the kernel-supplied
-/// `"fe80::1%en0"` to the numeric index on the way in, and Rust
-/// converts the numeric index back to an interface name on the way
-/// out. Scoping is meaningless for IPv4 and must be `0` there.
+/// NOT carry the `%zone` suffix — Swift converts between the zoned
+/// `"fe80::1%en0"` form and the numeric index in both directions.
+/// Scoping is meaningless for IPv4 and must be `0` there.
 ///
 /// Borrowed for the duration of the call; the Swift side may stage
 /// the host bytes on the stack of the closure that issues the C call,
@@ -522,6 +525,21 @@ typedef struct {
     uint32_t tcp_keepalive_count;
 } RamaTcpEgressConnectOptions;
 
+// ABI pins for the by-value structs above (mirror the Rust `offset_of!` tests).
+_Static_assert(sizeof(RamaUdpPeerView) == 32, "RamaUdpPeerView ABI drift");
+_Static_assert(offsetof(RamaUdpPeerView, host_utf8) == 8, "RamaUdpPeerView.host_utf8 offset drift");
+_Static_assert(offsetof(RamaUdpPeerView, host_utf8_len) == 16, "RamaUdpPeerView.host_utf8_len offset drift");
+_Static_assert(offsetof(RamaUdpPeerView, port) == 24, "RamaUdpPeerView.port offset drift");
+_Static_assert(offsetof(RamaUdpPeerView, scope_id) == 28, "RamaUdpPeerView.scope_id offset drift");
+_Static_assert(sizeof(RamaNwEgressParameters) == 11, "RamaNwEgressParameters ABI drift");
+_Static_assert(offsetof(RamaNwEgressParameters, prohibited_interface_types_mask) == 8, "RamaNwEgressParameters mask offset drift");
+_Static_assert(sizeof(RamaTcpEgressConnectOptions) == 56, "RamaTcpEgressConnectOptions ABI drift");
+_Static_assert(offsetof(RamaTcpEgressConnectOptions, has_connect_timeout_ms) == 11, "RamaTcpEgressConnectOptions.has_connect_timeout_ms offset drift");
+_Static_assert(offsetof(RamaTcpEgressConnectOptions, connect_timeout_ms) == 12, "RamaTcpEgressConnectOptions.connect_timeout_ms offset drift");
+_Static_assert(offsetof(RamaTcpEgressConnectOptions, linger_close_ms) == 20, "RamaTcpEgressConnectOptions.linger_close_ms offset drift");
+_Static_assert(offsetof(RamaTcpEgressConnectOptions, egress_eof_grace_ms) == 28, "RamaTcpEgressConnectOptions.egress_eof_grace_ms offset drift");
+_Static_assert(offsetof(RamaTcpEgressConnectOptions, tcp_keepalive_count) == 52, "RamaTcpEgressConnectOptions.tcp_keepalive_count offset drift");
+
 /// Returns a `RamaTcpDeliverStatus` so the Rust bridge can pause when Swift's
 /// `NwTcpConnectionWritePump` is full. Swift MUST call
 /// `rama_transparent_proxy_tcp_session_signal_egress_drain` after its writer
@@ -549,9 +567,9 @@ typedef struct {
     RamaTcpEgressWriteFn on_write_to_egress;
     RamaTcpEgressCloseFn on_close_egress;
     /// Called when the Rust egress channel has space again after
-    /// `rama_transparent_proxy_tcp_session_on_egress_bytes` returned `false`.
-    /// Swift MUST keep `connection.receive(...)` paused between the `false`
-    /// return and this callback firing.
+    /// `rama_transparent_proxy_tcp_session_on_egress_bytes` returned
+    /// `RAMA_TCP_DELIVER_PAUSED`. Swift MUST keep `connection.receive(...)`
+    /// paused between that return and this callback firing.
     RamaTcpEgressReadDemandFn on_egress_read_demand;
 } RamaTransparentProxyTcpEgressCallbacks;
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -277,6 +277,10 @@ typedef struct {
     uint32_t tcp_pressure_connect_timeout_ms;
     /// Connect-timeout clamp while the start-latency breaker is open.
     uint32_t tcp_breaker_connect_timeout_ms;
+    /// How the provider treats a flow it declines for its own reasons (start
+    /// hard cap / latency breaker, or a missing session): `0` = Block (default,
+    /// fail closed), `1` = Passthrough (fail open). Always logged either way.
+    uint32_t flow_refusal_action;
 } RamaTransparentProxyConfig;
 
 /// Initialization config passed once before using engine APIs.
@@ -314,6 +318,7 @@ _Static_assert(offsetof(RamaTransparentProxyNetworkRule, protocol) == 44, "RamaT
 _Static_assert(sizeof(RamaTransparentProxyConfig) == 80, "RamaTransparentProxyConfig ABI drift");
 _Static_assert(offsetof(RamaTransparentProxyConfig, flow_pressure_soft_cap) == 40, "RamaTransparentProxyConfig.flow_pressure_soft_cap offset drift");
 _Static_assert(offsetof(RamaTransparentProxyConfig, tcp_breaker_connect_timeout_ms) == 72, "RamaTransparentProxyConfig.tcp_breaker_connect_timeout_ms offset drift");
+_Static_assert(offsetof(RamaTransparentProxyConfig, flow_refusal_action) == 76, "RamaTransparentProxyConfig.flow_refusal_action offset drift");
 _Static_assert(sizeof(RamaTransparentProxyInitConfig) == 32, "RamaTransparentProxyInitConfig ABI drift");
 #endif
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -8,6 +8,9 @@
 extern "C" {
 #endif
 
+// Pointers are non-null unless annotated `_Nullable`.
+#pragma clang assume_nonnull begin
+
 /* ============================================================================
  * Threading & concurrency contract (violating any of this is UB).
  *
@@ -43,7 +46,7 @@ typedef struct RamaTransparentProxyUdpSession RamaTransparentProxyUdpSession;
 /// Ownership is retained by the caller. `ptr` may be NULL only if `len == 0`.
 typedef struct {
     /// Borrowed pointer to bytes.
-    const uint8_t* ptr;
+    const uint8_t* _Nullable ptr;
     /// Number of bytes at `ptr`.
     size_t len;
 } RamaBytesView;
@@ -53,7 +56,7 @@ typedef struct {
 /// Must be released with `rama_owned_bytes_free`.
 typedef struct {
     /// Owned allocation pointer (or NULL when empty).
-    uint8_t* ptr;
+    uint8_t* _Nullable ptr;
     /// Number of initialized bytes.
     size_t len;
     /// Allocation capacity.
@@ -77,9 +80,9 @@ typedef struct {
     /// Number of bytes at `ptr`.
     size_t len;
     /// Opaque owner handle passed back to `release` verbatim.
-    void* owner;
+    void* _Nullable owner;
     /// Releases `owner`; invoked exactly once, from any thread.
-    void (*release)(void* owner);
+    void (* _Nullable release)(void* _Nullable owner);
 } RamaBytesOwnedView;
 
 /// Transport protocol for one intercepted flow.
@@ -102,12 +105,14 @@ typedef enum {
 
 typedef struct {
     RamaTransparentProxyFlowAction action;
-    RamaTransparentProxyTcpSession* session;
+    /// Non-NULL only when `action == RAMA_FLOW_ACTION_INTERCEPT`.
+    RamaTransparentProxyTcpSession* _Nullable session;
 } RamaTransparentProxyTcpSessionResult;
 
 typedef struct {
     RamaTransparentProxyFlowAction action;
-    RamaTransparentProxyUdpSession* session;
+    /// Non-NULL only when `action == RAMA_FLOW_ACTION_INTERCEPT`.
+    RamaTransparentProxyUdpSession* _Nullable session;
 } RamaTransparentProxyUdpSessionResult;
 
 /// Protocol filter used by network interception rules.
@@ -130,7 +135,7 @@ typedef enum {
 /// - https://developer.apple.com/documentation/networkextension/neappproxyudpflow
 typedef struct {
     /// UTF-8 hostname/IP bytes (not NUL-terminated). May be NULL.
-    const char* host_utf8;
+    const char* _Nullable host_utf8;
     /// Length of `host_utf8` bytes.
     size_t host_utf8_len;
     /// TCP/UDP port.
@@ -154,15 +159,15 @@ typedef struct {
     /// Local endpoint assigned to this flow (if known).
     RamaTransparentProxyFlowEndpoint local_endpoint;
     /// Source app signing identifier UTF-8 bytes (not NUL-terminated). May be NULL.
-    const char* source_app_signing_identifier_utf8;
+    const char* _Nullable source_app_signing_identifier_utf8;
     /// Length of `source_app_signing_identifier_utf8`.
     size_t source_app_signing_identifier_utf8_len;
     /// Source app bundle identifier UTF-8 bytes (not NUL-terminated). May be NULL.
-    const char* source_app_bundle_identifier_utf8;
+    const char* _Nullable source_app_bundle_identifier_utf8;
     /// Length of `source_app_bundle_identifier_utf8`.
     size_t source_app_bundle_identifier_utf8_len;
     /// Source app audit token bytes. May be NULL.
-    const uint8_t* source_app_audit_token_bytes;
+    const uint8_t* _Nullable source_app_audit_token_bytes;
     /// Length of `source_app_audit_token_bytes`.
     size_t source_app_audit_token_bytes_len;
     /// Source app PID resolved by Swift when available.
@@ -173,12 +178,12 @@ typedef struct {
     /// Remote hostname (DNS name, not resolved IP) the originating app
     /// connected to, when exposed by the OS. UTF-8 bytes (not NUL-terminated).
     /// May be NULL.
-    const char* remote_hostname_utf8;
+    const char* _Nullable remote_hostname_utf8;
     /// Length of `remote_hostname_utf8`.
     size_t remote_hostname_utf8_len;
     /// Name of the network interface this flow egresses on (e.g. `en0`,
     /// `utun4`). UTF-8 bytes (not NUL-terminated). May be NULL.
-    const char* local_interface_name_utf8;
+    const char* _Nullable local_interface_name_utf8;
     /// Length of `local_interface_name_utf8`.
     size_t local_interface_name_utf8_len;
     /// Egress interface index. Only valid when `local_interface_index_is_set`.
@@ -204,7 +209,7 @@ typedef struct {
 /// - https://developer.apple.com/documentation/networkextension/nenetworkrule
 typedef struct {
     /// Optional remote network address UTF-8 bytes (not NUL-terminated). May be NULL.
-    const char* remote_network_utf8;
+    const char* _Nullable remote_network_utf8;
     /// Length of `remote_network_utf8`.
     size_t remote_network_utf8_len;
     /// Prefix length for remote network (CIDR).
@@ -217,7 +222,7 @@ typedef struct {
     /// Whether `remote_port` is explicitly set.
     bool remote_port_is_set;
     /// Optional local network address UTF-8 bytes (not NUL-terminated). May be NULL.
-    const char* local_network_utf8;
+    const char* _Nullable local_network_utf8;
     /// Length of `local_network_utf8`.
     size_t local_network_utf8_len;
     /// Prefix length for local network (CIDR).
@@ -245,7 +250,7 @@ typedef struct {
     /// Length of `tunnel_remote_address_utf8`.
     size_t tunnel_remote_address_utf8_len;
     /// Pointer to `rules_len` rules (may be NULL when empty).
-    const RamaTransparentProxyNetworkRule* rules;
+    const RamaTransparentProxyNetworkRule* _Nullable rules;
     /// Number of rules at `rules`.
     size_t rules_len;
     /// Per-flow TCP write-pump back-pressure cap in bytes.
@@ -281,12 +286,12 @@ typedef struct {
 typedef struct {
     /// Writable storage directory for Rust-managed state (certs, cache, etc).
     /// May be NULL/0 to let Rust choose a fallback directory.
-    const char* storage_dir_utf8;
+    const char* _Nullable storage_dir_utf8;
     /// Length of `storage_dir_utf8`.
     size_t storage_dir_utf8_len;
     /// Optional shared app-group directory if available.
     /// May be NULL/0 when no app-group is configured.
-    const char* app_group_dir_utf8;
+    const char* _Nullable app_group_dir_utf8;
     /// Length of `app_group_dir_utf8`.
     size_t app_group_dir_utf8_len;
 } RamaTransparentProxyInitConfig;
@@ -341,9 +346,9 @@ _Static_assert(sizeof(RamaTcpDeliverStatus) == 1, "RamaTcpDeliverStatus ABI drif
 /// `rama_transparent_proxy_tcp_session_signal_server_drain` after its writer
 /// drains capacity following a `Paused` return — without that the bridge
 /// stays parked forever.
-typedef RamaTcpDeliverStatus (*RamaTcpServerBytesFn)(void* context, RamaBytesView bytes);
-typedef void (*RamaTcpServerClosedFn)(void* context);
-typedef void (*RamaTcpClientReadDemandFn)(void* context);
+typedef RamaTcpDeliverStatus (*RamaTcpServerBytesFn)(void* _Nullable context, RamaBytesView bytes);
+typedef void (*RamaTcpServerClosedFn)(void* _Nullable context);
+typedef void (*RamaTcpClientReadDemandFn)(void* _Nullable context);
 
 /// Callbacks Swift provides for Rust TCP session events.
 ///
@@ -402,15 +407,15 @@ typedef struct {
 /// and the Rust side does the same in reverse.
 typedef struct {
     bool present;
-    const uint8_t* host_utf8;
+    const uint8_t* _Nullable host_utf8;
     size_t host_utf8_len;
     uint16_t port;
     uint32_t scope_id;
 } RamaUdpPeerView;
 
-typedef void (*RamaUdpServerDatagramFn)(void* context, RamaBytesView bytes, RamaUdpPeerView peer);
-typedef void (*RamaUdpClientReadDemandFn)(void* context);
-typedef void (*RamaUdpServerClosedFn)(void* context);
+typedef void (*RamaUdpServerDatagramFn)(void* _Nullable context, RamaBytesView bytes, RamaUdpPeerView peer);
+typedef void (*RamaUdpClientReadDemandFn)(void* _Nullable context);
+typedef void (*RamaUdpServerClosedFn)(void* _Nullable context);
 
 /// Callbacks Swift provides for Rust UDP session events.
 ///
@@ -544,9 +549,9 @@ _Static_assert(offsetof(RamaTcpEgressConnectOptions, tcp_keepalive_count) == 52,
 /// `NwTcpConnectionWritePump` is full. Swift MUST call
 /// `rama_transparent_proxy_tcp_session_signal_egress_drain` after its writer
 /// drains capacity following a `Paused` return.
-typedef RamaTcpDeliverStatus (*RamaTcpEgressWriteFn)(void* context, RamaBytesView bytes);
-typedef void (*RamaTcpEgressCloseFn)(void* context);
-typedef void (*RamaTcpEgressReadDemandFn)(void* context);
+typedef RamaTcpDeliverStatus (*RamaTcpEgressWriteFn)(void* _Nullable context, RamaBytesView bytes);
+typedef void (*RamaTcpEgressCloseFn)(void* _Nullable context);
+typedef void (*RamaTcpEgressReadDemandFn)(void* _Nullable context);
 
 /// Callbacks passed to `rama_transparent_proxy_tcp_session_activate`.
 ///
@@ -591,7 +596,7 @@ typedef uint8_t RamaPromoteConfirmStatus;
 /// pending writers, atomically rewires the data path to bypass
 /// Rust, then ACKs by calling
 /// `rama_transparent_proxy_tcp_session_confirm_promoted`.
-typedef void (*RamaTcpPromoteRequestFn)(void* context);
+typedef void (*RamaTcpPromoteRequestFn)(void* _Nullable context);
 
 /// Callbacks passed to
 /// `rama_transparent_proxy_tcp_session_register_promote_callbacks`.
@@ -607,13 +612,14 @@ typedef struct {
     /// lifetime contract above. Do NOT use for sensitive
     /// information / secrets.
     void* context;
-    RamaTcpPromoteRequestFn on_promote_request;
+    /// May be NULL — then a promote request is a no-op (see the register fn).
+    RamaTcpPromoteRequestFn _Nullable on_promote_request;
 } RamaTransparentProxyTcpPromoteCallbacks;
 
 /// Resolve a macOS audit token to a PID.
 ///
 /// Returns `-1` when `bytes/len` do not contain one complete `audit_token_t`.
-int32_t rama_apple_audit_token_to_pid(const uint8_t* bytes, size_t len);
+int32_t rama_apple_audit_token_to_pid(const uint8_t* _Nullable bytes, size_t len);
 
 
 // Engine lifecycle
@@ -621,36 +627,36 @@ int32_t rama_apple_audit_token_to_pid(const uint8_t* bytes, size_t len);
 /// Initialize Rust-side transparent proxy subsystem (idempotent).
 ///
 /// `config` may be NULL. In that case Rust uses internal fallback paths.
-bool rama_transparent_proxy_initialize(const RamaTransparentProxyInitConfig* config);
+bool rama_transparent_proxy_initialize(const RamaTransparentProxyInitConfig* _Nullable config);
 
 /// Fetch transparent proxy configuration for NETransparentProxyProvider setup.
 ///
 /// Returns an owned pointer, or NULL on failure.
 /// Caller must release it with `rama_transparent_proxy_config_free`.
-RamaTransparentProxyConfig* rama_transparent_proxy_get_config(RamaTransparentProxyEngine* engine);
+RamaTransparentProxyConfig* _Nullable rama_transparent_proxy_get_config(RamaTransparentProxyEngine* engine);
 
 /// Free a config previously returned by `rama_transparent_proxy_get_config`.
 ///
 /// NULL is allowed and ignored.
 void rama_transparent_proxy_config_free(
-    RamaTransparentProxyConfig* config
+    RamaTransparentProxyConfig* _Nullable config
 );
 
 /// Allocate a new transparent proxy engine.
 ///
 /// Returns NULL on failure.
-RamaTransparentProxyEngine* rama_transparent_proxy_engine_new(void);
+RamaTransparentProxyEngine* _Nullable rama_transparent_proxy_engine_new(void);
 
 /// Allocate a new transparent proxy engine with an optional opaque config blob.
 ///
 /// `engine_config` is borrowed for the duration of the call only.
 /// Returns NULL on failure.
-RamaTransparentProxyEngine* rama_transparent_proxy_engine_new_with_config(RamaBytesView engine_config);
+RamaTransparentProxyEngine* _Nullable rama_transparent_proxy_engine_new_with_config(RamaBytesView engine_config);
 
 /// Free an engine previously returned by `rama_transparent_proxy_engine_new`.
 ///
 /// NULL is allowed and ignored.
-void rama_transparent_proxy_engine_free(RamaTransparentProxyEngine* engine);
+void rama_transparent_proxy_engine_free(RamaTransparentProxyEngine* _Nullable engine);
 
 /// Stop the transparent proxy engine with provider stop reason.
 ///
@@ -659,7 +665,7 @@ void rama_transparent_proxy_engine_free(RamaTransparentProxyEngine* engine);
 /// NULL is allowed and ignored.
 /// Apple reference:
 /// - https://developer.apple.com/documentation/networkextension/neproviderstopreason
-void rama_transparent_proxy_engine_stop(RamaTransparentProxyEngine* engine, int32_t reason);
+void rama_transparent_proxy_engine_stop(RamaTransparentProxyEngine* _Nullable engine, int32_t reason);
 
 /// Forward an app-to-provider message into the transparent proxy handler.
 ///
@@ -674,13 +680,13 @@ RamaBytesOwned rama_transparent_proxy_engine_handle_app_message(
 /// Fire-and-forget; the handler's `on_system_sleep` runs detached
 /// on the engine runtime.  NULL engine is allowed and ignored.
 void rama_transparent_proxy_engine_notify_system_sleep(
-    RamaTransparentProxyEngine* engine
+    RamaTransparentProxyEngine* _Nullable engine
 );
 
 /// Symmetric counterpart of
 /// `rama_transparent_proxy_engine_notify_system_sleep`.
 void rama_transparent_proxy_engine_notify_system_wake(
-    RamaTransparentProxyEngine* engine
+    RamaTransparentProxyEngine* _Nullable engine
 );
 
 // TCP flow lifecycle
@@ -691,14 +697,14 @@ void rama_transparent_proxy_engine_notify_system_wake(
 /// Returns the merged Rust decision plus an optional session handle.
 RamaTransparentProxyTcpSessionResult rama_transparent_proxy_engine_new_tcp_session(
     RamaTransparentProxyEngine* engine,
-    const RamaTransparentProxyFlowMeta* meta,
+    const RamaTransparentProxyFlowMeta* _Nullable meta,
     RamaTransparentProxyTcpSessionCallbacks callbacks
 );
 
 /// Free a TCP session.
 ///
 /// NULL is allowed and ignored.
-void rama_transparent_proxy_tcp_session_free(RamaTransparentProxyTcpSession* session);
+void rama_transparent_proxy_tcp_session_free(RamaTransparentProxyTcpSession* _Nullable session);
 
 /// Deliver client->server TCP bytes into the Rust session.
 ///
@@ -801,7 +807,7 @@ void rama_transparent_proxy_tcp_session_signal_egress_drain(
 /// Idempotent: a later call replaces any prior registration.
 /// If `callbacks.on_promote_request` is NULL the call is a
 /// no-op. If no callback is ever registered, services that
-/// invoke `into_passthrough` see `PromoteError::EgressUnavailable`
+/// invoke `into_passthrough` see `PromoteError::NoCallbackRegistered`
 /// and `PromoteLayer` falls through to the in-Rust data path.
 ///
 /// After Swift completes the cutover it MUST call
@@ -810,7 +816,7 @@ void rama_transparent_proxy_tcp_session_signal_egress_drain(
 ///
 /// NULL `session` is allowed and ignored.
 void rama_transparent_proxy_tcp_session_register_promote_callbacks(
-    RamaTransparentProxyTcpSession* session,
+    RamaTransparentProxyTcpSession* _Nullable session,
     RamaTransparentProxyTcpPromoteCallbacks callbacks
 );
 
@@ -833,9 +839,9 @@ void rama_transparent_proxy_tcp_session_register_promote_callbacks(
 /// ran `into_passthrough`, or after a previous confirm) is a
 /// no-op. NULL `session` is allowed and ignored.
 void rama_transparent_proxy_tcp_session_confirm_promoted(
-    RamaTransparentProxyTcpSession* session,
+    RamaTransparentProxyTcpSession* _Nullable session,
     RamaPromoteConfirmStatus status,
-    const char* reason_ptr,
+    const char* _Nullable reason_ptr,
     size_t reason_len
 );
 
@@ -847,14 +853,14 @@ void rama_transparent_proxy_tcp_session_confirm_promoted(
 /// Returns the merged Rust decision plus an optional session handle.
 RamaTransparentProxyUdpSessionResult rama_transparent_proxy_engine_new_udp_session(
     RamaTransparentProxyEngine* engine,
-    const RamaTransparentProxyFlowMeta* meta,
+    const RamaTransparentProxyFlowMeta* _Nullable meta,
     RamaTransparentProxyUdpSessionCallbacks callbacks
 );
 
 /// Free a UDP session.
 ///
 /// NULL is allowed and ignored.
-void rama_transparent_proxy_udp_session_free(RamaTransparentProxyUdpSession* session);
+void rama_transparent_proxy_udp_session_free(RamaTransparentProxyUdpSession* _Nullable session);
 
 /// Deliver one client->server UDP datagram into Rust session.
 ///
@@ -885,6 +891,8 @@ void rama_transparent_proxy_udp_session_activate(
 
 /// Free Rust-owned byte buffer returned over FFI.
 void rama_owned_bytes_free(RamaBytesOwned bytes);
+
+#pragma clang assume_nonnull end
 
 #ifdef __cplusplus
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -52,6 +52,20 @@ struct RamaTransparentProxyConfigBridge {
     var tcpStartLatencyBreakerCloseP95Ms: UInt32
     var tcpPressureConnectTimeoutMs: UInt32
     var tcpBreakerConnectTimeoutMs: UInt32
+    /// When the provider declines a flow for its own reasons (start cap /
+    /// breaker, or a missing session), hand it to the kernel untouched instead
+    /// of blocking it. `false` (Block, fail closed) is the default.
+    var flowRefusalPassthrough: Bool
+}
+
+/// Log and decide fail-open (passthrough) vs fail-closed (blocked) for a flow the
+/// provider declines for its own reasons. Driven by `defaultFlowRefusalPassthrough`.
+func failOpenOnFlowRefusal(_ reason: String) -> Bool {
+    let passthrough = defaultFlowRefusalPassthrough
+    NSLog(
+        "RamaFFI: \(reason); \(passthrough ? "passing flow through (fail open)" : "blocking flow (fail closed)")"
+    )
+    return passthrough
 }
 
 enum RamaTransparentProxyFlowActionBridge: UInt32 {
@@ -626,7 +640,9 @@ final class RamaTransparentProxyEngineHandle {
                 tcpStartLatencyBreakerP95Ms: out.tcp_start_latency_breaker_p95_ms,
                 tcpStartLatencyBreakerCloseP95Ms: out.tcp_start_latency_breaker_close_p95_ms,
                 tcpPressureConnectTimeoutMs: out.tcp_pressure_connect_timeout_ms,
-                tcpBreakerConnectTimeoutMs: out.tcp_breaker_connect_timeout_ms
+                tcpBreakerConnectTimeoutMs: out.tcp_breaker_connect_timeout_ms,
+                // 0 = Block (fail closed), 1 = Passthrough (fail open).
+                flowRefusalPassthrough: out.flow_refusal_action == 1
             )
         }
     }
@@ -697,18 +713,15 @@ final class RamaTransparentProxyEngineHandle {
             }
             guard let action = RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
             else {
-                NSLog(
-                    "RamaFFI: ffi returned unknown tcp flow action \(result.action.rawValue); blocking flow"
-                )
                 callbackBox.release()
-                return .blocked
+                return failOpenOnFlowRefusal(
+                    "ffi returned unknown tcp flow action \(result.action.rawValue)")
+                    ? .passthrough : .blocked
             }
             if action == .intercept, result.session == nil {
-                NSLog(
-                    "RamaFFI: ffi returned tcp intercept without a session pointer; blocking flow"
-                )
                 callbackBox.release()
-                return .blocked
+                return failOpenOnFlowRefusal("ffi returned tcp intercept without a session pointer")
+                    ? .passthrough : .blocked
             }
             guard action == .intercept, let sessionPtr = result.session else {
                 callbackBox.release()
@@ -751,18 +764,15 @@ final class RamaTransparentProxyEngineHandle {
             }
             guard let action = RamaTransparentProxyFlowActionBridge(rawValue: result.action.rawValue)
             else {
-                NSLog(
-                    "RamaFFI: ffi returned unknown udp flow action \(result.action.rawValue); blocking flow"
-                )
                 callbackBox.release()
-                return .blocked
+                return failOpenOnFlowRefusal(
+                    "ffi returned unknown udp flow action \(result.action.rawValue)")
+                    ? .passthrough : .blocked
             }
             if action == .intercept, result.session == nil {
-                NSLog(
-                    "RamaFFI: ffi returned udp intercept without a session pointer; blocking flow"
-                )
                 callbackBox.release()
-                return .blocked
+                return failOpenOnFlowRefusal("ffi returned udp intercept without a session pointer")
+                    ? .passthrough : .blocked
             }
             guard action == .intercept, let sessionPtr = result.session else {
                 callbackBox.release()

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/PeerEgressConnection.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/PeerEgressConnection.swift
@@ -112,8 +112,8 @@ private func hostnameAndPort(of endpoint: NWEndpoint) -> (String, String)? {
     if let host = endpoint as? NWHostEndpoint {
         return (host.hostname, host.port)
     }
-    if let obj = endpoint as? NSObject,
-        obj.responds(to: NSSelectorFromString("hostname")),
+    let obj = endpoint as NSObject
+    if obj.responds(to: NSSelectorFromString("hostname")),
         obj.responds(to: NSSelectorFromString("port")),
         let hostname = obj.value(forKey: "hostname") as? String,
         let portStr = obj.value(forKey: "port") as? String

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionReadPump.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Pump/NwTcpConnectionReadPump.swift
@@ -58,6 +58,9 @@ final class NwTcpConnectionReadPump {
         queue.async { self.scheduleReadLocked() }
     }
 
+    /// Whether the EOF-grace backstop is armed; read on `queue`. Test seam.
+    var isEofBackstopArmed: Bool { eofWork != nil }
+
     /// Resume scheduling receives after the Rust side has freed egress
     /// capacity. No-op unless the pump is currently paused.
     func resume() {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -460,6 +460,14 @@ nonisolated(unsafe) var defaultFlowPressureIdleFloorMs: UInt32 = 120_000
 /// start. `0` disables hard admission refusal.
 nonisolated(unsafe) var defaultTcpStartInFlightHardCap: UInt32 = 128
 
+/// When the provider declines a flow for its OWN reasons — the start hard cap /
+/// latency breaker tripping, or the engine handing back an intercept decision
+/// without a session — hand the flow to the kernel untouched (fail open) instead
+/// of blocking it (fail closed). `false` (Block) is the default; the rama user
+/// opts in via `TransparentProxyConfig::with_flow_refusal_action(Passthrough)`.
+/// The chosen action is logged at each decision site regardless.
+nonisolated(unsafe) var defaultFlowRefusalPassthrough: Bool = false
+
 /// Softer pre-ready pressure level used by the latency breaker. A slow
 /// start-to-ready window opens the breaker, but admission refusal only begins
 /// once there is also real pre-ready pressure at/above this cap. That avoids
@@ -1004,8 +1012,12 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         defaultTcpStartLatencyBreakerCloseP95Ms = startup.tcpStartLatencyBreakerCloseP95Ms
         defaultTcpPressureConnectTimeoutMs = startup.tcpPressureConnectTimeoutMs
         defaultTcpBreakerConnectTimeoutMs = startup.tcpBreakerConnectTimeoutMs
+        defaultFlowRefusalPassthrough = startup.flowRefusalPassthrough
 
         logLifecycle("tcp write pump cap set to \(writePumpMaxPendingBytes) bytes from engine config")
+        logLifecycle(
+            "flow refusal action=\(defaultFlowRefusalPassthrough ? "passthrough (fail open)" : "block (fail closed)")"
+        )
         logLifecycle(
             "tcp overload config hardCap=\(defaultTcpStartInFlightHardCap) softCap=\(defaultTcpStartInFlightSoftCap) openP95Ms=\(defaultTcpStartLatencyBreakerP95Ms) closeP95Ms=\(defaultTcpStartLatencyBreakerCloseP95Ms) pressureTimeoutMs=\(defaultTcpPressureConnectTimeoutMs) breakerTimeoutMs=\(defaultTcpBreakerConnectTimeoutMs)"
         )

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -412,7 +412,7 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
 
         guard let session = sessionHandle else { return }
 
-        let writePump = buildEgressWritePump(connection: connection)
+        buildEgressWritePump(connection: connection)
         let readPump = buildEgressReadPump(connection: connection, session: session)
 
         // Register the Rust→Swift promote callback BEFORE
@@ -553,8 +553,8 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
 
     // MARK: - Phase: egress pump construction
 
-    private func buildEgressWritePump(connection: any NwConnectionLike) -> NwTcpConnectionWritePump
-    {
+    // Registers the egress write pump into `ctx.egressWritePump`; enqueue-driven.
+    private func buildEgressWritePump(connection: any NwConnectionLike) {
         let pump = NwTcpConnectionWritePump(
             connection: connection,
             queue: flowQueue,
@@ -594,7 +594,6 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             }
         )
         ctx.egressWritePump = pump
-        return pump
     }
 
     private func buildEgressReadPump(

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -113,9 +113,14 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             }
             let admission = core.admitTcpStart(flowId: flowId, meta: meta)
             guard case .admit(let token) = admission else {
-                if case .reject(let reason) = admission {
-                    core.logLifecycle("tcp admission rejected: \(reason)")
+                let reason: String
+                if case .reject(let r) = admission { reason = r } else { reason = "unavailable" }
+                if defaultFlowRefusalPassthrough {
+                    core.logLifecycle("tcp admission rejected: \(reason); passing through (fail open)")
+                    session.cancel()
+                    return false
                 }
+                core.logLifecycle("tcp admission rejected: \(reason); blocking (fail closed)")
                 let error = tcpUpstreamUnavailableError()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FFIAbiLayoutTests.swift
@@ -31,4 +31,13 @@ final class FFIAbiLayoutTests: XCTestCase {
         XCTAssertEqual(MemoryLayout<RamaTcpDeliverStatus>.size, 1)
         XCTAssertEqual(MemoryLayout<RamaPromoteConfirmStatus>.size, 1)
     }
+
+    func testEgressAndPeerStructLayouts() {
+        XCTAssertEqual(MemoryLayout<RamaUdpPeerView>.size, 32)
+        XCTAssertEqual(MemoryLayout<RamaUdpPeerView>.alignment, 8)
+        XCTAssertEqual(MemoryLayout<RamaNwEgressParameters>.size, 11)
+        XCTAssertEqual(MemoryLayout<RamaNwEgressParameters>.alignment, 1)
+        XCTAssertEqual(MemoryLayout<RamaTcpEgressConnectOptions>.size, 56)
+        XCTAssertEqual(MemoryLayout<RamaTcpEgressConnectOptions>.alignment, 4)
+    }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowRefusalActionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowRefusalActionTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import RamaAppleNetworkExtension
+
+/// The provider-side fail-open/closed decision for flows it declines for its own
+/// reasons (unknown action / missing session over FFI). The full admission-cap
+/// integration runs through `TcpFlowSession.start()`, which needs a real engine
+/// session and so is only reachable in the FFI e2e suite; this pins the decision
+/// logic + the `defaultFlowRefusalPassthrough` wiring.
+final class FlowRefusalActionTests: XCTestCase {
+    private var saved = false
+
+    override func setUp() {
+        super.setUp()
+        saved = defaultFlowRefusalPassthrough
+    }
+
+    override func tearDown() {
+        defaultFlowRefusalPassthrough = saved
+        super.tearDown()
+    }
+
+    func testDefaultsToFailClosed() {
+        defaultFlowRefusalPassthrough = false
+        XCTAssertFalse(failOpenOnFlowRefusal("unit reason"), "default is Block (fail closed)")
+    }
+
+    func testFailsOpenWhenConfigured() {
+        defaultFlowRefusalPassthrough = true
+        XCTAssertTrue(failOpenOnFlowRefusal("unit reason"), "Passthrough opts into fail open")
+    }
+}

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
@@ -246,7 +246,8 @@ final class ProviderStaticHelperTests: XCTestCase {
             tcpStartLatencyBreakerP95Ms: defaultTcpStartLatencyBreakerP95Ms,
             tcpStartLatencyBreakerCloseP95Ms: defaultTcpStartLatencyBreakerCloseP95Ms,
             tcpPressureConnectTimeoutMs: defaultTcpPressureConnectTimeoutMs,
-            tcpBreakerConnectTimeoutMs: defaultTcpBreakerConnectTimeoutMs)
+            tcpBreakerConnectTimeoutMs: defaultTcpBreakerConnectTimeoutMs,
+            flowRefusalPassthrough: defaultFlowRefusalPassthrough)
     }
 
     func testBuildNetworkSettingsEmptyRules() {
@@ -296,7 +297,8 @@ final class ProviderStaticHelperTests: XCTestCase {
             tcpStartLatencyBreakerP95Ms: 16,
             tcpStartLatencyBreakerCloseP95Ms: 17,
             tcpPressureConnectTimeoutMs: 18,
-            tcpBreakerConnectTimeoutMs: 19)
+            tcpBreakerConnectTimeoutMs: 19,
+            flowRefusalPassthrough: true)
 
         var logs: [String] = []
         RamaTransparentProxyProvider.applyRuntimeConfig(from: startup) { logs.append($0) }
@@ -312,7 +314,8 @@ final class ProviderStaticHelperTests: XCTestCase {
         XCTAssertEqual(defaultTcpStartLatencyBreakerCloseP95Ms, 17)
         XCTAssertEqual(defaultTcpPressureConnectTimeoutMs, 18)
         XCTAssertEqual(defaultTcpBreakerConnectTimeoutMs, 19)
-        XCTAssertEqual(logs.count, 3)
+        XCTAssertTrue(defaultFlowRefusalPassthrough)
+        XCTAssertEqual(logs.count, 4)
     }
 
     func testBuildNetworkSettingsRoutesIncludesAndExcludes() {

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpEgressPumpInteractionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpEgressPumpInteractionTests.swift
@@ -304,11 +304,14 @@ final class TcpEgressPumpInteractionTests: XCTestCase {
         let mock = MockNwConnection()
         mock.transition(to: .ready)
 
+        // Deadline far beyond the test's lifetime: the real backstop must not
+        // fire during the run. We assert the disarm cleared it directly rather
+        // than racing a wall-clock deadline (that race flaked on loaded CI).
         let readPump = NwTcpConnectionReadPump(
             connection: mock,
             session: session,
             queue: queue,
-            eofGraceDeadline: .milliseconds(150)
+            eofGraceDeadline: .seconds(60)
         )
 
         readPump.start()
@@ -319,16 +322,17 @@ final class TcpEgressPumpInteractionTests: XCTestCase {
         // Peer EOF: phase → .closed, EOF-grace backstop armed.
         mock.completePendingReceive(isComplete: true)
         waitForQueueDrain(queue)
+        XCTAssertTrue(
+            queue.sync { readPump.isEofBackstopArmed },
+            "peer EOF must arm the backstop before the promote disarms it")
 
-        // Promote lands within the grace window.
         let done = expectation(description: "cancelForPromote completed")
         readPump.cancelForPromote(onCarryover: { _ in }, onComplete: { done.fulfill() })
         wait(for: [done], timeout: 1.0)
 
-        // Well past the grace deadline the connection must still be alive:
-        // it now belongs to the promoted forwarder.
-        Thread.sleep(forTimeInterval: 0.45)
-        waitForQueueDrain(queue)
+        XCTAssertFalse(
+            queue.sync { readPump.isEofBackstopArmed },
+            "cancelForPromote must disarm the EOF-grace backstop")
         XCTAssertEqual(
             mock.cancelCount, 0,
             "stale EOF-grace timer must not cancel a promoted connection")

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionHalfCloseTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpFlowSessionHalfCloseTests.swift
@@ -119,7 +119,7 @@ final class TcpFlowSessionHalfCloseTests: XCTestCase {
     /// Client half-close closes our read side + forwards client EOF,
     /// and does NOT cancel the egress download pump / connection.
     func testClientHalfCloseKeepsEgressReadPumpAlive() {
-        let (session, core, flow, conn, queue) = makeArmedSession()
+        let (session, core, flow, conn, _) = makeArmedSession()
         defer { core.detachEngine(reason: 0) }
 
         // Client half-close: kernel readData completes with EOF.

--- a/ffi/apple/RamaAppleSecureEnclave/Sources/RamaAppleSEFFI/include/rama_apple_se_ffi.c
+++ b/ffi/apple/RamaAppleSecureEnclave/Sources/RamaAppleSEFFI/include/rama_apple_se_ffi.c
@@ -1,8 +1,15 @@
 #include "rama_apple_se_ffi.h"
+#include <stddef.h>
 #include <stdlib.h>
 
 void rama_apple_se_bytes_free(RamaSeBytes bytes) {
     if (bytes.ptr != NULL) {
+        // Wipe before free: on decrypt this holds the CA private key. Volatile so
+        // it isn't optimized away.
+        volatile unsigned char *p = (volatile unsigned char *)bytes.ptr;
+        for (size_t i = 0; i < bytes.len; i++) {
+            p[i] = 0;
+        }
         free(bytes.ptr);
     }
 }

--- a/ffi/apple/RamaAppleSecureEnclave/Sources/RamaAppleSecureEnclave/SecureEnclaveBridge.swift
+++ b/ffi/apple/RamaAppleSecureEnclave/Sources/RamaAppleSecureEnclave/SecureEnclaveBridge.swift
@@ -242,7 +242,9 @@ public func rama_apple_se_p256_decrypt(
             recipientPub: seKey.publicKey
         )
         let sealed = try AES.GCM.SealedBox(combined: combined)
-        let plaintext = try AES.GCM.open(sealed, using: symmetric)
+        var plaintext = try AES.GCM.open(sealed, using: symmetric)
+        // Wipe our copy of the decrypted secret once it's been handed off.
+        defer { plaintext.resetBytes(in: plaintext.startIndex..<plaintext.endIndex) }
         guard let bytes = allocSeBytes(plaintext) else {
             return RAMA_SE_ERR_SYSTEM
         }

--- a/ffi/apple/examples/transparent_proxy/README.md
+++ b/ffi/apple/examples/transparent_proxy/README.md
@@ -7,10 +7,10 @@ The sysext generates and stores the demo MITM root CA in the macOS System
 Keychain (`/Library/Keychains/System.keychain`) using Rama's built-in boring TLS
 support. The CA is created on first startup and reused on subsequent starts.
 
-The container app can delete the stored CA material via the `Rotate CA`
-menu command or the `--clean-secrets` launch flag; the sysext will create a
-fresh CA the next time it initialises. The container app does not create or
-read the CA.
+The container app can delete the stored CA material via the `Clear CA` menu
+command (while the proxy is running) or the `--clean-secrets` launch flag; the
+sysext then creates a fresh CA the next time it initialises. The container app
+does not create or read the CA.
 
 ## Build
 
@@ -63,9 +63,11 @@ The build helpers are:
 
 Both modes use the real system-extension product type. Developer mode uses the plain `app-proxy-provider` entitlement payload, while distribution mode switches the same entitlement template to `app-proxy-provider-systemextension`.
 
-At runtime, the container app menu includes `Rotate CA`, which deletes the
-CA material from the System Keychain and restarts the proxy. The sysext
-generates a fresh CA on the next startup.
+At runtime, the container app menu includes `Rotate CA` — which mints a fresh
+CA and swaps it in live over XPC without restarting the proxy (falling back to
+wiping the stored blobs, so the next start regenerates, when the proxy is
+inactive) — and `Clear CA`, which uninstalls trust and wipes the stored CA
+material so the sysext regenerates a fresh CA on its next startup.
 
 ## Signing Setup
 
@@ -120,10 +122,15 @@ A team `Account Holder` or `Admin` needs to do the one-time Apple Developer port
    - `org.ramaproxy.example.tproxy.dist.provider`
 2. Enable `Network Extensions` on the container app' and sysext App IDs for both developer and distribution modes.
 3. Enable `System Extension` on the container app's App ID used for direct distribution.
-4. Register the shared app-group identifiers used as protected-storage access groups:
-   - `group.org.ramaproxy.example.tproxy.dev.group`
-   - `group.org.ramaproxy.example.tproxy.dist.group`
-5. Enable the app-group / shared-keychain capability needed for the container app and sysext App IDs.
+4. Register the shared app-group identifiers. The entitlement value is
+   `$(APP_GROUP_ID)` = `$(AppIdentifierPrefix)` + the bundle base, i.e. prefixed
+   with your `<TEAMID>`:
+   - `<TEAMID>.org.ramaproxy.example.tproxy.dev`
+   - `<TEAMID>.org.ramaproxy.example.tproxy.dist`
+
+   The group is reused as the `NEMachServiceName` prefix; it is not an app-group
+   keychain — the CA material lives in the file-based System Keychain.
+5. Enable the App Groups capability for the container app and sysext App IDs.
 6. Create the Developer ID distribution profiles for the direct-distribution container app and sysext.
 
 ### What a normal developer needs locally
@@ -172,7 +179,7 @@ just build-tproxy-dist
 
 For distribution mode, the example expects these Developer ID profile names for the distribution bundle IDs `org.ramaproxy.example.tproxy.dist` and `org.ramaproxy.example.tproxy.dist.provider`:
 
-- `Rama Transparent Proxy Example (Container)`
+- `Rama Transparent Proxy Example (Host)` (the container app)
 - `Rama Transparent Proxy Example (Extension)`
 
 Only for distribution mode, if you intentionally renamed those profiles, should you override:
@@ -308,7 +315,8 @@ log show --last 5m --style compact --info --debug \
 ls -lt /Library/Logs/DiagnosticReports/ \
   | grep 'org\.ramaproxy\.example\.tproxy\.dev\.provider' | head -5
 
-# launchd job's MachServices block — should list <TEAM>.<group>.xpc => 0
+# launchd job's MachServices block — should list the NEMachServiceName,
+# i.e. <TEAM>.org.ramaproxy.example.tproxy.dev.provider.<version> => 0
 sudo launchctl print system/org.ramaproxy.example.tproxy.dev.provider \
   | grep -A 5 -i machservices
 
@@ -333,10 +341,10 @@ ClientHello, missing SNI, wrong ALPN, or an upstream alert.
 sudo tcpdump -i en0 -s 0 -C 100 -W 5 -w /tmp/rama-tproxy.pcap
 ```
 
-To decrypt the egress TLS in Wireshark, point the boring
-client at a keylog file via the provider config
-(`keylog_intent`); Wireshark's TLS dissector then reads the
-keys and the egress handshake becomes plaintext.
+To decrypt the egress TLS in Wireshark, enable the `Log TLS Session Keys`
+menu toggle (a runtime XPC command). The sysext then writes NSS-format key-log
+lines to `<storage_dir>/keylog/sslkeylog*`; point Wireshark's TLS dissector at
+that file and the egress handshake becomes plaintext.
 
 ### Reinstall recipes
 

--- a/ffi/apple/examples/transparent_proxy/justfile
+++ b/ffi/apple/examples/transparent_proxy/justfile
@@ -145,7 +145,10 @@ run-tproxy-ffi-e2e-swift-tsan: build-tproxy-rs-debug
 
 qa-rust: sort clippy rust-doc rust-test rust-test-ignored
 
-qa: qa-rust build-tproxy-dev
+check-spec-parity:
+    ./scripts/check_spec_parity.sh
+
+qa: qa-rust check-spec-parity build-tproxy-dev
 
 test-e2e: build-tproxy-rs-debug clippy-tproxy-ffi-e2e cleanup-tproxy-ffi-e2e run-tproxy-ffi-e2e run-tproxy-ffi-e2e-swift
 

--- a/ffi/apple/examples/transparent_proxy/scripts/check_spec_parity.sh
+++ b/ffi/apple/examples/transparent_proxy/scripts/check_spec_parity.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Cross-file parity checks for the transparent-proxy example. Fast, no Xcode
+# toolchain needed, so they run early in `just qa` (and thus in CI).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# dev and dist Xcode specs must declare the same SPM products, else a product
+# added to Project.yml but forgotten in Project.dist.yml silently breaks the
+# Developer-ID build (which no other recipe compiles).
+dev=$(grep -E '^[[:space:]]*product:' tproxy_app/Project.yml | awk '{print $2}' | sort -u)
+dist=$(grep -E '^[[:space:]]*product:' tproxy_app/Project.dist.yml | awk '{print $2}' | sort -u)
+if [ "$dev" != "$dist" ]; then
+    echo "Project.yml vs Project.dist.yml SPM product deps diverged:" >&2
+    diff <(echo "$dev") <(echo "$dist") >&2 || true
+    fail=1
+fi
+
+# CA keychain service names must match between the Rust sysext and the Swift
+# container, else `Clear CA` wipes nothing and leaves orphaned key material.
+rs=$(grep -oE 'rama-tproxy-demo-ca-[a-z-]+' tproxy_rs/src/tls/mod.rs | sort -u)
+sw=$(grep -oE 'rama-tproxy-demo-ca-[a-z-]+' tproxy_app/Container/main.swift | sort -u)
+if [ "$rs" != "$sw" ]; then
+    echo "CA keychain service names diverged between Rust and Swift:" >&2
+    diff <(echo "$rs") <(echo "$sw") >&2 || true
+    fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+    exit 1
+fi
+echo "spec parity OK (dev/dist products, Rust/Swift keychain names)"

--- a/ffi/apple/examples/transparent_proxy/tproxy_app/Container/ContainerController+Keychain.swift
+++ b/ffi/apple/examples/transparent_proxy/tproxy_app/Container/ContainerController+Keychain.swift
@@ -65,6 +65,14 @@ extension ContainerController {
         }
     }
 
+    /// Launch-time `--clean-secrets`. The provider isn't active yet, so
+    /// `clearCA()`'s XPC path would no-op; wipe locally and let the sysext
+    /// regenerate on start.
+    func clearStoredCAForLaunch() {
+        log("clean-secrets: wiping stored MITM CA material before start")
+        wipeStoredCASecretsLocally()
+    }
+
     /// Rotate the MITM CA. When the proxy is active, swap the live CA
     /// via XPC and update admin trust to match. When inactive, fall
     /// back to a plain wipe — the next start regenerates.

--- a/ffi/apple/examples/transparent_proxy/tproxy_app/Container/main.swift
+++ b/ffi/apple/examples/transparent_proxy/tproxy_app/Container/main.swift
@@ -19,6 +19,8 @@ final class ContainerController: NSObject, NSApplicationDelegate {
 
     let managerDescription = "Rama Transparent Proxy Example"
     let managerServerAddress = "127.0.0.1"
+    // Must match the Rust sysext (`tproxy_rs/src/tls/mod.rs`); `just
+    // check-spec-parity` fails the build on drift.
     static let secretAccount = "org.ramaproxy.example.tproxy"
     static let secretServiceKeyPEM = "rama-tproxy-demo-ca-key"
     static let secretServiceCertPEM = "rama-tproxy-demo-ca-crt"
@@ -80,7 +82,7 @@ final class ContainerController: NSObject, NSApplicationDelegate {
         log("container app launched")
         if cleanSecretsOnLaunch {
             log("launch flag detected: clearing MITM CA before start")
-            clearCA()
+            clearStoredCAForLaunch()
         }
         if resetProfileOnLaunch {
             log("launch flag detected: resetting saved proxy profile before start")

--- a/ffi/apple/examples/transparent_proxy/tproxy_app/Project.dist.yml
+++ b/ffi/apple/examples/transparent_proxy/tproxy_app/Project.dist.yml
@@ -19,6 +19,8 @@ targets:
       - target: RamaTransparentProxyExampleExtension
         embed: true
         codeSign: true
+      - package: RamaAppleNetworkExtension
+        product: RamaAppleXpcClient
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: org.ramaproxy.example.tproxy.dist
@@ -51,6 +53,8 @@ targets:
     dependencies:
       - package: RamaAppleNetworkExtension
         product: RamaAppleNetworkExtension
+      - package: RamaAppleNetworkExtension
+        product: RamaAppleSecureEnclave
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: org.ramaproxy.example.tproxy.dist.provider

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/config.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/config.rs
@@ -15,6 +15,9 @@ pub struct DemoProxyConfig {
     pub html_badge_enabled: bool,
     pub html_badge_label: String,
     pub peek_duration_s: f64,
+    // Egress connect timeout (ms); applied via `egress_tcp_connect_options`.
+    // `None`/`0` keeps the platform default.
+    pub tcp_connect_timeout_ms: Option<u64>,
     pub exclude_domains: Vec<String>,
     // Optional inline PEM overrides — if both are set they bypass the System Keychain.
     // Intended for environments (e.g. e2e test runners) that lack keychain access.
@@ -40,6 +43,7 @@ impl Default for DemoProxyConfig {
             html_badge_enabled: true,
             html_badge_label: "proxied by rama".to_owned(),
             peek_duration_s: 8.,
+            tcp_connect_timeout_ms: None,
             // Keep in sync with `policy::DomainExclusionList::default()`
             // — that's the engine-internal fallback; this is the
             // user-visible default that ships in the opaque config.

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/lib.rs
@@ -129,6 +129,7 @@ struct DemoTransparentProxyHandler {
     concurrency_limiter: Arc<concurrency::ConcurrencyLimiter>,
     tcp_mitm_service: tcp::DemoTcpMitmService,
     udp_service: rama::service::BoxService<apple_ne::UdpFlow, (), Infallible>,
+    egress_connect_timeout: Option<std::time::Duration>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -154,6 +155,11 @@ impl DemoTransparentProxyHandler {
         let udp_service = self::udp::try_new_service(ctx.clone()).await?.boxed();
 
         let demo_config = self::config::DemoProxyConfig::from_opaque_config(ctx.opaque_config())?;
+        // Treat 0 / absent as "platform default".
+        let egress_connect_timeout = demo_config
+            .tcp_connect_timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis);
         if let Some(xpc_service_name) = demo_config.xpc_service_name {
             self::demo_xpc_server::spawn_xpc_server(
                 xpc_service_name,
@@ -187,6 +193,7 @@ impl DemoTransparentProxyHandler {
             concurrency_limiter,
             tcp_mitm_service,
             udp_service,
+            egress_connect_timeout,
         })
     }
 }
@@ -194,6 +201,18 @@ impl DemoTransparentProxyHandler {
 impl TransparentProxyHandler for DemoTransparentProxyHandler {
     fn transparent_proxy_config(&self) -> TransparentProxyConfig {
         self.config.clone()
+    }
+
+    fn egress_tcp_connect_options(
+        &self,
+        _meta: &TransparentProxyFlowMeta,
+    ) -> Option<apple_ne::tproxy::NwTcpConnectOptions> {
+        // Unset ⇒ keep the engine/Swift defaults.
+        let connect_timeout = self.egress_connect_timeout?;
+        Some(apple_ne::tproxy::NwTcpConnectOptions {
+            connect_timeout: Some(connect_timeout),
+            ..Default::default()
+        })
     }
 
     async fn handle_app_message(&self, _exec: Executor, message: Bytes) -> Option<Bytes> {

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/mod.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/mod.rs
@@ -33,6 +33,8 @@ use rama::{
     },
 };
 
+// Must match the Swift container's mirror (`tproxy_app/Container/main.swift`);
+// `just check-spec-parity` fails the build on drift.
 const CA_SERVICE_CERT: &str = "rama-tproxy-demo-ca-crt";
 const CA_SERVICE_KEY: &str = "rama-tproxy-demo-ca-key";
 const SE_SERVICE_KEY: &str = "rama-tproxy-demo-ca-se-key";

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/secure_enclave.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tls/secure_enclave.rs
@@ -50,14 +50,31 @@ pub(super) fn load_or_create() -> Result<(X509, PKey<Private>), BoxError> {
                     tracing::info!("tls: loaded MITM CA from SE-encrypted system keychain entries");
                     Ok((cert, key))
                 }
-                Err(err) => {
-                    tracing::error!(
-                        error = %err,
-                        "tls: FAILED to decrypt stored MITM CA with Secure Enclave; WIPING \
-                         all entries and regenerating from scratch"
+                Err(first_err) => {
+                    // Retry once before wiping: a transient SE error shouldn't
+                    // destroy a working CA (a malformed envelope fails again).
+                    tracing::warn!(
+                        error = %first_err,
+                        "tls: Secure Enclave decrypt of stored MITM CA failed; retrying once \
+                         before considering the stored CA unrecoverable"
                     );
-                    wipe_all_ca_entries()?;
-                    generate_and_store()
+                    match decrypt_pair(&se_key, &cert_blob, &key_blob) {
+                        Ok((cert, key)) => {
+                            tracing::info!(
+                                "tls: Secure Enclave decrypt of MITM CA succeeded on retry"
+                            );
+                            Ok((cert, key))
+                        }
+                        Err(err) => {
+                            tracing::error!(
+                                error = %err,
+                                "tls: FAILED to decrypt stored MITM CA with Secure Enclave twice; \
+                                 WIPING all entries and regenerating from scratch"
+                            );
+                            wipe_all_ca_entries()?;
+                            generate_and_store()
+                        }
+                    }
                 }
             }
         }

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -244,6 +244,10 @@ pub struct TransparentProxyConfig {
     pub tcp_pressure_connect_timeout_ms: u32,
     /// See [`tproxy::TransparentProxyConfig::tcp_breaker_connect_timeout_ms`].
     pub tcp_breaker_connect_timeout_ms: u32,
+    /// Action when the provider declines a flow for its own reasons (start cap /
+    /// breaker, or missing session): `0` = Block (default), `1` = Passthrough.
+    /// See [`tproxy::FlowRefusalAction`].
+    pub flow_refusal_action: u32,
 }
 
 #[repr(C)]
@@ -325,6 +329,10 @@ impl TransparentProxyConfig {
             tcp_start_latency_breaker_close_p95_ms: config.tcp_start_latency_breaker_close_p95_ms(),
             tcp_pressure_connect_timeout_ms: config.tcp_pressure_connect_timeout_ms(),
             tcp_breaker_connect_timeout_ms: config.tcp_breaker_connect_timeout_ms(),
+            flow_refusal_action: match config.flow_refusal_action() {
+                tproxy::FlowRefusalAction::Block => 0,
+                tproxy::FlowRefusalAction::Passthrough => 1,
+            },
         }
     }
 
@@ -867,6 +875,28 @@ mod tests {
     }
 
     #[test]
+    fn flow_refusal_action_defaults_block_and_maps_to_ffi() {
+        use crate::tproxy::FlowRefusalAction;
+        // Default is fail-closed.
+        assert_eq!(
+            tproxy::TransparentProxyConfig::new().flow_refusal_action(),
+            FlowRefusalAction::Block
+        );
+        let block = TransparentProxyConfig::from_rust_type(&tproxy::TransparentProxyConfig::new());
+        assert_eq!(block.flow_refusal_action, 0);
+        // SAFETY: freshly built, not yet freed.
+        unsafe { block.free() };
+
+        let cfg = tproxy::TransparentProxyConfig::new()
+            .with_flow_refusal_action(FlowRefusalAction::Passthrough);
+        assert_eq!(cfg.flow_refusal_action(), FlowRefusalAction::Passthrough);
+        let pass = TransparentProxyConfig::from_rust_type(&cfg);
+        assert_eq!(pass.flow_refusal_action, 1);
+        // SAFETY: freshly built, not yet freed.
+        unsafe { pass.free() };
+    }
+
+    #[test]
     fn ffi_struct_layout_matches_c_header_on_64_bit_targets() {
         if size_of::<usize>() != 8 {
             return;
@@ -936,6 +966,8 @@ mod tests {
             offset_of!(TransparentProxyConfig, tcp_breaker_connect_timeout_ms),
             72
         );
+        // Slots into the former tail padding, so `sizeof` stays 80.
+        assert_eq!(offset_of!(TransparentProxyConfig, flow_refusal_action), 76);
 
         assert_eq!(size_of::<FfiTransparentProxyInitConfig>(), 32);
         assert_eq!(

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -766,15 +766,16 @@ mod tests {
     use std::mem::{align_of, offset_of, size_of};
     use std::ptr;
 
-    use crate::ffi::{BytesOwned, BytesOwnedView, BytesView};
+    use crate::ffi::{BytesOwned, BytesOwnedView, BytesView, UdpPeerView};
     use crate::tproxy::{
         self, NwInterfaceType, TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
         TransparentProxyRuleProtocol,
     };
 
     use super::{
-        NwEgressParameters, PromoteConfirmStatus, TransparentFlowEndpoint, TransparentProxyConfig,
-        TransparentProxyFlowMeta, TransparentProxyInitConfig as FfiTransparentProxyInitConfig,
+        NwEgressParameters, PromoteConfirmStatus, TcpEgressConnectOptions, TransparentFlowEndpoint,
+        TransparentProxyConfig, TransparentProxyFlowMeta,
+        TransparentProxyInitConfig as FfiTransparentProxyInitConfig,
         TransparentProxyNetworkRule as FfiTransparentProxyNetworkRule, interface_type_from_u8,
     };
 
@@ -941,6 +942,31 @@ mod tests {
             offset_of!(FfiTransparentProxyInitConfig, app_group_dir_utf8),
             16
         );
+
+        assert_eq!(size_of::<UdpPeerView>(), 32);
+        assert_eq!(align_of::<UdpPeerView>(), 8);
+        assert_eq!(offset_of!(UdpPeerView, host_utf8), 8);
+        assert_eq!(offset_of!(UdpPeerView, host_utf8_len), 16);
+        assert_eq!(offset_of!(UdpPeerView, port), 24);
+        assert_eq!(offset_of!(UdpPeerView, scope_id), 28);
+
+        assert_eq!(size_of::<NwEgressParameters>(), 11);
+        assert_eq!(align_of::<NwEgressParameters>(), 1);
+        assert_eq!(
+            offset_of!(NwEgressParameters, prohibited_interface_types_mask),
+            8
+        );
+
+        assert_eq!(size_of::<TcpEgressConnectOptions>(), 56);
+        assert_eq!(align_of::<TcpEgressConnectOptions>(), 4);
+        assert_eq!(
+            offset_of!(TcpEgressConnectOptions, has_connect_timeout_ms),
+            11
+        );
+        assert_eq!(offset_of!(TcpEgressConnectOptions, connect_timeout_ms), 12);
+        assert_eq!(offset_of!(TcpEgressConnectOptions, linger_close_ms), 20);
+        assert_eq!(offset_of!(TcpEgressConnectOptions, egress_eof_grace_ms), 28);
+        assert_eq!(offset_of!(TcpEgressConnectOptions, tcp_keepalive_count), 52);
     }
 
     /// Verify the `exclude` field round-trips through the FFI

--- a/rama-net-apple-networkextension/src/macros.rs
+++ b/rama-net-apple-networkextension/src/macros.rs
@@ -708,19 +708,20 @@ macro_rules! __transparent_proxy_ffi_emit {
             let c_opts = RamaTcpEgressConnectOptions {
                 parameters: $crate::ffi::tproxy::NwEgressParameters::from_rust_type(&opts.parameters),
                 has_connect_timeout_ms: opts.connect_timeout.is_some(),
+                // Saturate: an `as` cast would wrap a >u32::MAX-ms duration to a tiny value.
                 connect_timeout_ms: opts
                     .connect_timeout
-                    .map(|d| d.as_millis() as u32)
+                    .map(|d| u32::try_from(d.as_millis()).unwrap_or(u32::MAX))
                     .unwrap_or(0),
                 has_linger_close_ms: opts.linger_close_timeout.is_some(),
                 linger_close_ms: opts
                     .linger_close_timeout
-                    .map(|d| d.as_millis() as u32)
+                    .map(|d| u32::try_from(d.as_millis()).unwrap_or(u32::MAX))
                     .unwrap_or(0),
                 has_egress_eof_grace_ms: opts.egress_eof_grace.is_some(),
                 egress_eof_grace_ms: opts
                     .egress_eof_grace
-                    .map(|d| d.as_millis() as u32)
+                    .map(|d| u32::try_from(d.as_millis()).unwrap_or(u32::MAX))
                     .unwrap_or(0),
                 // Keepalive: `enabled` always sent; unset timings (`has_`
                 // false) let Swift apply its own defaults.
@@ -731,12 +732,12 @@ macro_rules! __transparent_proxy_ffi_emit {
                 // default with a degenerate value.
                 tcp_keepalive_idle_secs: opts
                     .tcp_keepalive_idle
-                    .map(|d| d.as_millis().div_ceil(1000) as u32)
+                    .map(|d| u32::try_from(d.as_millis().div_ceil(1000)).unwrap_or(u32::MAX))
                     .unwrap_or(0),
                 has_tcp_keepalive_interval_secs: opts.tcp_keepalive_interval.is_some(),
                 tcp_keepalive_interval_secs: opts
                     .tcp_keepalive_interval
-                    .map(|d| d.as_millis().div_ceil(1000) as u32)
+                    .map(|d| u32::try_from(d.as_millis().div_ceil(1000)).unwrap_or(u32::MAX))
                     .unwrap_or(0),
                 has_tcp_keepalive_count: opts.tcp_keepalive_count.is_some(),
                 tcp_keepalive_count: opts.tcp_keepalive_count.unwrap_or(0),

--- a/rama-net-apple-networkextension/src/process_shim.c
+++ b/rama-net-apple-networkextension/src/process_shim.c
@@ -6,8 +6,8 @@
 // updates. We therefore call the macro from C (where the SDK header
 // is authoritative) instead of extracting fields from Rust.
 //
-// The Rust caller passes (pointer, length); we re-validate the
-// length, memcpy into a local `audit_token_t`, and call the macro.
+// The Rust caller passes (pointer, length); we require an exact
+// `sizeof(audit_token_t)` match, memcpy into a local, and call the macro.
 
 #include <bsm/libbsm.h>
 #include <stddef.h>
@@ -15,7 +15,7 @@
 #include <string.h>
 
 int32_t __rama_audit_token_to_pid(const uint8_t *bytes, size_t len) {
-    if (bytes == NULL || len < sizeof(audit_token_t)) {
+    if (bytes == NULL || len != sizeof(audit_token_t)) {
         return -1;
     }
     audit_token_t token;

--- a/rama-net-apple-networkextension/src/system_keychain/secure_enclave.rs
+++ b/rama-net-apple-networkextension/src/system_keychain/secure_enclave.rs
@@ -294,3 +294,96 @@ fn take_bytes(bytes: RamaSeBytes) -> Vec<u8> {
     unsafe { rama_apple_se_bytes_free(bytes) };
     copied
 }
+
+#[cfg(test)]
+mod tests {
+    //! Pure pieces only: touching the `extern "C"` bridge symbols would fail to
+    //! link under `cargo test` (no Swift bridge) — those run from the Swift host.
+    use super::*;
+
+    #[test]
+    fn accessibility_as_raw_is_stable() {
+        // These integers are the ABI contract with the Swift bridge; pin them.
+        assert_eq!(SecureEnclaveAccessibility::AfterFirstUnlock.as_raw(), 0);
+        assert_eq!(SecureEnclaveAccessibility::Always.as_raw(), 1);
+    }
+
+    #[test]
+    fn error_from_code_maps_every_defined_code() {
+        assert!(matches!(
+            SecureEnclaveError::from_code(RAMA_SE_ERR_UNAVAILABLE),
+            SecureEnclaveError::Unavailable
+        ));
+        assert!(matches!(
+            SecureEnclaveError::from_code(RAMA_SE_ERR_BAD_INPUT),
+            SecureEnclaveError::BadInput
+        ));
+        assert!(matches!(
+            SecureEnclaveError::from_code(RAMA_SE_ERR_CRYPTO),
+            SecureEnclaveError::Crypto
+        ));
+        assert!(matches!(
+            SecureEnclaveError::from_code(RAMA_SE_ERR_SYSTEM),
+            SecureEnclaveError::System
+        ));
+    }
+
+    #[test]
+    fn error_from_unknown_code_preserves_value() {
+        match SecureEnclaveError::from_code(42) {
+            SecureEnclaveError::Unknown(42) => {}
+            other => panic!("expected Unknown(42), got {other:?}"),
+        }
+        // `RAMA_SE_OK` is not an error and must not collide with a defined variant.
+        assert!(matches!(
+            SecureEnclaveError::from_code(RAMA_SE_OK),
+            SecureEnclaveError::Unknown(0)
+        ));
+    }
+
+    #[test]
+    fn error_display_is_non_empty_for_every_variant() {
+        for err in [
+            SecureEnclaveError::Unavailable,
+            SecureEnclaveError::BadInput,
+            SecureEnclaveError::Crypto,
+            SecureEnclaveError::System,
+            SecureEnclaveError::Unknown(-99),
+        ] {
+            assert!(!err.to_string().is_empty());
+        }
+        assert!(SecureEnclaveError::Unknown(-99).to_string().contains("-99"));
+    }
+
+    #[test]
+    fn data_representation_round_trips_without_touching_the_bridge() {
+        let blob = vec![1u8, 2, 3, 4, 5];
+        let key = SecureEnclaveKey::from_data_representation(&blob);
+        assert_eq!(key.data_representation(), blob.as_slice());
+        // Zeroizing<Vec<u8>> input is also accepted.
+        let z = zeroize::Zeroizing::new(blob.clone());
+        assert_eq!(
+            SecureEnclaveKey::from_data_representation(&z).data_representation(),
+            blob.as_slice()
+        );
+    }
+
+    #[test]
+    fn empty_se_bytes_is_null_and_zero() {
+        assert!(RamaSeBytes::EMPTY.ptr.is_null());
+        assert_eq!(RamaSeBytes::EMPTY.len, 0);
+    }
+
+    #[test]
+    fn se_bytes_layout_matches_bridge_abi() {
+        // Pointer + length, no padding surprises — mirrors the C `RamaSeBytes`.
+        assert_eq!(
+            std::mem::size_of::<RamaSeBytes>(),
+            std::mem::size_of::<*mut u8>() + std::mem::size_of::<usize>()
+        );
+        assert_eq!(
+            std::mem::align_of::<RamaSeBytes>(),
+            std::mem::align_of::<*mut u8>()
+        );
+    }
+}

--- a/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/ffi_stream.rs
@@ -91,9 +91,13 @@ pub(crate) struct FfiBridgeStream {
     on_closed: ClosedSink,
     closed_fired: bool,
     paused_drain_max_wait: Duration,
-    /// Reaps a write parked on `Paused` whose drain never arrives. Armed on
-    /// `Paused`, cleared on progress.
+    /// Reaps a write parked on `Paused` whose drain never arrives. Armed fresh
+    /// at the start of each pause episode, cleared on every `Poll::Ready`.
     paused_backstop: Option<Pin<Box<Sleep>>>,
+    /// Drain generation when `paused_backstop` was armed; if it has since
+    /// advanced (Swift drained), the next pause is a new episode and re-arms
+    /// fresh, so a stale deadline can't fire against it.
+    paused_backstop_gen: u64,
 
     // ── shared per-flow state ──
     signals: Arc<TcpPerFlowSignals>,
@@ -124,6 +128,7 @@ impl FfiBridgeStream {
             closed_fired: false,
             paused_drain_max_wait,
             paused_backstop: None,
+            paused_backstop_gen: 0,
             signals,
             counters,
             close_reason,
@@ -210,11 +215,13 @@ impl AsyncWrite for FfiBridgeStream {
                 this.counters
                     .sent(this.direction)
                     .fetch_add(buf.len() as u64, Ordering::Relaxed);
-                this.paused_backstop = None; // progress: re-arm fresh next time
+                // Progress: end the pause episode so the next one arms fresh.
+                this.paused_backstop = None;
                 Poll::Ready(Ok(buf.len()))
             }
             // Peer gone → broken pipe; the forwarder tears the flow down.
             TcpDeliverStatus::Closed => {
+                this.paused_backstop = None;
                 this.record_reason(BridgeCloseReason::PeerEofRight);
                 Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::BrokenPipe,
@@ -222,9 +229,15 @@ impl AsyncWrite for FfiBridgeStream {
                 )))
             }
             TcpDeliverStatus::Paused => {
-                // Park for a drain wake (re-poll retries the same buffer) or
-                // the backstop deadline.
+                // Park for a drain wake or the backstop deadline. Arm a fresh
+                // deadline each pause episode (first pause, or first after a
+                // drain) so a stale timer from an earlier episode can't fire.
                 let max_wait = this.paused_drain_max_wait;
+                let cur_gen = this.signals.drain_generation(this.direction);
+                if this.paused_backstop.is_none() || cur_gen != this.paused_backstop_gen {
+                    this.paused_backstop_gen = cur_gen;
+                    this.paused_backstop = Some(Box::pin(tokio::time::sleep(max_wait)));
+                }
                 let backstop = this
                     .paused_backstop
                     .get_or_insert_with(|| Box::pin(tokio::time::sleep(max_wait)));
@@ -525,6 +538,52 @@ mod tests {
         match Pin::new(&mut s).poll_write(&mut cx, b"abc") {
             Poll::Ready(Err(e)) => assert_eq!(e.kind(), io::ErrorKind::TimedOut),
             other => panic!("expected TimedOut, got {other:?}"),
+        }
+    }
+
+    /// A near-elapsed backstop from an earlier pause episode must not fire
+    /// against a fresh pause: after a drain, the next pause re-arms a fresh
+    /// deadline rather than inheriting the stale one.
+    #[tokio::test(start_paused = true)]
+    async fn write_paused_backstop_rearms_after_drain() {
+        let (_tx, rx) = mpsc::channel::<Bytes>(4);
+        let signals = Arc::new(TcpPerFlowSignals::new());
+        let mut s = stream(
+            rx,
+            const_sink(TcpDeliverStatus::Paused),
+            noop(),
+            noop(),
+            BridgeDirection::Ingress,
+            Duration::from_millis(100),
+            signals.clone(),
+            Arc::new(TcpFlowByteCounters::default()),
+        );
+        let (_w, waker) = count_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // Episode 1: pause, arm the backstop; advance most of the way to its
+        // deadline without firing.
+        assert!(Pin::new(&mut s).poll_write(&mut cx, b"a").is_pending());
+        tokio::time::advance(Duration::from_millis(80)).await;
+
+        // Swift drained this direction (progress). A write abandoned mid-pause
+        // would never observe this as an `Accepted`; a fresh write re-pauses.
+        signals.note_drain(BridgeDirection::Ingress);
+
+        // Episode 2: still Paused. The backstop must re-arm fresh (100ms from
+        // now), not reuse episode 1's 80ms-elapsed deadline.
+        assert!(Pin::new(&mut s).poll_write(&mut cx, b"b").is_pending());
+        tokio::time::advance(Duration::from_millis(80)).await;
+        assert!(
+            Pin::new(&mut s).poll_write(&mut cx, b"b").is_pending(),
+            "fresh pause episode must not inherit the earlier episode's near-elapsed deadline",
+        );
+
+        // The fresh deadline still fires once genuinely exceeded.
+        tokio::time::advance(Duration::from_millis(40)).await;
+        match Pin::new(&mut s).poll_write(&mut cx, b"b") {
+            Poll::Ready(Err(e)) => assert_eq!(e.kind(), io::ErrorKind::TimedOut),
+            other => panic!("expected TimedOut on the fresh deadline, got {other:?}"),
         }
     }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -167,6 +167,8 @@ pub const DEFAULT_TCP_PAUSED_DRAIN_MAX_WAIT: Duration = Duration::from_mins(1);
 /// TCP response / upstream-write sink. Returns a [`TcpDeliverStatus`] so the
 /// stream's write side can pause when Swift's pending queue is full and
 /// resume after the matching `signal_*_drain`.
+// `&[u8]` is borrowed from `AsyncWrite::poll_write`, so Swift must copy it; once
+// rama has owned IO buffers end-to-end this could hand ownership over instead.
 type BytesStatusSink = Arc<dyn Fn(&[u8]) -> TcpDeliverStatus + Send + Sync + 'static>;
 /// UDP datagram sink. Carries the per-datagram peer in addition to
 /// the payload — see [`crate::Datagram`] for the direction-dependent

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -3,7 +3,7 @@ use std::{
     future::Future,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -582,6 +582,9 @@ pub struct TransparentProxyTcpSession {
     // contends with `on_client_bytes`, and only at cutover time.
     client_tx: Arc<parking_lot::Mutex<Option<mpsc::Sender<Bytes>>>>,
     saw_client_bytes: bool,
+    // Gates the `on_client_eof` fast-cancel so a server-speaks-first flow isn't
+    // torn down when the client half-closes without sending.
+    saw_server_bytes: bool,
 
     // egress data path (populated by activate).
     //
@@ -713,11 +716,11 @@ impl TransparentProxyTcpSession {
     /// buffered chunks then sees `None` (EOF). Dropping the sender (vs a
     /// side-channel flag) keeps the final chunk and the EOF strictly ordered.
     ///
-    /// If the client EOFs without ever sending a byte (`!saw_client_bytes`),
-    /// route through `cancel()` — nothing for the service to do. Asymmetric
-    /// with [`Self::on_egress_eof`]; see there.
+    /// With no bytes either way, fast-cancel (preconnect churn). If the server
+    /// already spoke, only close ingress so its response can still be relayed.
+    /// Asymmetric with [`Self::on_egress_eof`]; see there.
     pub fn on_client_eof(&mut self) {
-        if !self.saw_client_bytes {
+        if !self.saw_client_bytes && !self.saw_server_bytes {
             self.cancel();
             return;
         }
@@ -734,6 +737,7 @@ impl TransparentProxyTcpSession {
         if bytes.is_empty() {
             return TcpDeliverStatus::Accepted;
         }
+        self.saw_server_bytes = true;
         self.try_enqueue_egress(|| Bytes::copy_from_slice(bytes))
     }
 
@@ -749,6 +753,7 @@ impl TransparentProxyTcpSession {
             unsafe { view.release_now() };
             return TcpDeliverStatus::Accepted;
         }
+        self.saw_server_bytes = true;
         // SAFETY: see `on_client_bytes_owned` — buffer valid until its
         // `release` runs, and consumed only on the reserve-success path.
         self.try_enqueue_egress(move || unsafe { view.into_bytes() })
@@ -792,14 +797,14 @@ impl TransparentProxyTcpSession {
     /// Idempotent — the underlying `Notify` collapses redundant signals into
     /// a single permit.
     pub fn signal_server_drain(&self) {
-        self.signals.ingress_drain.wake();
+        self.signals.note_drain(BridgeDirection::Ingress);
     }
 
     /// Symmetric counterpart of [`Self::signal_server_drain`] for the egress
     /// request direction. Called by Swift when its `NwTcpConnectionWritePump`
     /// has drained capacity after `on_write_to_egress` returned `Paused`.
     pub fn signal_egress_drain(&self) {
-        self.signals.egress_drain.wake();
+        self.signals.note_drain(BridgeDirection::Egress);
     }
 
     /// Called by Swift when the egress `NWConnection` closes or fails.
@@ -950,7 +955,7 @@ impl TransparentProxyTcpSession {
     ///
     /// Idempotent: a later call replaces the previous registration.
     /// If no callback is registered when `into_passthrough` fires,
-    /// the future resolves with [`PromoteError::EgressUnavailable`]
+    /// the future resolves with [`PromoteError::NoCallbackRegistered`]
     /// and `PromoteLayer` falls through to the in-Rust data path.
     ///
     /// After Swift completes the cutover it MUST call
@@ -1014,9 +1019,9 @@ impl TransparentProxyTcpSession {
         //      `Paused` so it re-polls, observes (1) via the gated sink
         //      (now `Closed`), and unwinds.
         //   4. drop senders — natural EOF for the stream read sides.
-        //   5. abort the service task as a fallback for user code wedged
-        //      outside stream IO (its streams' `Drop` still fires the
-        //      gated close callbacks, no-op'd by (1)).
+        //   5. detach (NOT abort) the service task: its biased
+        //      `idle_guard.cancelled()` arm (from (2)) breaks the serve
+        //      loop and runs the close epilogue; aborting would lose it.
         *self.callback_active.lock() = false;
         // The receiver lives inside `flow_shutdown`'s inner future
         // and is dropped only when that future ends — which itself
@@ -1042,9 +1047,8 @@ impl TransparentProxyTcpSession {
         // `EngineShuttingDown` instead of hanging on the ACK
         // forever.
         self.promote_registry.abort_pending();
-        if let Some(task) = self.service_task.take() {
-            task.abort();
-        }
+        // Detach, don't abort — see step (5).
+        _ = self.service_task.take();
     }
 }
 
@@ -1318,6 +1322,7 @@ where
     SessionFlowAction::Intercept(TransparentProxyTcpSession {
         client_tx: client_tx_shared,
         saw_client_bytes: false,
+        saw_server_bytes: false,
         egress_tx: egress_tx_shared,
         signals,
         promote_registry,
@@ -2144,29 +2149,33 @@ impl std::fmt::Display for BridgeDirection {
     }
 }
 
-/// Per-flow backpressure flags and drain wakers, shared between the
-/// session's FFI surface and its two per-flow streams via a single `Arc`.
-/// One allocation instead of four (two `AtomicBool` + two `AtomicWaker`).
+/// Per-flow backpressure state, packed into one `Arc` shared by the session's
+/// FFI surface and its two per-flow streams.
 ///
 /// `*_paused` is set by `on_*_bytes` when the ingress channel is full and
-/// cleared (edge-triggered, firing the read-demand callback) by the
-/// matching stream's `poll_read` when it drains a slot. `*_drain` is
-/// registered by the matching stream's `poll_write` while parked on
-/// `Paused` and woken by `signal_*_drain`.
+/// cleared (edge-triggered, firing the read-demand callback) by the matching
+/// stream's `poll_read` on drain. `*_drain` is registered by `poll_write` while
+/// parked on `Paused` and woken by `signal_*_drain`, which also bumps
+/// `*_drain_gen` so the write side can distinguish a fresh pause episode from a
+/// continuously-parked one (see `FfiBridgeStream::poll_write`).
 pub(crate) struct TcpPerFlowSignals {
     ingress_paused: AtomicBool,
     ingress_drain: AtomicWaker,
+    ingress_drain_gen: AtomicU64,
     egress_paused: AtomicBool,
     egress_drain: AtomicWaker,
+    egress_drain_gen: AtomicU64,
 }
 
 impl TcpPerFlowSignals {
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             ingress_paused: AtomicBool::new(false),
             ingress_drain: AtomicWaker::new(),
+            ingress_drain_gen: AtomicU64::new(0),
             egress_paused: AtomicBool::new(false),
             egress_drain: AtomicWaker::new(),
+            egress_drain_gen: AtomicU64::new(0),
         }
     }
 
@@ -2182,6 +2191,26 @@ impl TcpPerFlowSignals {
             BridgeDirection::Ingress => &self.ingress_drain,
             BridgeDirection::Egress => &self.egress_drain,
         }
+    }
+
+    fn drain_gen_cell(&self, dir: BridgeDirection) -> &AtomicU64 {
+        match dir {
+            BridgeDirection::Ingress => &self.ingress_drain_gen,
+            BridgeDirection::Egress => &self.egress_drain_gen,
+        }
+    }
+
+    /// Monotonic drain count for `dir`; the write side snapshots it to tell a
+    /// fresh pause episode from a continuously-parked one (see `poll_write`).
+    pub(crate) fn drain_generation(&self, dir: BridgeDirection) -> u64 {
+        self.drain_gen_cell(dir).load(Ordering::Acquire)
+    }
+
+    /// Bump the drain generation then wake the parked write side. The `Release`
+    /// bump happens-before the wake, so the woken `poll_write` sees the new gen.
+    pub(crate) fn note_drain(&self, dir: BridgeDirection) {
+        self.drain_gen_cell(dir).fetch_add(1, Ordering::Release);
+        self.drain(dir).wake();
     }
 }
 

--- a/rama-net-apple-networkextension/src/tproxy/engine/promote.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/promote.rs
@@ -54,9 +54,7 @@ pub enum PromoteError {
     /// slot is populated at dispatch time. The egress NWConnection
     /// itself is never inspected on the Rust side — Swift owns that
     /// state and surfaces failures via [`Self::SwiftCutoverFailed`].
-    EgressUnavailable,
-    /// Kernel flow has already started closing on Swift's side.
-    IngressUnavailable,
+    NoCallbackRegistered,
     /// Engine-level shutdown raced ahead of this promote request.
     EngineShuttingDown,
     /// The registered promote callback panicked. The protocol can't
@@ -70,8 +68,7 @@ pub enum PromoteError {
 impl std::fmt::Display for PromoteError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::EgressUnavailable => f.write_str("no promote callback registered"),
-            Self::IngressUnavailable => f.write_str("ingress unavailable"),
+            Self::NoCallbackRegistered => f.write_str("no promote callback registered"),
             Self::EngineShuttingDown => f.write_str("engine shutting down"),
             Self::CallbackPanicked => f.write_str("promote callback panicked"),
             Self::SwiftCutoverFailed { reason } => {
@@ -557,7 +554,7 @@ impl PromoteRegistry {
             let rust_cb = self.rust_callback.lock().clone();
             if raw_cb.is_none() && rust_cb.is_none() {
                 *self.pending_ack.lock() = None;
-                return Err(PromoteError::EgressUnavailable);
+                return Err(PromoteError::NoCallbackRegistered);
             }
             // SAFETY (raw path): registration is FFI-owned; caller
             // keeps `context` valid until the session is freed.
@@ -802,13 +799,13 @@ mod tests {
         let rt = tokio::runtime::Handle::current();
         let shutdown = Arc::new(PromoteShutdown::new());
         let handle = PromoteHandle::new_engine(rt, shutdown, || async {
-            Err(PromoteError::EgressUnavailable)
+            Err(PromoteError::NoCallbackRegistered)
         });
         let h2 = handle.clone();
         let r1 = handle.into_passthrough().await;
         let r2 = h2.into_passthrough().await;
-        assert!(matches!(r1, Err(PromoteError::EgressUnavailable)));
-        assert!(matches!(r2, Err(PromoteError::EgressUnavailable)));
+        assert!(matches!(r1, Err(PromoteError::NoCallbackRegistered)));
+        assert!(matches!(r2, Err(PromoteError::NoCallbackRegistered)));
     }
 
     /// Round-3 audit: a panicking fire body MUST NOT leave waiters

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/common.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/common.rs
@@ -248,3 +248,77 @@ pub(super) fn build_engine_with_stop_drain_max_wait(
         .build()
         .expect("build engine")
 }
+
+// ── close-telemetry capture ────────────────────────────────────────────────
+//
+// On `cancel()` the Swift-facing callbacks are suppressed, so the only signal
+// the close epilogue ran is the `"tcp flow closed"` tracing event. A global
+// subscriber records each closed `flow_id`; tests filter by a unique id so they
+// hold whether run per-process (nextest) or shared (`cargo test`).
+
+use std::sync::{Once, OnceLock};
+
+static CLOSED_FLOW_IDS: OnceLock<parking_lot::Mutex<Vec<u64>>> = OnceLock::new();
+static INSTALL_CAPTURE: Once = Once::new();
+
+fn closed_flow_ids() -> &'static parking_lot::Mutex<Vec<u64>> {
+    CLOSED_FLOW_IDS.get_or_init(|| parking_lot::Mutex::new(Vec::new()))
+}
+
+#[derive(Default)]
+struct CloseVisitor {
+    flow_id: Option<u64>,
+    is_close: bool,
+}
+
+impl tracing::field::Visit for CloseVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "flow_id" {
+            self.flow_id = Some(value);
+        }
+    }
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" && format!("{value:?}").contains("tcp flow closed") {
+            self.is_close = true;
+        }
+    }
+}
+
+struct CloseCaptureSubscriber;
+
+impl tracing::Subscriber for CloseCaptureSubscriber {
+    fn enabled(&self, _md: &tracing::Metadata<'_>) -> bool {
+        true
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        let mut visitor = CloseVisitor::default();
+        event.record(&mut visitor);
+        if visitor.is_close
+            && let Some(id) = visitor.flow_id
+        {
+            closed_flow_ids().lock().push(id);
+        }
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+/// Install the close-capture subscriber exactly once for the test process.
+pub(super) fn install_close_capture() {
+    INSTALL_CAPTURE.call_once(|| {
+        // Ignore the error: if some other harness already set a global default we
+        // simply can't capture, and the caller's `flow_was_closed` will stay false
+        // (surfaced as a normal assertion failure rather than a panic here).
+        _ = tracing::subscriber::set_global_default(CloseCaptureSubscriber);
+    });
+}
+
+/// Whether a `"tcp flow closed"` telemetry event has been observed for `flow_id`.
+pub(super) fn flow_was_closed(flow_id: u64) -> bool {
+    closed_flow_ids().lock().contains(&flow_id)
+}

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/promote.rs
@@ -353,8 +353,8 @@ fn engine_promote_without_registered_callback_returns_egress_unavailable() {
         .recv_timeout(Duration::from_secs(5))
         .expect("service reported into_passthrough result");
     assert!(
-        matches!(r, Err(PromoteError::EgressUnavailable)),
-        "expected EgressUnavailable, got {r:?}",
+        matches!(r, Err(PromoteError::NoCallbackRegistered)),
+        "expected NoCallbackRegistered, got {r:?}",
     );
 
     // Drive the service to completion so engine.stop() doesn't hang

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/tcp.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/tcp.rs
@@ -615,3 +615,158 @@ fn tcp_bridge_observes_per_flow_shutdown_via_session_cancel() {
 
     engine.stop(0);
 }
+
+/// `cancel()` on an activated session must still run the flow's close epilogue
+/// (the `"tcp flow closed"` telemetry). Otherwise a cancelled flow logs an open
+/// with no matching close — a phantom "leaked" flow in the leak-hunting traces.
+#[test]
+fn tcp_cancel_after_activate_still_emits_close_telemetry() {
+    // Distinctive id that can't collide with the `next_flow_id()` sequence.
+    const ENG1_FLOW_ID: u64 = 0xE1E1_0001;
+    install_close_capture();
+
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(move |meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(
+                |bridge: BridgeIo<crate::TcpFlow, crate::NwTcpStream>| async move {
+                    // Park holding both halves so only the flow-guard
+                    // cancellation (from `cancel()`) can end the serve loop.
+                    let BridgeIo(stream, egress) = bridge;
+                    let _hold = (stream, egress);
+                    std::future::pending::<()>().await;
+                    Ok(())
+                },
+            )
+            .boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+        tcp_egress_options: None,
+        on_sleep: None,
+        on_wake: None,
+    };
+    let engine = build_engine(handler);
+
+    let mut meta = TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+        .with_remote_endpoint(HostWithPort::example_domain_with_port(443));
+    meta.flow_id = ENG1_FLOW_ID;
+
+    let SessionFlowAction::Intercept(mut session) =
+        engine.new_tcp_session(meta, |_| TcpDeliverStatus::Accepted, || {}, || {})
+    else {
+        panic!("expected intercept session");
+    };
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
+    std::thread::sleep(Duration::from_millis(20));
+
+    session.cancel();
+
+    let started = Instant::now();
+    while !flow_was_closed(ENG1_FLOW_ID) && started.elapsed() < Duration::from_secs(2) {
+        std::thread::sleep(Duration::from_millis(5));
+    }
+    assert!(
+        flow_was_closed(ENG1_FLOW_ID),
+        "cancel() must let the service task run its close epilogue (no phantom leaked flow)",
+    );
+
+    engine.stop(0);
+}
+
+/// A server-speaks-first flow whose client half-closes without sending must not
+/// be fast-cancelled: after `on_client_eof` the egress side stays alive
+/// (`on_egress_bytes` still returns `Accepted`).
+#[test]
+fn tcp_client_eof_after_server_bytes_keeps_egress_alive() {
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(
+                |bridge: BridgeIo<crate::TcpFlow, crate::NwTcpStream>| async move {
+                    let BridgeIo(stream, egress) = bridge;
+                    let _hold = (stream, egress);
+                    std::future::pending::<()>().await;
+                    Ok(())
+                },
+            )
+            .boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+        tcp_egress_options: None,
+        on_sleep: None,
+        on_wake: None,
+    };
+    let engine = build_engine(handler);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(443)),
+        |_| TcpDeliverStatus::Accepted,
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
+
+    // Server speaks first; client then half-closes having sent nothing.
+    assert_eq!(
+        session.on_egress_bytes(b"server-hello"),
+        TcpDeliverStatus::Accepted
+    );
+    session.on_client_eof();
+
+    // The flow must NOT have been cancelled: the egress direction is still open.
+    assert_eq!(
+        session.on_egress_bytes(b"more-response"),
+        TcpDeliverStatus::Accepted,
+        "server-speaks-first flow must survive a byte-less client EOF",
+    );
+
+    engine.stop(0);
+}
+
+/// Preconnect-churn case: client EOFs having sent nothing and the server never
+/// spoke either — still fast-cancels the flow.
+#[test]
+fn tcp_client_eof_with_no_bytes_either_side_fast_cancels() {
+    let handler = TestHandler {
+        app_message_handler: Arc::new(|_| None),
+        tcp_matcher: Arc::new(|meta| FlowAction::Intercept {
+            meta,
+            service: service_fn(
+                |_: BridgeIo<crate::TcpFlow, crate::NwTcpStream>| async move { Ok(()) },
+            )
+            .boxed(),
+        }),
+        udp_matcher: Arc::new(|_| FlowAction::Passthrough),
+        tcp_egress_options: None,
+        on_sleep: None,
+        on_wake: None,
+    };
+    let engine = build_engine(handler);
+
+    let SessionFlowAction::Intercept(mut session) = engine.new_tcp_session(
+        TransparentProxyFlowMeta::new(TransparentProxyFlowProtocol::Tcp)
+            .with_remote_endpoint(HostWithPort::example_domain_with_port(443)),
+        |_| TcpDeliverStatus::Accepted,
+        || {},
+        || {},
+    ) else {
+        panic!("expected intercept session");
+    };
+    session.activate(|_| TcpDeliverStatus::Accepted, || {}, || {});
+
+    session.on_client_eof();
+
+    // Fast-cancel fired: byte delivery now reports Closed.
+    assert_eq!(
+        session.on_egress_bytes(b"x"),
+        TcpDeliverStatus::Closed,
+        "byte-less EOF with no server response must fast-cancel the flow",
+    );
+
+    engine.stop(0);
+}

--- a/rama-net-apple-networkextension/src/tproxy/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/mod.rs
@@ -135,10 +135,11 @@ pub use self::{
         DEFAULT_FLOW_PRESSURE_SOFT_CAP, DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS,
         DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS, DEFAULT_TCP_START_IN_FLIGHT_HARD_CAP,
         DEFAULT_TCP_START_IN_FLIGHT_SOFT_CAP, DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS,
-        DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS, NwAttribution, NwEgressParameters,
-        NwInterfaceType, NwMultipathServiceType, NwServiceClass, NwTcpConnectOptions,
-        TransparentProxyConfig, TransparentProxyFlowAction, TransparentProxyFlowMeta,
-        TransparentProxyFlowProtocol, TransparentProxyNetworkRule, TransparentProxyRuleProtocol,
+        DEFAULT_TCP_START_LATENCY_BREAKER_P95_MS, FlowRefusalAction, NwAttribution,
+        NwEgressParameters, NwInterfaceType, NwMultipathServiceType, NwServiceClass,
+        NwTcpConnectOptions, TransparentProxyConfig, TransparentProxyFlowAction,
+        TransparentProxyFlowMeta, TransparentProxyFlowProtocol, TransparentProxyNetworkRule,
+        TransparentProxyRuleProtocol,
     },
 };
 pub use crate::process::AuditToken;

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -584,6 +584,30 @@ impl TransparentProxyNetworkRule {
     }
 }
 
+/// How the provider treats a flow it declines to intercept for its OWN reasons
+/// — the pre-ready TCP start hard cap / latency breaker tripping, or a missing /
+/// invalid session — as distinct from a [`crate::tproxy::FlowAction::Blocked`]
+/// your handler returns. Default [`Block`](Self::Block) (fail closed); set
+/// [`Passthrough`](Self::Passthrough) to fail open. The chosen action is always
+/// logged at the decision site.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FlowRefusalAction {
+    /// Refuse the flow (fail closed).
+    #[default]
+    Block,
+    /// Hand the flow to the kernel untouched (fail open).
+    Passthrough,
+}
+
+impl std::fmt::Display for FlowRefusalAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Block => "block",
+            Self::Passthrough => "passthrough",
+        })
+    }
+}
+
 /// Engine-level transparent proxy configuration.
 ///
 /// This configuration is long-lived and shared by all flows handled by one
@@ -628,6 +652,10 @@ pub struct TransparentProxyConfig {
     tcp_pressure_connect_timeout_ms: u32,
     /// Connect-timeout clamp while the start-latency breaker is open.
     tcp_breaker_connect_timeout_ms: u32,
+    /// How to treat a flow the provider declines to intercept for its own
+    /// reasons (start hard cap / latency breaker, or a missing session).
+    /// Default [`FlowRefusalAction::Block`].
+    flow_refusal_action: FlowRefusalAction,
 }
 
 impl TransparentProxyConfig {
@@ -651,6 +679,7 @@ impl TransparentProxyConfig {
             tcp_start_latency_breaker_close_p95_ms: DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS,
             tcp_pressure_connect_timeout_ms: DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS,
             tcp_breaker_connect_timeout_ms: DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS,
+            flow_refusal_action: FlowRefusalAction::Block,
         }
     }
 
@@ -734,6 +763,23 @@ impl TransparentProxyConfig {
     #[must_use]
     pub fn tcp_breaker_connect_timeout_ms(&self) -> u32 {
         self.tcp_breaker_connect_timeout_ms
+    }
+
+    /// How the provider treats a flow it declines for its own reasons; see
+    /// [`FlowRefusalAction`].
+    #[must_use]
+    pub fn flow_refusal_action(&self) -> FlowRefusalAction {
+        self.flow_refusal_action
+    }
+
+    generate_set_and_with! {
+        /// Set how the provider treats a flow it declines to intercept for its
+        /// own reasons — start hard cap / latency breaker, or a missing session.
+        /// Default [`FlowRefusalAction::Block`] (fail closed).
+        pub fn flow_refusal_action(mut self, action: FlowRefusalAction) -> Self {
+            self.flow_refusal_action = action;
+            self
+        }
     }
 
     generate_set_and_with! {

--- a/rama-net-apple-xpc/src/client.rs
+++ b/rama-net-apple-xpc/src/client.rs
@@ -23,6 +23,7 @@ pub struct XpcClientConfig {
     target_queue_label: Option<ArcStr>,
     peer_requirement: Option<PeerSecurityRequirement>,
     max_pending_events: usize,
+    call_timeout: Option<std::time::Duration>,
 }
 
 impl XpcClientConfig {
@@ -36,6 +37,7 @@ impl XpcClientConfig {
             target_queue_label: None,
             peer_requirement: None,
             max_pending_events: DEFAULT_MAX_PENDING_EVENTS,
+            call_timeout: None,
         }
     }
 
@@ -84,6 +86,17 @@ impl XpcClientConfig {
             self
         }
     }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Per-request timeout for [`XpcConnection::send_request`] and its helpers.
+        /// `None` (default) waits indefinitely; set a bound to get
+        /// [`XpcError::CallTimedOut`](crate::XpcError::CallTimedOut) instead of a
+        /// hang when a peer never replies.
+        pub fn call_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
+            self.call_timeout = timeout;
+            self
+        }
+    }
 }
 
 impl XpcConnection {
@@ -99,6 +112,7 @@ impl XpcConnection {
             target_queue_label,
             peer_requirement,
             max_pending_events,
+            call_timeout,
         } = config;
         tracing::debug!(
             service = %service_name,
@@ -124,6 +138,13 @@ impl XpcConnection {
             requirement.apply(connection.raw as _)?;
         }
 
-        Self::from_owned_peer_with_capacity(connection, max_pending_events, max_pending_events)
+        Ok(
+            Self::from_owned_peer_with_capacity(
+                connection,
+                max_pending_events,
+                max_pending_events,
+            )?
+            .with_call_timeout(call_timeout),
+        )
     }
 }

--- a/rama-net-apple-xpc/src/client.rs
+++ b/rama-net-apple-xpc/src/client.rs
@@ -144,7 +144,7 @@ impl XpcConnection {
                 max_pending_events,
                 max_pending_events,
             )?
-            .with_call_timeout(call_timeout),
+            .maybe_with_call_timeout(call_timeout),
         )
     }
 }

--- a/rama-net-apple-xpc/src/connection.rs
+++ b/rama-net-apple-xpc/src/connection.rs
@@ -270,12 +270,13 @@ impl XpcConnection {
         })
     }
 
-    /// Set the per-request timeout for [`send_request`](Self::send_request); `None`
-    /// waits indefinitely.
-    #[must_use]
-    pub fn with_call_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
-        self.call_timeout = timeout;
-        self
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the per-request timeout for [`send_request`](Self::send_request); `None`
+        /// waits indefinitely.
+        pub fn call_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
+            self.call_timeout = timeout;
+            self
+        }
     }
 
     /// Current per-request timeout, if any. See [`with_call_timeout`](Self::with_call_timeout).

--- a/rama-net-apple-xpc/src/connection.rs
+++ b/rama-net-apple-xpc/src/connection.rs
@@ -109,9 +109,14 @@ impl ReceivedXpcMessage {
         };
 
         // SAFETY: self.raw_event.raw is a valid XPC dictionary object retained by
-        // OwnedXpcObject. xpc_dictionary_create_reply returns a new retained dictionary
-        // or NULL if the message does not support replies.
+        // OwnedXpcObject. Returns a retained reply dictionary, or NULL for a
+        // fire-and-forget message (no reply context).
         let reply = unsafe { xpc_dictionary_create_reply(self.raw_event.raw) };
+        // NULL ⇒ nothing to reply to; `ReplyNotExpected` lets a server swallow it
+        // rather than treating it as a fatal error.
+        if reply.is_null() {
+            return Err(XpcError::ReplyNotExpected);
+        }
         let reply = OwnedXpcObject::from_raw(reply, "reply message")?;
 
         for (key, value) in values {
@@ -177,6 +182,9 @@ pub struct XpcConnection {
     connection: OwnedXpcObject,
     extensions: Extensions,
     receiver: Receiver<XpcEvent>,
+    /// Per-request timeout for [`send_request`](Self::send_request); `None` waits
+    /// indefinitely. Set via [`with_call_timeout`](Self::with_call_timeout).
+    call_timeout: Option<std::time::Duration>,
 }
 
 // SAFETY: `XpcConnection` wraps an `OwnedXpcObject` (an `xpc_connection_t`), an
@@ -258,7 +266,21 @@ impl XpcConnection {
             connection,
             extensions: Extensions::new(),
             receiver,
+            call_timeout: None,
         })
+    }
+
+    /// Set the per-request timeout for [`send_request`](Self::send_request); `None`
+    /// waits indefinitely.
+    #[must_use]
+    pub fn with_call_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
+        self.call_timeout = timeout;
+        self
+    }
+
+    /// Current per-request timeout, if any. See [`with_call_timeout`](Self::with_call_timeout).
+    pub fn call_timeout(&self) -> Option<std::time::Duration> {
+        self.call_timeout
     }
 
     /// Await the next event from the peer.
@@ -279,6 +301,7 @@ impl XpcConnection {
     /// [`send_request`](Self::send_request) when you need the peer's response.
     pub fn send(&self, message: XpcMessage) -> Result<(), XpcError> {
         tracing::trace!(message = ?message, "xpc send");
+        Self::ensure_dictionary(&message)?;
         let object = OwnedXpcObject::from_message(message)?;
         // SAFETY: self.connection.raw is a valid xpc_connection_t held by OwnedXpcObject
         // for the lifetime of &self. object.raw is a valid retained XPC object.
@@ -298,6 +321,7 @@ impl XpcConnection {
     /// connection closes before a reply is delivered.
     pub async fn send_request(&self, message: XpcMessage) -> Result<XpcMessage, XpcError> {
         tracing::trace!(message = ?message, "xpc send request");
+        Self::ensure_dictionary(&message)?;
         let object = OwnedXpcObject::from_message(message)?;
         let (reply_sender, reply_receiver) = oneshot::channel();
         let reply_sender = Mutex::new(Some(reply_sender));
@@ -345,11 +369,29 @@ impl XpcConnection {
             }
         }
 
-        let reply = reply_receiver
-            .await
-            .map_err(|_e| XpcError::ReplyCanceled)??;
+        let reply = match self.call_timeout {
+            Some(timeout) => match tokio::time::timeout(timeout, reply_receiver).await {
+                Ok(res) => res.map_err(|_e| XpcError::ReplyCanceled)??,
+                Err(_elapsed) => return Err(XpcError::CallTimedOut(timeout)),
+            },
+            None => reply_receiver
+                .await
+                .map_err(|_e| XpcError::ReplyCanceled)??,
+        };
         tracing::trace!(reply = ?reply, "xpc received reply");
         Ok(reply)
+    }
+
+    /// libxpc aborts the process on a non-dictionary top-level message; reject it
+    /// as a recoverable [`XpcError::InvalidMessage`] instead.
+    fn ensure_dictionary(message: &XpcMessage) -> Result<(), XpcError> {
+        if matches!(message, XpcMessage::Dictionary(_)) {
+            Ok(())
+        } else {
+            Err(XpcError::InvalidMessage(rama_utils::str::arcstr::arcstr!(
+                "top-level xpc connection message must be a Dictionary"
+            )))
+        }
     }
 
     /// Send a selector call to the peer without waiting for a reply.

--- a/rama-net-apple-xpc/src/error.rs
+++ b/rama-net-apple-xpc/src/error.rs
@@ -59,6 +59,11 @@ pub enum XpcError {
     ReplyNotExpected,
     /// The connection closed before the reply callback was invoked.
     ReplyCanceled,
+    /// A request exceeded its configured per-request timeout before a reply arrived.
+    CallTimedOut(std::time::Duration),
+    /// The peer replied with a structured error envelope (`{"$error": …}`); see
+    /// [`error_envelope`](crate::router::error_envelope).
+    Remote { code: i64, message: ArcStr },
     /// A connection-level error received from the XPC event stream.
     Connection(XpcConnectionError),
     /// An XPC message does not conform to the expected protocol structure
@@ -86,6 +91,12 @@ impl fmt::Display for XpcError {
             Self::ReplyNotExpected => f.write_str("incoming xpc message does not support replies"),
             Self::ReplyCanceled => {
                 f.write_str("xpc reply callback dropped before delivering a response")
+            }
+            Self::CallTimedOut(timeout) => {
+                write!(f, "xpc request timed out after {timeout:?}")
+            }
+            Self::Remote { code, message } => {
+                write!(f, "xpc peer returned error {code}: {message}")
             }
             Self::Connection(err) => write!(f, "xpc connection error: {err}"),
             Self::InvalidMessage(msg) => write!(f, "invalid xpc message structure: {msg}"),

--- a/rama-net-apple-xpc/src/integration_tests.rs
+++ b/rama-net-apple-xpc/src/integration_tests.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 use tokio::time::timeout;
 
 use crate::{
-    XpcConnection, XpcEndpoint, XpcEvent, XpcListener, XpcListenerConfig, XpcMessage,
+    XpcConnection, XpcEndpoint, XpcError, XpcEvent, XpcListener, XpcListenerConfig, XpcMessage,
     connection::DEFAULT_MAX_PENDING_EVENTS, object::OwnedXpcObject,
 };
 
@@ -379,4 +379,178 @@ async fn self_cancel_delivers_final_invalidation_event() {
         Some(XpcEvent::Error(crate::XpcConnectionError::Invalidated(_))) => {}
         other => panic!("expected final Invalidated event after self-cancel, got {other:?}"),
     }
+}
+
+// ── send() / send_request() dictionary guard (must not abort the process) ──
+
+/// A non-Dictionary top-level message would make libxpc abort the process. The
+/// guard must turn that into a recoverable `InvalidMessage` on both send paths,
+/// and the process must stay alive (reaching the asserts proves it).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_paths_reject_non_dictionary_without_aborting() {
+    let (_server, endpoint) = XpcEndpoint::anonymous_channel(None).expect("anonymous_channel");
+    let client = endpoint.into_connection().expect("into_connection");
+
+    let err = client.send(XpcMessage::Int64(1)).unwrap_err();
+    assert!(matches!(err, XpcError::InvalidMessage(_)), "got {err:?}");
+
+    let err = client.send(XpcMessage::Array(vec![])).unwrap_err();
+    assert!(matches!(err, XpcError::InvalidMessage(_)), "got {err:?}");
+
+    let err = client
+        .send_request(XpcMessage::String("nope".into()))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, XpcError::InvalidMessage(_)), "got {err:?}");
+}
+
+// ── reply to a fire-and-forget message ────────────────────────────────────
+
+/// A message the peer sent via `send` (not `send_request`) carries no reply
+/// context. Replying to it must return `ReplyNotExpected` — NOT a hard
+/// `NullObject` — so a server can swallow it without tearing down the connection.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reply_to_fire_and_forget_message_returns_reply_not_expected() {
+    let (server, endpoint) = XpcEndpoint::anonymous_channel(None).expect("anonymous_channel");
+
+    let server_task = tokio::spawn(async move {
+        let mut server = server;
+        let mut peer = next_peer(&mut server).await;
+        let event = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("recv")
+            .expect("closed");
+        let msg = match event {
+            XpcEvent::Message(m) => m,
+            other => panic!("expected Message, got {other:?}"),
+        };
+        let mut reply = std::collections::BTreeMap::new();
+        reply.insert("x".to_owned(), XpcMessage::Int64(1));
+        matches!(
+            msg.reply(XpcMessage::Dictionary(reply)),
+            Err(XpcError::ReplyNotExpected)
+        )
+    });
+
+    tokio::task::yield_now().await;
+    let client = endpoint.into_connection().expect("into_connection");
+    let mut payload = std::collections::BTreeMap::new();
+    payload.insert("k".to_owned(), XpcMessage::Int64(1));
+    // Fire-and-forget: no reply context on the receiving side.
+    client.send(XpcMessage::Dictionary(payload)).expect("send");
+
+    let is_reply_not_expected = timeout(Duration::from_secs(3), server_task)
+        .await
+        .expect("server timeout")
+        .expect("server task");
+    assert!(
+        is_reply_not_expected,
+        "reply to a fire-and-forget message must be ReplyNotExpected"
+    );
+}
+
+// ── opt-in per-request timeout ─────────────────────────────────────────────
+
+/// With `call_timeout` set, a request whose peer never replies resolves to
+/// `CallTimedOut` instead of hanging forever. The default (no timeout) is
+/// covered implicitly by every other request test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_request_times_out_when_peer_never_replies() {
+    let (server, endpoint) = XpcEndpoint::anonymous_channel(None).expect("anonymous_channel");
+
+    // Hold the listener, the peer, AND the received request alive — never replying —
+    // so the peer connection is not interrupted and only the timeout can resolve the
+    // client's call.
+    let _server_task = tokio::spawn(async move {
+        let mut server = server;
+        let mut peer = next_peer(&mut server).await;
+        let held = timeout(Duration::from_secs(3), peer.recv()).await;
+        std::future::pending::<()>().await;
+        drop((server, peer, held));
+    });
+
+    tokio::task::yield_now().await;
+    let client = endpoint
+        .into_connection()
+        .expect("into_connection")
+        .with_call_timeout(Some(Duration::from_millis(300)));
+    assert_eq!(client.call_timeout(), Some(Duration::from_millis(300)));
+
+    let mut req = std::collections::BTreeMap::new();
+    req.insert("ping".to_owned(), XpcMessage::Int64(1));
+    let err = timeout(
+        Duration::from_secs(5),
+        client.send_request(XpcMessage::Dictionary(req)),
+    )
+    .await
+    .expect("timeout wrapper must not itself expire")
+    .unwrap_err();
+    assert!(matches!(err, XpcError::CallTimedOut(_)), "got {err:?}");
+}
+
+// ── server resilience: one bad request never tears down the connection ─────
+
+/// End-to-end proof that an unknown selector AND a failing handler both resolve
+/// to a structured error reply and leave the peer connection alive: a good
+/// request issued afterwards must still succeed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_survives_unknown_selector_and_handler_error() {
+    use crate::router::{ERROR_CODE_HANDLER_FAILED, ERROR_CODE_UNKNOWN_SELECTOR};
+    use crate::{XpcMessageRouter, XpcServer};
+    use rama_core::{error::BoxError, rt::Executor, service::service_fn};
+    use std::convert::Infallible;
+
+    let (server_conn, endpoint) = XpcEndpoint::anonymous_channel(None).expect("anonymous_channel");
+
+    let router = XpcMessageRouter::new()
+        .with_typed_route::<u32, u32, _>(
+            "double:withReply:",
+            service_fn(|n: u32| async move { Ok::<_, Infallible>(n * 2) }),
+        )
+        .with_route(
+            "boom:withReply:",
+            service_fn(|_: XpcMessage| async move {
+                Err::<Option<XpcMessage>, BoxError>(BoxError::from(std::io::Error::other("kaboom")))
+            }),
+        );
+
+    let server = XpcServer::new(router);
+    let executor = Executor::new();
+    tokio::spawn(async move {
+        _ = server.serve_connection(server_conn, executor).await;
+    });
+    tokio::task::yield_now().await;
+
+    let client = endpoint
+        .into_connection()
+        .expect("into_connection")
+        .with_call_timeout(Some(Duration::from_secs(3)));
+
+    // 1. Unknown selector → structured Remote(UNKNOWN_SELECTOR), connection lives.
+    let err = client
+        .request_typed::<(), u32>("nope:withReply:".into(), &())
+        .await
+        .unwrap_err();
+    match err {
+        XpcError::Remote { code, .. } => assert_eq!(code, ERROR_CODE_UNKNOWN_SELECTOR),
+        other => panic!("expected Remote(UNKNOWN_SELECTOR), got {other:?}"),
+    }
+
+    // 2. Handler that returns Err → Remote(HANDLER_FAILED), connection still lives.
+    let err = client
+        .request_typed::<u32, u32>("boom:withReply:".into(), &1)
+        .await
+        .unwrap_err();
+    match err {
+        XpcError::Remote { code, .. } => assert_eq!(code, ERROR_CODE_HANDLER_FAILED),
+        other => panic!("expected Remote(HANDLER_FAILED), got {other:?}"),
+    }
+
+    // 3. A good request AFTER the two bad ones must still succeed — proof the
+    //    connection was never torn down.
+    let doubled: u32 = client
+        .request_typed::<u32, u32>("double:withReply:".into(), &21)
+        .await
+        .expect("good request after bad ones must succeed");
+    assert_eq!(doubled, 42);
 }

--- a/rama-net-apple-xpc/src/integration_tests.rs
+++ b/rama-net-apple-xpc/src/integration_tests.rs
@@ -473,7 +473,7 @@ async fn send_request_times_out_when_peer_never_replies() {
     let client = endpoint
         .into_connection()
         .expect("into_connection")
-        .with_call_timeout(Some(Duration::from_millis(300)));
+        .with_call_timeout(Duration::from_millis(300));
     assert_eq!(client.call_timeout(), Some(Duration::from_millis(300)));
 
     let mut req = std::collections::BTreeMap::new();
@@ -524,7 +524,7 @@ async fn server_survives_unknown_selector_and_handler_error() {
     let client = endpoint
         .into_connection()
         .expect("into_connection")
-        .with_call_timeout(Some(Duration::from_secs(3)));
+        .with_call_timeout(Duration::from_secs(3));
 
     // 1. Unknown selector → structured Remote(UNKNOWN_SELECTOR), connection lives.
     let err = client

--- a/rama-net-apple-xpc/src/lib.rs
+++ b/rama-net-apple-xpc/src/lib.rs
@@ -152,7 +152,7 @@ mod listener;
 mod message;
 mod object;
 mod peer;
-mod router;
+pub mod router;
 mod server;
 mod util;
 

--- a/rama-net-apple-xpc/src/object.rs
+++ b/rama-net-apple-xpc/src/object.rs
@@ -104,28 +104,36 @@ impl OwnedXpcObject {
                 endpoint.raw_object().raw
             }
             XpcMessage::Array(values) => {
-                // SAFETY: Passing null/0 creates an empty mutable array.
-                let raw = unsafe { xpc_array_create(ptr::null_mut(), 0) };
+                // SAFETY: null/0 creates an empty mutable array. Owned now so a `?`
+                // inside the loop releases it rather than leaking.
+                let array = Self::from_raw(
+                    unsafe { xpc_array_create(ptr::null_mut(), 0) },
+                    "array encode",
+                )?;
                 for value in values {
                     let value = Self::from_message_inner(value, depth + 1)?;
-                    // SAFETY: raw is a valid mutable XPC array; value.raw is a valid
+                    // SAFETY: array.raw is a valid mutable XPC array; value.raw is a valid
                     // retained XPC object. xpc_array_append_value retains value.raw.
-                    unsafe { xpc_array_append_value(raw, value.raw) };
+                    unsafe { xpc_array_append_value(array.raw, value.raw) };
                 }
-                raw
+                return Ok(array);
             }
             XpcMessage::Dictionary(values) => {
-                // SAFETY: Passing null/null/0 creates an empty mutable dictionary.
-                let raw = unsafe { xpc_dictionary_create(ptr::null(), ptr::null_mut(), 0) };
+                // SAFETY: null/null/0 creates an empty mutable dictionary. Owned now so
+                // a `?` inside the loop releases it rather than leaking.
+                let dict = Self::from_raw(
+                    unsafe { xpc_dictionary_create(ptr::null(), ptr::null_mut(), 0) },
+                    "dictionary encode",
+                )?;
                 for (key, value) in values {
                     let key = make_c_string(&key)?;
                     let value = Self::from_message_inner(value, depth + 1)?;
-                    // SAFETY: raw is a valid mutable XPC dictionary. key.as_ptr() is a
+                    // SAFETY: dict.raw is a valid mutable XPC dictionary. key.as_ptr() is a
                     // valid null-terminated C string. value.raw is a valid retained XPC
                     // object. xpc_dictionary_set_value retains value.raw.
-                    unsafe { xpc_dictionary_set_value(raw, key.as_ptr(), value.raw) };
+                    unsafe { xpc_dictionary_set_value(dict.raw, key.as_ptr(), value.raw) };
                 }
-                raw
+                return Ok(dict);
             }
         };
         Self::from_raw(raw, "message encode")

--- a/rama-net-apple-xpc/src/router/mod.rs
+++ b/rama-net-apple-xpc/src/router/mod.rs
@@ -1,4 +1,3 @@
-use rama_core::error::BoxErrorExt as _;
 use std::borrow::Cow;
 
 use ahash::{HashMap, HashMapExt as _};
@@ -15,6 +14,47 @@ use self::{raw_adapter::RawAdapter, typed_adapter::TypedAdapter};
 
 // Reply key for Xpc router handler
 const RESULT_KEY: &str = "$result";
+// Reply key for a structured error envelope produced instead of a `$result`.
+const ERROR_KEY: &str = "$error";
+
+/// Error code for a selector with no registered route and no fallback.
+pub const ERROR_CODE_UNKNOWN_SELECTOR: i64 = 1;
+/// Error code for a message that is not a well-formed call (missing/invalid `$selector`).
+pub const ERROR_CODE_INVALID_MESSAGE: i64 = 2;
+/// Error code for a registered handler that returned an error.
+pub const ERROR_CODE_HANDLER_FAILED: i64 = 3;
+
+/// Build an error reply `{"$error": {"code": <code>, "message": <message>}}`,
+/// returned in place of a `$result` so a failed call gets a definite reply
+/// instead of a hang. [`extract_result`] surfaces it as [`XpcError::Remote`].
+pub fn error_envelope(code: i64, message: impl Into<String>) -> XpcMessage {
+    let mut inner = std::collections::BTreeMap::new();
+    inner.insert("code".to_owned(), XpcMessage::Int64(code));
+    inner.insert("message".to_owned(), XpcMessage::String(message.into()));
+    let mut outer = std::collections::BTreeMap::new();
+    outer.insert(ERROR_KEY.to_owned(), XpcMessage::Dictionary(inner));
+    XpcMessage::Dictionary(outer)
+}
+
+/// `Some((code, message))` when `reply` is an `{"$error": …}` envelope.
+fn parse_error_envelope(reply: &XpcMessage) -> Option<(i64, String)> {
+    let XpcMessage::Dictionary(map) = reply else {
+        return None;
+    };
+    let XpcMessage::Dictionary(inner) = map.get(ERROR_KEY)? else {
+        return None;
+    };
+    let code = match inner.get("code") {
+        Some(XpcMessage::Int64(c)) => *c,
+        Some(XpcMessage::Uint64(c)) => i64::try_from(*c).unwrap_or(i64::MAX),
+        _ => 0,
+    };
+    let message = match inner.get("message") {
+        Some(XpcMessage::String(s)) => s.clone(),
+        _ => String::new(),
+    };
+    Some((code, message))
+}
 
 /// A type-erased, clone-able service that processes an [`XpcMessage`] and
 /// optionally returns a reply [`XpcMessage`].
@@ -51,9 +91,9 @@ type BoxedRoute = rama_core::service::BoxService<XpcMessage, Option<XpcMessage>,
 ///
 /// # Fallback
 ///
-/// An optional fallback service handles any selector that has no registered
-/// route.  Without a fallback, unknown selectors are silently ignored (returning
-/// `Ok(None)`).
+/// An optional fallback service handles any selector with no registered route.
+/// Without one, an unknown or malformed selector resolves to an [`error_envelope`]
+/// reply (not an `Err`), so one bad request never tears down the peer connection.
 #[derive(Clone)]
 pub struct XpcMessageRouter {
     routes: HashMap<Cow<'static, str>, BoxedRoute>,
@@ -175,22 +215,22 @@ impl Service<XpcMessage> for XpcMessageRouter {
     type Error = BoxError;
 
     async fn serve(&self, input: XpcMessage) -> Result<Self::Output, Self::Error> {
-        // Peek at the selector without consuming the message.
-        let selector = match &input {
-            XpcMessage::Dictionary(map) => match map.get("$selector") {
-                Some(XpcMessage::String(s)) => s.as_str(),
-                _ => {
-                    return Err(BoxError::from(XpcError::InvalidMessage(arcstr!(
-                        "XpcMessageRouter: missing or non-string '$selector'"
-                    ))));
-                }
-            },
-            _ => {
-                return Err(BoxError::from(XpcError::InvalidMessage(arcstr!(
-                    "XpcMessageRouter: expected a Dictionary"
-                ))));
-            }
+        // Malformed calls answer with an error envelope, never an `Err`.
+        let XpcMessage::Dictionary(map) = &input else {
+            tracing::warn!("xpc router: message is not a Dictionary");
+            return Ok(Some(error_envelope(
+                ERROR_CODE_INVALID_MESSAGE,
+                "XpcMessageRouter: expected a Dictionary",
+            )));
         };
+        let Some(XpcMessage::String(selector)) = map.get("$selector") else {
+            tracing::warn!("xpc router: missing or non-string '$selector'");
+            return Ok(Some(error_envelope(
+                ERROR_CODE_INVALID_MESSAGE,
+                "XpcMessageRouter: missing or non-string '$selector'",
+            )));
+        };
+        let selector = selector.as_str();
 
         if let Some(handler) = self.routes.get(selector) {
             tracing::info!(selector, "xpc router dispatching selector");
@@ -203,9 +243,10 @@ impl Service<XpcMessage> for XpcMessageRouter {
         }
 
         tracing::warn!(selector, "xpc router missing selector");
-        Err(BoxError::from_static_str(
-            "XpcMessageRouter: no matching router found and no fallback defined",
-        ))
+        Ok(Some(error_envelope(
+            ERROR_CODE_UNKNOWN_SELECTOR,
+            format!("XpcMessageRouter: no route registered for selector '{selector}'"),
+        )))
     }
 }
 
@@ -214,6 +255,12 @@ impl Service<XpcMessage> for XpcMessageRouter {
 /// Used on the client side after [`crate::XpcConnection::request_selector`] to decode
 /// the reply returned by a typed server handler.
 pub fn extract_result<T: DeserializeOwned>(reply: XpcMessage) -> Result<T, XpcError> {
+    if let Some((code, message)) = parse_error_envelope(&reply) {
+        return Err(XpcError::Remote {
+            code,
+            message: message.into(),
+        });
+    }
     let XpcMessage::Dictionary(mut map) = reply else {
         return Err(XpcError::InvalidMessage(arcstr!(
             "router reply: expected a Dictionary"

--- a/rama-net-apple-xpc/src/router/tests.rs
+++ b/rama-net-apple-xpc/src/router/tests.rs
@@ -89,10 +89,19 @@ async fn raw_route_receives_full_message() {
 // ── unknown selector ─────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn unknown_selector_returns_none_without_fallback() {
+async fn unknown_selector_returns_error_envelope_without_fallback() {
     let router = XpcMessageRouter::new();
     let call = make_call("unknownSelector", vec![]);
-    router.serve(call).await.unwrap_err();
+    // An error-envelope reply, not an Err (which would tear down the connection).
+    let reply = router.serve(call).await.expect("serve").expect("reply");
+    let err = extract_result::<()>(reply).unwrap_err();
+    match err {
+        XpcError::Remote { code, message } => {
+            assert_eq!(code, ERROR_CODE_UNKNOWN_SELECTOR);
+            assert!(message.contains("unknownSelector"), "message: {message}");
+        }
+        other => panic!("expected Remote error, got {other:?}"),
+    }
 }
 
 // ── fallback ─────────────────────────────────────────────────────────────
@@ -141,31 +150,69 @@ async fn known_route_takes_priority_over_fallback() {
 // ── without_fallback ─────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn without_fallback_removes_it() {
-    let router = XpcMessageRouter::new();
+async fn without_fallback_returns_unknown_selector_envelope() {
+    let router = XpcMessageRouter::new().without_fallback();
     let call = make_call("sel", vec![]);
-    router.serve(call).await.unwrap_err();
+    let (code, _msg) = error_of(router.serve(call).await);
+    assert_eq!(code, ERROR_CODE_UNKNOWN_SELECTOR);
 }
 
 // ── invalid message ──────────────────────────────────────────────────────
+//
+// A malformed call must NOT be an `Err` (which tears down the peer connection)
+// — it resolves to an INVALID_MESSAGE error envelope.
 
 #[tokio::test]
-async fn error_on_non_dictionary_input() {
+async fn non_dictionary_input_returns_invalid_message_envelope() {
     let router = XpcMessageRouter::new();
-    let err = router.serve(XpcMessage::Null).await.unwrap_err();
-    assert!(err.to_string().contains("XpcMessageRouter"));
+    let (code, _msg) = error_of(router.serve(XpcMessage::Null).await);
+    assert_eq!(code, ERROR_CODE_INVALID_MESSAGE);
 }
 
 #[tokio::test]
-async fn error_on_missing_selector_key() {
+async fn missing_selector_key_returns_invalid_message_envelope() {
     let mut map = std::collections::BTreeMap::new();
     map.insert("foo".to_owned(), XpcMessage::Null);
-    let err = router_serve(XpcMessage::Dictionary(map)).await.unwrap_err();
-    assert!(err.to_string().contains("XpcMessageRouter"));
+    let (code, _msg) = error_of(router_serve(XpcMessage::Dictionary(map)).await);
+    assert_eq!(code, ERROR_CODE_INVALID_MESSAGE);
+}
+
+#[tokio::test]
+async fn non_string_selector_returns_invalid_message_envelope() {
+    let mut map = std::collections::BTreeMap::new();
+    map.insert("$selector".to_owned(), XpcMessage::Int64(7));
+    let (code, _msg) = error_of(router_serve(XpcMessage::Dictionary(map)).await);
+    assert_eq!(code, ERROR_CODE_INVALID_MESSAGE);
+}
+
+// ── error envelope round-trip ────────────────────────────────────────────
+
+#[tokio::test]
+async fn error_envelope_round_trips_via_extract_result() {
+    let env = error_envelope(ERROR_CODE_HANDLER_FAILED, "boom");
+    let err = extract_result::<Pong>(env).unwrap_err();
+    match err {
+        XpcError::Remote { code, message } => {
+            assert_eq!(code, ERROR_CODE_HANDLER_FAILED);
+            assert_eq!(&*message, "boom");
+        }
+        other => panic!("expected Remote, got {other:?}"),
+    }
 }
 
 async fn router_serve(msg: XpcMessage) -> Result<Option<XpcMessage>, BoxError> {
     XpcMessageRouter::new().serve(msg).await
+}
+
+// Decode a router reply that is expected to be an error envelope, returning (code, message).
+fn error_of(reply: Result<Option<XpcMessage>, BoxError>) -> (i64, String) {
+    let reply = reply
+        .expect("serve should not Err")
+        .expect("expected a reply");
+    match extract_result::<()>(reply).unwrap_err() {
+        XpcError::Remote { code, message } => (code, message.to_string()),
+        other => panic!("expected Remote error, got {other:?}"),
+    }
 }
 
 // ── clone ────────────────────────────────────────────────────────────────

--- a/rama-net-apple-xpc/src/server.rs
+++ b/rama-net-apple-xpc/src/server.rs
@@ -26,6 +26,11 @@ use crate::{
 /// [`XpcConnection::send_request`], replying is not possible and the server silently
 /// ignores [`XpcError::ReplyNotExpected`].
 ///
+/// A failing message (handler error, or a reply that can't be delivered) is logged
+/// and, when a reply is expected, answered with an
+/// [`error_envelope`](crate::router::error_envelope) — it never tears down the peer
+/// connection; only a kernel [`XpcEvent::Error`] does.
+///
 /// This adapter is intentionally minimal. It keeps [`XpcMessage`] as the public wire
 /// type, while leaving room for higher-level typed codecs and request-routing layers
 /// to be built on top later.
@@ -118,7 +123,7 @@ where
                     self.spawn_peer_task(peer, &executor);
                 }
                 Some(XpcEvent::Message(message)) => {
-                    handle_message(self.service.as_ref(), message, None).await?;
+                    handle_message(self.service.as_ref(), message, None).await;
                 }
                 Some(XpcEvent::Error(err)) => {
                     log_connection_close(&err, "xpc server event stream closed");
@@ -167,7 +172,7 @@ where
                 tracing::warn!("xpc server received unexpected nested peer connection event");
             }
             Some(XpcEvent::Message(message)) => {
-                handle_message(service.as_ref(), message, Some((pid, asid))).await?;
+                handle_message(service.as_ref(), message, Some((pid, asid))).await;
             }
             Some(XpcEvent::Error(err)) => {
                 log_connection_close(&err, "xpc peer connection closed");
@@ -177,12 +182,14 @@ where
     }
 }
 
+/// Handle one message. Infallible by design: a handler error or undeliverable reply
+/// is logged (and answered with an error envelope when a reply is expected), never
+/// propagated, so one bad request can't tear down the peer connection.
 async fn handle_message<S>(
     service: &S,
     message: ReceivedXpcMessage,
     peer_identity: Option<(i32, i32)>,
-) -> Result<(), BoxError>
-where
+) where
     S: Service<XpcMessage, Output = Option<XpcMessage>, Error: Into<BoxError>>,
 {
     let request = message.message().clone();
@@ -193,37 +200,39 @@ where
     } else {
         tracing::info!(selector, "xpc server handling message");
     }
-    let reply = service.serve(request).await.map_err(Into::into)?;
 
-    if let Some(reply) = reply {
-        match message.reply(reply) {
-            Ok(()) => {
-                if let Some((pid, asid)) = peer_identity {
-                    tracing::info!(pid, asid, selector, "xpc server sent reply");
-                } else {
-                    tracing::info!(selector, "xpc server sent reply");
-                }
-            }
-            Err(XpcError::ReplyNotExpected) => {
-                tracing::warn!(
-                    selector,
-                    "xpc server service produced a reply for a fire-and-forget message"
-                );
-            }
-            Err(err) => return Err(err.into()),
+    let reply = match service.serve(request).await {
+        Ok(reply) => reply,
+        Err(err) => {
+            let err: BoxError = err.into();
+            tracing::warn!(selector, %err, "xpc server handler failed; replying with error envelope");
+            Some(crate::router::error_envelope(
+                crate::router::ERROR_CODE_HANDLER_FAILED,
+                err.to_string(),
+            ))
         }
-    } else if let Some((pid, asid)) = peer_identity {
-        tracing::warn!(
-            pid,
-            asid,
-            selector,
-            "xpc server service completed without reply"
-        );
-    } else {
-        tracing::warn!(selector, "xpc server service completed without reply");
-    }
+    };
 
-    Ok(())
+    let Some(reply) = reply else {
+        tracing::debug!(selector, "xpc server service completed without reply");
+        return;
+    };
+
+    match message.reply(reply) {
+        Ok(()) => {
+            tracing::info!(selector, "xpc server sent reply");
+        }
+        // Fire-and-forget message: nothing to reply to.
+        Err(XpcError::ReplyNotExpected) => {
+            tracing::debug!(
+                selector,
+                "xpc server produced a reply for a fire-and-forget message"
+            );
+        }
+        Err(err) => {
+            tracing::warn!(selector, %err, "xpc server failed to deliver reply");
+        }
+    }
 }
 
 fn message_selector(message: &XpcMessage) -> Option<String> {


### PR DESCRIPTION
- Harden NE/XPC/SE, fix dist spec & docs
- Pin FFI struct layouts, fix header docs
- Annotate FFI header nullability
- Note owned-IO-buffer future zero-copy
- Minor fixes to previous NE/XPC commits
- Configurable fail-open for NE refusals
- Deflake EOF-grace promote-disarm test
