### PR TITLE
IoForwardService expose result

### DIFF
--- a/benches/e2e_http_client_server.rs
+++ b/benches/e2e_http_client_server.rs
@@ -39,7 +39,6 @@ use rama::{
         },
     },
     io::Io,
-    layer::ConsumeErrLayer,
     net::{
         Protocol,
         address::{ProxyAddress, SocketAddress},
@@ -253,10 +252,7 @@ where
             Executor::default(),
             MethodMatcher::CONNECT,
             DefaultHttpProxyConnectReplyService::new(),
-            (
-                ConsumeErrLayer::default(),
-                IoToProxyBridgeIoLayer::extension_connector_target(),
-            )
+            IoToProxyBridgeIoLayer::extension_connector_target()
                 .into_layer(IoForwardService::new(Executor::default())),
         ),
         RemoveResponseHeaderLayer::hop_by_hop(),

--- a/examples/grpc/src/shared/tests/integration/max_message_size.rs
+++ b/examples/grpc/src/shared/tests/integration/max_message_size.rs
@@ -274,5 +274,5 @@ async fn max_message_run(case: &TestCase) -> Result<(), Status> {
         buf: client_blob.clone(),
     });
 
-    client.unary_call(req).await.map(|_| ())
+    client.unary_call(req).await.map(drop)
 }

--- a/examples/src/http_connect_proxy.rs
+++ b/examples/src/http_connect_proxy.rs
@@ -157,14 +157,11 @@ async fn main() {
                         exec.clone(),
                         MethodMatcher::CONNECT,
                         DefaultHttpProxyConnectReplyService::new(),
-                        (
-                            ConsumeErrLayer::default(),
-                            IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                                rama::dns::client::DnsConnector::new(
-                                    rama::tcp::client::service::TcpConnector::new(),
-                                ),
-                            ),
-                        ).into_layer(IoForwardService::new(exec)),
+                        IoToProxyBridgeIoLayer::extension_connector_target()
+                            .with_connector(rama::dns::client::DnsConnector::new(
+                                rama::tcp::client::service::TcpConnector::new(),
+                            ))
+                            .into_layer(IoForwardService::new(exec)),
                     ),
                     RemoveResponseHeaderLayer::hop_by_hop(),
                     RemoveRequestHeaderLayer::hop_by_hop(),

--- a/examples/src/http_https_socks5_and_socks5h_connect_proxy.rs
+++ b/examples/src/http_https_socks5_and_socks5h_connect_proxy.rs
@@ -115,14 +115,10 @@ async fn main() {
                 exec.clone(),
                 MethodMatcher::CONNECT,
                 DefaultHttpProxyConnectReplyService::new(),
-                (
-                    ConsumeErrLayer::default(),
-                    IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                        rama::dns::client::DnsConnector::new(
-                            rama::tcp::client::service::TcpConnector::new(),
-                        ),
-                    ),
-                )
+                IoToProxyBridgeIoLayer::extension_connector_target()
+                    .with_connector(rama::dns::client::DnsConnector::new(
+                        rama::tcp::client::service::TcpConnector::new(),
+                    ))
                     .into_layer(IoForwardService::new(exec)),
             ),
             RemoveResponseHeaderLayer::hop_by_hop(),

--- a/examples/src/http_mitm_relay_proxy_boring.rs
+++ b/examples/src/http_mitm_relay_proxy_boring.rs
@@ -155,7 +155,7 @@ fn new_mitm_svc<Ingress: Io + Unpin + ExtensionsRef>(
         ArcLayer::new(),
     ));
     let maybe_http_relay = HttpPeekRouter::new(http_mitm_relay)
-        .with_fallback(MapOutputLayer::new(|_| ()).into_layer(IoForwardService::new(exec.clone())));
+        .with_fallback(MapOutputLayer::new(drop).into_layer(IoForwardService::new(exec.clone())));
 
     let tls_mitm_relay = TlsMitmRelay::try_new_with_cached_self_signed_issuer(&SelfSignedData {
         organisation_name: Some("HTTP MITM Relay Proxy Boring Example".to_owned()),

--- a/examples/src/http_mitm_relay_proxy_boring.rs
+++ b/examples/src/http_mitm_relay_proxy_boring.rs
@@ -49,7 +49,7 @@ use rama::{
         server::HttpServer,
     },
     io::Io,
-    layer::{ArcLayer, ConsumeErrLayer},
+    layer::{ArcLayer, ConsumeErrLayer, MapOutputLayer},
     net::{http::server::HttpPeekRouter, proxy::IoForwardService, user::credentials::basic},
     rt::Executor,
     tcp::{proxy::IoToProxyBridgeIoLayer, server::TcpListener},
@@ -154,8 +154,8 @@ fn new_mitm_svc<Ingress: Io + Unpin + ExtensionsRef>(
         ),
         ArcLayer::new(),
     ));
-    let maybe_http_relay =
-        HttpPeekRouter::new(http_mitm_relay).with_fallback(IoForwardService::new(exec.clone()));
+    let maybe_http_relay = HttpPeekRouter::new(http_mitm_relay)
+        .with_fallback(MapOutputLayer::new(|_| ()).into_layer(IoForwardService::new(exec.clone())));
 
     let tls_mitm_relay = TlsMitmRelay::try_new_with_cached_self_signed_issuer(&SelfSignedData {
         organisation_name: Some("HTTP MITM Relay Proxy Boring Example".to_owned()),

--- a/examples/src/https_connect_proxy.rs
+++ b/examples/src/https_connect_proxy.rs
@@ -111,14 +111,10 @@ async fn main() {
                     exec.clone(),
                     MethodMatcher::CONNECT,
                     DefaultHttpProxyConnectReplyService::new(),
-                    (
-                        ConsumeErrLayer::default(),
-                        IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                            rama::dns::client::DnsConnector::new(
-                                rama::tcp::client::service::TcpConnector::new(),
-                            ),
-                        ),
-                    )
+                    IoToProxyBridgeIoLayer::extension_connector_target()
+                        .with_connector(rama::dns::client::DnsConnector::new(
+                            rama::tcp::client::service::TcpConnector::new(),
+                        ))
                         .into_layer(IoForwardService::new(exec)),
                 ),
             )

