### PR TITLE
feat: add http-backend feature for slimmer http builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,21 +463,26 @@ http = [
     "rama-fastcgi?/http",
     "rama-tower?/http",
 ]
-http-full = [
+# minimal http client stack: connector builder + `EasyHttpWebClient`,
+# without the extras (ws, idna, compression, embedded ua profiles, ...)
+http-client = [
     "http",
     "tcp",
     "dns",
-    "ws",
-    "idna",
     "dep:rama-http-backend",
     "dep:rama-http-core",
+    "dep:tokio",
+]
+http-full = [
+    "http-client",
+    "ws",
+    "idna",
     "dep:ahash",
     "ua-embed-profiles",
     "compression",
     "multipart",
     "html",
     "rss",
-    "dep:tokio",
     "rama-grpc?/transport",
 ]
 multipart = ["http", "rama-http?/multipart"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,7 +481,6 @@ http-full = [
     "dns",
     "ws",
     "idna",
-    "dep:ahash",
     "ua-embed-profiles",
     "compression",
     "multipart",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -463,18 +463,22 @@ http = [
     "rama-fastcgi?/http",
     "rama-tower?/http",
 ]
-# minimal http client stack: connector builder + `EasyHttpWebClient`,
-# without the extras (ws, idna, compression, embedded ua profiles, ...)
-http-client = [
+# generic http backend closure (connector/server plumbing), without
+# committing to client, proxy or server specifics: those feature-gate
+# their own extra requirements (e.g. `EasyHttpWebClient` also needs
+# `tcp` + `dns`) on top of this.
+http-backend = [
     "http",
-    "tcp",
-    "dns",
     "dep:rama-http-backend",
     "dep:rama-http-core",
     "dep:tokio",
 ]
 http-full = [
-    "http-client",
+    "http-backend",
+    # `EasyHttpWebClient` (see `http::client`) needs these on top of
+    # `http-backend`; kept here so `http-full` stays a strict superset.
+    "tcp",
+    "dns",
     "ws",
     "idna",
     "dep:ahash",

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -11,13 +11,13 @@ pub use ::rama_http::{
     layer, matcher, mime, opentelemetry, proto, protocols, request, response, service, sse, utils,
 };
 
-#[cfg(feature = "http-full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
+#[cfg(feature = "http-client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-client")))]
 #[doc(inline)]
 pub use ::rama_http_core as core;
 
-#[cfg(feature = "http-full")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-full")))]
+#[cfg(feature = "http-client")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-client")))]
 pub mod client;
 
 #[cfg(feature = "http-full")]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -40,8 +40,22 @@ pub use ::rama_http_backend::proxy;
 #[doc(inline)]
 pub use ::rama_ws as ws;
 
-#[cfg(feature = "tls")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
+// `CertIssuerHttpClient` builds on `EasyHttpWebClient`, hence the same gates as `http::client`.
+#[cfg(all(
+    feature = "tls",
+    feature = "http-backend",
+    feature = "dns",
+    feature = "tcp"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        feature = "tls",
+        feature = "http-backend",
+        feature = "dns",
+        feature = "tcp"
+    )))
+)]
 pub mod tls;
 
 #[cfg(feature = "grpc")]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -11,13 +11,18 @@ pub use ::rama_http::{
     layer, matcher, mime, opentelemetry, proto, protocols, request, response, service, sse, utils,
 };
 
-#[cfg(feature = "http-client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-client")))]
+#[cfg(feature = "http-backend")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http-backend")))]
 #[doc(inline)]
 pub use ::rama_http_core as core;
 
-#[cfg(feature = "http-client")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http-client")))]
+// `EasyHttpWebClient` and its connector builder additionally need `dns` + `tcp`
+// on top of `http-backend` (default dns/transport connectors, proxy tunneling, ...).
+#[cfg(all(feature = "http-backend", feature = "dns", feature = "tcp"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "http-backend", feature = "dns", feature = "tcp")))
+)]
 pub mod client;
 
 #[cfg(feature = "http-full")]


### PR DESCRIPTION
The `EasyHttpWebClient` stack was only reachable via `http-full`, which drags in ws, idna (icu), compression, embedded ua profiles, multipart, html and rss — none of which are required by the http backend itself.

The new `http-backend` feature enables just `dep:rama-http-backend`, `dep:rama-http-core` and `dep:tokio` on top of `http`. `http::client` is gated on `http-backend` + `dns` + `tcp`, and `http::tls` (`CertIssuerHttpClient`) now shares those gates, fixing a pre-existing `http,tls` build break. `http-full` stays a strict superset (its redundant `dep:ahash`, already enabled via `std`, is dropped), so existing users are unaffected.

A client-only build (`http-backend,dns,tcp`) drops ~50 crates from the dependency tree (229 → 176 without default features). Optional features such as compression, rustls, ring, socks5, opentelemetry and unix compose with it as before.