### PR TITLE
validate full request-line in HTTP peek routing

### DIFF
--- a/rama-core/src/io/mod.rs
+++ b/rama-core/src/io/mod.rs
@@ -2,7 +2,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 mod read;
 #[doc(inline)]
-pub use read::{ChainReader, HeapReader, StackReader, discard};
+pub use read::{ChainReader, HeapReader, ReplayReader, StackReader, discard};
 
 mod prefix;
 #[doc(inline)]

--- a/rama-core/src/io/read.rs
+++ b/rama-core/src/io/read.rs
@@ -237,6 +237,94 @@ impl<const N: usize> Read for StackReader<N> {
     }
 }
 
+/// Reader replaying a [`Bytes`] buffer, releasing it once fully consumed.
+///
+/// Unlike [`HeapReader`] the backing allocation is dropped at EOF, so the
+/// reader can be held for a connection's lifetime (e.g. as the prefix of a
+/// [`PrefixedIo`]) without retaining the replayed bytes.
+///
+/// [`PrefixedIo`]: super::PrefixedIo
+#[derive(Debug, Clone, Default)]
+pub struct ReplayReader {
+    data: Bytes,
+}
+
+impl ReplayReader {
+    /// Creates a new `ReplayReader` with the specified bytes data.
+    #[must_use]
+    pub const fn new(data: Bytes) -> Self {
+        Self { data }
+    }
+
+    /// How many bytes are there remaining
+    #[must_use]
+    pub fn remaining(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns true if there are any more bytes to consume
+    #[must_use]
+    pub fn has_remaining(&self) -> bool {
+        !self.data.is_empty()
+    }
+
+    fn advance(&mut self, n: usize) {
+        if n >= self.data.len() {
+            // EOF: release the backing allocation
+            self.data = Bytes::new();
+        } else {
+            self.data.advance(n);
+        }
+    }
+}
+
+impl From<Bytes> for ReplayReader {
+    #[inline]
+    fn from(data: Bytes) -> Self {
+        Self::new(data)
+    }
+}
+
+impl AsyncRead for ReplayReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let to_copy = self.data.len().min(buf.remaining());
+        if to_copy > 0 {
+            buf.put_slice(&self.data[..to_copy]);
+            self.advance(to_copy);
+        }
+
+        // done
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncBufRead for ReplayReader {
+    fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        Poll::Ready(Ok(&self.get_mut().data))
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_mut().advance(amt);
+    }
+}
+
+impl Read for ReplayReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let to_copy = self.data.len().min(buf.len());
+        if to_copy > 0 {
+            buf[..to_copy].copy_from_slice(&self.data[..to_copy]);
+            self.advance(to_copy);
+        }
+
+        // done
+        Ok(to_copy)
+    }
+}
+
 pin_project! {
     /// Reader that can be used to chain two readers together.
     #[must_use = "streams do nothing unless polled"]
@@ -372,6 +460,19 @@ mod test {
     use super::*;
 
     use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn test_replay_reader_releases_buffer_at_eof() {
+        let data = Bytes::from(vec![7u8; 64]);
+        let mut reader = ReplayReader::new(data.clone());
+        let mut out = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut out)
+            .await
+            .unwrap();
+        assert_eq!(vec![7u8; 64], out);
+        // the reader dropped its handle at EOF: ours is unique again
+        data.try_into_mut().expect("replay buffer was released");
+    }
 
     #[tokio::test]
     async fn test_discard_consumes_exact_bytes() {

--- a/rama-net/src/byte_sets.rs
+++ b/rama-net/src/byte_sets.rs
@@ -75,6 +75,7 @@ const LABEL_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b
 const PATTERN_NAME_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
 
 /// RFC 9110 `tchar`, used by HTTP methods and other token-valued fields.
+#[cfg(feature = "http")]
 const HTTP_TOKEN_BYTE_SET: [bool; 256] =
     set_each(set_ascii_alphanum([false; 256]), b"!#$%&'*+-.^_`|~");
 
@@ -85,6 +86,7 @@ pub(crate) const fn is_control_byte(b: u8) -> bool {
     CONTROL_BYTE_SET[b as usize]
 }
 
+#[cfg(feature = "http")]
 #[inline(always)]
 pub(crate) const fn is_http_token_byte(b: u8) -> bool {
     HTTP_TOKEN_BYTE_SET[b as usize]

--- a/rama-net/src/byte_sets.rs
+++ b/rama-net/src/byte_sets.rs
@@ -74,11 +74,20 @@ const LABEL_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b
 /// label, kept separate so the two grammars can drift independently.
 const PATTERN_NAME_BYTE_SET: [bool; 256] = set_each(set_ascii_alphanum([false; 256]), b"_-");
 
+/// RFC 9110 `tchar`, used by HTTP methods and other token-valued fields.
+const HTTP_TOKEN_BYTE_SET: [bool; 256] =
+    set_each(set_ascii_alphanum([false; 256]), b"!#$%&'*+-.^_`|~");
+
 // --- Predicates (single-load hot path) -------------------------------------
 
 #[inline(always)]
 pub(crate) const fn is_control_byte(b: u8) -> bool {
     CONTROL_BYTE_SET[b as usize]
+}
+
+#[inline(always)]
+pub(crate) const fn is_http_token_byte(b: u8) -> bool {
+    HTTP_TOKEN_BYTE_SET[b as usize]
 }
 
 /// `Some(b)` when `%h1h2` pct-decodes to a control byte `b` (smuggling

--- a/rama-net/src/http/server/mod.rs
+++ b/rama-net/src/http/server/mod.rs
@@ -5,5 +5,7 @@
 
 pub mod peek;
 pub use peek::{
+    DEFAULT_HTTP_PEEK_READ_BUFFER_SIZE, DEFAULT_HTTP1_REQUEST_LINE_MAX_SIZE, HttpPeekConfig,
     HttpPeekRouter, HttpPeekVersion, HttpPrefixedIo, NoHttpRejectError, peek_http_input,
+    peek_http_input_with_config,
 };

--- a/rama-net/src/http/server/peek.rs
+++ b/rama-net/src/http/server/peek.rs
@@ -340,18 +340,24 @@ pub enum HttpPeekVersion {
 
 #[derive(Debug, Clone, Copy)]
 enum Http1PeekState {
+    /// A leading `\r` was read; only the `\n` completing an empty line may follow.
+    LeadingLf,
     Method {
+        start: usize,
         len: usize,
     },
     Target {
+        method_start: usize,
         method_end: usize,
         target: HttpRequestTargetState,
     },
     Http09Lf {
+        method_start: usize,
         method_end: usize,
         target_end: usize,
     },
     Version {
+        method_start: usize,
         method_end: usize,
         target_end: usize,
         offset: usize,
@@ -415,7 +421,7 @@ impl HttpPeekState {
             http1: if max_http1_request_line_size == 0 {
                 Http1PeekState::Invalid
             } else {
-                Http1PeekState::Method { len: 0 }
+                Http1PeekState::Method { start: 0, len: 0 }
             },
             h2_offset: Some(0),
             max_http1_request_line_size,
@@ -475,28 +481,55 @@ impl HttpPeekState {
 
         let state = core::mem::replace(&mut self.http1, Http1PeekState::Invalid);
         self.http1 = match state {
-            Http1PeekState::Method { len } => {
+            Http1PeekState::Method { start, len } => {
                 if is_http_token_byte(byte) {
-                    Http1PeekState::Method { len: len + 1 }
+                    Http1PeekState::Method {
+                        start,
+                        len: len + 1,
+                    }
                 } else if byte == b' ' && len > 0 {
                     Http1PeekState::Target {
-                        method_end: len,
-                        target: if &buffer[..len] == b"CONNECT" {
+                        method_start: start,
+                        method_end: start + len,
+                        target: if &buffer[start..start + len] == b"CONNECT" {
                             HttpRequestTargetState::Authority
                         } else {
                             HttpRequestTargetState::Start
                         },
                     }
+                } else if len == 0 && byte == b'\n' {
+                    // httparse parity: skip empty lines before the request-line
+                    Http1PeekState::Method {
+                        start: total_len,
+                        len: 0,
+                    }
+                } else if len == 0 && byte == b'\r' {
+                    Http1PeekState::LeadingLf
                 } else {
                     tracing::trace!(byte, "HTTP/1 peek rejected invalid method byte");
                     Http1PeekState::Invalid
                 }
             }
-            Http1PeekState::Target { method_end, target } => {
-                if matches!(byte, b' ' | b'\r') {
+            Http1PeekState::LeadingLf => {
+                if byte == b'\n' {
+                    Http1PeekState::Method {
+                        start: total_len,
+                        len: 0,
+                    }
+                } else {
+                    tracing::trace!(byte, "HTTP/1 peek rejected bare CR before request-line");
+                    Http1PeekState::Invalid
+                }
+            }
+            Http1PeekState::Target {
+                method_start,
+                method_end,
+                target,
+            } => {
+                if matches!(byte, b' ' | b'\r' | b'\n') {
                     let target_start = method_end + 1;
                     let target_end = total_len - 1;
-                    let method = &buffer[..method_end];
+                    let method = &buffer[method_start..method_end];
                     let target = &buffer[target_start..target_end];
                     let authority_form = method == b"CONNECT";
                     if target == b"*" && method != b"OPTIONS" {
@@ -507,15 +540,29 @@ impl HttpPeekState {
                     } else {
                         match validate_http_request_target(target, authority_form) {
                             Ok(()) if byte == b' ' => Http1PeekState::Version {
+                                method_start,
                                 method_end,
                                 target_end,
                                 offset: 0,
                                 candidates: HTTP_1_CANDIDATES,
                             },
-                            Ok(()) if method == b"GET" && target != b"*" => {
-                                Http1PeekState::Http09Lf {
-                                    method_end,
-                                    target_end,
+                            Ok(()) if method == b"GET" => {
+                                if byte == b'\n' {
+                                    // httparse parity: bare LF terminates the simple-request
+                                    trace_http1_match(
+                                        buffer,
+                                        method_start,
+                                        method_end,
+                                        target_end,
+                                        "HTTP/0.9",
+                                    );
+                                    Http1PeekState::Matched
+                                } else {
+                                    Http1PeekState::Http09Lf {
+                                        method_start,
+                                        method_end,
+                                        target_end,
+                                    }
                                 }
                             }
                             Ok(()) => {
@@ -529,18 +576,23 @@ impl HttpPeekState {
                         }
                     }
                 } else if let Some(target) = target.push(byte) {
-                    Http1PeekState::Target { method_end, target }
+                    Http1PeekState::Target {
+                        method_start,
+                        method_end,
+                        target,
+                    }
                 } else {
                     tracing::trace!(byte, "HTTP/1 peek rejected invalid request-target byte");
                     Http1PeekState::Invalid
                 }
             }
             Http1PeekState::Http09Lf {
+                method_start,
                 method_end,
                 target_end,
             } => {
                 if byte == b'\n' {
-                    trace_http1_match(buffer, method_end, target_end, "HTTP/0.9");
+                    trace_http1_match(buffer, method_start, method_end, target_end, "HTTP/0.9");
                     Http1PeekState::Matched
                 } else {
                     tracing::trace!(byte, "HTTP/0.9 peek rejected invalid line ending");
@@ -548,30 +600,50 @@ impl HttpPeekState {
                 }
             }
             Http1PeekState::Version {
+                method_start,
                 method_end,
                 target_end,
                 offset,
                 mut candidates,
             } => {
-                if HTTP_10.get(offset) != Some(&byte) {
-                    candidates &= !HTTP_10_CANDIDATE;
-                }
-                if HTTP_11.get(offset) != Some(&byte) {
-                    candidates &= !HTTP_11_CANDIDATE;
-                }
-
-                if candidates == 0 {
-                    tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
-                    Http1PeekState::Invalid
-                } else if offset + 1 == HTTP_10.len() {
-                    trace_http1_version_match(buffer, method_end, target_end, candidates);
-                    Http1PeekState::Matched
-                } else {
-                    Http1PeekState::Version {
+                if byte == b'\n' && HTTP_10.get(offset) == Some(&b'\r') {
+                    // httparse parity: bare LF may terminate the request-line
+                    trace_http1_version_match(
+                        buffer,
+                        method_start,
                         method_end,
                         target_end,
-                        offset: offset + 1,
                         candidates,
+                    );
+                    Http1PeekState::Matched
+                } else {
+                    if HTTP_10.get(offset) != Some(&byte) {
+                        candidates &= !HTTP_10_CANDIDATE;
+                    }
+                    if HTTP_11.get(offset) != Some(&byte) {
+                        candidates &= !HTTP_11_CANDIDATE;
+                    }
+
+                    if candidates == 0 {
+                        tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
+                        Http1PeekState::Invalid
+                    } else if offset + 1 == HTTP_10.len() {
+                        trace_http1_version_match(
+                            buffer,
+                            method_start,
+                            method_end,
+                            target_end,
+                            candidates,
+                        );
+                        Http1PeekState::Matched
+                    } else {
+                        Http1PeekState::Version {
+                            method_start,
+                            method_end,
+                            target_end,
+                            offset: offset + 1,
+                            candidates,
+                        }
                     }
                 }
             }
@@ -581,22 +653,34 @@ impl HttpPeekState {
 }
 
 #[inline]
-fn trace_http1_match(buffer: &[u8], method_end: usize, target_end: usize, version: &'static str) {
+fn trace_http1_match(
+    buffer: &[u8],
+    method_start: usize,
+    method_end: usize,
+    target_end: usize,
+    version: &'static str,
+) {
     // Method bytes are RFC 9110 `tchar`, and target validation guarantees
     // UTF-8, so both views are safe and borrow the single replay buffer.
-    let method = unsafe { core::str::from_utf8_unchecked(&buffer[..method_end]) };
+    let method = unsafe { core::str::from_utf8_unchecked(&buffer[method_start..method_end]) };
     let target = unsafe { core::str::from_utf8_unchecked(&buffer[method_end + 1..target_end]) };
     tracing::trace!(method, target, version, "HTTP/1 peek matched request-line");
 }
 
 #[inline]
-fn trace_http1_version_match(buffer: &[u8], method_end: usize, target_end: usize, candidates: u8) {
+fn trace_http1_version_match(
+    buffer: &[u8],
+    method_start: usize,
+    method_end: usize,
+    target_end: usize,
+    candidates: u8,
+) {
     let version = if candidates == 0b01 {
         "HTTP/1.0"
     } else {
         "HTTP/1.1"
     };
-    trace_http1_match(buffer, method_end, target_end, version);
+    trace_http1_match(buffer, method_start, method_end, target_end, version);
 }
 
 #[inline]
@@ -634,9 +718,13 @@ where
 ///
 /// HTTP/1.0 and HTTP/1.1 are accepted only after a complete request-line
 /// containing a valid method token, request target, supported version, and
-/// terminating CRLF has been read. An HTTP/0.9 simple-request is accepted as
-/// HTTP/1x after `GET`, a valid request target, and CRLF. HTTP/2 is accepted
-/// only after its complete client preface.
+/// line terminator has been read. An HTTP/0.9 simple-request is accepted as
+/// HTTP/1x after `GET`, a valid request target, and a line terminator.
+/// Matching lenient HTTP/1 parsers such as httparse, a bare LF is accepted
+/// as line terminator and empty lines before the request-line are skipped
+/// (they count toward [`HttpPeekConfig::max_http1_request_line_size`]).
+/// HTTP/2 is accepted only after its complete client preface, starting at
+/// the first byte.
 pub async fn peek_http_input_with_config<PeekableInput>(
     mut input: PeekableInput,
     config: HttpPeekConfig,
@@ -781,6 +869,10 @@ mod test {
     #[test]
     fn test_http1_state_rejects_at_first_impossible_byte() {
         assert_eq!(HttpPeekDecision::Reject, state_decision(b" "));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"\rG"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"\r\r"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"\r"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"\r\n\nGET"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GE("));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET \t"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET \x7f"));
@@ -914,6 +1006,12 @@ mod test {
             b"M-SEARCH /discovery HTTP/1.1\r\n",
             b"!#$%&'*+-.^_`|~ /extension HTTP/1.1\r\n",
             "GET /café HTTP/1.1\r\n".as_bytes(),
+            b"GET / HTTP/1.1\n",
+            b"GET /legacy HTTP/1.0\n",
+            b"GET /\n",
+            b"\r\nGET / HTTP/1.1\r\n",
+            b"\n\n\r\nGET / HTTP/1.1\n",
+            b"\nCONNECT example.com:443 HTTP/1.1\r\n",
         ];
 
         for &content in CASES {
@@ -931,13 +1029,13 @@ mod test {
             b"GET *\r\n",
             b"GET * HTTP/1.1\r\n",
             b"POST * HTTP/1.1\r\n",
-            b"GET /\n",
             b"OPTIONS icap://icap.example.net/service ICAP/1.0\r\n",
             b"OPTIONS * RTSP/2.0\r\n",
             b"OPTIONS sip:service@example.com SIP/2.0\r\n",
             b"GET / HTTP/1.1",
-            b"GET / HTTP/1.1\n",
             b"GET / HTTP/1.2\r\n",
+            b"\rGET / HTTP/1.1\r\n",
+            b"\r\nPRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
             b"GET  / HTTP/1.1\r\n",
             b"GET /path#fragment HTTP/1.1\r\n",
             b"GE(T / HTTP/1.1\r\n",
@@ -966,6 +1064,11 @@ mod test {
         let (version, replayed) = peek_fragmented_bytes(HTTP09).await;
         assert_eq!(Some(HttpPeekVersion::Http1x), version);
         assert_eq!(HTTP09, replayed);
+
+        const HTTP1_LENIENT: &[u8] = b"\r\n\nGET /lenient HTTP/1.1\nbody";
+        let (version, replayed) = peek_fragmented_bytes(HTTP1_LENIENT).await;
+        assert_eq!(Some(HttpPeekVersion::Http1x), version);
+        assert_eq!(HTTP1_LENIENT, replayed);
 
         const H2: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nframes";
         let (version, replayed) = peek_fragmented_bytes(H2).await;

--- a/rama-net/src/http/server/peek.rs
+++ b/rama-net/src/http/server/peek.rs
@@ -1,17 +1,62 @@
 //! types and logic for [`HttpPeekRouter`]
 
-use std::time::Duration;
+use std::{io::Cursor, time::Duration};
 
 use rama_core::{
     Service,
+    bytes::{Bytes, BytesMut},
     error::{BoxError, ErrorContext},
-    io::{
-        PeekIoProvider, PrefixedIo, StackReader,
-        peek::{PeekOutput, peek_input_until},
-    },
+    io::{PeekIoProvider, PrefixedIo},
     service::RejectService,
     telemetry::tracing,
 };
+use rama_utils::octets::kib;
+use tokio::{io::AsyncReadExt as _, time::Instant};
+
+use crate::{
+    byte_sets::{is_control_byte, is_http_token_byte, is_scheme_first_byte, is_scheme_rest_byte},
+    uri::parser::validate_http_request_target,
+};
+
+/// Default maximum number of bytes inspected for an HTTP/1 request-line.
+///
+/// RFC 9112 recommends that HTTP senders and recipients support request-lines
+/// of at least 8000 octets. The slightly larger power-of-two default leaves
+/// room for the terminating CRLF while keeping protocol detection bounded.
+pub const DEFAULT_HTTP1_REQUEST_LINE_MAX_SIZE: usize = kib(8);
+
+/// Default maximum number of bytes requested from the transport per peek read.
+pub const DEFAULT_HTTP_PEEK_READ_BUFFER_SIZE: usize = 512;
+
+/// Resource limits used while detecting HTTP on a byte stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HttpPeekConfig {
+    /// timeout applied to the complete HTTP peek operation
+    pub timeout: Option<Duration>,
+    /// maximum number of bytes inspected for an HTTP/1 request-line
+    pub max_http1_request_line_size: usize,
+    /// maximum number of bytes requested per transport read
+    pub read_buffer_size: usize,
+}
+
+impl Default for HttpPeekConfig {
+    fn default() -> Self {
+        Self {
+            timeout: None,
+            max_http1_request_line_size: DEFAULT_HTTP1_REQUEST_LINE_MAX_SIZE,
+            read_buffer_size: DEFAULT_HTTP_PEEK_READ_BUFFER_SIZE,
+        }
+    }
+}
+
+impl HttpPeekConfig {
+    /// Create an HTTP peek configuration using the defaults.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
 /// A [`Service`] router that can be used to support
 /// http/1x and h2 traffic as well as non-tls traffic.
 ///
@@ -21,7 +66,7 @@ use rama_core::{
 pub struct HttpPeekRouter<T, F = RejectService<(), NoHttpRejectError>> {
     http_acceptor: T,
     fallback: F,
-    peek_timeout: Option<Duration>,
+    peek_config: HttpPeekConfig,
 }
 
 /// Type wrapper used by [`HttpPeekRouter::new_dual`]
@@ -59,7 +104,7 @@ impl<T> HttpPeekRouter<HttpAutoAcceptor<T>> {
         Self {
             http_acceptor: HttpAutoAcceptor(auto_acceptor),
             fallback: RejectService::new(NoHttpRejectError),
-            peek_timeout: None,
+            peek_config: HttpPeekConfig::default(),
         }
     }
 }
@@ -71,7 +116,7 @@ impl<T> HttpPeekRouter<Http1Acceptor<T>> {
         Self {
             http_acceptor: Http1Acceptor(http1_acceptor),
             fallback: RejectService::new(NoHttpRejectError),
-            peek_timeout: None,
+            peek_config: HttpPeekConfig::default(),
         }
     }
 }
@@ -83,7 +128,7 @@ impl<T> HttpPeekRouter<H2Acceptor<T>> {
         Self {
             http_acceptor: H2Acceptor(h2_acceptor),
             fallback: RejectService::new(NoHttpRejectError),
-            peek_timeout: None,
+            peek_config: HttpPeekConfig::default(),
         }
     }
 }
@@ -94,7 +139,7 @@ impl<T> HttpPeekRouter<T> {
         HttpPeekRouter {
             http_acceptor: self.http_acceptor,
             fallback,
-            peek_timeout: self.peek_timeout,
+            peek_config: self.peek_config,
         }
     }
 }
@@ -103,7 +148,15 @@ impl<T, F> HttpPeekRouter<T, F> {
     rama_utils::macros::generate_set_and_with! {
         /// Set the peek window to timeout on
         pub fn peek_timeout(mut self, peek_timeout: Option<Duration>) -> Self {
-            self.peek_timeout = peek_timeout;
+            self.peek_config.timeout = peek_timeout;
+            self
+        }
+    }
+
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the resource limits used while peeking for HTTP.
+        pub fn peek_config(mut self, peek_config: HttpPeekConfig) -> Self {
+            self.peek_config = peek_config;
             self
         }
     }
@@ -119,7 +172,7 @@ impl<T, U> HttpPeekRouter<HttpDualAcceptor<T, U>> {
                 h2: h2_acceptor,
             },
             fallback: RejectService::new(NoHttpRejectError),
-            peek_timeout: None,
+            peek_config: HttpPeekConfig::default(),
         }
     }
 }
@@ -143,7 +196,7 @@ where
     type Error = BoxError;
 
     async fn serve(&self, input: PeekableInput) -> Result<Self::Output, Self::Error> {
-        let (version, peek_input) = peek_http_input(input, self.peek_timeout).await?;
+        let (version, peek_input) = peek_http_input_with_config(input, self.peek_config).await?;
         if version.is_some() {
             tracing::debug!(
                 "http peek [auto]: HTTP detect: version = {version:?}; continue with http_acceptor svc"
@@ -179,7 +232,7 @@ where
     type Error = BoxError;
 
     async fn serve(&self, input: PeekableInput) -> Result<Self::Output, Self::Error> {
-        let (version, peek_input) = peek_http_input(input, self.peek_timeout).await?;
+        let (version, peek_input) = peek_http_input_with_config(input, self.peek_config).await?;
         if version == Some(HttpPeekVersion::Http1x) {
             tracing::debug!("http peek: serve[http1]: http/1x acceptor; version = {version:?}");
             self.http_acceptor
@@ -213,7 +266,7 @@ where
     type Error = BoxError;
 
     async fn serve(&self, input: PeekableInput) -> Result<Self::Output, Self::Error> {
-        let (version, peek_input) = peek_http_input(input, self.peek_timeout).await?;
+        let (version, peek_input) = peek_http_input_with_config(input, self.peek_config).await?;
         if version == Some(HttpPeekVersion::H2) {
             tracing::debug!("http peek: serve[h2]: http acceptor; version = {version:?}");
             self.http_acceptor
@@ -253,7 +306,7 @@ where
     type Error = BoxError;
 
     async fn serve(&self, input: PeekableInput) -> Result<Self::Output, Self::Error> {
-        let (version, peek_input) = peek_http_input(input, self.peek_timeout).await?;
+        let (version, peek_input) = peek_http_input_with_config(input, self.peek_config).await?;
         match version {
             Some(HttpPeekVersion::H2) => {
                 tracing::trace!("http peek: serve[dual]: h2 acceptor; version = {version:?}");
@@ -285,8 +338,271 @@ pub enum HttpPeekVersion {
     H2,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum Http1PeekState {
+    Method {
+        len: usize,
+    },
+    Target {
+        method_end: usize,
+        target: HttpRequestTargetState,
+    },
+    Http09Lf {
+        method_end: usize,
+        target_end: usize,
+    },
+    Version {
+        method_end: usize,
+        target_end: usize,
+        offset: usize,
+        candidates: u8,
+    },
+    Matched,
+    Invalid,
+}
+
+#[derive(Debug)]
+struct HttpPeekState {
+    http1: Http1PeekState,
+    h2_offset: Option<usize>,
+    max_http1_request_line_size: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HttpPeekDecision {
+    Continue,
+    Matched(HttpPeekVersion),
+    Reject,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum HttpRequestTargetState {
+    Start,
+    Origin,
+    Asterisk,
+    Scheme { len: usize },
+    AbsoluteFirstSlash,
+    AbsoluteSecondSlash,
+    Absolute,
+    Authority,
+}
+
+impl HttpRequestTargetState {
+    fn push(self, byte: u8) -> Option<Self> {
+        if !is_http_request_target_prefix_byte(byte) {
+            return None;
+        }
+
+        match self {
+            Self::Start if byte == b'/' => Some(Self::Origin),
+            Self::Start if byte == b'*' => Some(Self::Asterisk),
+            Self::Start if is_scheme_first_byte(byte) => Some(Self::Scheme { len: 1 }),
+            Self::Origin if byte != b'#' => Some(Self::Origin),
+            Self::Scheme { len: _ } if byte == b':' => Some(Self::AbsoluteFirstSlash),
+            Self::Scheme { len }
+                if len < crate::proto::MAX_SCHEME_LEN && is_scheme_rest_byte(byte) =>
+            {
+                Some(Self::Scheme { len: len + 1 })
+            }
+            Self::AbsoluteFirstSlash if byte == b'/' => Some(Self::AbsoluteSecondSlash),
+            Self::AbsoluteSecondSlash if byte == b'/' => Some(Self::Absolute),
+            Self::Absolute if byte != b'#' => Some(Self::Absolute),
+            Self::Authority if !matches!(byte, b'/' | b'?' | b'#') => Some(Self::Authority),
+            _ => None,
+        }
+    }
+}
+
+impl HttpPeekState {
+    fn new(max_http1_request_line_size: usize) -> Self {
+        Self {
+            http1: if max_http1_request_line_size == 0 {
+                Http1PeekState::Invalid
+            } else {
+                Http1PeekState::Method { len: 0 }
+            },
+            h2_offset: Some(0),
+            max_http1_request_line_size,
+        }
+    }
+
+    fn max_peek_len(&self) -> usize {
+        let http1 = if matches!(
+            self.http1,
+            Http1PeekState::Invalid | Http1PeekState::Matched
+        ) {
+            0
+        } else {
+            self.max_http1_request_line_size
+        };
+        let h2 = self.h2_offset.map(|_| H2_MAGIC_PREFIX.len()).unwrap_or(0);
+        http1.max(h2)
+    }
+
+    fn push_byte(&mut self, byte: u8, total_len: usize, buffer: &[u8]) -> HttpPeekDecision {
+        if let Some(offset) = self.h2_offset {
+            if H2_MAGIC_PREFIX.get(offset) == Some(&byte) {
+                let next = offset + 1;
+                if next == H2_MAGIC_PREFIX.len() {
+                    tracing::trace!(version = "HTTP/2", "HTTP peek matched client preface");
+                    return HttpPeekDecision::Matched(HttpPeekVersion::H2);
+                }
+                self.h2_offset = Some(next);
+            } else {
+                self.h2_offset = None;
+            }
+        }
+
+        self.push_http1_byte(byte, total_len, buffer);
+
+        if matches!(self.http1, Http1PeekState::Matched) {
+            return HttpPeekDecision::Matched(HttpPeekVersion::Http1x);
+        }
+
+        if total_len >= self.max_http1_request_line_size {
+            self.http1 = Http1PeekState::Invalid;
+        }
+
+        if matches!(self.http1, Http1PeekState::Invalid) && self.h2_offset.is_none() {
+            HttpPeekDecision::Reject
+        } else {
+            HttpPeekDecision::Continue
+        }
+    }
+
+    fn push_http1_byte(&mut self, byte: u8, total_len: usize, buffer: &[u8]) {
+        const HTTP_10: &[u8] = b"HTTP/1.0\r\n";
+        const HTTP_11: &[u8] = b"HTTP/1.1\r\n";
+        const HTTP_10_CANDIDATE: u8 = 0b01;
+        const HTTP_11_CANDIDATE: u8 = 0b10;
+        const HTTP_1_CANDIDATES: u8 = 0b11;
+
+        let state = core::mem::replace(&mut self.http1, Http1PeekState::Invalid);
+        self.http1 = match state {
+            Http1PeekState::Method { len } => {
+                if is_http_token_byte(byte) {
+                    Http1PeekState::Method { len: len + 1 }
+                } else if byte == b' ' && len > 0 {
+                    Http1PeekState::Target {
+                        method_end: len,
+                        target: if &buffer[..len] == b"CONNECT" {
+                            HttpRequestTargetState::Authority
+                        } else {
+                            HttpRequestTargetState::Start
+                        },
+                    }
+                } else {
+                    tracing::trace!(byte, "HTTP/1 peek rejected invalid method byte");
+                    Http1PeekState::Invalid
+                }
+            }
+            Http1PeekState::Target { method_end, target } => {
+                if matches!(byte, b' ' | b'\r') {
+                    let target_start = method_end + 1;
+                    let target_end = total_len - 1;
+                    let method = &buffer[..method_end];
+                    let target = &buffer[target_start..target_end];
+                    let authority_form = method == b"CONNECT";
+                    match validate_http_request_target(target, authority_form) {
+                        Ok(()) if byte == b' ' => Http1PeekState::Version {
+                            method_end,
+                            target_end,
+                            offset: 0,
+                            candidates: HTTP_1_CANDIDATES,
+                        },
+                        Ok(()) if method == b"GET" && target != b"*" => Http1PeekState::Http09Lf {
+                            method_end,
+                            target_end,
+                        },
+                        Ok(()) => {
+                            tracing::trace!("HTTP/0.9 peek rejected method other than GET");
+                            Http1PeekState::Invalid
+                        }
+                        Err(err) => {
+                            tracing::trace!(%err, "HTTP/1 peek rejected invalid request target");
+                            Http1PeekState::Invalid
+                        }
+                    }
+                } else if let Some(target) = target.push(byte) {
+                    Http1PeekState::Target { method_end, target }
+                } else {
+                    tracing::trace!(byte, "HTTP/1 peek rejected invalid request-target byte");
+                    Http1PeekState::Invalid
+                }
+            }
+            Http1PeekState::Http09Lf {
+                method_end,
+                target_end,
+            } => {
+                if byte == b'\n' {
+                    trace_http1_match(buffer, method_end, target_end, "HTTP/0.9");
+                    Http1PeekState::Matched
+                } else {
+                    tracing::trace!(byte, "HTTP/0.9 peek rejected invalid line ending");
+                    Http1PeekState::Invalid
+                }
+            }
+            Http1PeekState::Version {
+                method_end,
+                target_end,
+                offset,
+                mut candidates,
+            } => {
+                if HTTP_10.get(offset) != Some(&byte) {
+                    candidates &= !HTTP_10_CANDIDATE;
+                }
+                if HTTP_11.get(offset) != Some(&byte) {
+                    candidates &= !HTTP_11_CANDIDATE;
+                }
+
+                if candidates == 0 {
+                    tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
+                    Http1PeekState::Invalid
+                } else if offset + 1 == HTTP_10.len() {
+                    trace_http1_version_match(buffer, method_end, target_end, candidates);
+                    Http1PeekState::Matched
+                } else {
+                    Http1PeekState::Version {
+                        method_end,
+                        target_end,
+                        offset: offset + 1,
+                        candidates,
+                    }
+                }
+            }
+            state @ (Http1PeekState::Matched | Http1PeekState::Invalid) => state,
+        };
+    }
+}
+
+#[inline]
+fn trace_http1_match(buffer: &[u8], method_end: usize, target_end: usize, version: &'static str) {
+    // Method bytes are RFC 9110 `tchar`, and target validation guarantees
+    // UTF-8, so both views are safe and borrow the single replay buffer.
+    let method = unsafe { core::str::from_utf8_unchecked(&buffer[..method_end]) };
+    let target = unsafe { core::str::from_utf8_unchecked(&buffer[method_end + 1..target_end]) };
+    tracing::trace!(method, target, version, "HTTP/1 peek matched request-line");
+}
+
+#[inline]
+fn trace_http1_version_match(buffer: &[u8], method_end: usize, target_end: usize, candidates: u8) {
+    let version = if candidates == 0b01 {
+        "HTTP/1.0"
+    } else {
+        "HTTP/1.1"
+    };
+    trace_http1_match(buffer, method_end, target_end, version);
+}
+
+#[inline]
+fn is_http_request_target_prefix_byte(byte: u8) -> bool {
+    byte != b' ' && !is_control_byte(byte)
+}
+
+/// Detect HTTP using [`HttpPeekConfig::default`] and return an input that
+/// replays every byte consumed during detection.
 pub async fn peek_http_input<PeekableInput>(
-    mut input: PeekableInput,
+    input: PeekableInput,
     timeout: Option<Duration>,
 ) -> Result<
     (
@@ -298,57 +614,113 @@ pub async fn peek_http_input<PeekableInput>(
 where
     PeekableInput: PeekIoProvider<PeekIo: Unpin>,
 {
-    let mut peek_buf = [0u8; HTTP_HEADER_PEEK_LEN];
+    peek_http_input_with_config(
+        input,
+        HttpPeekConfig {
+            timeout,
+            ..Default::default()
+        },
+    )
+    .await
+}
 
-    let PeekOutput {
-        data: maybe_http_version,
-        peek_size,
-    } = peek_input_until(input.peek_io_mut(), &mut peek_buf, timeout, |buffer| {
-        const HTTP_METHODS: &[&[u8]] = &[
-            b"GET ",
-            b"POST ",
-            b"PUT ",
-            b"DELETE ",
-            b"HEAD ",
-            b"OPTIONS ",
-            b"CONNECT ",
-            b"TRACE ",
-            b"PATCH ",
-        ];
+/// Detect HTTP using explicit resource limits and return an input that
+/// replays every byte consumed during detection.
+///
+/// HTTP/1.0 and HTTP/1.1 are accepted only after a complete request-line
+/// containing a valid method token, request target, supported version, and
+/// terminating CRLF has been read. An HTTP/0.9 simple-request is accepted as
+/// HTTP/1x after `GET`, a valid request target, and CRLF. HTTP/2 is accepted
+/// only after its complete client preface.
+pub async fn peek_http_input_with_config<PeekableInput>(
+    mut input: PeekableInput,
+    config: HttpPeekConfig,
+) -> Result<
+    (
+        Option<HttpPeekVersion>,
+        PeekableInput::Mapped<HttpPrefixedIo<PeekableInput::PeekIo>>,
+    ),
+    BoxError,
+>
+where
+    PeekableInput: PeekIoProvider<PeekIo: Unpin>,
+{
+    let mut state = HttpPeekState::new(config.max_http1_request_line_size);
+    let max_peek_len = state.max_peek_len();
+    let read_buffer_size = config.read_buffer_size.max(1);
+    let mut buffer = BytesMut::with_capacity(read_buffer_size.min(max_peek_len));
+    let mut total_len = 0usize;
+    let mut matched_version = None;
+    let deadline = config.timeout.map(|duration| Instant::now() + duration);
 
-        if buffer.eq(H2_MAGIC_PREFIX) {
-            Some(HttpPeekVersion::H2)
-        } else if HTTP_METHODS.iter().any(|method| buffer.starts_with(method)) {
-            Some(HttpPeekVersion::Http1x)
-        } else {
-            None
+    'peek: loop {
+        let remaining = state.max_peek_len().saturating_sub(total_len);
+        if remaining == 0 {
+            break;
         }
-    })
-    .await;
 
-    tracing::trace!("http prefix read loop finished: version = {maybe_http_version:?}");
+        let read_capacity = remaining.min(read_buffer_size);
+        buffer.reserve(read_capacity);
+        let read_start = buffer.len();
+        let mut limited = input.peek_io_mut().take(read_capacity as u64);
+        let read = limited.read_buf(&mut buffer);
+        let read_size = match deadline {
+            Some(deadline) => match tokio::time::timeout_at(deadline, read).await {
+                Ok(Ok(size)) => size,
+                Ok(Err(err)) => {
+                    tracing::debug!(%err, "HTTP peek read failed");
+                    break;
+                }
+                Err(err) => {
+                    tracing::debug!(%err, "HTTP peek timed out");
+                    break;
+                }
+            },
+            None => match read.await {
+                Ok(size) => size,
+                Err(err) => {
+                    tracing::debug!(%err, "HTTP peek read failed");
+                    break;
+                }
+            },
+        };
 
-    let offset = HTTP_HEADER_PEEK_LEN - peek_size;
-    if offset > 0 {
-        tracing::trace!(
-            "move http peek buffer cursor due to reading not enough (read: {peek_size})"
-        );
-        peek_buf.copy_within(0..peek_size, offset);
+        let Some(_) = core::num::NonZeroUsize::new(read_size) else {
+            break;
+        };
+
+        for index in read_start..buffer.len() {
+            total_len = index + 1;
+            match state.push_byte(buffer[index], total_len, &buffer) {
+                HttpPeekDecision::Continue => {}
+                HttpPeekDecision::Matched(version) => {
+                    matched_version = Some(version);
+                    break 'peek;
+                }
+                HttpPeekDecision::Reject => {
+                    break 'peek;
+                }
+            }
+        }
+        total_len = buffer.len();
     }
 
-    let mut peek = StackReader::new(peek_buf);
-    peek.skip(offset);
+    tracing::trace!(
+        version = ?matched_version,
+        peek_size = buffer.len(),
+        "HTTP peek read loop finished"
+    );
 
+    let peek = Cursor::new(buffer.freeze());
     let peek_input = input.map_peek_io(|io| PrefixedIo::new(peek, io));
 
-    Ok((maybe_http_version, peek_input))
+    Ok((matched_version, peek_input))
 }
 
 const H2_MAGIC_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-const HTTP_HEADER_PEEK_LEN: usize = H2_MAGIC_PREFIX.len();
 
 /// [`PrefixedIo`] alias used by [`HttpPeekRouter`].
-pub type HttpPrefixedIo<S> = PrefixedIo<StackReader<HTTP_HEADER_PEEK_LEN>, S>;
+pub type HttpPrefixedIo<S> = PrefixedIo<Cursor<Bytes>, S>;
 
 #[cfg(test)]
 mod test {
@@ -365,7 +737,75 @@ mod test {
         stream::io::StreamReader,
     };
 
-    use tokio::io::AsyncReadExt as _;
+    async fn peek_bytes(
+        content: &[u8],
+        config: HttpPeekConfig,
+    ) -> (Option<HttpPeekVersion>, Vec<u8>) {
+        let input = ServiceInput::new(std::io::Cursor::new(content.to_vec()));
+        let (version, mut input) = peek_http_input_with_config(input, config).await.unwrap();
+        let mut replayed = Vec::new();
+        input.read_to_end(&mut replayed).await.unwrap();
+        (version, replayed)
+    }
+
+    async fn peek_fragmented_bytes(content: &'static [u8]) -> (Option<HttpPeekVersion>, Vec<u8>) {
+        let reader = StreamReader::new(rama_core::futures::stream::iter(
+            content
+                .iter()
+                .map(|&byte| Ok::<_, std::io::Error>(Bytes::copy_from_slice(&[byte]))),
+        ));
+        let io = Box::pin(tokio::io::join(reader, tokio::io::sink()));
+        let (version, mut io) = peek_http_input(io, None).await.unwrap();
+        let mut replayed = Vec::new();
+        io.read_to_end(&mut replayed).await.unwrap();
+        (version, replayed)
+    }
+
+    fn state_decision(content: &[u8]) -> HttpPeekDecision {
+        let mut state = HttpPeekState::new(DEFAULT_HTTP1_REQUEST_LINE_MAX_SIZE);
+        let mut decision = HttpPeekDecision::Continue;
+        for (index, &byte) in content.iter().enumerate() {
+            decision = state.push_byte(byte, index + 1, &content[..=index]);
+            if decision != HttpPeekDecision::Continue {
+                break;
+            }
+        }
+        decision
+    }
+
+    #[test]
+    fn test_http1_state_rejects_at_first_impossible_byte() {
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b" "));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GE("));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET \t"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET \x7f"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET /\t"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"CONNECT h\t"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET ["));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET *x"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET ht!"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET /#"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http:x"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http:/x"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http://x#"));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(b"CONNECT host/"));
+
+        // A leading byte of a potentially valid UTF-8 target is not enough
+        // information to reject; validation completes at the target delimiter.
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET /\xc3"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET http:/"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"CONNECT ["));
+
+        let mut max_scheme = b"GET ".to_vec();
+        max_scheme.extend(core::iter::repeat_n(b'a', crate::proto::MAX_SCHEME_LEN));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(&max_scheme));
+        max_scheme.push(b':');
+        assert_eq!(HttpPeekDecision::Continue, state_decision(&max_scheme));
+
+        let mut oversized_scheme = b"GET ".to_vec();
+        oversized_scheme.extend(core::iter::repeat_n(b'a', crate::proto::MAX_SCHEME_LEN + 1));
+        assert_eq!(HttpPeekDecision::Reject, state_decision(&oversized_scheme));
+    }
 
     #[tokio::test]
     async fn test_peek_router() {
@@ -397,12 +837,17 @@ mod test {
         assert_eq!("http", response);
 
         const HTTP_METHODS: &[&str] = &[
-            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PATCH",
         ];
         for method in HTTP_METHODS {
+            let target = if *method == "CONNECT" {
+                "example.com:443"
+            } else {
+                "/foobar"
+            };
             let response = peek_http_svc
                 .serve(ServiceInput::new(std::io::Cursor::new(
-                    format!("{method} /foobar HTTP/1.1").into_bytes(),
+                    format!("{method} {target} HTTP/1.1\r\n").into_bytes(),
                 )))
                 .await
                 .unwrap();
@@ -432,7 +877,7 @@ mod test {
                     yielder.yield_item(Bytes::from_static(b"EC")).await;
                     tokio::time::sleep(Duration::from_millis(50)).await;
                     yielder
-                        .yield_item(Bytes::from_static(b"T http://foobar.com"))
+                        .yield_item(Bytes::from_static(b"T foobar.com:443 HTTP/1.1\r\n"))
                         .await;
                 })
                 .map(Ok::<_, std::io::Error>),
@@ -445,6 +890,153 @@ mod test {
 
             assert_eq!(Some(HttpPeekVersion::Http1x), http_version);
         }
+    }
+
+    #[tokio::test]
+    async fn test_peek_http1_complete_request_line_forms() {
+        const CASES: &[&[u8]] = &[
+            b"GET /\r\n",
+            b"GET http://example.com/legacy\r\n",
+            b"GET / HTTP/1.1\r\n",
+            b"GET /legacy HTTP/1.0\r\n",
+            b"OPTIONS * HTTP/1.1\r\n",
+            b"GET http://example.com/resource?q=1 HTTP/1.1\r\n",
+            b"CONNECT example.com:443 HTTP/1.1\r\n",
+            b"PROPFIND /collection HTTP/1.1\r\n",
+            b"QUERY /search HTTP/1.1\r\n",
+            b"M-SEARCH /discovery HTTP/1.1\r\n",
+            b"!#$%&'*+-.^_`|~ /extension HTTP/1.1\r\n",
+            "GET /café HTTP/1.1\r\n".as_bytes(),
+        ];
+
+        for &content in CASES {
+            let (version, replayed) = peek_bytes(content, HttpPeekConfig::default()).await;
+            assert_eq!(Some(HttpPeekVersion::Http1x), version, "{content:?}");
+            assert_eq!(content, replayed, "{content:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_peek_http1_rejects_other_text_protocols_and_invalid_lines() {
+        const CASES: &[&[u8]] = &[
+            b"POST /\r\n",
+            b"get /\r\n",
+            b"GET *\r\n",
+            b"GET /\n",
+            b"OPTIONS icap://icap.example.net/service ICAP/1.0\r\n",
+            b"OPTIONS * RTSP/2.0\r\n",
+            b"OPTIONS sip:service@example.com SIP/2.0\r\n",
+            b"GET / HTTP/1.1",
+            b"GET / HTTP/1.1\n",
+            b"GET / HTTP/1.2\r\n",
+            b"GET  / HTTP/1.1\r\n",
+            b"GET /path#fragment HTTP/1.1\r\n",
+            b"GE(T / HTTP/1.1\r\n",
+            b"GE(/ HTTP/1.1\r\n",
+            b" / HTTP/1.1\r\n",
+            b"GET /bad\ttarget HTTP/1.1\r\n",
+            b"GET http://[bad]/ HTTP/1.1\r\n",
+            b"CONNECT /not-authority HTTP/1.1\r\n",
+        ];
+
+        for &content in CASES {
+            let (version, replayed) = peek_bytes(content, HttpPeekConfig::default()).await;
+            assert_eq!(None, version, "{content:?}");
+            assert_eq!(content, replayed, "{content:?}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_peek_handles_single_byte_fragmentation() {
+        const HTTP1: &[u8] = b"PROPFIND /collection HTTP/1.1\r\nbody";
+        let (version, replayed) = peek_fragmented_bytes(HTTP1).await;
+        assert_eq!(Some(HttpPeekVersion::Http1x), version);
+        assert_eq!(HTTP1, replayed);
+
+        const HTTP09: &[u8] = b"GET /legacy\r\n";
+        let (version, replayed) = peek_fragmented_bytes(HTTP09).await;
+        assert_eq!(Some(HttpPeekVersion::Http1x), version);
+        assert_eq!(HTTP09, replayed);
+
+        const H2: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\nframes";
+        let (version, replayed) = peek_fragmented_bytes(H2).await;
+        assert_eq!(Some(HttpPeekVersion::H2), version);
+        assert_eq!(H2, replayed);
+
+        const ICAP: &[u8] = b"OPTIONS icap://icap.example.net/service ICAP/1.0\r\n";
+        let (version, replayed) = peek_fragmented_bytes(ICAP).await;
+        assert_eq!(None, version);
+        assert_eq!(ICAP, replayed);
+    }
+
+    #[tokio::test]
+    async fn test_peek_http1_configurable_buffer_limits() {
+        const CONTENT: &[u8] = b"GET /configurable HTTP/1.1\r\n";
+
+        let exact = HttpPeekConfig {
+            max_http1_request_line_size: CONTENT.len(),
+            read_buffer_size: 1,
+            ..Default::default()
+        };
+
+        let (version, replayed) = peek_bytes(CONTENT, exact).await;
+        assert_eq!(Some(HttpPeekVersion::Http1x), version);
+        assert_eq!(CONTENT, replayed);
+
+        let zero_read_size = HttpPeekConfig {
+            read_buffer_size: 0,
+            ..exact
+        };
+
+        let (version, replayed) = peek_bytes(CONTENT, zero_read_size).await;
+        assert_eq!(Some(HttpPeekVersion::Http1x), version);
+        assert_eq!(CONTENT, replayed);
+
+        let too_small = HttpPeekConfig {
+            max_http1_request_line_size: CONTENT.len() - 1,
+            ..exact
+        };
+
+        let (version, replayed) = peek_bytes(CONTENT, too_small).await;
+        assert_eq!(None, version);
+        assert_eq!(CONTENT, replayed);
+
+        let disabled = HttpPeekConfig {
+            max_http1_request_line_size: 0,
+            ..exact
+        };
+
+        let (version, replayed) = peek_bytes(CONTENT, disabled).await;
+        assert_eq!(None, version);
+        assert_eq!(CONTENT, replayed);
+
+        let (version, replayed) = peek_bytes(H2_MAGIC_PREFIX, disabled).await;
+        assert_eq!(Some(HttpPeekVersion::H2), version);
+        assert_eq!(H2_MAGIC_PREFIX, replayed);
+    }
+
+    #[tokio::test]
+    async fn test_peek_http1_timeout_replays_partial_request_line() {
+        const PREFIX: &[u8] = b"GET /slow ";
+        const SUFFIX: &[u8] = b"HTTP/1.1\r\n";
+        let reader = StreamReader::new(
+            stream_fn(async |mut yielder| {
+                yielder.yield_item(Bytes::from_static(PREFIX)).await;
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                yielder.yield_item(Bytes::from_static(SUFFIX)).await;
+            })
+            .map(Ok::<_, std::io::Error>),
+        );
+        let io = Box::pin(tokio::io::join(reader, tokio::io::sink()));
+
+        let (version, mut io) = peek_http_input(io, Some(Duration::from_millis(10)))
+            .await
+            .unwrap();
+        assert_eq!(None, version);
+
+        let mut replayed = Vec::new();
+        io.read_to_end(&mut replayed).await.unwrap();
+        assert_eq!([PREFIX, SUFFIX].concat(), replayed);
     }
 
     #[tokio::test]
@@ -469,12 +1061,17 @@ mod test {
         assert_eq!("other", response);
 
         const HTTP_METHODS: &[&str] = &[
-            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PATCH",
         ];
         for method in HTTP_METHODS {
+            let target = if *method == "CONNECT" {
+                "example.com:443"
+            } else {
+                "/foobar"
+            };
             let response = peek_http_svc
                 .serve(ServiceInput::new(std::io::Cursor::new(
-                    format!("{method} /foobar HTTP/1.1").into_bytes(),
+                    format!("{method} {target} HTTP/1.1\r\n").into_bytes(),
                 )))
                 .await
                 .unwrap();
@@ -516,12 +1113,17 @@ mod test {
         assert_eq!("h2", response);
 
         const HTTP_METHODS: &[&str] = &[
-            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PATCH",
         ];
         for method in HTTP_METHODS {
+            let target = if *method == "CONNECT" {
+                "example.com:443"
+            } else {
+                "/foobar"
+            };
             let response = peek_http_svc
                 .serve(ServiceInput::new(std::io::Cursor::new(
-                    format!("{method} /foobar HTTP/1.1").into_bytes(),
+                    format!("{method} {target} HTTP/1.1\r\n").into_bytes(),
                 )))
                 .await
                 .unwrap();
@@ -565,12 +1167,17 @@ mod test {
         assert_eq!("h2", response);
 
         const HTTP_METHODS: &[&str] = &[
-            "GET ", "POST ", "PUT ", "DELETE ", "HEAD ", "OPTIONS ", "CONNECT ", "TRACE ", "PATCH ",
+            "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "CONNECT", "TRACE", "PATCH",
         ];
         for method in HTTP_METHODS {
+            let target = if *method == "CONNECT" {
+                "example.com:443"
+            } else {
+                "/foobar"
+            };
             let response = peek_http_svc
                 .serve(ServiceInput::new(std::io::Cursor::new(
-                    format!("{method} /foobar HTTP/1.1").into_bytes(),
+                    format!("{method} {target} HTTP/1.1\r\n").into_bytes(),
                 )))
                 .await
                 .unwrap();

--- a/rama-net/src/http/server/peek.rs
+++ b/rama-net/src/http/server/peek.rs
@@ -1,12 +1,12 @@
 //! types and logic for [`HttpPeekRouter`]
 
-use std::{io::Cursor, time::Duration};
+use std::time::Duration;
 
 use rama_core::{
     Service,
-    bytes::{Bytes, BytesMut},
+    bytes::BytesMut,
     error::{BoxError, ErrorContext},
-    io::{PeekIoProvider, PrefixedIo},
+    io::{PeekIoProvider, PrefixedIo, ReplayReader},
     service::RejectService,
     telemetry::tracing,
 };
@@ -361,7 +361,7 @@ enum Http1PeekState {
         method_end: usize,
         target_end: usize,
         offset: usize,
-        candidates: u8,
+        minor: u8,
     },
     Matched,
     Invalid,
@@ -473,11 +473,8 @@ impl HttpPeekState {
     }
 
     fn push_http1_byte(&mut self, byte: u8, total_len: usize, buffer: &[u8]) {
-        const HTTP_10: &[u8] = b"HTTP/1.0\r\n";
-        const HTTP_11: &[u8] = b"HTTP/1.1\r\n";
-        const HTTP_10_CANDIDATE: u8 = 0b01;
-        const HTTP_11_CANDIDATE: u8 = 0b10;
-        const HTTP_1_CANDIDATES: u8 = 0b11;
+        // `HTTP/1.` + any minor digit + line terminator.
+        const VERSION_PREFIX: &[u8] = b"HTTP/1.";
 
         let state = core::mem::replace(&mut self.http1, Http1PeekState::Invalid);
         self.http1 = match state {
@@ -544,7 +541,7 @@ impl HttpPeekState {
                                 method_end,
                                 target_end,
                                 offset: 0,
-                                candidates: HTTP_1_CANDIDATES,
+                                minor: 0,
                             },
                             Ok(()) if method == b"GET" => {
                                 if byte == b'\n' {
@@ -604,47 +601,49 @@ impl HttpPeekState {
                 method_end,
                 target_end,
                 offset,
-                mut candidates,
+                minor,
             } => {
-                if byte == b'\n' && HTTP_10.get(offset) == Some(&b'\r') {
-                    // httparse parity: bare LF may terminate the request-line
-                    trace_http1_version_match(
-                        buffer,
-                        method_start,
-                        method_end,
-                        target_end,
-                        candidates,
-                    );
-                    Http1PeekState::Matched
-                } else {
-                    if HTTP_10.get(offset) != Some(&byte) {
-                        candidates &= !HTTP_10_CANDIDATE;
-                    }
-                    if HTTP_11.get(offset) != Some(&byte) {
-                        candidates &= !HTTP_11_CANDIDATE;
-                    }
-
-                    if candidates == 0 {
-                        tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
-                        Http1PeekState::Invalid
-                    } else if offset + 1 == HTTP_10.len() {
-                        trace_http1_version_match(
-                            buffer,
-                            method_start,
-                            method_end,
-                            target_end,
-                            candidates,
-                        );
-                        Http1PeekState::Matched
-                    } else {
+                if offset < VERSION_PREFIX.len() {
+                    if byte == VERSION_PREFIX[offset] {
                         Http1PeekState::Version {
                             method_start,
                             method_end,
                             target_end,
                             offset: offset + 1,
-                            candidates,
+                            minor,
                         }
+                    } else {
+                        tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
+                        Http1PeekState::Invalid
                     }
+                } else if offset == VERSION_PREFIX.len() {
+                    if byte.is_ascii_digit() {
+                        Http1PeekState::Version {
+                            method_start,
+                            method_end,
+                            target_end,
+                            offset: offset + 1,
+                            minor: byte,
+                        }
+                    } else {
+                        tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid version byte");
+                        Http1PeekState::Invalid
+                    }
+                } else if byte == b'\n' {
+                    // httparse parity: bare LF may terminate the request-line
+                    trace_http1_version_match(buffer, method_start, method_end, target_end, minor);
+                    Http1PeekState::Matched
+                } else if byte == b'\r' && offset == VERSION_PREFIX.len() + 1 {
+                    Http1PeekState::Version {
+                        method_start,
+                        method_end,
+                        target_end,
+                        offset: offset + 1,
+                        minor,
+                    }
+                } else {
+                    tracing::trace!(byte, offset, "HTTP/1 peek rejected invalid line ending");
+                    Http1PeekState::Invalid
                 }
             }
             state @ (Http1PeekState::Matched | Http1PeekState::Invalid) => state,
@@ -673,13 +672,13 @@ fn trace_http1_version_match(
     method_start: usize,
     method_end: usize,
     target_end: usize,
-    candidates: u8,
+    minor: u8,
 ) {
-    let version = if candidates == 0b01 {
-        "HTTP/1.0"
-    } else {
-        "HTTP/1.1"
-    };
+    const VERSIONS: [&str; 10] = [
+        "HTTP/1.0", "HTTP/1.1", "HTTP/1.2", "HTTP/1.3", "HTTP/1.4", "HTTP/1.5", "HTTP/1.6",
+        "HTTP/1.7", "HTTP/1.8", "HTTP/1.9",
+    ];
+    let version = VERSIONS[usize::from(minor.saturating_sub(b'0')).min(9)];
     trace_http1_match(buffer, method_start, method_end, target_end, version);
 }
 
@@ -717,7 +716,7 @@ where
 /// replays every byte consumed during detection.
 ///
 /// HTTP/1.0 and HTTP/1.1 are accepted only after a complete request-line
-/// containing a valid method token, request target, supported version, and
+/// containing a valid method token, request target, `HTTP/1.<digit>` version, and
 /// line terminator has been read. An HTTP/0.9 simple-request is accepted as
 /// HTTP/1x after `GET`, a valid request target, and a line terminator.
 /// Matching lenient HTTP/1 parsers such as httparse, a bare LF is accepted
@@ -804,7 +803,7 @@ where
         "HTTP peek read loop finished"
     );
 
-    let peek = Cursor::new(buffer.freeze());
+    let peek = ReplayReader::new(buffer.freeze());
     let peek_input = input.map_peek_io(|io| PrefixedIo::new(peek, io));
 
     Ok((matched_version, peek_input))
@@ -813,7 +812,7 @@ where
 const H2_MAGIC_PREFIX: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
 /// [`PrefixedIo`] alias used by [`HttpPeekRouter`].
-pub type HttpPrefixedIo<S> = PrefixedIo<Cursor<Bytes>, S>;
+pub type HttpPrefixedIo<S> = PrefixedIo<ReplayReader, S>;
 
 #[cfg(test)]
 mod test {
@@ -1008,6 +1007,8 @@ mod test {
             "GET /café HTTP/1.1\r\n".as_bytes(),
             b"GET / HTTP/1.1\n",
             b"GET /legacy HTTP/1.0\n",
+            b"GET / HTTP/1.2\r\n",
+            b"GET / HTTP/1.9\n",
             b"GET /\n",
             b"\r\nGET / HTTP/1.1\r\n",
             b"\n\n\r\nGET / HTTP/1.1\n",
@@ -1033,7 +1034,10 @@ mod test {
             b"OPTIONS * RTSP/2.0\r\n",
             b"OPTIONS sip:service@example.com SIP/2.0\r\n",
             b"GET / HTTP/1.1",
-            b"GET / HTTP/1.2\r\n",
+            b"GET / HTTP/1.a\r\n",
+            b"GET / HTTP/1.10\r\n",
+            b"GET / HTTP/2.0\r\n",
+            b"GET / HTTP/1.1\r\r",
             b"\rGET / HTTP/1.1\r\n",
             b"\r\nPRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
             b"GET  / HTTP/1.1\r\n",

--- a/rama-net/src/http/server/peek.rs
+++ b/rama-net/src/http/server/peek.rs
@@ -381,8 +381,6 @@ enum HttpRequestTargetState {
     Origin,
     Asterisk,
     Scheme { len: usize },
-    AbsoluteFirstSlash,
-    AbsoluteSecondSlash,
     Absolute,
     Authority,
 }
@@ -398,14 +396,12 @@ impl HttpRequestTargetState {
             Self::Start if byte == b'*' => Some(Self::Asterisk),
             Self::Start if is_scheme_first_byte(byte) => Some(Self::Scheme { len: 1 }),
             Self::Origin if byte != b'#' => Some(Self::Origin),
-            Self::Scheme { len: _ } if byte == b':' => Some(Self::AbsoluteFirstSlash),
+            Self::Scheme { len: _ } if byte == b':' => Some(Self::Absolute),
             Self::Scheme { len }
                 if len < crate::proto::MAX_SCHEME_LEN && is_scheme_rest_byte(byte) =>
             {
                 Some(Self::Scheme { len: len + 1 })
             }
-            Self::AbsoluteFirstSlash if byte == b'/' => Some(Self::AbsoluteSecondSlash),
-            Self::AbsoluteSecondSlash if byte == b'/' => Some(Self::Absolute),
             Self::Absolute if byte != b'#' => Some(Self::Absolute),
             Self::Authority if !matches!(byte, b'/' | b'?' | b'#') => Some(Self::Authority),
             _ => None,
@@ -503,24 +499,33 @@ impl HttpPeekState {
                     let method = &buffer[..method_end];
                     let target = &buffer[target_start..target_end];
                     let authority_form = method == b"CONNECT";
-                    match validate_http_request_target(target, authority_form) {
-                        Ok(()) if byte == b' ' => Http1PeekState::Version {
-                            method_end,
-                            target_end,
-                            offset: 0,
-                            candidates: HTTP_1_CANDIDATES,
-                        },
-                        Ok(()) if method == b"GET" && target != b"*" => Http1PeekState::Http09Lf {
-                            method_end,
-                            target_end,
-                        },
-                        Ok(()) => {
-                            tracing::trace!("HTTP/0.9 peek rejected method other than GET");
-                            Http1PeekState::Invalid
-                        }
-                        Err(err) => {
-                            tracing::trace!(%err, "HTTP/1 peek rejected invalid request target");
-                            Http1PeekState::Invalid
+                    if target == b"*" && method != b"OPTIONS" {
+                        tracing::trace!(
+                            "HTTP/1 peek rejected asterisk-form for method other than OPTIONS"
+                        );
+                        Http1PeekState::Invalid
+                    } else {
+                        match validate_http_request_target(target, authority_form) {
+                            Ok(()) if byte == b' ' => Http1PeekState::Version {
+                                method_end,
+                                target_end,
+                                offset: 0,
+                                candidates: HTTP_1_CANDIDATES,
+                            },
+                            Ok(()) if method == b"GET" && target != b"*" => {
+                                Http1PeekState::Http09Lf {
+                                    method_end,
+                                    target_end,
+                                }
+                            }
+                            Ok(()) => {
+                                tracing::trace!("HTTP/0.9 peek rejected method other than GET");
+                                Http1PeekState::Invalid
+                            }
+                            Err(err) => {
+                                tracing::trace!(%err, "HTTP/1 peek rejected invalid request target");
+                                Http1PeekState::Invalid
+                            }
                         }
                     }
                 } else if let Some(target) = target.push(byte) {
@@ -785,15 +790,14 @@ mod test {
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET *x"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET ht!"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET /#"));
-        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http:x"));
-        assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http:/x"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"GET http://x#"));
         assert_eq!(HttpPeekDecision::Reject, state_decision(b"CONNECT host/"));
 
         // A leading byte of a potentially valid UTF-8 target is not enough
         // information to reject; validation completes at the target delimiter.
         assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET /\xc3"));
-        assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET http:/"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET http:x"));
+        assert_eq!(HttpPeekDecision::Continue, state_decision(b"GET http:/x"));
         assert_eq!(HttpPeekDecision::Continue, state_decision(b"CONNECT ["));
 
         let mut max_scheme = b"GET ".to_vec();
@@ -897,10 +901,13 @@ mod test {
         const CASES: &[&[u8]] = &[
             b"GET /\r\n",
             b"GET http://example.com/legacy\r\n",
+            b"GET urn:legacy\r\n",
             b"GET / HTTP/1.1\r\n",
             b"GET /legacy HTTP/1.0\r\n",
             b"OPTIONS * HTTP/1.1\r\n",
             b"GET http://example.com/resource?q=1 HTTP/1.1\r\n",
+            b"GET urn:opaque HTTP/1.1\r\n",
+            b"GET http:/single-slash HTTP/1.1\r\n",
             b"CONNECT example.com:443 HTTP/1.1\r\n",
             b"PROPFIND /collection HTTP/1.1\r\n",
             b"QUERY /search HTTP/1.1\r\n",
@@ -922,6 +929,8 @@ mod test {
             b"POST /\r\n",
             b"get /\r\n",
             b"GET *\r\n",
+            b"GET * HTTP/1.1\r\n",
+            b"POST * HTTP/1.1\r\n",
             b"GET /\n",
             b"OPTIONS icap://icap.example.net/service ICAP/1.0\r\n",
             b"OPTIONS * RTSP/2.0\r\n",

--- a/rama-net/src/proto.rs
+++ b/rama-net/src/proto.rs
@@ -425,7 +425,7 @@ const fn validate_scheme_slice(s: &[u8]) -> bool {
 
 // Require the scheme to not be too long in order to enable further
 // optimizations later.
-const MAX_SCHEME_LEN: usize = 64;
+pub(crate) const MAX_SCHEME_LEN: usize = 64;
 
 // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
 //

--- a/rama-net/src/uri/parser/authority.rs
+++ b/rama-net/src/uri/parser/authority.rs
@@ -5,7 +5,7 @@ use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use super::ParserMode;
 use super::check_pct_encoded;
 use crate::address::parse_utils;
-use crate::address::{Domain, Host, UninterpretedHost};
+use crate::address::{Domain, Host, OptPort, UninterpretedHost};
 use crate::byte_sets::{
     is_control_byte, is_ipvfuture_tail_byte, is_reg_name_byte, is_userinfo_byte,
 };
@@ -29,13 +29,7 @@ pub(super) fn parse_optional_authority(
     start: usize,
     mode: ParserMode,
 ) -> Result<AuthorityScan, ParseError> {
-    if bytes.len() >= start + 2 && bytes[start] == b'/' && bytes[start + 1] == b'/' {
-        let auth_start = start + 2;
-        // Authority ends at the first `/`, `?`, `#`, or end of input.
-        let auth_end = bytes[auth_start..]
-            .iter()
-            .position(|&b| matches!(b, b'/' | b'?' | b'#'))
-            .map_or(bytes.len(), |p| p + auth_start);
+    if let Some((auth_start, auth_end)) = find_optional_authority(bytes, start) {
         let auth = parse_authority(bytes, auth_start, auth_end, mode)?;
         Ok(AuthorityScan {
             authority: Some(auth),
@@ -47,6 +41,21 @@ pub(super) fn parse_optional_authority(
             path_start: start,
         })
     }
+}
+
+/// Return the authority byte range when `bytes[start..]` begins with `//`.
+/// Both materializing URI parsing and borrowed request-target validation use
+/// this boundary scan.
+pub(super) fn find_optional_authority(bytes: &[u8], start: usize) -> Option<(usize, usize)> {
+    if !bytes.get(start..)?.starts_with(b"//") {
+        return None;
+    }
+    let authority_start = start + 2;
+    let authority_end = bytes[authority_start..]
+        .iter()
+        .position(|&b| matches!(b, b'/' | b'?' | b'#'))
+        .map_or(bytes.len(), |offset| authority_start + offset);
+    Some((authority_start, authority_end))
 }
 
 /// Parse the bytes `[start, end)` of the parent buffer as an RFC 3986 §3.2
@@ -78,6 +87,65 @@ pub(super) fn parse_authority(
     end: usize,
     mode: ParserMode,
 ) -> Result<LazyAuthority, ParseError> {
+    let scanned = scan_authority(bytes, start, end, mode)?;
+    let host = match scanned.host {
+        ScannedHost::Empty { at } => Host::Uninterpreted(UninterpretedHost::from_validated_bytes(
+            bytes.slice(at..at),
+            false,
+        )),
+        ScannedHost::Ipv6(address) => Host::Address(IpAddr::V6(address)),
+        ScannedHost::IpvFuture { start, end } => Host::Uninterpreted(
+            UninterpretedHost::from_validated_bytes(bytes.slice(start..end), true),
+        ),
+        ScannedHost::RegName { start, end } => {
+            let host_bytes = &bytes[start..end];
+            // Safety: `scan_host_and_port` validated this exact range as UTF-8.
+            let host_str = unsafe { core::str::from_utf8_unchecked(host_bytes) };
+            if let Ok(address) = host_str.parse::<Ipv4Addr>() {
+                Host::Address(IpAddr::V4(address))
+            } else if host_bytes.is_ascii() && Domain::try_from(host_str).is_ok() {
+                let domain_bytes = bytes.slice(start..end);
+                // Safety: `Domain::try_from(host_str)` returned `Ok` above.
+                let domain = unsafe { Domain::from_maybe_borrowed_unchecked(domain_bytes) };
+                Host::Name(domain)
+            } else {
+                Host::Uninterpreted(UninterpretedHost::from_validated_bytes(
+                    bytes.slice(start..end),
+                    false,
+                ))
+            }
+        }
+    };
+
+    Ok(LazyAuthority {
+        userinfo_range: scanned.userinfo_range,
+        host,
+        port: scanned.port,
+    })
+}
+
+struct ScannedAuthority {
+    userinfo_range: Option<(u16, u16)>,
+    host: ScannedHost,
+    port: OptPort,
+}
+
+enum ScannedHost {
+    Empty { at: usize },
+    Ipv6(Ipv6Addr),
+    IpvFuture { start: usize, end: usize },
+    RegName { start: usize, end: usize },
+}
+
+/// Scan and validate an authority without retaining or allocating bytes.
+/// Parsing and borrowed request-target validation both use this grammar pass;
+/// only the parser materializes the resulting typed host.
+fn scan_authority(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    mode: ParserMode,
+) -> Result<ScannedAuthority, ParseError> {
     // Walk authority bytes. Two invariants per byte:
     //   1. No control bytes (smuggling / header-injection vector).
     //   2. In graceful mode, non-ASCII bytes must form well-formed
@@ -114,11 +182,8 @@ pub(super) fn parse_authority(
         validate_userinfo_strict(&bytes[s as usize..e as usize])?;
     }
 
-    // Parse host + optional port from bytes[host_start..end].
-    let host_view = &bytes[host_start..end];
-    let (host, port) = parse_host_and_port(bytes, host_start, host_view, mode)?;
-
-    Ok(LazyAuthority {
+    let (host, port) = scan_host_and_port(bytes, host_start, end, mode)?;
+    Ok(ScannedAuthority {
         userinfo_range,
         host,
         port,
@@ -144,32 +209,18 @@ fn validate_userinfo_strict(bytes: &[u8]) -> Result<(), ParseError> {
     Ok(())
 }
 
-/// Parse the host and optional port. `parent` is the full URI buffer
-/// (used for zero-copy slicing of `Domain` / `UninterpretedHost` bytes);
-/// `host_start` is the absolute offset; `view` is
-/// `&parent[host_start..end]`.
-///
-/// Returns `(host, port)`. The host's variant is chosen by the input
-/// shape — see [`parse_authority`] for the full table. No parser-time
-/// canonicalization happens; bytes are always preserved or zero-copy
-/// sliced from `parent`.
-fn parse_host_and_port(
-    parent: &Bytes,
+fn scan_host_and_port(
+    bytes: &[u8],
     host_start: usize,
-    view: &[u8],
+    end: usize,
     mode: ParserMode,
-) -> Result<(Host, crate::address::OptPort), ParseError> {
+) -> Result<(ScannedHost, OptPort), ParseError> {
+    let view = &bytes[host_start..end];
     // RFC 3986 §3.2.2 `reg-name = *(...)` allows empty — `file:///path`,
     // `unix:///run/x`, etc. Stored as `Host::Uninterpreted(b"")`; callers
     // that need a non-empty host check `host.as_str().is_empty()`.
     if view.is_empty() {
-        return Ok((
-            Host::Uninterpreted(UninterpretedHost::from_validated_bytes(
-                parent.slice(host_start..host_start),
-                false,
-            )),
-            crate::address::OptPort::Unset,
-        ));
+        return Ok((ScannedHost::Empty { at: host_start }, OptPort::Unset));
     }
 
     // --- IP-literal (bracketed) -------------------------------------------
@@ -187,8 +238,10 @@ fn parse_host_and_port(
             // IANA, so there's nothing to decode. Bytes are stored
             // without the surrounding brackets.
             validate_ipvfuture(inside)?;
-            let body = parent.slice(inside_start..inside_start + inside.len());
-            Host::Uninterpreted(UninterpretedHost::from_validated_bytes(body, true))
+            ScannedHost::IpvFuture {
+                start: inside_start,
+                end: inside_start + inside.len(),
+            }
         } else {
             // Standard IPv6.
             if parse_utils::ipv6_bracket_has_zone(inside) {
@@ -200,13 +253,13 @@ fn parse_host_and_port(
             let Ok(addr) = s.parse::<Ipv6Addr>() else {
                 return Err(ParseError::InvalidComponent(Component::Host));
             };
-            Host::Address(IpAddr::V6(addr))
+            ScannedHost::Ipv6(addr)
         };
 
         // After `]`, optional `:port`.
         let after = &view[close_rel + 1..];
         let port = match after {
-            [] => crate::address::OptPort::Unset,
+            [] => OptPort::Unset,
             [b':', rest @ ..] => parse_port(rest)?,
             _ => return Err(ParseError::InvalidComponent(Component::Authority)),
         };
@@ -222,45 +275,27 @@ fn parse_host_and_port(
             let port = parse_port(&view[colon + 1..])?;
             (&view[..colon], port)
         }
-        None => (view, crate::address::OptPort::Unset),
+        None => (view, OptPort::Unset),
     };
     if host_bytes_rel.is_empty() {
         return Err(ParseError::InvalidComponent(Component::Host));
     }
-    let host_bytes_len = host_bytes_rel.len();
-
     // Validate against (i)reg-name grammar. Rejects mode-incompatible
     // bytes early — strict-mode non-ASCII, illegal punctuation, malformed
     // pct-escapes, smuggling-vector pct-decoded control bytes.
     validate_reg_name(host_bytes_rel, mode)?;
 
-    let Ok(host_str) = core::str::from_utf8(host_bytes_rel) else {
+    if core::str::from_utf8(host_bytes_rel).is_err() {
         return Err(ParseError::InvalidComponent(Component::Host));
-    };
+    }
 
-    // Try the typed-host shapes first, in priority order:
-    //   1. IPv4 dotted-quad.
-    //   2. DNS-label-shaped ASCII reg-name → `Host::Name` (zero-copy).
-    //   3. Anything else legal under reg-name (already validated above)
-    //      → `Host::Uninterpreted` (zero-copy, preserved verbatim).
-    let host = if let Ok(v4) = host_str.parse::<Ipv4Addr>() {
-        Host::Address(IpAddr::V4(v4))
-    } else if host_bytes_rel.is_ascii() && Domain::try_from(host_str).is_ok() {
-        // ASCII DNS-label-shaped fast path: zero-copy slice into Domain.
-        let domain_bytes = parent.slice(host_start..host_start + host_bytes_len);
-        // Safety: `Domain::try_from(host_str)` returned `Ok` above —
-        // the bytes are validated DNS-label-shape.
-        let domain = unsafe { Domain::from_maybe_borrowed_unchecked(domain_bytes) };
-        Host::Name(domain)
-    } else {
-        // Reg-name with pct-encoding, sub-delims, or raw UTF-8.
-        // Stored verbatim; conversion to Domain / IpAddr is opt-in
-        // via `TryFrom<&UninterpretedHost>`.
-        let body = parent.slice(host_start..host_start + host_bytes_len);
-        Host::Uninterpreted(UninterpretedHost::from_validated_bytes(body, false))
-    };
-
-    Ok((host, port))
+    Ok((
+        ScannedHost::RegName {
+            start: host_start,
+            end: host_start + host_bytes_rel.len(),
+        },
+        port,
+    ))
 }
 
 /// RFC 3986 §3.2.2 `reg-name` validation, with optional IRI extension.
@@ -299,70 +334,7 @@ pub(super) fn validate_authority(
     end: usize,
     mode: ParserMode,
 ) -> Result<(), ParseError> {
-    let mut i = start;
-    while i < end {
-        let b = bytes[i];
-        if is_control_byte(b) {
-            return Err(ParseError::ControlCharInUri { at: i, byte: b });
-        }
-        if mode == ParserMode::Graceful && b >= 0x80 {
-            i += super::check_utf8_sequence(bytes, i)?;
-        } else {
-            i += 1;
-        }
-    }
-
-    let userinfo_end = parse_utils::find_userinfo_split(&bytes[start..end]);
-    if let (ParserMode::Strict, Some(end)) = (mode, userinfo_end) {
-        validate_userinfo_strict(&bytes[start..start + end])?;
-    }
-    let host_start = userinfo_end.map_or(start, |end| start + end + 1);
-    validate_host_and_port(&bytes[host_start..end], mode)
-}
-
-fn validate_host_and_port(view: &[u8], mode: ParserMode) -> Result<(), ParseError> {
-    if view.is_empty() {
-        return Ok(());
-    }
-
-    if view[0] == b'[' {
-        let close = view
-            .iter()
-            .position(|&b| b == b']')
-            .ok_or(ParseError::InvalidComponent(Component::Host))?;
-        let inside = &view[1..close];
-        if matches!(inside.first(), Some(b'v' | b'V')) {
-            validate_ipvfuture(inside)?;
-        } else {
-            if parse_utils::ipv6_bracket_has_zone(inside) {
-                return Err(ParseError::IPv6ZoneNotSupported);
-            }
-            let Ok(address) = core::str::from_utf8(inside) else {
-                return Err(ParseError::InvalidComponent(Component::Host));
-            };
-            if address.parse::<Ipv6Addr>().is_err() {
-                return Err(ParseError::InvalidComponent(Component::Host));
-            }
-        }
-
-        return match &view[close + 1..] {
-            [] => Ok(()),
-            [b':', port @ ..] => parse_port(port).map(drop),
-            _ => Err(ParseError::InvalidComponent(Component::Authority)),
-        };
-    }
-
-    let host = match view.iter().rposition(|&b| b == b':') {
-        Some(colon) => {
-            parse_port(&view[colon + 1..])?;
-            &view[..colon]
-        }
-        None => view,
-    };
-    if host.is_empty() {
-        return Err(ParseError::InvalidComponent(Component::Host));
-    }
-    validate_reg_name(host, mode)
+    scan_authority(bytes, start, end, mode).map(drop)
 }
 
 fn validate_reg_name(bytes: &[u8], mode: ParserMode) -> Result<(), ParseError> {

--- a/rama-net/src/uri/parser/authority.rs
+++ b/rama-net/src/uri/parser/authority.rs
@@ -287,6 +287,84 @@ pub(crate) fn validate_reg_name_strict(bytes: &[u8]) -> Result<(), ParseError> {
     validate_reg_name(bytes, ParserMode::Strict)
 }
 
+/// Validate an authority without constructing its typed, owned representation.
+///
+/// This is the borrowed counterpart of [`parse_authority`], intended for
+/// callers that only need to classify wire bytes. It deliberately follows the
+/// graceful parser rules so a successful validation has the same acceptance
+/// envelope as [`crate::uri::Uri::parse_authority_form`].
+pub(super) fn validate_authority(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    mode: ParserMode,
+) -> Result<(), ParseError> {
+    let mut i = start;
+    while i < end {
+        let b = bytes[i];
+        if is_control_byte(b) {
+            return Err(ParseError::ControlCharInUri { at: i, byte: b });
+        }
+        if mode == ParserMode::Graceful && b >= 0x80 {
+            i += super::check_utf8_sequence(bytes, i)?;
+        } else {
+            i += 1;
+        }
+    }
+
+    let userinfo_end = parse_utils::find_userinfo_split(&bytes[start..end]);
+    if let (ParserMode::Strict, Some(end)) = (mode, userinfo_end) {
+        validate_userinfo_strict(&bytes[start..start + end])?;
+    }
+    let host_start = userinfo_end.map_or(start, |end| start + end + 1);
+    validate_host_and_port(&bytes[host_start..end], mode)
+}
+
+fn validate_host_and_port(view: &[u8], mode: ParserMode) -> Result<(), ParseError> {
+    if view.is_empty() {
+        return Ok(());
+    }
+
+    if view[0] == b'[' {
+        let close = view
+            .iter()
+            .position(|&b| b == b']')
+            .ok_or(ParseError::InvalidComponent(Component::Host))?;
+        let inside = &view[1..close];
+        if matches!(inside.first(), Some(b'v' | b'V')) {
+            validate_ipvfuture(inside)?;
+        } else {
+            if parse_utils::ipv6_bracket_has_zone(inside) {
+                return Err(ParseError::IPv6ZoneNotSupported);
+            }
+            let Ok(address) = core::str::from_utf8(inside) else {
+                return Err(ParseError::InvalidComponent(Component::Host));
+            };
+            if address.parse::<Ipv6Addr>().is_err() {
+                return Err(ParseError::InvalidComponent(Component::Host));
+            }
+        }
+
+        return match &view[close + 1..] {
+            [] => Ok(()),
+            [b':', port @ ..] => parse_port(port).map(drop),
+            _ => Err(ParseError::InvalidComponent(Component::Authority)),
+        };
+    }
+
+    let host = match view.iter().rposition(|&b| b == b':') {
+        Some(colon) => {
+            parse_port(&view[colon + 1..])?;
+            &view[..colon]
+        }
+        None => view,
+    };
+    if host.is_empty() {
+        return Err(ParseError::InvalidComponent(Component::Host));
+    }
+    validate_reg_name(host, mode)
+}
+
 fn validate_reg_name(bytes: &[u8], mode: ParserMode) -> Result<(), ParseError> {
     let mut i = 0;
     while i < bytes.len() {

--- a/rama-net/src/uri/parser/authority.rs
+++ b/rama-net/src/uri/parser/authority.rs
@@ -328,6 +328,7 @@ pub(crate) fn validate_reg_name_strict(bytes: &[u8]) -> Result<(), ParseError> {
 /// callers that only need to classify wire bytes. It deliberately follows the
 /// graceful parser rules so a successful validation has the same acceptance
 /// envelope as [`crate::uri::Uri::parse_authority_form`].
+#[cfg(feature = "http")]
 pub(super) fn validate_authority(
     bytes: &[u8],
     start: usize,

--- a/rama-net/src/uri/parser/mod.rs
+++ b/rama-net/src/uri/parser/mod.rs
@@ -220,6 +220,65 @@ pub(super) fn parse_authority_form(bytes: Bytes, mode: ParserMode) -> Result<Uri
     ))
 }
 
+/// Validate an HTTP request-target directly from borrowed wire bytes.
+///
+/// Unlike the URI constructors this function retains no component values and
+/// therefore performs no allocation or reference-counted buffer cloning. The
+/// accepted forms mirror the graceful URI parser, with the HTTP-specific
+/// constraints that fragments and absolute-form targets without an authority
+/// are rejected.
+pub(crate) fn validate_http_request_target(
+    bytes: &[u8],
+    authority_form: bool,
+) -> Result<(), ParseError> {
+    if bytes.is_empty() {
+        return Err(ParseError::Empty);
+    }
+    if bytes.len() > MAX_URI_LEN {
+        return Err(ParseError::TooLong { len: bytes.len() });
+    }
+
+    if authority_form {
+        if bytes.iter().any(|&b| matches!(b, b'/' | b'?' | b'#')) {
+            return Err(ParseError::InvalidComponent(Component::Authority));
+        }
+        return authority::validate_authority(bytes, 0, bytes.len(), ParserMode::Graceful);
+    }
+
+    if bytes == b"*" {
+        return Ok(());
+    }
+
+    if bytes[0] == b'/' {
+        let scan = path::scan_path_query_fragment(bytes, 0, ParserMode::Graceful)?;
+        return if scan.fragment.is_some() {
+            Err(ParseError::InvalidComponent(Component::Fragment))
+        } else {
+            Ok(())
+        };
+    }
+
+    let scheme_end = scheme::find_scheme_end(bytes)
+        .filter(|&end| end <= crate::proto::MAX_SCHEME_LEN)
+        .ok_or(ParseError::InvalidComponent(Component::Scheme))?;
+    let authority_start = scheme_end + 1;
+    if !bytes[authority_start..].starts_with(b"//") {
+        return Err(ParseError::InvalidComponent(Component::Authority));
+    }
+    let authority_start = authority_start + 2;
+    let authority_end = bytes[authority_start..]
+        .iter()
+        .position(|&b| matches!(b, b'/' | b'?' | b'#'))
+        .map_or(bytes.len(), |offset| authority_start + offset);
+    authority::validate_authority(bytes, authority_start, authority_end, ParserMode::Graceful)?;
+    let scan = path::scan_path_query_fragment(bytes, authority_end, ParserMode::Graceful)?;
+    if scan.fragment.is_some() {
+        Err(ParseError::InvalidComponent(Component::Fragment))
+    } else {
+        Ok(())
+    }
+}
+
 /// Parse any RFC 3986 URI-reference — absolute URI or relative-ref.
 ///
 /// Accepts everything [`parse`] accepts, plus the relative-ref grammar

--- a/rama-net/src/uri/parser/mod.rs
+++ b/rama-net/src/uri/parser/mod.rs
@@ -225,8 +225,7 @@ pub(super) fn parse_authority_form(bytes: Bytes, mode: ParserMode) -> Result<Uri
 /// Unlike the URI constructors this function retains no component values and
 /// therefore performs no allocation or reference-counted buffer cloning. The
 /// accepted forms mirror the graceful URI parser, with the HTTP-specific
-/// constraints that fragments and absolute-form targets without an authority
-/// are rejected.
+/// constraint that fragments are rejected.
 pub(crate) fn validate_http_request_target(
     bytes: &[u8],
     authority_form: bool,
@@ -261,17 +260,16 @@ pub(crate) fn validate_http_request_target(
     let scheme_end = scheme::find_scheme_end(bytes)
         .filter(|&end| end <= crate::proto::MAX_SCHEME_LEN)
         .ok_or(ParseError::InvalidComponent(Component::Scheme))?;
-    let authority_start = scheme_end + 1;
-    if !bytes[authority_start..].starts_with(b"//") {
-        return Err(ParseError::InvalidComponent(Component::Authority));
-    }
-    let authority_start = authority_start + 2;
-    let authority_end = bytes[authority_start..]
-        .iter()
-        .position(|&b| matches!(b, b'/' | b'?' | b'#'))
-        .map_or(bytes.len(), |offset| authority_start + offset);
-    authority::validate_authority(bytes, authority_start, authority_end, ParserMode::Graceful)?;
-    let scan = path::scan_path_query_fragment(bytes, authority_end, ParserMode::Graceful)?;
+    let after_colon = scheme_end + 1;
+    let path_start = if let Some((authority_start, authority_end)) =
+        authority::find_optional_authority(bytes, after_colon)
+    {
+        authority::validate_authority(bytes, authority_start, authority_end, ParserMode::Graceful)?;
+        authority_end
+    } else {
+        after_colon
+    };
+    let scan = path::scan_path_query_fragment(bytes, path_start, ParserMode::Graceful)?;
     if scan.fragment.is_some() {
         Err(ParseError::InvalidComponent(Component::Fragment))
     } else {

--- a/rama-net/src/uri/parser/mod.rs
+++ b/rama-net/src/uri/parser/mod.rs
@@ -226,6 +226,7 @@ pub(super) fn parse_authority_form(bytes: Bytes, mode: ParserMode) -> Result<Uri
 /// therefore performs no allocation or reference-counted buffer cloning. The
 /// accepted forms mirror the graceful URI parser, with the HTTP-specific
 /// constraint that fragments are rejected.
+#[cfg(feature = "http")]
 pub(crate) fn validate_http_request_target(
     bytes: &[u8],
     authority_form: bool,

--- a/rama-net/src/uri/parser/path.rs
+++ b/rama-net/src/uri/parser/path.rs
@@ -11,8 +11,6 @@ use super::{check_pct_encoded, check_utf8_sequence};
 use crate::byte_sets::{is_control_byte, is_path_byte, is_query_fragment_byte};
 use crate::uri::ParseError;
 
-use rama_core::bytes::Bytes;
-
 /// Result of the path/query/fragment scan: where the path ends and what
 /// ranges (if any) the query and fragment occupy in the parent buffer.
 #[derive(Debug)]
@@ -30,7 +28,7 @@ enum Section {
 }
 
 pub(super) fn scan_path_query_fragment(
-    bytes: &Bytes,
+    bytes: &[u8],
     start: usize,
     mode: ParserMode,
 ) -> Result<PathQueryFragment, ParseError> {

--- a/rama-net/src/uri/parser/tests/mod.rs
+++ b/rama-net/src/uri/parser/tests/mod.rs
@@ -59,6 +59,7 @@ pub(super) mod query_collect;
 pub(super) mod query_deserialize;
 pub(super) mod query_mut;
 pub(super) mod query_pairs;
+pub(super) mod request_target;
 pub(super) mod resolve;
 pub(super) mod rfc3986_examples;
 pub(super) mod serde;

--- a/rama-net/src/uri/parser/tests/mod.rs
+++ b/rama-net/src/uri/parser/tests/mod.rs
@@ -59,6 +59,7 @@ pub(super) mod query_collect;
 pub(super) mod query_deserialize;
 pub(super) mod query_mut;
 pub(super) mod query_pairs;
+#[cfg(feature = "http")]
 pub(super) mod request_target;
 pub(super) mod resolve;
 pub(super) mod rfc3986_examples;

--- a/rama-net/src/uri/parser/tests/request_target.rs
+++ b/rama-net/src/uri/parser/tests/request_target.rs
@@ -1,0 +1,163 @@
+//! Borrowed HTTP request-target validation and parser parity.
+
+use super::super::{MAX_URI_LEN, validate_http_request_target};
+use crate::uri::{Component, ParseError, Uri};
+
+#[test]
+fn borrowed_validator_accepts_each_http_request_target_form() {
+    const NON_AUTHORITY: &[&[u8]] = &[
+        b"*",
+        b"/",
+        b"/resource?q=1",
+        "/café".as_bytes(),
+        b"http://example.com/resource?q=1",
+        b"custom+scheme://user@example.com:8443/path",
+        b"urn:opaque",
+        b"http:/single-slash",
+        b"http://[2001:db8::1]:8080/",
+        b"http://[v1.future]:8080/",
+    ];
+    for target in NON_AUTHORITY {
+        assert!(
+            validate_http_request_target(target, false).is_ok(),
+            "{target:?}"
+        );
+    }
+
+    const AUTHORITY: &[&[u8]] = &[
+        b"example.com",
+        b"example.com:443",
+        b"user@example.com:443",
+        b"127.0.0.1:80",
+        b"[2001:db8::1]:443",
+        b"[v1.future]:443",
+    ];
+    for target in AUTHORITY {
+        assert!(
+            validate_http_request_target(target, true).is_ok(),
+            "{target:?}"
+        );
+    }
+}
+
+#[test]
+fn borrowed_validator_rejects_non_http_target_shapes() {
+    const NON_AUTHORITY: &[&[u8]] = &[
+        b"",
+        b"relative/path",
+        b"http://[invalid]/",
+        b"http://example.com:65536/",
+        b"/path#fragment",
+        b"http://example.com/path#fragment",
+        b"/bad\ttarget",
+    ];
+    for target in NON_AUTHORITY {
+        assert!(
+            validate_http_request_target(target, false).is_err(),
+            "{target:?}"
+        );
+    }
+
+    const AUTHORITY: &[&[u8]] = &[
+        b"",
+        b"example.com/path",
+        b"example.com?query",
+        b"example.com#fragment",
+        b":443",
+        b"[2001:db8::1",
+        b"[2001:db8::1]suffix",
+        b"example.com:65536",
+        b"bad host:443",
+    ];
+    for target in AUTHORITY {
+        assert!(
+            validate_http_request_target(target, true).is_err(),
+            "{target:?}"
+        );
+    }
+}
+
+#[test]
+fn borrowed_authority_validation_matches_regular_parsing() {
+    const CASES: &[&[u8]] = &[
+        b"example.com",
+        b"example.com:",
+        b"example.com:443",
+        b"user@@example.com:443",
+        b"127.0.0.1:80",
+        b"[2001:db8::1]:443",
+        b"[vF.a:b]:443",
+        b"exa%6Dple.com:443",
+        "café.example:443".as_bytes(),
+        b":443",
+        b"[2001:db8::1",
+        b"[fe80::1%25eth0]:443",
+        b"[v.future]:443",
+        b"example.com:65536",
+        b"bad\\host:443",
+    ];
+
+    for target in CASES {
+        let borrowed = validate_http_request_target(target, true);
+        let parsed = Uri::parse_authority_form(*target);
+        assert_eq!(borrowed.is_ok(), parsed.is_ok(), "{target:?}");
+    }
+}
+
+#[test]
+fn borrowed_non_authority_validation_matches_regular_parsing() {
+    const CASES: &[&[u8]] = &[
+        b"*",
+        b"/",
+        b"/resource?q=1",
+        "/café".as_bytes(),
+        b"http://example.com/resource?q=1",
+        b"custom+scheme://user@example.com:8443/path",
+        b"http://[2001:db8::1]:8080/",
+        b"http://[v1.future]:8080/",
+        b"relative/path",
+        b"urn:opaque",
+        b"http:/missing-slash",
+        b"http://[invalid]/",
+        b"http://example.com:65536/",
+        b"/bad\ttarget",
+    ];
+
+    for target in CASES {
+        let borrowed = validate_http_request_target(target, false);
+        let parsed = Uri::parse(*target).and_then(|uri| {
+            if uri.fragment().is_some() {
+                Err(ParseError::InvalidComponent(Component::Authority))
+            } else {
+                Ok(uri)
+            }
+        });
+        assert_eq!(borrowed.is_ok(), parsed.is_ok(), "{target:?}");
+    }
+}
+
+#[test]
+fn borrowed_validator_enforces_uri_length_limit() {
+    let at_limit = vec![b'/'; MAX_URI_LEN];
+    validate_http_request_target(&at_limit, false).unwrap();
+
+    let over_limit = vec![b'/'; MAX_URI_LEN + 1];
+    assert!(matches!(
+        validate_http_request_target(&over_limit, false),
+        Err(ParseError::TooLong { len }) if len == MAX_URI_LEN + 1
+    ));
+}
+
+#[test]
+fn borrowed_validator_enforces_scheme_length_limit() {
+    let mut at_limit = vec![b'a'; crate::proto::MAX_SCHEME_LEN];
+    at_limit.extend_from_slice(b"://example.com/");
+    validate_http_request_target(&at_limit, false).unwrap();
+
+    let mut over_limit = vec![b'a'; crate::proto::MAX_SCHEME_LEN + 1];
+    over_limit.extend_from_slice(b"://example.com/");
+    assert!(matches!(
+        validate_http_request_target(&over_limit, false),
+        Err(ParseError::InvalidComponent(Component::Scheme))
+    ));
+}

--- a/rama-net/src/uri/parser/tests/request_target.rs
+++ b/rama-net/src/uri/parser/tests/request_target.rs
@@ -114,6 +114,7 @@ fn borrowed_non_authority_validation_matches_regular_parsing() {
         b"http://example.com/resource?q=1",
         b"custom+scheme://user@example.com:8443/path",
         b"http://[2001:db8::1]:8080/",
+        b"http://127.0.0.1:8080/",
         b"http://[v1.future]:8080/",
         b"relative/path",
         b"urn:opaque",


### PR DESCRIPTION
HTTP peek now only routes to the http acceptor after validating a complete request-line (with httparse-style leniency: bare LF, leading empty lines, any HTTP/1.x), bounded in memory and releasing its replay buffer once drained — so routing decisions agree with what the h1 server actually accepts.