--- a/examples/src/mitm_ocsp_relay_gate.rs
+++ b/examples/src/mitm_ocsp_relay_gate.rs
@@ -57,8 +57,8 @@ use rama::{
             extract::{Bytes, Path, State},
         },
     },
-    layer::ConsumeErrLayer,
-    net::proxy::IoForwardService,
+    layer::{ConsumeErrLayer, MapOutput},
+    net::proxy::{IoForwardOutcome, IoForwardService},
     rt::Executor,
     service::service_fn,
     tcp::{proxy::IoToProxyBridgeIoLayer, server::TcpListener},
@@ -305,10 +305,13 @@ fn mitm_app(
     exec: Executor,
 ) -> PeekTlsClientHelloService<
     rama::tls::boring::proxy::TlsMitmRelayService<InMemoryBoringMitmCertIssuer, IoForwardService>,
-    IoForwardService,
+    MapOutput<IoForwardService, fn(IoForwardOutcome)>,
 > {
+    // The peek router needs its two branches to share an output type: the TLS-MITM
+    // relay yields `()`, so discard the plain-forward fallback's outcome to match.
     let forward = IoForwardService::new(exec);
-    PeekTlsClientHelloService::new(relay.into_layer(forward.clone())).with_fallback(forward)
+    PeekTlsClientHelloService::new(relay.into_layer(forward.clone()))
+        .with_fallback(MapOutput::new(forward, |_| ()))
 }
 
 async fn reject_non_connect(_req: Request) -> Result<Response, Infallible> {

--- a/examples/src/proxy_connectivity_check.rs
+++ b/examples/src/proxy_connectivity_check.rs
@@ -181,7 +181,7 @@ async fn main() {
     let socks5_svc = HttpPeekRouter::new(HttpServer::auto(exec.clone()).service(proxy_service))
         .with_fallback(
             (
-                MapOutputLayer::new(|_| ()),
+                MapOutputLayer::new(drop),
                 IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
                     rama::dns::client::DnsConnector::new(
                         rama::tcp::client::service::TcpConnector::new(),

--- a/examples/src/proxy_connectivity_check.rs
+++ b/examples/src/proxy_connectivity_check.rs
@@ -55,7 +55,7 @@ use rama::{
         server::HttpServer,
         service::web::response::Html,
     },
-    layer::{ConsumeErrLayer, HijackLayer},
+    layer::{ConsumeErrLayer, HijackLayer, MapOutputLayer},
     net::{
         address::SocketAddress, http::server::HttpPeekRouter, proxy::IoForwardService,
         stream::SocketInfo, user::credentials::basic,
@@ -168,14 +168,10 @@ async fn main() {
                 exec.clone(),
                 MethodMatcher::CONNECT,
                 DefaultHttpProxyConnectReplyService::new(),
-                (
-                    ConsumeErrLayer::default(),
-                    IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                        rama::dns::client::DnsConnector::new(
-                            rama::tcp::client::service::TcpConnector::new(),
-                        ),
-                    ),
-                )
+                IoToProxyBridgeIoLayer::extension_connector_target()
+                    .with_connector(rama::dns::client::DnsConnector::new(
+                        rama::tcp::client::service::TcpConnector::new(),
+                    ))
                     .into_layer(IoForwardService::new(exec.clone())),
             ),
         )
@@ -184,10 +180,14 @@ async fn main() {
 
     let socks5_svc = HttpPeekRouter::new(HttpServer::auto(exec.clone()).service(proxy_service))
         .with_fallback(
-            IoToProxyBridgeIoLayer::extension_connector_target()
-                .with_connector(rama::dns::client::DnsConnector::new(
-                    rama::tcp::client::service::TcpConnector::new(),
-                ))
+            (
+                MapOutputLayer::new(|_| ()),
+                IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
+                    rama::dns::client::DnsConnector::new(
+                        rama::tcp::client::service::TcpConnector::new(),
+                    ),
+                ),
+            )
                 .into_layer(IoForwardService::new(exec.clone())),
         );
     let socks5_acceptor = Socks5Acceptor::new(exec.clone())

--- a/examples/src/socks5_and_http_proxy.rs
+++ b/examples/src/socks5_and_http_proxy.rs
@@ -87,14 +87,10 @@ async fn main() {
                 exec.clone(),
                 MethodMatcher::CONNECT,
                 DefaultHttpProxyConnectReplyService::new(),
-                (
-                    ConsumeErrLayer::default(),
-                    IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                        rama::dns::client::DnsConnector::new(
-                            rama::tcp::client::service::TcpConnector::new(),
-                        ),
-                    ),
-                )
+                IoToProxyBridgeIoLayer::extension_connector_target()
+                    .with_connector(rama::dns::client::DnsConnector::new(
+                        rama::tcp::client::service::TcpConnector::new(),
+                    ))
                     .into_layer(IoForwardService::new(exec)),
             ),
             RemoveResponseHeaderLayer::hop_by_hop(),

--- a/examples/src/tls_sni_router.rs
+++ b/examples/src/tls_sni_router.rs
@@ -174,6 +174,7 @@ where
             .into_layer(IoForwardService::new(self.exec.clone()))
             .serve(stream)
             .await
+            .map(|_| ())
     }
 }
 

--- a/examples/src/tls_sni_router.rs
+++ b/examples/src/tls_sni_router.rs
@@ -174,7 +174,7 @@ where
             .into_layer(IoForwardService::new(self.exec.clone()))
             .serve(stream)
             .await
-            .map(|_| ())
+            .map(drop)
     }
 }
 

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/tests/shared/servers.rs
@@ -36,7 +36,7 @@ use rama::{
             server::{WebSocketAcceptor, WebSocketEchoService},
         },
     },
-    layer::ConsumeErrLayer,
+    layer::{ConsumeErrLayer, MapOutputLayer},
     net::{
         address::{Domain, SocketAddress},
         proxy::IoForwardService,
@@ -408,7 +408,7 @@ pub(crate) async fn spawn_combined_proxy() -> (u16, tokio::task::JoinHandle<()>)
                 .negate()
                 .and_method_connect(),
             DefaultHttpProxyConnectReplyService::new(),
-            ConsumeErrLayer::trace_as_debug().into_layer(
+            (ConsumeErrLayer::trace_as_debug(), MapOutputLayer::new(drop)).into_layer(
                 IoToProxyBridgeIoLayer::extension_connector_target()
                     .with_connector(rama::dns::client::DnsConnector::new(
                         rama::tcp::client::service::TcpConnector::new(),
@@ -446,7 +446,8 @@ async fn http_plain_proxy(req: Request) -> Result<Response, Infallible> {
         let ws_client = HttpUpgradeMitmRelayLayer::new(
             Executor::default(),
             HttpWebSocketRelayServiceRequestMatcher::new(
-                ConsumeErrLayer::trace_as_debug().into_layer(IoForwardService::default()),
+                (ConsumeErrLayer::trace_as_debug(), MapOutputLayer::new(drop))
+                    .into_layer(IoForwardService::default()),
             ),
         )
         .into_layer(inner_client);

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tcp.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/tcp.rs
@@ -30,7 +30,7 @@ use rama::{
         },
     },
     io::{BridgeIo, Io},
-    layer::{ArcLayer, ConsumeErrLayer, HijackLayer},
+    layer::{ArcLayer, ConsumeErrLayer, HijackLayer, MapOutput, MapOutputLayer},
     net::{
         address::Domain,
         apple::networkextension::{
@@ -168,7 +168,7 @@ impl DemoTcpMitmService {
         // (non-TLS plain traffic, SNI-excluded TLS passthrough);
         // leave the inner fallback (post-TLS-MITM cleartext) as plain
         // `IoForwardService`.
-        let plain_passthrough = IoForwardService::new(exec.clone());
+        let plain_passthrough = MapOutput::new(IoForwardService::new(exec.clone()), drop);
         let promote_passthrough = PromoteLayer::new().into_layer(plain_passthrough.clone());
 
         let inner_http_router = HttpPeekRouter::new(http_mitm_svc.clone())
@@ -259,7 +259,7 @@ impl DemoTcpMitmService {
                         // CONNECT tunnel inner stream — post-HTTP-decoding,
                         // NOT a raw kernel-flow bridge. Do not promote here;
                         // see `PromoteHandle`'s safety contract.
-                        ConsumeErrLayer::trace_as_debug()
+                        (ConsumeErrLayer::trace_as_debug(), MapOutputLayer::new(drop))
                             .into_layer(IoForwardService::new(exec))
                             .boxed()
                     } else {

--- a/rama-cli/src/cmd/serve/proxy/mod.rs
+++ b/rama-cli/src/cmd/serve/proxy/mod.rs
@@ -19,7 +19,7 @@ use rama::{
         service::web::response::IntoResponse,
     },
     layer::{
-        ConsumeErrLayer, LimitLayer, TimeoutLayer,
+        LimitLayer, TimeoutLayer,
         limit::policy::{ConcurrentPolicy, UnlimitedPolicy},
     },
     net::{address::SocketAddress, proxy::IoForwardService},
@@ -69,14 +69,10 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandProxy) -> Result<(), Bo
                     exec.clone(),
                     MethodMatcher::CONNECT,
                     DefaultHttpProxyConnectReplyService::new(),
-                    (
-                        ConsumeErrLayer::default(),
-                        IoToProxyBridgeIoLayer::extension_connector_target().with_connector(
-                            rama::dns::client::DnsConnector::new(
-                                rama::tcp::client::service::TcpConnector::new(),
-                            ),
-                        ),
-                    )
+                    IoToProxyBridgeIoLayer::extension_connector_target()
+                        .with_connector(rama::dns::client::DnsConnector::new(
+                            rama::tcp::client::service::TcpConnector::new(),
+                        ))
                         .into_layer(IoForwardService::new(exec)),
                 ),
                 RemoveResponseHeaderLayer::hop_by_hop(),

--- a/rama-http-core/src/h2/proto/streams/stream.rs
+++ b/rama-http-core/src/h2/proto/streams/stream.rs
@@ -140,7 +140,7 @@ impl fmt::Debug for Stream {
             .field("send_flow", &self.send_flow)
             .field("requested_send_capacity", &self.requested_send_capacity)
             .field("buffered_send_data", &self.buffered_send_data)
-            .field("send_task", &self.send_task.as_ref().map(|_| ()))
+            .field("send_task", &self.send_task.as_ref().map(drop))
             .field("pending_send", &self.pending_send)
             .field(
                 "next_pending_send_capacity",

--- a/rama-http/src/layer/upgrade/layer.rs
+++ b/rama-http/src/layer/upgrade/layer.rs
@@ -31,7 +31,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = (), Error: Into<BoxError>> + Clone,
+        H: Service<Upgraded, Error: Into<BoxError>> + Clone,
     {
         Self::new_with_error_sink(
             exec,
@@ -54,7 +54,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = ()> + Clone,
+        H: Service<Upgraded> + Clone,
         Sink: ErrorSink<H::Error>,
     {
         Self {
@@ -78,7 +78,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = ()> + Clone,
+        H: Service<Upgraded> + Clone,
     {
         Self::new_with_error_sink(exec, matcher, responder, handler, DropErrorSink::new())
     }
@@ -90,7 +90,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = (), Error: Into<BoxError>> + Clone,
+        H: Service<Upgraded, Error: Into<BoxError>> + Clone,
     {
         self.on_with_error_sink(matcher, responder, handler, TracingErrorSink::default())
     }
@@ -102,7 +102,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = ()> + Clone,
+        H: Service<Upgraded> + Clone,
     {
         self.on_with_error_sink(matcher, responder, handler, DropErrorSink::new())
     }
@@ -120,7 +120,7 @@ impl<O> UpgradeLayer<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = ()> + Clone,
+        H: Service<Upgraded> + Clone,
         Sink: ErrorSink<H::Error>,
     {
         self.handlers.push(Arc::new(UpgradeHandler::new(

--- a/rama-http/src/layer/upgrade/mitm/svc.rs
+++ b/rama-http/src/layer/upgrade/mitm/svc.rs
@@ -73,7 +73,7 @@ where
                 Response<ResBody>,
                 Error: Into<S::Error>,
                 ModifiedInput = Response<ModResBody>,
-                Service: Service<BridgeIo<Upgraded, Upgraded>, Output = (), Error: Into<BoxError>>,
+                Service: Service<BridgeIo<Upgraded, Upgraded>, Error: Into<BoxError>>,
             >,
         >,
     S: Service<Request, Output = Response<ResBody>>,

--- a/rama-http/src/layer/upgrade/service.rs
+++ b/rama-http/src/layer/upgrade/service.rs
@@ -4,10 +4,11 @@
 
 use super::Upgraded;
 use crate::opentelemetry::version_as_protocol_version;
+use rama_core::Layer;
 use rama_core::error::ErrorExt as _;
 use rama_core::error_sink::ErrorSink;
 use rama_core::extensions::ExtensionsRef;
-use rama_core::layer::ConsumeErr;
+use rama_core::layer::{ConsumeErrLayer, MapOutputLayer};
 use rama_core::rt::Executor;
 use rama_core::telemetry::tracing::{self, Instrument};
 use rama_core::{Service, extensions::Extensions, matcher::Matcher, service::BoxService};
@@ -52,13 +53,17 @@ impl<O> UpgradeHandler<O> {
     where
         M: Matcher<Request>,
         R: Service<Request, Output = UpgradeResponse<Request, O>, Error = O> + Clone,
-        H: Service<Upgraded, Output = ()> + Clone,
+        H: Service<Upgraded> + Clone,
         Sink: ErrorSink<H::Error>,
     {
         let sink = Arc::new(sink);
-        // Consume the handler's error in place via its sink, so the boxed
-        // handler is `Infallible` regardless of the handler's error type.
-        let handler = ConsumeErr::new(handler, move |err| sink.sink_error(err)).boxed();
+        let handler = (
+            ConsumeErrLayer::new(move |err| sink.sink_error(err)),
+            MapOutputLayer::new(drop),
+        )
+            .into_layer(handler)
+            .boxed();
+
         Self {
             matcher: Box::new(matcher),
             responder: responder.boxed(),

--- a/rama-net/src/proxy/forward.rs
+++ b/rama-net/src/proxy/forward.rs
@@ -10,7 +10,6 @@ use rama_core::rt::Executor;
 use rama_core::telemetry::tracing;
 use rama_core::{
     Service,
-    error::{BoxError, ErrorExt},
     io::{BridgeIo, Io},
 };
 use rama_utils::macros::generate_set_and_with;
@@ -185,8 +184,8 @@ where
     S: Io + Unpin,
     T: Io + Unpin,
 {
-    type Output = ();
-    type Error = BoxError;
+    type Output = IoForwardOutcome;
+    type Error = IoForwardOutcome;
 
     async fn serve(
         &self,
@@ -226,26 +225,95 @@ where
             );
         }
 
-        match outcome.fatal_error {
-            None => Ok(()),
-            Some(err) => {
-                if crate::conn::is_connection_error(&err) {
-                    Ok(())
-                } else {
-                    Err(err.context("(proxy) I/O forwarder"))
-                }
-            }
-        }
+        // The outcome is returned either way; the `Result` variant signals a
+        // clean vs errored close.
+        let errored = outcome
+            .fatal_error
+            .as_ref()
+            .is_some_and(|err| !crate::conn::is_connection_error(err));
+        if errored { Err(outcome) } else { Ok(outcome) }
     }
 }
 
+/// The result of an [`IoForwardService`] bridge, describing why and how the
+/// forward ended.
+///
+/// Returned as both the service [`Output`](IoForwardService) (on a clean close)
+/// and its [`Error`](IoForwardService) (on a genuine, non-connection error close),
+/// so callers get the full picture regardless of the `Result` variant. The
+/// variant itself signals clean-vs-errored: benign peer disconnects (connection
+/// resets/aborts) are reported as `Ok`, still carrying the classified
+/// [`reason`](Self::reason) and [`fatal_error`](Self::fatal_error).
 #[derive(Debug)]
-struct BridgeOutcome {
+pub struct IoForwardOutcome {
     reason: BridgeCloseReason,
     bytes_l_to_r: u64,
     bytes_r_to_l: u64,
     age: Duration,
     fatal_error: Option<std::io::Error>,
+}
+
+impl IoForwardOutcome {
+    /// Why the bridge closed.
+    #[must_use]
+    pub fn reason(&self) -> BridgeCloseReason {
+        self.reason
+    }
+
+    /// Bytes copied from the left (ingress) half to the right (egress) half.
+    #[must_use]
+    pub fn bytes_l_to_r(&self) -> u64 {
+        self.bytes_l_to_r
+    }
+
+    /// Bytes copied from the right (egress) half to the left (ingress) half.
+    #[must_use]
+    pub fn bytes_r_to_l(&self) -> u64 {
+        self.bytes_r_to_l
+    }
+
+    /// Total bytes copied in both directions.
+    #[must_use]
+    pub fn bytes_total(&self) -> u64 {
+        self.bytes_l_to_r.saturating_add(self.bytes_r_to_l)
+    }
+
+    /// How long the bridge was open.
+    #[must_use]
+    pub fn age(&self) -> Duration {
+        self.age
+    }
+
+    /// The fatal I/O error that ended the bridge, if any.
+    #[must_use]
+    pub fn fatal_error(&self) -> Option<&std::io::Error> {
+        self.fatal_error.as_ref()
+    }
+}
+
+impl std::fmt::Display for IoForwardOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "(proxy) I/O forwarder closed: reason={}, bytes_l_to_r={}, bytes_r_to_l={}, age_ms={}",
+            self.reason,
+            self.bytes_l_to_r,
+            self.bytes_r_to_l,
+            u64::try_from(self.age.as_millis()).unwrap_or(u64::MAX),
+        )?;
+        if let Some(err) = &self.fatal_error {
+            write!(f, ", error={err}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for IoForwardOutcome {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.fatal_error
+            .as_ref()
+            .map(|err| err as &(dyn std::error::Error + 'static))
+    }
 }
 
 #[expect(clippy::too_many_arguments)]
@@ -258,7 +326,7 @@ async fn run_bridge<S, T>(
     first_byte_timeout_start: FirstByteTimeoutStart,
     shutdown_grace: Duration,
     buf_size: usize,
-) -> BridgeOutcome
+) -> IoForwardOutcome
 where
     S: Io + Unpin,
     T: Io + Unpin,
@@ -351,7 +419,7 @@ where
         (false, false) => {}
     }
 
-    BridgeOutcome {
+    IoForwardOutcome {
         reason,
         bytes_l_to_r: bytes_l_to_r.load(Ordering::Relaxed),
         bytes_r_to_l: bytes_r_to_l.load(Ordering::Relaxed),
@@ -610,7 +678,7 @@ fn classify_copy_error(err: &std::io::Error, direction: CopyDirection) -> Bridge
     }
 }
 
-fn emit_close_event(outcome: &BridgeOutcome) {
+fn emit_close_event(outcome: &IoForwardOutcome) {
     let age_ms = u64::try_from(outcome.age.as_millis()).unwrap_or(u64::MAX);
     if outcome.fatal_error.is_some() {
         tracing::debug!(
@@ -644,7 +712,7 @@ mod tests {
 
     use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
 
-    async fn run_default<S, T>(left: S, right: T)
+    async fn run_default<S, T>(left: S, right: T) -> IoForwardOutcome
     where
         S: Io + Unpin,
         T: Io + Unpin,
@@ -758,13 +826,14 @@ mod tests {
         let (_b_user, b_proxy) = duplex(64);
 
         let started = Instant::now();
-        tokio::time::timeout(
+        let outcome = tokio::time::timeout(
             Duration::from_secs(2),
             svc.serve(BridgeIo(a_proxy, b_proxy)),
         )
         .await
         .expect("idle bridge did not unwind within 2s")
         .unwrap();
+        assert_eq!(outcome.reason(), BridgeCloseReason::IdleTimeout);
         let elapsed = started.elapsed();
         assert!(
             elapsed >= Duration::from_millis(80),
@@ -1009,13 +1078,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forward_byte_counters_visible_via_close_log() {
+    async fn forward_outcome_reports_reason_and_byte_counts() {
         let (mut a_user, a_proxy) = duplex(64);
         let (mut b_user, b_proxy) = duplex(64);
 
-        let task = tokio::spawn(async move {
-            run_default(a_proxy, b_proxy).await;
-        });
+        let task = tokio::spawn(async move { run_default(a_proxy, b_proxy).await });
 
         a_user.write_all(b"abc").await.unwrap();
         let mut buf = [0u8; 3];
@@ -1026,7 +1093,20 @@ mod tests {
 
         drop(a_user);
         drop(b_user);
-        task.await.unwrap();
+        let outcome = task.await.unwrap();
+
+        assert!(
+            matches!(
+                outcome.reason(),
+                BridgeCloseReason::PeerEofLeft | BridgeCloseReason::PeerEofRight
+            ),
+            "unexpected reason: {:?}",
+            outcome.reason(),
+        );
+        assert_eq!(outcome.bytes_l_to_r(), 3);
+        assert_eq!(outcome.bytes_r_to_l(), 5);
+        assert_eq!(outcome.bytes_total(), 8);
+        assert!(outcome.fatal_error().is_none());
     }
 
     #[tokio::test]
@@ -1150,5 +1230,111 @@ mod tests {
             write_side_shut.load(Ordering::Acquire),
             "write_side_shut flag must be set so run_bridge skips a duplicate shutdown",
         );
+    }
+
+    /// An [`Io`] whose reader either errors once with a configured kind, or
+    /// pends forever; its writer always accepts. Used to drive the bridge into
+    /// a specific terminal error reason.
+    struct ScriptedIo {
+        read_err: Option<std::io::ErrorKind>,
+        errored: bool,
+    }
+
+    impl ScriptedIo {
+        fn erroring(kind: std::io::ErrorKind) -> Self {
+            Self {
+                read_err: Some(kind),
+                errored: false,
+            }
+        }
+
+        fn pending() -> Self {
+            Self {
+                read_err: None,
+                errored: false,
+            }
+        }
+    }
+
+    impl tokio::io::AsyncRead for ScriptedIo {
+        fn poll_read(
+            mut self: std::pin::Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+            _buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            match self.read_err {
+                Some(kind) if !self.errored => {
+                    self.errored = true;
+                    std::task::Poll::Ready(Err(std::io::Error::new(kind, "scripted")))
+                }
+                // Never yields data or EOF: keeps this direction open so the
+                // bridge closes on the other direction's error.
+                _ => std::task::Poll::Pending,
+            }
+        }
+    }
+
+    impl tokio::io::AsyncWrite for ScriptedIo {
+        fn poll_write(
+            self: std::pin::Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+            buf: &[u8],
+        ) -> std::task::Poll<std::io::Result<usize>> {
+            std::task::Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(
+            self: std::pin::Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: std::pin::Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<std::io::Result<()>> {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_genuine_error_surfaces_as_err_outcome() {
+        // `InvalidData` is not a connection error, so it propagates as `Err`.
+        let left = ScriptedIo::erroring(std::io::ErrorKind::InvalidData);
+        let right = ScriptedIo::pending();
+
+        let svc = IoForwardService::default();
+        let outcome = svc
+            .serve(BridgeIo(left, right))
+            .await
+            .expect_err("genuine (non-connection) error must surface as Err");
+
+        assert!(outcome.fatal_error().is_some());
+        assert!(
+            matches!(
+                outcome.reason(),
+                BridgeCloseReason::ReadErrorLeft | BridgeCloseReason::WriteErrorRight
+            ),
+            "unexpected reason: {:?}",
+            outcome.reason(),
+        );
+    }
+
+    #[tokio::test]
+    async fn forward_connection_error_stays_ok_but_is_exposed() {
+        // `ConnectionReset` is a benign peer disconnect: swallowed to `Ok`, but
+        // the error and reason are still exposed on the outcome.
+        let left = ScriptedIo::erroring(std::io::ErrorKind::ConnectionReset);
+        let right = ScriptedIo::pending();
+
+        let svc = IoForwardService::default();
+        let outcome = svc
+            .serve(BridgeIo(left, right))
+            .await
+            .expect("connection reset must stay Ok");
+
+        assert_eq!(outcome.reason(), BridgeCloseReason::ReadErrorLeft);
+        assert!(outcome.fatal_error().is_some());
     }
 }

--- a/rama-net/src/proxy/forward.rs
+++ b/rama-net/src/proxy/forward.rs
@@ -185,7 +185,7 @@ where
     T: Io + Unpin,
 {
     type Output = IoForwardOutcome;
-    type Error = IoForwardOutcome;
+    type Error = IoForwardError;
 
     async fn serve(
         &self,
@@ -226,24 +226,29 @@ where
         }
 
         // The outcome is returned either way; the `Result` variant signals a
-        // clean vs errored close.
+        // clean vs errored close (an errored close wraps the outcome in
+        // [`IoForwardError`], which still exposes it).
         let errored = outcome
             .fatal_error
             .as_ref()
             .is_some_and(|err| !crate::conn::is_connection_error(err));
-        if errored { Err(outcome) } else { Ok(outcome) }
+        if errored {
+            Err(IoForwardError(outcome))
+        } else {
+            Ok(outcome)
+        }
     }
 }
 
 /// The result of an [`IoForwardService`] bridge, describing why and how the
 /// forward ended.
 ///
-/// Returned as both the service [`Output`](IoForwardService) (on a clean close)
-/// and its [`Error`](IoForwardService) (on a genuine, non-connection error close),
-/// so callers get the full picture regardless of the `Result` variant. The
-/// variant itself signals clean-vs-errored: benign peer disconnects (connection
-/// resets/aborts) are reported as `Ok`, still carrying the classified
-/// [`reason`](Self::reason) and [`fatal_error`](Self::fatal_error).
+/// Returned as the service [`Output`](IoForwardService) on a clean or benign
+/// close. A genuine (non-connection) error close instead yields an
+/// [`IoForwardError`], which carries this same outcome. Either way callers get
+/// the full picture: benign peer disconnects (connection resets/aborts) are
+/// reported as `Ok`, still carrying the classified [`reason`](Self::reason) and
+/// [`fatal_error`](Self::fatal_error).
 #[derive(Debug)]
 pub struct IoForwardOutcome {
     reason: BridgeCloseReason,
@@ -308,10 +313,49 @@ impl std::fmt::Display for IoForwardOutcome {
     }
 }
 
-impl std::error::Error for IoForwardOutcome {
+/// The [`Error`](IoForwardService) returned by [`IoForwardService`] when the
+/// bridge ended on a genuine (non-connection) I/O error.
+///
+/// Wraps the full [`IoForwardOutcome`] of the closed bridge: [`Deref`] or
+/// [`outcome`](Self::outcome) to inspect the reason, byte counts, age, and the
+/// underlying error.
+///
+/// [`Deref`]: std::ops::Deref
+#[derive(Debug)]
+pub struct IoForwardError(IoForwardOutcome);
+
+impl IoForwardError {
+    /// The outcome of the bridge that errored.
+    #[must_use]
+    pub fn outcome(&self) -> &IoForwardOutcome {
+        &self.0
+    }
+
+    /// Consume this error, returning the underlying [`IoForwardOutcome`].
+    #[must_use]
+    pub fn into_outcome(self) -> IoForwardOutcome {
+        self.0
+    }
+}
+
+impl std::ops::Deref for IoForwardError {
+    type Target = IoForwardOutcome;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for IoForwardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl std::error::Error for IoForwardError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.fatal_error
-            .as_ref()
+        self.0
+            .fatal_error()
             .map(|err| err as &(dyn std::error::Error + 'static))
     }
 }
@@ -1305,19 +1349,19 @@ mod tests {
         let right = ScriptedIo::pending();
 
         let svc = IoForwardService::default();
-        let outcome = svc
+        let err = svc
             .serve(BridgeIo(left, right))
             .await
             .expect_err("genuine (non-connection) error must surface as Err");
 
-        assert!(outcome.fatal_error().is_some());
+        assert!(err.fatal_error().is_some());
         assert!(
             matches!(
-                outcome.reason(),
+                err.outcome().reason(),
                 BridgeCloseReason::ReadErrorLeft | BridgeCloseReason::WriteErrorRight
             ),
             "unexpected reason: {:?}",
-            outcome.reason(),
+            err.reason(),
         );
     }
 

--- a/rama-net/src/proxy/mod.rs
+++ b/rama-net/src/proxy/mod.rs
@@ -6,7 +6,9 @@ pub mod dial9;
 
 mod forward;
 #[doc(inline)]
-pub use forward::{BridgeCloseReason, FirstByteTimeoutStart, IoForwardOutcome, IoForwardService};
+pub use forward::{
+    BridgeCloseReason, FirstByteTimeoutStart, IoForwardError, IoForwardOutcome, IoForwardService,
+};
 
 mod idle;
 #[doc(inline)]

--- a/rama-net/src/proxy/mod.rs
+++ b/rama-net/src/proxy/mod.rs
@@ -6,7 +6,7 @@ pub mod dial9;
 
 mod forward;
 #[doc(inline)]
-pub use forward::{BridgeCloseReason, FirstByteTimeoutStart, IoForwardService};
+pub use forward::{BridgeCloseReason, FirstByteTimeoutStart, IoForwardOutcome, IoForwardService};
 
 mod idle;
 #[doc(inline)]

--- a/rama-socks5/src/proxy/mitm/service.rs
+++ b/rama-socks5/src/proxy/mitm/service.rs
@@ -49,8 +49,8 @@ impl<I> Socks5MitmRelayService<I> {
 
 impl<I, F, Ingress, Egress> Service<BridgeIo<Ingress, Egress>> for Socks5MitmRelayService<I, F>
 where
-    I: Service<BridgeIo<Ingress, Egress>, Output = (), Error: Into<BoxError>>,
-    F: Service<BridgeIo<Ingress, Egress>, Output = (), Error: Into<BoxError>>,
+    I: Service<BridgeIo<Ingress, Egress>, Error: Into<BoxError>>,
+    F: Service<BridgeIo<Ingress, Egress>, Error: Into<BoxError>>,
     Ingress: Io + Unpin + extensions::ExtensionsRef,
     Egress: Io + Unpin + extensions::ExtensionsRef,
 {
@@ -69,11 +69,13 @@ where
                 .dpi_svc
                 .serve(BridgeIo(ingress_stream, egress_stream))
                 .await
+                .map(|_| ())
                 .context("serve socks5 handshake-relayed bridge I/O using DPI svc"),
             Socks5MitmHandshakeOutcome::UnsupportedFlow => self
                 .fallback_svc
                 .serve(BridgeIo(ingress_stream, egress_stream))
                 .await
+                .map(|_| ())
                 .context("serve socks5 handshake-relayed bridge I/O using fallback svc"),
         }
     }

--- a/rama-socks5/src/proxy/mitm/service.rs
+++ b/rama-socks5/src/proxy/mitm/service.rs
@@ -69,13 +69,13 @@ where
                 .dpi_svc
                 .serve(BridgeIo(ingress_stream, egress_stream))
                 .await
-                .map(|_| ())
+                .map(drop)
                 .context("serve socks5 handshake-relayed bridge I/O using DPI svc"),
             Socks5MitmHandshakeOutcome::UnsupportedFlow => self
                 .fallback_svc
                 .serve(BridgeIo(ingress_stream, egress_stream))
                 .await
-                .map(|_| ())
+                .map(drop)
                 .context("serve socks5 handshake-relayed bridge I/O using fallback svc"),
         }
     }

--- a/rama-socks5/src/server/bind.rs
+++ b/rama-socks5/src/server/bind.rs
@@ -365,7 +365,7 @@ where
             .serve(BridgeIo(ingress_stream, incoming_stream))
             .instrument(tracing::trace_span!("socks5::bind::serve"))
             .await
-            .map(|_| ())
+            .map(drop)
             .map_err(|err| Error::service(err).with_context("serve bind pipe"))
     }
 }

--- a/rama-socks5/src/server/bind.rs
+++ b/rama-socks5/src/server/bind.rs
@@ -224,8 +224,7 @@ impl<S, F, StreamService> Socks5BinderSeal<S> for Binder<F, StreamService>
 where
     S: Io + Unpin,
     F: SocketService<Socket: Acceptor<Stream: Unpin>>,
-    StreamService:
-        Service<BridgeIo<S, <F::Socket as Acceptor>::Stream>, Output = (), Error: Into<BoxError>>,
+    StreamService: Service<BridgeIo<S, <F::Socket as Acceptor>::Stream>, Error: Into<BoxError>>,
 {
     async fn accept_bind(
         &self,
@@ -366,6 +365,7 @@ where
             .serve(BridgeIo(ingress_stream, incoming_stream))
             .instrument(tracing::trace_span!("socks5::bind::serve"))
             .await
+            .map(|_| ())
             .map_err(|err| Error::service(err).with_context("serve bind pipe"))
     }
 }

--- a/rama-socks5/src/server/connect.rs
+++ b/rama-socks5/src/server/connect.rs
@@ -294,7 +294,7 @@ where
             .serve(BridgeIo(ingress_stream, egress_stream))
             .instrument(trace_span!("socks5::connect::proxy::serve"))
             .await
-            .map(|_| ())
+            .map(drop)
             .map_err(|err| Error::service(err).with_context("serve connect pipe"))
     }
 }
@@ -370,7 +370,7 @@ where
             .serve(stream)
             .instrument(trace_span!("socks5::connect::lazy::serve"))
             .await
-            .map(|_| ())
+            .map(drop)
             .map_err(|err| Error::service(err).with_context("inner stream (proxy) service"))
     }
 }

--- a/rama-socks5/src/server/connect.rs
+++ b/rama-socks5/src/server/connect.rs
@@ -201,8 +201,7 @@ impl<S, InnerConnector, StreamService> Socks5ConnectorSeal<S>
 where
     S: Io + Unpin + ExtensionsRef,
     InnerConnector: ConnectorService<TransportRequest, Connection: Io + Socket + Unpin>,
-    StreamService:
-        Service<BridgeIo<S, InnerConnector::Connection>, Output = (), Error: Into<BoxError>>,
+    StreamService: Service<BridgeIo<S, InnerConnector::Connection>, Error: Into<BoxError>>,
 {
     async fn accept_connect(
         &self,
@@ -295,6 +294,7 @@ where
             .serve(BridgeIo(ingress_stream, egress_stream))
             .instrument(trace_span!("socks5::connect::proxy::serve"))
             .await
+            .map(|_| ())
             .map_err(|err| Error::service(err).with_context("serve connect pipe"))
     }
 }
@@ -348,7 +348,7 @@ impl Default for LazyConnector<IoToProxyBridgeIo<IoForwardService>> {
 impl<S, StreamService> Socks5ConnectorSeal<S> for LazyConnector<StreamService>
 where
     S: Io + Unpin + ExtensionsRef,
-    StreamService: Service<S, Output = (), Error: Into<BoxError>>,
+    StreamService: Service<S, Error: Into<BoxError>>,
 {
     async fn accept_connect(&self, mut stream: S, destination: HostWithPort) -> Result<(), Error> {
         tracing::trace!(
@@ -370,6 +370,7 @@ where
             .serve(stream)
             .instrument(trace_span!("socks5::connect::lazy::serve"))
             .await
+            .map(|_| ())
             .map_err(|err| Error::service(err).with_context("inner stream (proxy) service"))
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/service.rs
+++ b/rama-tls-boring/src/proxy/mitm/service.rs
@@ -69,7 +69,7 @@ impl<Issuer, Inner, Ingress, Egress> Service<BridgeIo<Ingress, Egress>>
     for TlsMitmRelayService<Issuer, Inner>
 where
     Issuer: super::issuer::BoringMitmCertIssuer<Error: Into<BoxError>>,
-    Inner: Service<BridgeIo<TlsStream<Ingress>, TlsStream<Egress>>, Output = (), Error: Into<BoxError>>,
+    Inner: Service<BridgeIo<TlsStream<Ingress>, TlsStream<Egress>>, Error: Into<BoxError>>,
     Ingress: Io + Unpin + extensions::ExtensionsRef,
     Egress: Io + Unpin + extensions::ExtensionsRef,
 {
@@ -113,6 +113,7 @@ where
         self.inner
             .serve(tls_input)
             .await
+            .map(|_| ())
             .map_err(TlsMitmRelayError::tls_serve)
     }
 }
@@ -121,7 +122,7 @@ impl<Issuer, Inner, Ingress, Egress> Service<InputWithClientHello<BridgeIo<Ingre
     for TlsMitmRelayService<Issuer, Inner>
 where
     Issuer: super::issuer::BoringMitmCertIssuer<Error: Into<BoxError>>,
-    Inner: Service<BridgeIo<TlsStream<Ingress>, TlsStream<Egress>>, Output = (), Error: Into<BoxError>>,
+    Inner: Service<BridgeIo<TlsStream<Ingress>, TlsStream<Egress>>, Error: Into<BoxError>>,
     Ingress: Io + Unpin + extensions::ExtensionsRef,
     Egress: Io + Unpin + extensions::ExtensionsRef,
 {
@@ -182,6 +183,7 @@ where
         self.inner
             .serve(tls_input)
             .await
+            .map(|_| ())
             .map_err(TlsMitmRelayError::tls_serve)
     }
 }

--- a/rama-tls-boring/src/proxy/mitm/service.rs
+++ b/rama-tls-boring/src/proxy/mitm/service.rs
@@ -113,7 +113,7 @@ where
         self.inner
             .serve(tls_input)
             .await
-            .map(|_| ())
+            .map(drop)
             .map_err(TlsMitmRelayError::tls_serve)
     }
 }
@@ -183,7 +183,7 @@ where
         self.inner
             .serve(tls_input)
             .await
-            .map(|_| ())
+            .map(drop)
             .map_err(TlsMitmRelayError::tls_serve)
     }
 }

--- a/rama-ttrpc/src/client/request_handlers.rs
+++ b/rama-ttrpc/src/client/request_handlers.rs
@@ -61,7 +61,7 @@ pub trait RequestHandler {
 
 macro_rules! try_join_all {
     ($($e:expr),* $(,)?) => { async {
-        tokio::try_join! { $($e),* }.map(|_| ())
+        tokio::try_join! { $($e),* }.map(drop)
     } };
 }
 

--- a/rama-ws/src/protocol/mod.rs
+++ b/rama-ws/src/protocol/mod.rs
@@ -769,7 +769,7 @@ impl WebSocketContext {
             Message::Pong(data) => {
                 self.set_additional(Frame::pong(data));
                 // Note: user pongs can be user flushed so no need to flush here
-                return self._write(stream, None).map(|_| ());
+                return self._write(stream, None).map(drop);
             }
             Message::Close(code) => return self.close(stream, code),
             Message::Frame(f) => f,

--- a/tests/http-core/client.rs
+++ b/tests/http-core/client.rs
@@ -1787,7 +1787,7 @@ mod conn {
 
         let (mut client, conn) = rt.block_on(conn::http1::handshake(tcp)).unwrap();
 
-        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(|_| ()));
+        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(drop));
 
         let req = Request::builder()
             .uri("/")
@@ -1889,7 +1889,7 @@ mod conn {
 
         let (mut client, conn) = rt.block_on(conn::http1::handshake(tcp)).unwrap();
 
-        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(|_| ()));
+        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(drop));
 
         let (mut sender, recv) = mpsc::channel::<Result<Frame<Bytes>, BoxError>>(0);
 
@@ -1952,7 +1952,7 @@ mod conn {
 
         let (mut client, conn) = rt.block_on(conn::http1::handshake(tcp)).unwrap();
 
-        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(|_| ()));
+        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(drop));
 
         let req = Request::builder()
             .uri("http://rama.local/a")
@@ -2005,7 +2005,7 @@ mod conn {
 
         let (mut client, conn) = rt.block_on(conn::http1::handshake(tcp)).unwrap();
 
-        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(|_| ()));
+        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(drop));
 
         let req = Request::builder()
             .uri("/a")
@@ -2047,7 +2047,7 @@ mod conn {
 
         let (mut client, conn) = rt.block_on(conn::http1::handshake(tcp)).unwrap();
 
-        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(|_| ()));
+        rt.spawn(conn.map_err(|e| panic!("conn error: {e}")).map(drop));
 
         let req = Request::builder()
             .uri("/a")

--- a/tests/http-core/support/mod.rs
+++ b/tests/http-core/support/mod.rs
@@ -489,7 +489,7 @@ async fn async_test(cfg: __TestConfig) {
         for (creq, cres) in cfg.client_msgs {
             client_futures.push(make_request(creq, cres));
         }
-        Box::pin(rama::futures::future::join_all(client_futures).map(|_| ()))
+        Box::pin(rama::futures::future::join_all(client_futures).map(drop))
     } else {
         let mut client_futures: Pin<Box<dyn Future<Output = ()> + Send>> =
             Box::pin(std::future::ready(()));
@@ -497,7 +497,7 @@ async fn async_test(cfg: __TestConfig) {
             let mk_request = make_request.clone();
             client_futures = Box::pin(client_futures.then(move |_| mk_request(creq, cres)));
         }
-        Box::pin(client_futures.map(|_| ()))
+        Box::pin(client_futures.map(drop))
     };
 
     client_futures.await;


### PR DESCRIPTION
This PR does two things. The main goal is to expose the IoForwardService result so external users/layers can handle the different failures/success modes however they need. 

And since this now changes output type to IoForwardResult instead of (), we have to deal with this. Two options here are: always using MapOutputLayer (or DiscardOutputLayer, this is easier for certain generics), or loosen the bounds we have on forwarding layers to just accept any Output. I went with the second option since stricter bounds here are honestly not needed and they just slightly tell the user this output will be dropped (kind of), and its waaay more ergonomic in use. But what do you think @GlenDC, I guess the tradeoff here is mostly: ergonomic in use (while bounds still correct), or stricter (slightly more expressive bounds) at the cost of DiscardOutputLayer/MapOutputLayer everywhere