### PR TITLE
feat(http): RFC 9421 signature primitives (headers + signature base)

### DIFF
--- a/rama-http-headers/src/common/mod.rs
+++ b/rama-http-headers/src/common/mod.rs
@@ -80,6 +80,11 @@ pub use self::sec_websocket_protocol::SecWebSocketProtocol;
 pub use self::sec_websocket_version::SecWebSocketVersion;
 pub use self::server::Server;
 pub use self::set_cookie::SetCookie;
+pub use self::signature::Signature;
+pub use self::signature_input::{
+    ComponentIdentifier, SignatureInput, SignatureParameters, SignatureParams,
+    serialize_signature_params_value,
+};
 pub use self::strict_transport_security::StrictTransportSecurity;
 pub use self::te::{Te, TeDirective};
 pub use self::transfer_encoding::{TransferEncoding, TransferEncodingDirective};
@@ -213,6 +218,8 @@ pub mod sec_websocket_protocol;
 mod sec_websocket_version;
 mod server;
 mod set_cookie;
+mod signature;
+pub mod signature_input;
 mod strict_transport_security;
 mod te;
 mod transfer_encoding;

--- a/rama-http-headers/src/common/signature.rs
+++ b/rama-http-headers/src/common/signature.rs
@@ -1,0 +1,146 @@
+//! `Signature` typed header (RFC 9421 §4.2).
+//!
+//! A Structured Fields Dictionary of label → byte-sequence signature values.
+
+use rama_http_types::{HeaderName, HeaderValue};
+
+use crate::util::structured_fields::{
+    BareItem, Dictionary, DictionaryMember, Item, parse_dictionary, serialize_dictionary,
+};
+use crate::{Error, HeaderDecode, HeaderEncode, TypedHeader};
+
+/// The `Signature` header field (RFC 9421).
+///
+/// Contains one or more labeled signature values as byte sequences.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Signature {
+    dict: Dictionary,
+}
+
+impl Signature {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace a labeled signature value.
+    pub fn insert(&mut self, label: impl Into<String>, signature: impl Into<Vec<u8>>) {
+        self.dict.insert(
+            label,
+            DictionaryMember::Item(Item::byte_sequence(signature)),
+        );
+    }
+
+    /// Get the signature bytes for a label.
+    pub fn get(&self, label: &str) -> Option<&[u8]> {
+        match self.dict.get(label)? {
+            DictionaryMember::Item(item) => match &item.bare {
+                BareItem::ByteSequence(bytes) => Some(bytes.as_slice()),
+                _ => None,
+            },
+            DictionaryMember::InnerList(_) => None,
+        }
+    }
+
+    /// Labels present in this header, in order.
+    pub fn labels(&self) -> impl Iterator<Item = &str> {
+        self.dict.keys()
+    }
+
+    /// Number of labeled signatures.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.dict.members.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.dict.members.is_empty()
+    }
+
+    /// Access the underlying Structured Fields dictionary.
+    #[must_use]
+    pub fn as_dictionary(&self) -> &Dictionary {
+        &self.dict
+    }
+}
+
+impl TypedHeader for Signature {
+    fn name() -> &'static HeaderName {
+        &::rama_http_types::header::SIGNATURE
+    }
+}
+
+impl HeaderDecode for Signature {
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let mut combined = Dictionary::new();
+        let mut any = false;
+        for value in values {
+            any = true;
+            let s = value.to_str().map_err(|_err| Error::invalid())?;
+            let dict = parse_dictionary(s).map_err(|_err| Error::invalid())?;
+            for (key, member) in dict.members {
+                // Signature members must be byte-sequence items
+                match &member {
+                    DictionaryMember::Item(item)
+                        if matches!(item.bare, BareItem::ByteSequence(_)) => {}
+                    _ => return Err(Error::invalid()),
+                }
+                if combined.get(&key).is_some() {
+                    return Err(Error::invalid());
+                }
+                combined.members.push((key, member));
+            }
+        }
+        if !any {
+            return Err(Error::invalid());
+        }
+        Ok(Self { dict: combined })
+    }
+}
+
+impl HeaderEncode for Signature {
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        let s = serialize_dictionary(&self.dict);
+        if let Ok(value) = HeaderValue::from_str(&s) {
+            values.extend(std::iter::once(value));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{test_decode, test_encode};
+
+    #[test]
+    fn decode_single() {
+        let sig = test_decode::<Signature>(&["sig1=:dGVzdA==:"]).unwrap();
+        assert_eq!(sig.get("sig1"), Some(b"test".as_slice()));
+    }
+
+    #[test]
+    fn round_trip() {
+        let mut sig = Signature::new();
+        sig.insert("sig1", b"hello".to_vec());
+        sig.insert("proxy_sig", b"world".to_vec());
+        let map = test_encode(sig.clone());
+        let value = map.get(Signature::name()).unwrap().to_str().unwrap();
+        let decoded = test_decode::<Signature>(&[value]).unwrap();
+        assert_eq!(decoded.get("sig1"), Some(b"hello".as_slice()));
+        assert_eq!(decoded.get("proxy_sig"), Some(b"world".as_slice()));
+    }
+
+    #[test]
+    fn multi_label_rfc_example_shape() {
+        // Shape from RFC 9421 §4.3 (truncated base64 for brevity in this unit test)
+        let input = "sig1=:dGVzdA==:, proxy_sig=:d29ybGQ=:";
+        let sig = test_decode::<Signature>(&[input]).unwrap();
+        assert_eq!(sig.len(), 2);
+        assert_eq!(sig.get("sig1"), Some(b"test".as_slice()));
+        assert_eq!(sig.get("proxy_sig"), Some(b"world".as_slice()));
+    }
+}

--- a/rama-http-headers/src/common/signature_input.rs
+++ b/rama-http-headers/src/common/signature_input.rs
@@ -112,7 +112,7 @@ fn serialize_component_item(out: &mut String, item: &Item) {
 }
 
 /// Signature-level parameters from the Inner List.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SignatureParameters {
     pub created: Option<i64>,
     pub expires: Option<i64>,
@@ -122,7 +122,25 @@ pub struct SignatureParameters {
     pub tag: Option<String>,
     /// Any additional / unrecognized parameters, preserved for round-trip.
     pub extra: Parameters,
+    /// Exact SF parameter order from the wire. When set, serialization uses this
+    /// instead of reconstructing from the typed fields (RFC 9421 verification
+    /// requires `@signature-params` to match the received `Signature-Input` member).
+    wire_order: Option<Parameters>,
 }
+
+impl PartialEq for SignatureParameters {
+    fn eq(&self, other: &Self) -> bool {
+        self.created == other.created
+            && self.expires == other.expires
+            && self.nonce == other.nonce
+            && self.alg == other.alg
+            && self.keyid == other.keyid
+            && self.tag == other.tag
+            && self.extra == other.extra
+    }
+}
+
+impl Eq for SignatureParameters {}
 
 impl SignatureParameters {
     #[must_use]
@@ -131,7 +149,10 @@ impl SignatureParameters {
     }
 
     fn from_sf(params: &Parameters) -> Self {
-        let mut out = Self::default();
+        let mut out = Self {
+            wire_order: Some(params.clone()),
+            ..Self::default()
+        };
         for p in &params.params {
             match (p.name.as_str(), &p.value) {
                 ("created", ParameterValue::Integer(n)) => out.created = Some(*n),
@@ -149,8 +170,11 @@ impl SignatureParameters {
     }
 
     fn to_sf(&self) -> Parameters {
+        if let Some(ref ordered) = self.wire_order {
+            return ordered.clone();
+        }
         let mut params = Parameters::new();
-        // Preserve a stable, RFC-example-friendly order: created, expires, nonce, alg, keyid, tag
+        // Stable order for freshly constructed parameters (signing path).
         if let Some(n) = self.created {
             params.insert("created", ParameterValue::Integer(n));
         }
@@ -367,7 +391,11 @@ mod tests {
                     created: Some(1618884475),
                     keyid: Some("test-key".into()),
                     alg: Some("ed25519".into()),
-                    ..Default::default()
+                    expires: None,
+                    nonce: None,
+                    tag: None,
+                    extra: Parameters::default(),
+                    wire_order: None,
                 },
             },
         );
@@ -375,6 +403,18 @@ mod tests {
         let value = map.get(SignatureInput::name()).unwrap().to_str().unwrap();
         let decoded = test_decode::<SignatureInput>(&[value]).unwrap();
         assert_eq!(decoded, hdr);
+    }
+
+    #[test]
+    fn serialize_signature_params_preserves_wire_order() {
+        let input =
+            r#"sig1=("@method" "@path");keyid="test-key";created=1618884475;alg="ed25519""#;
+        let hdr = test_decode::<SignatureInput>(&[input]).unwrap();
+        let serialized = hdr.serialize_signature_params("sig1").unwrap();
+        assert_eq!(
+            serialized,
+            r#"("@method" "@path");keyid="test-key";created=1618884475;alg="ed25519""#
+        );
     }
 
     #[test]

--- a/rama-http-headers/src/common/signature_input.rs
+++ b/rama-http-headers/src/common/signature_input.rs
@@ -129,14 +129,17 @@ fn serialize_component_item(out: &mut String, item: &Item) {
             }
             ParameterValue::DisplayString(s) => {
                 out.push_str("=%\"");
+                // RFC 9651 §4.1.11: encode %x22 / %x25 / non-ldash-char with lc-hexdig.
                 for b in s.as_bytes() {
                     match *b {
-                        0x20..=0x21 | 0x23..=0x5b | 0x5d..=0x7e => out.push(*b as char),
+                        0x20..=0x21 | 0x23..=0x24 | 0x26..=0x5b | 0x5d..=0x7e => {
+                            out.push(*b as char);
+                        }
                         _ => {
+                            const LC_HEX: &[u8; 16] = b"0123456789abcdef";
                             out.push('%');
-                            const HEX: &[u8; 16] = b"0123456789ABCDEF";
-                            out.push(char::from(HEX[(b >> 4) as usize]));
-                            out.push(char::from(HEX[(b & 0xf) as usize]));
+                            out.push(char::from(LC_HEX[(b >> 4) as usize]));
+                            out.push(char::from(LC_HEX[(b & 0xf) as usize]));
                         }
                     }
                 }

--- a/rama-http-headers/src/common/signature_input.rs
+++ b/rama-http-headers/src/common/signature_input.rs
@@ -101,11 +101,46 @@ fn serialize_component_item(out: &mut String, item: &Item) {
                 out.push('=');
                 out.push_str(&n.to_string());
             }
+            ParameterValue::Decimal {
+                negative,
+                integer,
+                fraction,
+                fraction_digits,
+            } => {
+                out.push('=');
+                if *negative {
+                    out.push('-');
+                }
+                out.push_str(&integer.to_string());
+                out.push('.');
+                let width = usize::from(*fraction_digits);
+                out.push_str(&format!("{fraction:0width$}"));
+            }
             ParameterValue::ByteSequence(bytes) => {
                 use base64::Engine as _;
                 out.push_str("=:");
                 out.push_str(&base64::engine::general_purpose::STANDARD.encode(bytes));
                 out.push(':');
+            }
+            ParameterValue::Date(n) => {
+                out.push('=');
+                out.push('@');
+                out.push_str(&n.to_string());
+            }
+            ParameterValue::DisplayString(s) => {
+                out.push_str("=%\"");
+                for b in s.as_bytes() {
+                    match *b {
+                        0x20..=0x21 | 0x23..=0x5b | 0x5d..=0x7e => out.push(*b as char),
+                        _ => {
+                            out.push('%');
+                            const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                            out.push(char::from(HEX[(b >> 4) as usize]));
+                            out.push(char::from(HEX[(b & 0xf) as usize]));
+                        }
+                    }
+                }
+                out.push('"');
             }
         }
     }
@@ -148,25 +183,41 @@ impl SignatureParameters {
         Self::default()
     }
 
-    fn from_sf(params: &Parameters) -> Self {
+    fn from_sf(params: &Parameters) -> Result<Self, Error> {
         let mut out = Self {
             wire_order: Some(params.clone()),
             ..Self::default()
         };
         for p in &params.params {
-            match (p.name.as_str(), &p.value) {
-                ("created", ParameterValue::Integer(n)) => out.created = Some(*n),
-                ("expires", ParameterValue::Integer(n)) => out.expires = Some(*n),
-                ("nonce", ParameterValue::String(s)) => out.nonce = Some(s.clone()),
-                ("alg", ParameterValue::String(s) | ParameterValue::Token(s)) => {
-                    out.alg = Some(s.clone());
-                }
-                ("keyid", ParameterValue::String(s)) => out.keyid = Some(s.clone()),
-                ("tag", ParameterValue::String(s)) => out.tag = Some(s.clone()),
+            match p.name.as_str() {
+                "created" => match &p.value {
+                    ParameterValue::Integer(n) => out.created = Some(*n),
+                    _ => return Err(Error::invalid()),
+                },
+                "expires" => match &p.value {
+                    ParameterValue::Integer(n) => out.expires = Some(*n),
+                    _ => return Err(Error::invalid()),
+                },
+                "nonce" => match &p.value {
+                    ParameterValue::String(s) => out.nonce = Some(s.clone()),
+                    _ => return Err(Error::invalid()),
+                },
+                "alg" => match &p.value {
+                    ParameterValue::String(s) => out.alg = Some(s.clone()),
+                    _ => return Err(Error::invalid()),
+                },
+                "keyid" => match &p.value {
+                    ParameterValue::String(s) => out.keyid = Some(s.clone()),
+                    _ => return Err(Error::invalid()),
+                },
+                "tag" => match &p.value {
+                    ParameterValue::String(s) => out.tag = Some(s.clone()),
+                    _ => return Err(Error::invalid()),
+                },
                 _ => out.extra.params.push(p.clone()),
             }
         }
-        out
+        Ok(out)
     }
 
     fn to_sf(&self) -> Parameters {
@@ -292,7 +343,7 @@ fn params_from_inner_list(list: &InnerList) -> Result<SignatureParams, Error> {
     }
     Ok(SignatureParams {
         components,
-        parameters: SignatureParameters::from_sf(&list.parameters),
+        parameters: SignatureParameters::from_sf(&list.parameters)?,
     })
 }
 
@@ -407,8 +458,7 @@ mod tests {
 
     #[test]
     fn serialize_signature_params_preserves_wire_order() {
-        let input =
-            r#"sig1=("@method" "@path");keyid="test-key";created=1618884475;alg="ed25519""#;
+        let input = r#"sig1=("@method" "@path");keyid="test-key";created=1618884475;alg="ed25519""#;
         let hdr = test_decode::<SignatureInput>(&[input]).unwrap();
         let serialized = hdr.serialize_signature_params("sig1").unwrap();
         assert_eq!(
@@ -426,6 +476,14 @@ mod tests {
         assert_eq!(
             serialized,
             r#"("@method" "@authority" "@path");created=1618884475;keyid="test-key-ecc-p256""#
+        );
+    }
+
+    #[test]
+    fn reject_alg_as_token_and_wrong_created_type() {
+        assert!(test_decode::<SignatureInput>(&[r#"sig1=("@method");alg=ed25519"#]).is_none());
+        assert!(
+            test_decode::<SignatureInput>(&[r#"sig1=("@method");created="1618884475""#]).is_none()
         );
     }
 

--- a/rama-http-headers/src/common/signature_input.rs
+++ b/rama-http-headers/src/common/signature_input.rs
@@ -1,0 +1,401 @@
+//! `Signature-Input` typed header (RFC 9421 §4.1).
+//!
+//! A Structured Fields Dictionary of label → Inner List of covered components
+//! plus signature parameters (`created`, `expires`, `keyid`, `alg`, …).
+
+use rama_http_types::{HeaderName, HeaderValue};
+
+use crate::util::structured_fields::{
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, ParameterValue, Parameters,
+    parse_dictionary, serialize_dictionary,
+};
+use crate::{Error, HeaderDecode, HeaderEncode, TypedHeader};
+
+/// A single signature's metadata from `Signature-Input`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureParams {
+    /// Ordered covered component identifiers (as SF strings, e.g. `"@method"`).
+    pub components: Vec<ComponentIdentifier>,
+    /// Signature parameters (`created`, `keyid`, `alg`, …).
+    pub parameters: SignatureParameters,
+}
+
+/// A covered component identifier with optional component parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentIdentifier {
+    /// Component name, e.g. `@method` or `content-digest`.
+    pub name: String,
+    /// Component-level parameters (`sf`, `bs`, `tr`, `key`, `req`, `name`, …).
+    pub parameters: Parameters,
+}
+
+impl ComponentIdentifier {
+    #[must_use]
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            parameters: Parameters::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_parameters(mut self, parameters: Parameters) -> Self {
+        self.parameters = parameters;
+        self
+    }
+
+    /// Serialize as used in the signature base / Signature-Input (quoted name + params).
+    #[must_use]
+    pub fn serialize_identifier(&self) -> String {
+        let item = Item {
+            bare: BareItem::String(self.name.clone()),
+            parameters: self.parameters.clone(),
+        };
+        let mut out = String::new();
+        // Reuse dictionary item serialization via a tiny helper path:
+        // build a one-item inner list serialization manually
+        serialize_component_item(&mut out, &item);
+        out
+    }
+}
+
+fn serialize_component_item(out: &mut String, item: &Item) {
+    match &item.bare {
+        BareItem::String(s) => {
+            out.push('"');
+            for c in s.chars() {
+                if c == '"' || c == '\\' {
+                    out.push('\\');
+                }
+                out.push(c);
+            }
+            out.push('"');
+        }
+        other => {
+            // Component identifiers must be strings per RFC 9421
+            let _ = other;
+            out.push_str("\"\"");
+        }
+    }
+    for p in &item.parameters.params {
+        out.push(';');
+        out.push_str(&p.name);
+        match &p.value {
+            ParameterValue::Boolean(true) => {}
+            ParameterValue::Boolean(false) => out.push_str("=?0"),
+            ParameterValue::String(s) => {
+                out.push_str("=\"");
+                for c in s.chars() {
+                    if c == '"' || c == '\\' {
+                        out.push('\\');
+                    }
+                    out.push(c);
+                }
+                out.push('"');
+            }
+            ParameterValue::Token(t) => {
+                out.push('=');
+                out.push_str(t);
+            }
+            ParameterValue::Integer(n) => {
+                out.push('=');
+                out.push_str(&n.to_string());
+            }
+            ParameterValue::ByteSequence(bytes) => {
+                use base64::Engine as _;
+                out.push_str("=:");
+                out.push_str(&base64::engine::general_purpose::STANDARD.encode(bytes));
+                out.push(':');
+            }
+        }
+    }
+}
+
+/// Signature-level parameters from the Inner List.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SignatureParameters {
+    pub created: Option<i64>,
+    pub expires: Option<i64>,
+    pub nonce: Option<String>,
+    pub alg: Option<String>,
+    pub keyid: Option<String>,
+    pub tag: Option<String>,
+    /// Any additional / unrecognized parameters, preserved for round-trip.
+    pub extra: Parameters,
+}
+
+impl SignatureParameters {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn from_sf(params: &Parameters) -> Self {
+        let mut out = Self::default();
+        for p in &params.params {
+            match (p.name.as_str(), &p.value) {
+                ("created", ParameterValue::Integer(n)) => out.created = Some(*n),
+                ("expires", ParameterValue::Integer(n)) => out.expires = Some(*n),
+                ("nonce", ParameterValue::String(s)) => out.nonce = Some(s.clone()),
+                ("alg", ParameterValue::String(s) | ParameterValue::Token(s)) => {
+                    out.alg = Some(s.clone());
+                }
+                ("keyid", ParameterValue::String(s)) => out.keyid = Some(s.clone()),
+                ("tag", ParameterValue::String(s)) => out.tag = Some(s.clone()),
+                _ => out.extra.params.push(p.clone()),
+            }
+        }
+        out
+    }
+
+    fn to_sf(&self) -> Parameters {
+        let mut params = Parameters::new();
+        // Preserve a stable, RFC-example-friendly order: created, expires, nonce, alg, keyid, tag
+        if let Some(n) = self.created {
+            params.insert("created", ParameterValue::Integer(n));
+        }
+        if let Some(n) = self.expires {
+            params.insert("expires", ParameterValue::Integer(n));
+        }
+        if let Some(ref s) = self.nonce {
+            params.insert("nonce", ParameterValue::String(s.clone()));
+        }
+        if let Some(ref s) = self.alg {
+            params.insert("alg", ParameterValue::String(s.clone()));
+        }
+        if let Some(ref s) = self.keyid {
+            params.insert("keyid", ParameterValue::String(s.clone()));
+        }
+        if let Some(ref s) = self.tag {
+            params.insert("tag", ParameterValue::String(s.clone()));
+        }
+        for p in &self.extra.params {
+            params.params.push(p.clone());
+        }
+        params
+    }
+}
+
+/// The `Signature-Input` header field (RFC 9421).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SignatureInput {
+    /// Ordered (label, params) entries.
+    entries: Vec<(String, SignatureParams)>,
+}
+
+impl SignatureInput {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, label: impl Into<String>, params: SignatureParams) {
+        let label = label.into();
+        if let Some((_, existing)) = self.entries.iter_mut().find(|(k, _)| *k == label) {
+            *existing = params;
+        } else {
+            self.entries.push((label, params));
+        }
+    }
+
+    pub fn get(&self, label: &str) -> Option<&SignatureParams> {
+        self.entries
+            .iter()
+            .find(|(k, _)| k == label)
+            .map(|(_, v)| v)
+    }
+
+    pub fn labels(&self) -> impl Iterator<Item = &str> {
+        self.entries.iter().map(|(k, _)| k.as_str())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &SignatureParams)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Serialize the Signature-Input member value for a label (used as `@signature-params`).
+    ///
+    /// This is the Inner List serialization *without* the label key, matching RFC 9421 §2.3.
+    pub fn serialize_signature_params(&self, label: &str) -> Option<String> {
+        let params = self.get(label)?;
+        Some(serialize_signature_params_value(params))
+    }
+}
+
+/// Serialize a [`SignatureParams`] value as it appears in `Signature-Input` / `@signature-params`.
+#[must_use]
+pub fn serialize_signature_params_value(params: &SignatureParams) -> String {
+    let items: Vec<Item> = params
+        .components
+        .iter()
+        .map(|c| Item {
+            bare: BareItem::String(c.name.clone()),
+            parameters: c.parameters.clone(),
+        })
+        .collect();
+    let list = InnerList {
+        items,
+        parameters: params.parameters.to_sf(),
+    };
+    let mut dict = Dictionary::new();
+    // Use a throwaway key then strip it — serialize just the value part
+    dict.insert("_", DictionaryMember::InnerList(list));
+    let full = serialize_dictionary(&dict);
+    // full is `_=(...);...` — strip the `_=` prefix
+    full.strip_prefix("_=").unwrap_or(&full).to_owned()
+}
+
+fn params_from_inner_list(list: &InnerList) -> Result<SignatureParams, Error> {
+    let mut components = Vec::with_capacity(list.items.len());
+    for item in &list.items {
+        let BareItem::String(name) = &item.bare else {
+            return Err(Error::invalid());
+        };
+        components.push(ComponentIdentifier {
+            name: name.clone(),
+            parameters: item.parameters.clone(),
+        });
+    }
+    Ok(SignatureParams {
+        components,
+        parameters: SignatureParameters::from_sf(&list.parameters),
+    })
+}
+
+impl TypedHeader for SignatureInput {
+    fn name() -> &'static HeaderName {
+        &::rama_http_types::header::SIGNATURE_INPUT
+    }
+}
+
+impl HeaderDecode for SignatureInput {
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        let mut entries = Vec::new();
+        let mut any = false;
+        for value in values {
+            any = true;
+            let s = value.to_str().map_err(|_err| Error::invalid())?;
+            let dict = parse_dictionary(s).map_err(|_err| Error::invalid())?;
+            for (key, member) in dict.members {
+                let DictionaryMember::InnerList(list) = member else {
+                    return Err(Error::invalid());
+                };
+                if entries.iter().any(|(k, _)| k == &key) {
+                    return Err(Error::invalid());
+                }
+                entries.push((key, params_from_inner_list(&list)?));
+            }
+        }
+        if !any {
+            return Err(Error::invalid());
+        }
+        Ok(Self { entries })
+    }
+}
+
+impl HeaderEncode for SignatureInput {
+    fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
+        let mut dict = Dictionary::new();
+        for (label, params) in &self.entries {
+            let items: Vec<Item> = params
+                .components
+                .iter()
+                .map(|c| Item {
+                    bare: BareItem::String(c.name.clone()),
+                    parameters: c.parameters.clone(),
+                })
+                .collect();
+            dict.insert(
+                label.clone(),
+                DictionaryMember::InnerList(InnerList {
+                    items,
+                    parameters: params.parameters.to_sf(),
+                }),
+            );
+        }
+        let s = serialize_dictionary(&dict);
+        if let Ok(value) = HeaderValue::from_str(&s) {
+            values.extend(std::iter::once(value));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::{test_decode, test_encode};
+
+    #[test]
+    fn decode_rfc_example() {
+        let input = r#"sig1=("@method" "@authority" "@path" "content-digest" "content-type" "content-length");created=1618884475;keyid="test-key-ecc-p256""#;
+        let hdr = test_decode::<SignatureInput>(&[input]).unwrap();
+        let params = hdr.get("sig1").unwrap();
+        assert_eq!(params.components.len(), 6);
+        assert_eq!(params.components[0].name, "@method");
+        assert_eq!(params.components[3].name, "content-digest");
+        assert_eq!(params.parameters.created, Some(1618884475));
+        assert_eq!(
+            params.parameters.keyid.as_deref(),
+            Some("test-key-ecc-p256")
+        );
+    }
+
+    #[test]
+    fn round_trip() {
+        let mut hdr = SignatureInput::new();
+        hdr.insert(
+            "sig1",
+            SignatureParams {
+                components: vec![
+                    ComponentIdentifier::new("@method"),
+                    ComponentIdentifier::new("@path"),
+                ],
+                parameters: SignatureParameters {
+                    created: Some(1618884475),
+                    keyid: Some("test-key".into()),
+                    alg: Some("ed25519".into()),
+                    ..Default::default()
+                },
+            },
+        );
+        let map = test_encode(hdr.clone());
+        let value = map.get(SignatureInput::name()).unwrap().to_str().unwrap();
+        let decoded = test_decode::<SignatureInput>(&[value]).unwrap();
+        assert_eq!(decoded, hdr);
+    }
+
+    #[test]
+    fn serialize_signature_params_matches_member_value() {
+        let input =
+            r#"sig1=("@method" "@authority" "@path");created=1618884475;keyid="test-key-ecc-p256""#;
+        let hdr = test_decode::<SignatureInput>(&[input]).unwrap();
+        let serialized = hdr.serialize_signature_params("sig1").unwrap();
+        assert_eq!(
+            serialized,
+            r#"("@method" "@authority" "@path");created=1618884475;keyid="test-key-ecc-p256""#
+        );
+    }
+
+    #[test]
+    fn multi_label() {
+        let input =
+            r#"sig1=("@method");created=1, proxy_sig=("@method" "forwarded");created=2;keyid="p""#;
+        let hdr = test_decode::<SignatureInput>(&[input]).unwrap();
+        assert_eq!(hdr.len(), 2);
+        assert!(hdr.get("sig1").is_some());
+        assert!(hdr.get("proxy_sig").is_some());
+    }
+}

--- a/rama-http-headers/src/util/mod.rs
+++ b/rama-http-headers/src/util/mod.rs
@@ -30,6 +30,7 @@ mod http_date;
 mod iter;
 //mod quality_value;
 mod seconds;
+pub mod structured_fields;
 mod value_string;
 
 pub use value_string::HeaderValueString;

--- a/rama-http-headers/src/util/structured_fields/mod.rs
+++ b/rama-http-headers/src/util/structured_fields/mod.rs
@@ -10,8 +10,9 @@ mod parse;
 mod serialize;
 mod types;
 
-pub use parse::{ParseError, parse_dictionary};
-pub use serialize::serialize_dictionary;
+pub use parse::{ParseError, parse_dictionary, parse_item, parse_list};
+pub use serialize::{serialize_dictionary, serialize_item_value, serialize_list};
 pub use types::{
-    BareItem, Dictionary, DictionaryMember, InnerList, Item, Parameter, ParameterValue, Parameters,
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, List, ListMember, Parameter,
+    ParameterValue, Parameters,
 };

--- a/rama-http-headers/src/util/structured_fields/mod.rs
+++ b/rama-http-headers/src/util/structured_fields/mod.rs
@@ -11,7 +11,9 @@ mod serialize;
 mod types;
 
 pub use parse::{ParseError, parse_dictionary, parse_item, parse_list};
-pub use serialize::{serialize_dictionary, serialize_item_value, serialize_list};
+pub use serialize::{
+    serialize_dictionary, serialize_inner_list_value, serialize_item_value, serialize_list,
+};
 pub use types::{
     BareItem, Dictionary, DictionaryMember, InnerList, Item, List, ListMember, Parameter,
     ParameterValue, Parameters,

--- a/rama-http-headers/src/util/structured_fields/mod.rs
+++ b/rama-http-headers/src/util/structured_fields/mod.rs
@@ -1,0 +1,17 @@
+//! Minimal Structured Fields (RFC 9651) subset for HTTP Message Signatures (RFC 9421).
+//!
+//! Covers Dictionaries, Inner Lists, Items, and Parameters needed by
+//! `Signature` / `Signature-Input` (and later `Content-Digest`).
+//!
+//! `ponytail:` not a full RFC 9651 implementation; upgrade to a general SF
+//! library (or expand this module) if other headers need the full grammar.
+
+mod parse;
+mod serialize;
+mod types;
+
+pub use parse::{ParseError, parse_dictionary};
+pub use serialize::serialize_dictionary;
+pub use types::{
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, Parameter, ParameterValue, Parameters,
+};

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -204,15 +204,17 @@ impl<'a> Parser<'a> {
                 Some(b'%') => {
                     let hi = self.bump().ok_or_else(|| self.err("truncated percent"))?;
                     let lo = self.bump().ok_or_else(|| self.err("truncated percent"))?;
-                    let h =
-                        hex_nibble(hi).ok_or_else(|| self.err("invalid hex in display string"))?;
-                    let l =
-                        hex_nibble(lo).ok_or_else(|| self.err("invalid hex in display string"))?;
+                    // RFC 9651 §4.2.8: pct-encoded uses lc-hexdig only.
+                    let h = lc_hex_nibble(hi)
+                        .ok_or_else(|| self.err("invalid hex in display string"))?;
+                    let l = lc_hex_nibble(lo)
+                        .ok_or_else(|| self.err("invalid hex in display string"))?;
                     bytes.push((h << 4) | l);
                 }
                 Some(c)
                     if (0x20..=0x21).contains(&c)
-                        || (0x23..=0x5b).contains(&c)
+                        || (0x23..=0x24).contains(&c)
+                        || (0x26..=0x5b).contains(&c)
                         || (0x5d..=0x7e).contains(&c) =>
                 {
                     bytes.push(c);
@@ -422,11 +424,10 @@ fn bare_to_parameter_value(bare: BareItem) -> ParameterValue {
     }
 }
 
-fn hex_nibble(c: u8) -> Option<u8> {
+fn lc_hex_nibble(c: u8) -> Option<u8> {
     match c {
         b'0'..=b'9' => Some(c - b'0'),
         b'a'..=b'f' => Some(c - b'a' + 10),
-        b'A'..=b'F' => Some(c - b'A' + 10),
         _ => None,
     }
 }
@@ -580,6 +581,15 @@ mod tests {
     #[test]
     fn reject_control_char_in_string() {
         assert!(parse_item("\"a\x01b\"").is_err());
+    }
+
+    #[test]
+    fn reject_uppercase_hex_in_display_string() {
+        assert!(parse_item("%\"caf%C3%A9\"").is_err());
+        assert_eq!(
+            parse_item("%\"caf%c3%a9\"").unwrap().bare,
+            BareItem::DisplayString("café".into())
+        );
     }
 
     #[test]

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -57,8 +57,16 @@ impl<'a> Parser<'a> {
         Some(b)
     }
 
+    /// OWS = *( SP / HTAB ) — used around commas in dictionaries/lists.
     fn skip_ows(&mut self) {
         while matches!(self.peek(), Some(b' ' | b'\t')) {
+            self.pos += 1;
+        }
+    }
+
+    /// `*SP` — used after `;` in parameters and between Inner List items.
+    fn skip_sp(&mut self) {
+        while self.peek() == Some(b' ') {
             self.pos += 1;
         }
     }
@@ -135,20 +143,20 @@ impl<'a> Parser<'a> {
 
     fn parse_inner_list(&mut self) -> Result<InnerList, ParseError> {
         self.expect(b'(', "expected '('")?;
-        self.skip_ows();
+        self.skip_sp();
         let mut items = Vec::new();
         while self.peek() != Some(b')') {
             if self.pos >= self.input.len() {
                 return Err(self.err("unterminated inner list"));
             }
             items.push(self.parse_item()?);
-            let had_ws = matches!(self.peek(), Some(b' ' | b'\t'));
-            self.skip_ows();
+            let had_sp = self.peek() == Some(b' ');
+            self.skip_sp();
             if self.peek() == Some(b')') {
                 break;
             }
-            if !had_ws {
-                return Err(self.err("expected whitespace between inner-list items"));
+            if !had_sp {
+                return Err(self.err("expected SP between inner-list items"));
             }
         }
         self.expect(b')', "expected ')'")?;
@@ -226,9 +234,15 @@ impl<'a> Parser<'a> {
                     Some(_) => return Err(self.err("invalid escape in string")),
                     None => return Err(self.err("unterminated escape")),
                 },
-                Some(b'\n' | b'\r') => return Err(self.err("newline in string")),
-                Some(c) if c <= 0x7f => out.push(c as char),
-                Some(_) => return Err(self.err("non-ASCII in string")),
+                // RFC 9651: unescaped = %x20-21 / %x23-5B / %x5D-7E
+                Some(c)
+                    if (0x20..=0x21).contains(&c)
+                        || (0x23..=0x5b).contains(&c)
+                        || (0x5d..=0x7e).contains(&c) =>
+                {
+                    out.push(c as char);
+                }
+                Some(_) => return Err(self.err("invalid character in string")),
                 None => return Err(self.err("unterminated string")),
             }
         }
@@ -246,8 +260,7 @@ impl<'a> Parser<'a> {
         let encoded = std::str::from_utf8(&self.input[start..self.pos])
             .map_err(|_err| self.err("invalid utf-8 in byte sequence"))?;
         self.expect(b':', "expected closing ':'")?;
-        B64.decode(encoded)
-            .map_err(|_err| self.err("invalid base64 in byte sequence"))
+        decode_sf_base64(encoded).map_err(|_err| self.err("invalid base64 in byte sequence"))
     }
 
     fn parse_boolean(&mut self) -> Result<bool, ParseError> {
@@ -273,13 +286,15 @@ impl<'a> Parser<'a> {
         while matches!(self.peek(), Some(b'0'..=b'9')) {
             self.pos += 1;
         }
-        if self.pos - int_start > 12 {
-            return Err(self.err("integer too long"));
-        }
+        let int_len = self.pos - int_start;
         let int_str = std::str::from_utf8(&self.input[int_start..self.pos])
             .map_err(|_err| self.err("invalid integer"))?;
 
         if self.peek() != Some(b'.') {
+            // RFC 9651 Integer: 1*15 DIGIT
+            if int_len > 15 {
+                return Err(self.err("integer too long"));
+            }
             let mut n: i64 = int_str
                 .parse()
                 .map_err(|_err| self.err("integer out of range"))?;
@@ -287,6 +302,11 @@ impl<'a> Parser<'a> {
                 n = -n;
             }
             return Ok(BareItem::Integer(n));
+        }
+
+        // RFC 9651 Decimal: integer part 1*12 DIGIT
+        if int_len > 12 {
+            return Err(self.err("decimal integer part too long"));
         }
 
         self.bump(); // '.'
@@ -346,6 +366,8 @@ impl<'a> Parser<'a> {
         let mut params = Parameters::new();
         while self.peek() == Some(b';') {
             self.bump();
+            // RFC 9651: parameters = *( ";" *SP parameter )
+            self.skip_sp();
             let name = self.parse_key()?;
             let value = if self.peek() == Some(b'=') {
                 self.bump();
@@ -360,6 +382,21 @@ impl<'a> Parser<'a> {
         }
         Ok(params)
     }
+}
+
+/// Decode SF Byte Sequence base64, accepting omitted padding (RFC 9651 SHOULD).
+fn decode_sf_base64(encoded: &str) -> Result<Vec<u8>, ()> {
+    if encoded.as_bytes().iter().any(|b| b.is_ascii_whitespace()) {
+        return Err(());
+    }
+    let mut padded = encoded.to_owned();
+    match padded.len() % 4 {
+        0 => {}
+        2 => padded.push_str("=="),
+        3 => padded.push('='),
+        _ => return Err(()),
+    }
+    B64.decode(padded.as_bytes()).map_err(|_err| ())
 }
 
 fn bare_to_parameter_value(bare: BareItem) -> ParameterValue {
@@ -491,6 +528,58 @@ mod tests {
             list.parameters.get("keyid"),
             Some(&ParameterValue::String("test-key-ecc-p256".into()))
         );
+    }
+
+    #[test]
+    fn parse_parameters_allow_sp_after_semicolon() {
+        let input = r#"sig1=("@method"); created=1; keyid="k""#;
+        let dict = parse_dictionary(input).unwrap();
+        let DictionaryMember::InnerList(list) = dict.get("sig1").unwrap() else {
+            panic!("expected inner list");
+        };
+        assert_eq!(
+            list.parameters.get("created"),
+            Some(&ParameterValue::Integer(1))
+        );
+        assert_eq!(
+            list.parameters.get("keyid"),
+            Some(&ParameterValue::String("k".into()))
+        );
+    }
+
+    #[test]
+    fn parse_15_digit_integer() {
+        let input = r#"sig1=("@method");created=123456789012345"#;
+        let dict = parse_dictionary(input).unwrap();
+        let DictionaryMember::InnerList(list) = dict.get("sig1").unwrap() else {
+            panic!("expected inner list");
+        };
+        assert_eq!(
+            list.parameters.get("created"),
+            Some(&ParameterValue::Integer(123456789012345))
+        );
+    }
+
+    #[test]
+    fn reject_16_digit_integer() {
+        let input = r#"sig1=("@method");created=1234567890123456"#;
+        assert!(parse_dictionary(input).is_err());
+    }
+
+    #[test]
+    fn parse_unpadded_byte_sequence() {
+        // "test" base64 without padding would be dGVzdA (needs ==)
+        let input = "sig1=:dGVzdA:";
+        let dict = parse_dictionary(input).unwrap();
+        let DictionaryMember::Item(item) = dict.get("sig1").unwrap() else {
+            panic!("expected item");
+        };
+        assert_eq!(item.bare, BareItem::ByteSequence(b"test".to_vec()));
+    }
+
+    #[test]
+    fn reject_control_char_in_string() {
+        assert!(parse_item("\"a\x01b\"").is_err());
     }
 
     #[test]

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -1,0 +1,354 @@
+//! Structured Fields parser (RFC 9651 subset).
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+
+use super::types::{
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, Parameter, ParameterValue, Parameters,
+};
+
+/// Parse error for Structured Fields input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub message: &'static str,
+    pub position: usize,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "structured fields parse error at {}: {}",
+            self.position, self.message
+        )
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+struct Parser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn err(&self, message: &'static str) -> ParseError {
+        ParseError {
+            message,
+            position: self.pos,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn bump(&mut self) -> Option<u8> {
+        let b = self.peek()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn skip_ows(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t')) {
+            self.pos += 1;
+        }
+    }
+
+    fn expect(&mut self, b: u8, msg: &'static str) -> Result<(), ParseError> {
+        match self.bump() {
+            Some(c) if c == b => Ok(()),
+            _ => Err(self.err(msg)),
+        }
+    }
+
+    fn parse_dictionary(mut self) -> Result<Dictionary, ParseError> {
+        self.skip_ows();
+        let mut dict = Dictionary::new();
+        if self.pos >= self.input.len() {
+            return Ok(dict);
+        }
+
+        loop {
+            self.skip_ows();
+            let key = self.parse_key()?;
+            self.skip_ows();
+
+            let member = if self.peek() == Some(b'=') {
+                self.bump();
+                self.skip_ows();
+                if self.peek() == Some(b'(') {
+                    DictionaryMember::InnerList(self.parse_inner_list()?)
+                } else {
+                    DictionaryMember::Item(self.parse_item()?)
+                }
+            } else {
+                // Boolean true shorthand: `key` alone
+                DictionaryMember::Item(
+                    Item::boolean(true).with_parameters(self.parse_parameters()?),
+                )
+            };
+
+            if dict.get(&key).is_some() {
+                return Err(self.err("duplicate dictionary key"));
+            }
+            dict.members.push((key, member));
+
+            self.skip_ows();
+            if self.pos >= self.input.len() {
+                break;
+            }
+            self.expect(b',', "expected ',' between dictionary members")?;
+            self.skip_ows();
+            if self.pos >= self.input.len() {
+                return Err(self.err("trailing comma in dictionary"));
+            }
+        }
+
+        Ok(dict)
+    }
+
+    fn parse_key(&mut self) -> Result<String, ParseError> {
+        let start = self.pos;
+        let first = self.bump().ok_or_else(|| self.err("expected key"))?;
+        if !(first.is_ascii_lowercase() || first == b'*') {
+            return Err(self.err("key must start with lcalpha or '*'"));
+        }
+        while matches!(
+            self.peek(),
+            Some(b'a'..=b'z' | b'0'..=b'9' | b'_' | b'-' | b'.' | b'*')
+        ) {
+            self.pos += 1;
+        }
+        Ok(std::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_err| self.err("invalid utf-8 in key"))?
+            .to_owned())
+    }
+
+    fn parse_inner_list(&mut self) -> Result<InnerList, ParseError> {
+        self.expect(b'(', "expected '('")?;
+        self.skip_ows();
+        let mut items = Vec::new();
+        while self.peek() != Some(b')') {
+            if self.pos >= self.input.len() {
+                return Err(self.err("unterminated inner list"));
+            }
+            items.push(self.parse_item()?);
+            let had_ws = matches!(self.peek(), Some(b' ' | b'\t'));
+            self.skip_ows();
+            if self.peek() == Some(b')') {
+                break;
+            }
+            if !had_ws {
+                return Err(self.err("expected whitespace between inner-list items"));
+            }
+        }
+        self.expect(b')', "expected ')'")?;
+        let parameters = self.parse_parameters()?;
+        Ok(InnerList { items, parameters })
+    }
+
+    fn parse_item(&mut self) -> Result<Item, ParseError> {
+        let bare = self.parse_bare_item()?;
+        let parameters = self.parse_parameters()?;
+        Ok(Item { bare, parameters })
+    }
+
+    fn parse_bare_item(&mut self) -> Result<BareItem, ParseError> {
+        match self.peek() {
+            Some(b'"') => Ok(BareItem::String(self.parse_string()?)),
+            Some(b':') => Ok(BareItem::ByteSequence(self.parse_byte_sequence()?)),
+            Some(b'?') => Ok(BareItem::Boolean(self.parse_boolean()?)),
+            Some(b'-' | b'0'..=b'9') => Ok(BareItem::Integer(self.parse_integer()?)),
+            Some(b'a'..=b'z' | b'A'..=b'Z' | b'*') => Ok(BareItem::Token(self.parse_token()?)),
+            _ => Err(self.err("expected bare item")),
+        }
+    }
+
+    fn parse_string(&mut self) -> Result<String, ParseError> {
+        self.expect(b'"', "expected '\"'")?;
+        let mut out = String::new();
+        loop {
+            match self.bump() {
+                Some(b'"') => return Ok(out),
+                Some(b'\\') => match self.bump() {
+                    Some(c @ (b'\\' | b'"')) => out.push(c as char),
+                    Some(_) => return Err(self.err("invalid escape in string")),
+                    None => return Err(self.err("unterminated escape")),
+                },
+                Some(b'\n' | b'\r') => return Err(self.err("newline in string")),
+                Some(c) if c <= 0x7f => out.push(c as char),
+                Some(_) => return Err(self.err("non-ASCII in string")),
+                None => return Err(self.err("unterminated string")),
+            }
+        }
+    }
+
+    fn parse_byte_sequence(&mut self) -> Result<Vec<u8>, ParseError> {
+        self.expect(b':', "expected ':'")?;
+        let start = self.pos;
+        while let Some(c) = self.peek() {
+            if c == b':' {
+                break;
+            }
+            self.pos += 1;
+        }
+        let encoded = std::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_err| self.err("invalid utf-8 in byte sequence"))?;
+        self.expect(b':', "expected closing ':'")?;
+        B64.decode(encoded)
+            .map_err(|_err| self.err("invalid base64 in byte sequence"))
+    }
+
+    fn parse_boolean(&mut self) -> Result<bool, ParseError> {
+        self.expect(b'?', "expected '?'")?;
+        match self.bump() {
+            Some(b'1') => Ok(true),
+            Some(b'0') => Ok(false),
+            _ => Err(self.err("expected ?0 or ?1")),
+        }
+    }
+
+    fn parse_integer(&mut self) -> Result<i64, ParseError> {
+        let start = self.pos;
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+        if !matches!(self.peek(), Some(b'0'..=b'9')) {
+            return Err(self.err("expected digit"));
+        }
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.pos += 1;
+        }
+        // Reject decimals for this subset (RFC allows Decimal; we only need Integer)
+        if self.peek() == Some(b'.') {
+            return Err(self.err("decimals not supported in this subset"));
+        }
+        let s = std::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_err| self.err("invalid integer"))?;
+        s.parse().map_err(|_err| self.err("integer out of range"))
+    }
+
+    fn parse_token(&mut self) -> Result<String, ParseError> {
+        let start = self.pos;
+        let first = self.bump().ok_or_else(|| self.err("expected token"))?;
+        if !(first.is_ascii_alphabetic() || first == b'*') {
+            return Err(self.err("invalid token start"));
+        }
+        while let Some(c) = self.peek() {
+            if is_tchar(c) || c == b':' || c == b'/' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        Ok(std::str::from_utf8(&self.input[start..self.pos])
+            .map_err(|_err| self.err("invalid utf-8 in token"))?
+            .to_owned())
+    }
+
+    fn parse_parameters(&mut self) -> Result<Parameters, ParseError> {
+        let mut params = Parameters::new();
+        while self.peek() == Some(b';') {
+            self.bump();
+            let name = self.parse_key()?;
+            let value = if self.peek() == Some(b'=') {
+                self.bump();
+                match self.parse_bare_item()? {
+                    BareItem::String(s) => ParameterValue::String(s),
+                    BareItem::Token(t) => ParameterValue::Token(t),
+                    BareItem::Integer(n) => ParameterValue::Integer(n),
+                    BareItem::Boolean(b) => ParameterValue::Boolean(b),
+                    BareItem::ByteSequence(b) => ParameterValue::ByteSequence(b),
+                }
+            } else {
+                ParameterValue::Boolean(true)
+            };
+            if params.get(&name).is_some() {
+                return Err(self.err("duplicate parameter"));
+            }
+            params.params.push(Parameter { name, value });
+        }
+        Ok(params)
+    }
+}
+
+fn is_tchar(c: u8) -> bool {
+    matches!(
+        c,
+        b'!' | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+            | b'0'..=b'9'
+            | b'a'..=b'z'
+            | b'A'..=b'Z'
+    )
+}
+
+/// Parse a Structured Fields Dictionary from a header field value.
+pub fn parse_dictionary(input: &str) -> Result<Dictionary, ParseError> {
+    Parser::new(input).parse_dictionary()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_signature_input_example() {
+        let input =
+            r#"sig1=("@method" "@authority" "@path");created=1618884475;keyid="test-key-ecc-p256""#;
+        let dict = parse_dictionary(input).unwrap();
+        let member = dict.get("sig1").unwrap();
+        let DictionaryMember::InnerList(list) = member else {
+            panic!("expected inner list");
+        };
+        assert_eq!(list.items.len(), 3);
+        assert_eq!(list.items[0].bare, BareItem::String("@method".into()));
+        assert_eq!(
+            list.parameters.get("created"),
+            Some(&ParameterValue::Integer(1618884475))
+        );
+        assert_eq!(
+            list.parameters.get("keyid"),
+            Some(&ParameterValue::String("test-key-ecc-p256".into()))
+        );
+    }
+
+    #[test]
+    fn parse_signature_byte_sequence() {
+        let input = "sig1=:dGVzdA==:";
+        let dict = parse_dictionary(input).unwrap();
+        let DictionaryMember::Item(item) = dict.get("sig1").unwrap() else {
+            panic!("expected item");
+        };
+        assert_eq!(item.bare, BareItem::ByteSequence(b"test".to_vec()));
+    }
+
+    #[test]
+    fn parse_multi_label() {
+        let input = r#"sig1=("@method");created=1, proxy_sig=("@method" "forwarded");keyid="p""#;
+        let dict = parse_dictionary(input).unwrap();
+        assert_eq!(dict.members.len(), 2);
+        assert!(dict.get("sig1").is_some());
+        assert!(dict.get("proxy_sig").is_some());
+    }
+}

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -309,7 +309,7 @@ impl<'a> Parser<'a> {
         let mut fraction: u16 = frac_str
             .parse()
             .map_err(|_err| self.err("invalid fraction"))?;
-        while digits > 1 && fraction % 10 == 0 {
+        while digits > 1 && fraction.is_multiple_of(10) {
             fraction /= 10;
             digits -= 1;
         }

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -167,9 +167,51 @@ impl<'a> Parser<'a> {
             Some(b'"') => Ok(BareItem::String(self.parse_string()?)),
             Some(b':') => Ok(BareItem::ByteSequence(self.parse_byte_sequence()?)),
             Some(b'?') => Ok(BareItem::Boolean(self.parse_boolean()?)),
-            Some(b'-' | b'0'..=b'9') => Ok(BareItem::Integer(self.parse_integer()?)),
+            Some(b'@') => Ok(BareItem::Date(self.parse_date()?)),
+            Some(b'%') => Ok(BareItem::DisplayString(self.parse_display_string()?)),
+            Some(b'-' | b'0'..=b'9') => self.parse_integer_or_decimal(),
             Some(b'a'..=b'z' | b'A'..=b'Z' | b'*') => Ok(BareItem::Token(self.parse_token()?)),
             _ => Err(self.err("expected bare item")),
+        }
+    }
+
+    fn parse_date(&mut self) -> Result<i64, ParseError> {
+        self.expect(b'@', "expected '@'")?;
+        match self.parse_integer_or_decimal()? {
+            BareItem::Integer(n) => Ok(n),
+            _ => Err(self.err("date requires an integer")),
+        }
+    }
+
+    fn parse_display_string(&mut self) -> Result<String, ParseError> {
+        self.expect(b'%', "expected '%'")?;
+        self.expect(b'"', "expected '\"' after %")?;
+        let mut bytes = Vec::new();
+        loop {
+            match self.bump() {
+                Some(b'"') => {
+                    return String::from_utf8(bytes)
+                        .map_err(|_err| self.err("invalid utf-8 in display string"));
+                }
+                Some(b'%') => {
+                    let hi = self.bump().ok_or_else(|| self.err("truncated percent"))?;
+                    let lo = self.bump().ok_or_else(|| self.err("truncated percent"))?;
+                    let h =
+                        hex_nibble(hi).ok_or_else(|| self.err("invalid hex in display string"))?;
+                    let l =
+                        hex_nibble(lo).ok_or_else(|| self.err("invalid hex in display string"))?;
+                    bytes.push((h << 4) | l);
+                }
+                Some(c)
+                    if (0x20..=0x21).contains(&c)
+                        || (0x23..=0x5b).contains(&c)
+                        || (0x5d..=0x7e).contains(&c) =>
+                {
+                    bytes.push(c);
+                }
+                Some(_) => return Err(self.err("invalid byte in display string")),
+                None => return Err(self.err("unterminated display string")),
+            }
         }
     }
 
@@ -217,24 +259,69 @@ impl<'a> Parser<'a> {
         }
     }
 
-    fn parse_integer(&mut self) -> Result<i64, ParseError> {
-        let start = self.pos;
-        if self.peek() == Some(b'-') {
+    fn parse_integer_or_decimal(&mut self) -> Result<BareItem, ParseError> {
+        let negative = if self.peek() == Some(b'-') {
             self.pos += 1;
-        }
+            true
+        } else {
+            false
+        };
         if !matches!(self.peek(), Some(b'0'..=b'9')) {
             return Err(self.err("expected digit"));
+        }
+        let int_start = self.pos;
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.pos += 1;
+        }
+        if self.pos - int_start > 12 {
+            return Err(self.err("integer too long"));
+        }
+        let int_str = std::str::from_utf8(&self.input[int_start..self.pos])
+            .map_err(|_err| self.err("invalid integer"))?;
+
+        if self.peek() != Some(b'.') {
+            let mut n: i64 = int_str
+                .parse()
+                .map_err(|_err| self.err("integer out of range"))?;
+            if negative {
+                n = -n;
+            }
+            return Ok(BareItem::Integer(n));
+        }
+
+        self.bump(); // '.'
+        let frac_start = self.pos;
+        if !matches!(self.peek(), Some(b'0'..=b'9')) {
+            return Err(self.err("expected fractional digit"));
         }
         while matches!(self.peek(), Some(b'0'..=b'9')) {
             self.pos += 1;
         }
-        // Reject decimals for this subset (RFC allows Decimal; we only need Integer)
-        if self.peek() == Some(b'.') {
-            return Err(self.err("decimals not supported in this subset"));
+        let frac_len = self.pos - frac_start;
+        if !(1..=3).contains(&frac_len) {
+            return Err(self.err("decimal fraction must be 1 to 3 digits"));
         }
-        let s = std::str::from_utf8(&self.input[start..self.pos])
-            .map_err(|_err| self.err("invalid integer"))?;
-        s.parse().map_err(|_err| self.err("integer out of range"))
+        let frac_str = std::str::from_utf8(&self.input[frac_start..self.pos])
+            .map_err(|_err| self.err("invalid fraction"))?;
+
+        // Strip trailing zeros but keep at least one fractional digit.
+        let mut digits = frac_len as u8;
+        let mut fraction: u16 = frac_str
+            .parse()
+            .map_err(|_err| self.err("invalid fraction"))?;
+        while digits > 1 && fraction % 10 == 0 {
+            fraction /= 10;
+            digits -= 1;
+        }
+        let integer: u64 = int_str
+            .parse()
+            .map_err(|_err| self.err("integer out of range"))?;
+        Ok(BareItem::Decimal {
+            negative,
+            integer,
+            fraction,
+            fraction_digits: digits,
+        })
     }
 
     fn parse_token(&mut self) -> Result<String, ParseError> {
@@ -262,13 +349,7 @@ impl<'a> Parser<'a> {
             let name = self.parse_key()?;
             let value = if self.peek() == Some(b'=') {
                 self.bump();
-                match self.parse_bare_item()? {
-                    BareItem::String(s) => ParameterValue::String(s),
-                    BareItem::Token(t) => ParameterValue::Token(t),
-                    BareItem::Integer(n) => ParameterValue::Integer(n),
-                    BareItem::Boolean(b) => ParameterValue::Boolean(b),
-                    BareItem::ByteSequence(b) => ParameterValue::ByteSequence(b),
-                }
+                bare_to_parameter_value(self.parse_bare_item()?)
             } else {
                 ParameterValue::Boolean(true)
             };
@@ -278,6 +359,38 @@ impl<'a> Parser<'a> {
             params.params.push(Parameter { name, value });
         }
         Ok(params)
+    }
+}
+
+fn bare_to_parameter_value(bare: BareItem) -> ParameterValue {
+    match bare {
+        BareItem::String(s) => ParameterValue::String(s),
+        BareItem::Token(t) => ParameterValue::Token(t),
+        BareItem::Integer(n) => ParameterValue::Integer(n),
+        BareItem::Boolean(b) => ParameterValue::Boolean(b),
+        BareItem::ByteSequence(b) => ParameterValue::ByteSequence(b),
+        BareItem::Decimal {
+            negative,
+            integer,
+            fraction,
+            fraction_digits,
+        } => ParameterValue::Decimal {
+            negative,
+            integer,
+            fraction,
+            fraction_digits,
+        },
+        BareItem::Date(n) => ParameterValue::Date(n),
+        BareItem::DisplayString(s) => ParameterValue::DisplayString(s),
+    }
+}
+
+fn hex_nibble(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
     }
 }
 

--- a/rama-http-headers/src/util/structured_fields/parse.rs
+++ b/rama-http-headers/src/util/structured_fields/parse.rs
@@ -4,7 +4,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 
 use super::types::{
-    BareItem, Dictionary, DictionaryMember, InnerList, Item, Parameter, ParameterValue, Parameters,
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, List, ListMember, Parameter,
+    ParameterValue, Parameters,
 };
 
 /// Parse error for Structured Fields input.
@@ -306,6 +307,52 @@ fn is_tchar(c: u8) -> bool {
 /// Parse a Structured Fields Dictionary from a header field value.
 pub fn parse_dictionary(input: &str) -> Result<Dictionary, ParseError> {
     Parser::new(input).parse_dictionary()
+}
+
+/// Parse a Structured Fields List from a header field value.
+pub fn parse_list(input: &str) -> Result<List, ParseError> {
+    Parser::new(input).parse_list()
+}
+
+/// Parse a Structured Fields Item from a header field value.
+pub fn parse_item(input: &str) -> Result<Item, ParseError> {
+    let mut p = Parser::new(input);
+    p.skip_ows();
+    let item = p.parse_item()?;
+    p.skip_ows();
+    if p.pos < p.input.len() {
+        return Err(p.err("trailing data after item"));
+    }
+    Ok(item)
+}
+
+impl Parser<'_> {
+    fn parse_list(mut self) -> Result<List, ParseError> {
+        self.skip_ows();
+        let mut members = Vec::new();
+        if self.pos >= self.input.len() {
+            return Ok(List::new(members));
+        }
+        loop {
+            self.skip_ows();
+            let member = if self.peek() == Some(b'(') {
+                ListMember::InnerList(self.parse_inner_list()?)
+            } else {
+                ListMember::Item(self.parse_item()?)
+            };
+            members.push(member);
+            self.skip_ows();
+            if self.pos >= self.input.len() {
+                break;
+            }
+            self.expect(b',', "expected ',' between list members")?;
+            self.skip_ows();
+            if self.pos >= self.input.len() {
+                return Err(self.err("trailing comma in list"));
+            }
+        }
+        Ok(List::new(members))
+    }
 }
 
 #[cfg(test)]

--- a/rama-http-headers/src/util/structured_fields/serialize.rs
+++ b/rama-http-headers/src/util/structured_fields/serialize.rs
@@ -89,6 +89,20 @@ fn serialize_bare_item(out: &mut String, bare: &BareItem) {
         BareItem::Integer(n) => {
             out.push_str(&n.to_string());
         }
+        BareItem::Decimal {
+            negative,
+            integer,
+            fraction,
+            fraction_digits,
+        } => {
+            if *negative {
+                out.push('-');
+            }
+            out.push_str(&integer.to_string());
+            out.push('.');
+            let width = usize::from(*fraction_digits);
+            out.push_str(&format!("{fraction:0width$}"));
+        }
         BareItem::Boolean(true) => out.push_str("?1"),
         BareItem::Boolean(false) => out.push_str("?0"),
         BareItem::ByteSequence(bytes) => {
@@ -96,8 +110,29 @@ fn serialize_bare_item(out: &mut String, bare: &BareItem) {
             out.push_str(&B64.encode(bytes));
             out.push(':');
         }
+        BareItem::Date(n) => {
+            out.push('@');
+            out.push_str(&n.to_string());
+        }
+        BareItem::DisplayString(s) => {
+            out.push('%');
+            out.push('"');
+            for b in s.as_bytes() {
+                match *b {
+                    0x20..=0x21 | 0x23..=0x5b | 0x5d..=0x7e => out.push(*b as char),
+                    _ => {
+                        out.push('%');
+                        out.push(char::from(HEX[(b >> 4) as usize]));
+                        out.push(char::from(HEX[(b & 0xf) as usize]));
+                    }
+                }
+            }
+            out.push('"');
+        }
     }
 }
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
 
 fn serialize_parameters(out: &mut String, params: &Parameters) {
     for p in &params.params {
@@ -121,9 +156,34 @@ fn serialize_parameters(out: &mut String, params: &Parameters) {
                 out.push('=');
                 out.push_str(&n.to_string());
             }
+            ParameterValue::Decimal {
+                negative,
+                integer,
+                fraction,
+                fraction_digits,
+            } => {
+                out.push('=');
+                serialize_bare_item(
+                    out,
+                    &BareItem::Decimal {
+                        negative: *negative,
+                        integer: *integer,
+                        fraction: *fraction,
+                        fraction_digits: *fraction_digits,
+                    },
+                );
+            }
             ParameterValue::ByteSequence(bytes) => {
                 out.push('=');
                 serialize_bare_item(out, &BareItem::ByteSequence(bytes.clone()));
+            }
+            ParameterValue::Date(n) => {
+                out.push('=');
+                serialize_bare_item(out, &BareItem::Date(*n));
+            }
+            ParameterValue::DisplayString(s) => {
+                out.push('=');
+                serialize_bare_item(out, &BareItem::DisplayString(s.clone()));
             }
         }
     }

--- a/rama-http-headers/src/util/structured_fields/serialize.rs
+++ b/rama-http-headers/src/util/structured_fields/serialize.rs
@@ -56,6 +56,13 @@ pub fn serialize_item_value(item: &Item) -> String {
     out
 }
 
+/// Serialize an Inner List (including trailing parameters).
+pub fn serialize_inner_list_value(list: &InnerList) -> String {
+    let mut out = String::new();
+    serialize_inner_list(&mut out, list);
+    out
+}
+
 fn serialize_inner_list(out: &mut String, list: &InnerList) {
     out.push('(');
     for (i, item) in list.items.iter().enumerate() {

--- a/rama-http-headers/src/util/structured_fields/serialize.rs
+++ b/rama-http-headers/src/util/structured_fields/serialize.rs
@@ -1,0 +1,131 @@
+//! Structured Fields serializer (RFC 9651 subset).
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as B64;
+
+use super::types::{
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, ParameterValue, Parameters,
+};
+
+/// Serialize a Dictionary to a Structured Fields header value string.
+pub fn serialize_dictionary(dict: &Dictionary) -> String {
+    let mut out = String::new();
+    for (i, (key, member)) in dict.members.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(key);
+        match member {
+            DictionaryMember::Item(item) => {
+                // Boolean-true shorthand without parameters: just the key
+                if matches!(item.bare, BareItem::Boolean(true)) && item.parameters.is_empty() {
+                    continue;
+                }
+                out.push('=');
+                serialize_item(&mut out, item);
+            }
+            DictionaryMember::InnerList(list) => {
+                out.push('=');
+                serialize_inner_list(&mut out, list);
+            }
+        }
+    }
+    out
+}
+
+fn serialize_inner_list(out: &mut String, list: &InnerList) {
+    out.push('(');
+    for (i, item) in list.items.iter().enumerate() {
+        if i > 0 {
+            out.push(' ');
+        }
+        serialize_item(out, item);
+    }
+    out.push(')');
+    serialize_parameters(out, &list.parameters);
+}
+
+fn serialize_item(out: &mut String, item: &Item) {
+    serialize_bare_item(out, &item.bare);
+    serialize_parameters(out, &item.parameters);
+}
+
+fn serialize_bare_item(out: &mut String, bare: &BareItem) {
+    match bare {
+        BareItem::String(s) => {
+            out.push('"');
+            for c in s.chars() {
+                if c == '"' || c == '\\' {
+                    out.push('\\');
+                }
+                out.push(c);
+            }
+            out.push('"');
+        }
+        BareItem::Token(t) => out.push_str(t),
+        BareItem::Integer(n) => {
+            out.push_str(&n.to_string());
+        }
+        BareItem::Boolean(true) => out.push_str("?1"),
+        BareItem::Boolean(false) => out.push_str("?0"),
+        BareItem::ByteSequence(bytes) => {
+            out.push(':');
+            out.push_str(&B64.encode(bytes));
+            out.push(':');
+        }
+    }
+}
+
+fn serialize_parameters(out: &mut String, params: &Parameters) {
+    for p in &params.params {
+        out.push(';');
+        out.push_str(&p.name);
+        match &p.value {
+            ParameterValue::Boolean(true) => {}
+            ParameterValue::Boolean(false) => {
+                out.push('=');
+                out.push_str("?0");
+            }
+            ParameterValue::String(s) => {
+                out.push('=');
+                serialize_bare_item(out, &BareItem::String(s.clone()));
+            }
+            ParameterValue::Token(t) => {
+                out.push('=');
+                out.push_str(t);
+            }
+            ParameterValue::Integer(n) => {
+                out.push('=');
+                out.push_str(&n.to_string());
+            }
+            ParameterValue::ByteSequence(bytes) => {
+                out.push('=');
+                serialize_bare_item(out, &BareItem::ByteSequence(bytes.clone()));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::structured_fields::parse_dictionary;
+
+    #[test]
+    fn round_trip_signature_input() {
+        let input =
+            r#"sig1=("@method" "@authority" "@path");created=1618884475;keyid="test-key-ecc-p256""#;
+        let dict = parse_dictionary(input).unwrap();
+        let encoded = serialize_dictionary(&dict);
+        let again = parse_dictionary(&encoded).unwrap();
+        assert_eq!(dict, again);
+    }
+
+    #[test]
+    fn round_trip_byte_sequence() {
+        let input = "sig1=:dGVzdA==:";
+        let dict = parse_dictionary(input).unwrap();
+        let encoded = serialize_dictionary(&dict);
+        assert_eq!(parse_dictionary(&encoded).unwrap(), dict);
+    }
+}

--- a/rama-http-headers/src/util/structured_fields/serialize.rs
+++ b/rama-http-headers/src/util/structured_fields/serialize.rs
@@ -4,7 +4,8 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as B64;
 
 use super::types::{
-    BareItem, Dictionary, DictionaryMember, InnerList, Item, ParameterValue, Parameters,
+    BareItem, Dictionary, DictionaryMember, InnerList, Item, List, ListMember, ParameterValue,
+    Parameters,
 };
 
 /// Serialize a Dictionary to a Structured Fields header value string.
@@ -30,6 +31,28 @@ pub fn serialize_dictionary(dict: &Dictionary) -> String {
             }
         }
     }
+    out
+}
+
+/// Serialize a List to a Structured Fields header value string.
+pub fn serialize_list(list: &List) -> String {
+    let mut out = String::new();
+    for (i, member) in list.members.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        match member {
+            ListMember::Item(item) => serialize_item(&mut out, item),
+            ListMember::InnerList(inner) => serialize_inner_list(&mut out, inner),
+        }
+    }
+    out
+}
+
+/// Serialize a single Item (bare item + parameters).
+pub fn serialize_item_value(item: &Item) -> String {
+    let mut out = String::new();
+    serialize_item(&mut out, item);
     out
 }
 

--- a/rama-http-headers/src/util/structured_fields/serialize.rs
+++ b/rama-http-headers/src/util/structured_fields/serialize.rs
@@ -117,13 +117,17 @@ fn serialize_bare_item(out: &mut String, bare: &BareItem) {
         BareItem::DisplayString(s) => {
             out.push('%');
             out.push('"');
+            // RFC 9651 §3.3.8 / §4.1.11: encode %x00-1f / %x22 / %x25 / %x7f-ff
+            // with lowercase hex; allow ldash-char otherwise.
             for b in s.as_bytes() {
                 match *b {
-                    0x20..=0x21 | 0x23..=0x5b | 0x5d..=0x7e => out.push(*b as char),
+                    0x20..=0x21 | 0x23..=0x24 | 0x26..=0x5b | 0x5d..=0x7e => {
+                        out.push(*b as char);
+                    }
                     _ => {
                         out.push('%');
-                        out.push(char::from(HEX[(b >> 4) as usize]));
-                        out.push(char::from(HEX[(b & 0xf) as usize]));
+                        out.push(char::from(LC_HEX[(b >> 4) as usize]));
+                        out.push(char::from(LC_HEX[(b & 0xf) as usize]));
                     }
                 }
             }
@@ -132,7 +136,7 @@ fn serialize_bare_item(out: &mut String, bare: &BareItem) {
     }
 }
 
-const HEX: &[u8; 16] = b"0123456789ABCDEF";
+const LC_HEX: &[u8; 16] = b"0123456789abcdef";
 
 fn serialize_parameters(out: &mut String, params: &Parameters) {
     for p in &params.params {
@@ -192,7 +196,7 @@ fn serialize_parameters(out: &mut String, params: &Parameters) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::structured_fields::parse_dictionary;
+    use crate::util::structured_fields::{BareItem, Item, parse_dictionary, parse_item};
 
     #[test]
     fn round_trip_signature_input() {
@@ -210,5 +214,13 @@ mod tests {
         let dict = parse_dictionary(input).unwrap();
         let encoded = serialize_dictionary(&dict);
         assert_eq!(parse_dictionary(&encoded).unwrap(), dict);
+    }
+
+    #[test]
+    fn display_string_encodes_percent_and_uses_lowercase_hex() {
+        let item = Item::new(BareItem::DisplayString("100% café".into()));
+        let encoded = serialize_item_value(&item);
+        assert_eq!(encoded, "%\"100%25 caf%c3%a9\"");
+        assert_eq!(parse_item(&encoded).unwrap(), item);
     }
 }

--- a/rama-http-headers/src/util/structured_fields/types.rs
+++ b/rama-http-headers/src/util/structured_fields/types.rs
@@ -130,14 +130,26 @@ impl Item {
     }
 }
 
-/// Bare item kinds used by this subset.
+/// Bare item kinds used by this subset (RFC 9651).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BareItem {
     String(String),
     Token(String),
     ByteSequence(Vec<u8>),
     Integer(i64),
+    /// Decimal with up to 12 integer digits and 1..=3 fractional digits.
+    /// `fraction` is the fractional significand; `fraction_digits` is 1..=3.
+    Decimal {
+        negative: bool,
+        integer: u64,
+        fraction: u16,
+        fraction_digits: u8,
+    },
     Boolean(bool),
+    /// SF Date: integer seconds since Unix epoch.
+    Date(i64),
+    /// SF Display String (decoded Unicode / UTF-8 bytes).
+    DisplayString(String),
 }
 
 /// Ordered parameters attached to an Item or Inner List.
@@ -193,7 +205,15 @@ pub enum ParameterValue {
     String(String),
     Token(String),
     Integer(i64),
+    Decimal {
+        negative: bool,
+        integer: u64,
+        fraction: u16,
+        fraction_digits: u8,
+    },
     ByteSequence(Vec<u8>),
+    Date(i64),
+    DisplayString(String),
 }
 
 impl fmt::Display for BareItem {
@@ -202,9 +222,26 @@ impl fmt::Display for BareItem {
             Self::String(s) => write!(f, "\"{s}\""),
             Self::Token(t) => write!(f, "{t}"),
             Self::Integer(n) => write!(f, "{n}"),
+            Self::Decimal {
+                negative,
+                integer,
+                fraction,
+                fraction_digits,
+            } => {
+                if *negative {
+                    write!(f, "-")?;
+                }
+                write!(
+                    f,
+                    "{integer}.{fraction:0width$}",
+                    width = usize::from(*fraction_digits)
+                )
+            }
             Self::Boolean(true) => write!(f, "?1"),
             Self::Boolean(false) => write!(f, "?0"),
             Self::ByteSequence(_) => write!(f, ":…:"),
+            Self::Date(n) => write!(f, "@{n}"),
+            Self::DisplayString(s) => write!(f, "%\"{s}\""),
         }
     }
 }

--- a/rama-http-headers/src/util/structured_fields/types.rs
+++ b/rama-http-headers/src/util/structured_fields/types.rs
@@ -1,0 +1,190 @@
+//! Structured field value types (RFC 9651 subset).
+
+use std::fmt;
+
+/// A Structured Fields Dictionary (ordered members).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Dictionary {
+    pub members: Vec<(String, DictionaryMember)>,
+}
+
+impl Dictionary {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, key: &str) -> Option<&DictionaryMember> {
+        self.members.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+    }
+
+    pub fn insert(&mut self, key: impl Into<String>, value: DictionaryMember) {
+        let key = key.into();
+        if let Some((_, existing)) = self.members.iter_mut().find(|(k, _)| *k == key) {
+            *existing = value;
+        } else {
+            self.members.push((key, value));
+        }
+    }
+
+    pub fn keys(&self) -> impl Iterator<Item = &str> {
+        self.members.iter().map(|(k, _)| k.as_str())
+    }
+}
+
+/// A Dictionary member value: either an Item or an Inner List.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DictionaryMember {
+    Item(Item),
+    InnerList(InnerList),
+}
+
+/// An Inner List: ordered Items plus list-level Parameters.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct InnerList {
+    pub items: Vec<Item>,
+    pub parameters: Parameters,
+}
+
+impl InnerList {
+    #[must_use]
+    pub fn new(items: Vec<Item>) -> Self {
+        Self {
+            items,
+            parameters: Parameters::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_parameters(mut self, parameters: Parameters) -> Self {
+        self.parameters = parameters;
+        self
+    }
+}
+
+/// An Item: bare item plus parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Item {
+    pub bare: BareItem,
+    pub parameters: Parameters,
+}
+
+impl Item {
+    #[must_use]
+    pub fn new(bare: BareItem) -> Self {
+        Self {
+            bare,
+            parameters: Parameters::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_parameters(mut self, parameters: Parameters) -> Self {
+        self.parameters = parameters;
+        self
+    }
+
+    #[must_use]
+    pub fn string(s: impl Into<String>) -> Self {
+        Self::new(BareItem::String(s.into()))
+    }
+
+    #[must_use]
+    pub fn token(s: impl Into<String>) -> Self {
+        Self::new(BareItem::Token(s.into()))
+    }
+
+    #[must_use]
+    pub fn byte_sequence(bytes: impl Into<Vec<u8>>) -> Self {
+        Self::new(BareItem::ByteSequence(bytes.into()))
+    }
+
+    #[must_use]
+    pub fn integer(n: i64) -> Self {
+        Self::new(BareItem::Integer(n))
+    }
+
+    #[must_use]
+    pub fn boolean(b: bool) -> Self {
+        Self::new(BareItem::Boolean(b))
+    }
+}
+
+/// Bare item kinds used by this subset.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BareItem {
+    String(String),
+    Token(String),
+    ByteSequence(Vec<u8>),
+    Integer(i64),
+    Boolean(bool),
+}
+
+/// Ordered parameters attached to an Item or Inner List.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Parameters {
+    pub params: Vec<Parameter>,
+}
+
+impl Parameters {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get(&self, name: &str) -> Option<&ParameterValue> {
+        self.params
+            .iter()
+            .find(|p| p.name == name)
+            .map(|p| &p.value)
+    }
+
+    pub fn insert(&mut self, name: impl Into<String>, value: ParameterValue) {
+        let name = name.into();
+        if let Some(existing) = self.params.iter_mut().find(|p| p.name == name) {
+            existing.value = value;
+        } else {
+            self.params.push(Parameter { name, value });
+        }
+    }
+
+    #[must_use]
+    pub fn with(mut self, name: impl Into<String>, value: ParameterValue) -> Self {
+        self.insert(name, value);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.params.is_empty()
+    }
+}
+
+/// A single parameter (`name` or `name=value`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Parameter {
+    pub name: String,
+    pub value: ParameterValue,
+}
+
+/// Parameter values (boolean true when bare flag with no `=`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParameterValue {
+    Boolean(bool),
+    String(String),
+    Token(String),
+    Integer(i64),
+    ByteSequence(Vec<u8>),
+}
+
+impl fmt::Display for BareItem {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::String(s) => write!(f, "\"{s}\""),
+            Self::Token(t) => write!(f, "{t}"),
+            Self::Integer(n) => write!(f, "{n}"),
+            Self::Boolean(true) => write!(f, "?1"),
+            Self::Boolean(false) => write!(f, "?0"),
+            Self::ByteSequence(_) => write!(f, ":…:"),
+        }
+    }
+}

--- a/rama-http-headers/src/util/structured_fields/types.rs
+++ b/rama-http-headers/src/util/structured_fields/types.rs
@@ -39,6 +39,26 @@ pub enum DictionaryMember {
     InnerList(InnerList),
 }
 
+/// An SF List: ordered members (RFC 9651 §3.1). Used by `;sf` field serialization.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct List {
+    pub members: Vec<ListMember>,
+}
+
+impl List {
+    #[must_use]
+    pub fn new(members: Vec<ListMember>) -> Self {
+        Self { members }
+    }
+}
+
+/// A List member value: either an Item or an Inner List.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ListMember {
+    Item(Item),
+    InnerList(InnerList),
+}
+
 /// An Inner List: ordered Items plus list-level Parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct InnerList {

--- a/rama-http-types/src/header/mod.rs
+++ b/rama-http-types/src/header/mod.rs
@@ -193,6 +193,8 @@ pub use self::name::{
     SEC_CH_DOWNLINK,
     ACCEPT_CH,
     CRITICAL_CH,
+    SIGNATURE,
+    SIGNATURE_INPUT,
 };
 
 /// Maximum length of a header name

--- a/rama-http-types/src/header/name.rs
+++ b/rama-http-types/src/header/name.rs
@@ -1140,6 +1140,12 @@ standard_headers! {
 
     /// `Critical-CH` — critical client-hint negotiation.
     (CriticalCh, CRITICAL_CH, b"critical-ch");
+
+    /// `Signature` — HTTP Message Signatures (RFC 9421).
+    (Signature, SIGNATURE, b"signature");
+
+    /// `Signature-Input` — HTTP Message Signatures (RFC 9421).
+    (SignatureInput, SIGNATURE_INPUT, b"signature-input");
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/rama-http/specifications/rfc9421.md
+++ b/rama-http/specifications/rfc9421.md
@@ -1,0 +1,13 @@
+# RFC 9421 — HTTP Message Signatures
+
+Canonical specification:
+https://www.rfc-editor.org/rfc/rfc9421.html
+
+Related: RFC 9530 (Digest Fields / Content-Digest):
+https://www.rfc-editor.org/rfc/rfc9530.html
+
+Structured Fields (RFC 9651) are used by Signature / Signature-Input:
+https://www.rfc-editor.org/rfc/rfc9651.html
+
+rama implements signing/verification layers behind the `message-signature`
+Cargo feature on `rama-http`, with crypto primitives in `rama-crypto::http_message_signature`.

--- a/rama-http/src/layer/message_signature/base.rs
+++ b/rama-http/src/layer/message_signature/base.rs
@@ -88,18 +88,14 @@ fn validate_component_value_ascii(value: &str) -> Result<(), SignatureBaseError>
         ));
     }
     if !value.is_ascii() {
-        return Err(SignatureBaseError::new(
-            "component value must be ASCII",
-        ));
+        return Err(SignatureBaseError::new("component value must be ASCII"));
     }
     Ok(())
 }
 
 fn validate_signature_base_ascii(base: &str) -> Result<(), SignatureBaseError> {
     if !base.is_ascii() {
-        return Err(SignatureBaseError::new(
-            "signature base must be ASCII",
-        ));
+        return Err(SignatureBaseError::new("signature base must be ASCII"));
     }
     // Printable ASCII + LF separators between lines (already joined with \n)
     for b in base.bytes() {
@@ -223,12 +219,7 @@ mod tests {
                 .with("key", ParameterValue::String("sha-256".into()))
                 .with("sf", ParameterValue::Boolean(true)),
         );
-        let err = build_signature_base(
-            &ctx,
-            &[a, b],
-            &SignatureParameters::default(),
-        )
-        .unwrap_err();
+        let err = build_signature_base(&ctx, &[a, b], &SignatureParameters::default()).unwrap_err();
         assert!(err.message.contains("duplicate"));
     }
 }

--- a/rama-http/src/layer/message_signature/base.rs
+++ b/rama-http/src/layer/message_signature/base.rs
@@ -1,0 +1,174 @@
+//! Signature base assembly (RFC 9421 §2.5).
+
+use rama_http_headers::signature_input::{
+    ComponentIdentifier, SignatureParameters, SignatureParams,
+};
+use rama_http_headers::{SignatureInput, serialize_signature_params_value};
+use std::fmt;
+
+use super::component::{
+    ComponentContext, ComponentError, resolve_component_value, serialize_component_identifier,
+};
+
+/// Error building a signature base.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureBaseError {
+    pub message: String,
+}
+
+impl SignatureBaseError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for SignatureBaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "signature base error: {}", self.message)
+    }
+}
+
+impl std::error::Error for SignatureBaseError {}
+
+impl From<ComponentError> for SignatureBaseError {
+    fn from(e: ComponentError) -> Self {
+        Self { message: e.message }
+    }
+}
+
+/// Build the signature base string for the given covered components and params.
+///
+/// The result is the exact byte sequence (as UTF-8 string) passed to HTTP_SIGN / HTTP_VERIFY.
+pub fn build_signature_base(
+    ctx: &ComponentContext<'_>,
+    components: &[ComponentIdentifier],
+    parameters: &SignatureParameters,
+) -> Result<String, SignatureBaseError> {
+    // Dedup check: each component identifier (name + params) must appear once
+    let mut seen = Vec::new();
+    for c in components {
+        let key = serialize_component_identifier(c);
+        if seen.iter().any(|s| s == &key) {
+            return Err(SignatureBaseError::new(format!(
+                "duplicate component identifier: {key}"
+            )));
+        }
+        seen.push(key);
+    }
+
+    let mut lines = Vec::with_capacity(components.len() + 1);
+    for c in components {
+        let value = resolve_component_value(ctx, c)?;
+        if value.contains('\n') {
+            return Err(SignatureBaseError::new(
+                "component value must not contain newline",
+            ));
+        }
+        let id = serialize_component_identifier(c);
+        lines.push(format!("{id}: {value}"));
+    }
+
+    let params = SignatureParams {
+        components: components.to_vec(),
+        parameters: parameters.clone(),
+    };
+    let params_line = build_signature_params_line(&params);
+    lines.push(format!("\"@signature-params\": {params_line}"));
+
+    Ok(lines.join("\n"))
+}
+
+/// Serialize the `@signature-params` component value (Inner List + params).
+#[must_use]
+pub fn build_signature_params_line(params: &SignatureParams) -> String {
+    // Re-export path: use the same serialization as Signature-Input member values
+    serialize_signature_params_value(params)
+}
+
+/// Build a [`SignatureInput`] entry for a label from components + parameters.
+#[must_use]
+pub fn signature_input_for_label(
+    label: impl Into<String>,
+    components: Vec<ComponentIdentifier>,
+    parameters: SignatureParameters,
+) -> SignatureInput {
+    let mut input = SignatureInput::new();
+    input.insert(
+        label,
+        SignatureParams {
+            components,
+            parameters,
+        },
+    );
+    input
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama_http_types::{HeaderMap, HeaderValue, Method, Request};
+
+    /// RFC 9421 §4.3 proxy signature-base example (without content-digest body specifics).
+    #[test]
+    fn rfc_4_3_signature_base_shape() {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-type", HeaderValue::from_static("application/json"));
+        headers.insert("content-length", HeaderValue::from_static("18"));
+        headers.insert(
+            "content-digest",
+            HeaderValue::from_static(
+                "sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:",
+            ),
+        );
+        headers.insert(
+            "forwarded",
+            HeaderValue::from_static("for=192.0.2.123;host=example.com;proto=https"),
+        );
+        headers.insert(
+            "host",
+            HeaderValue::from_static("origin.host.internal.example"),
+        );
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("https://origin.host.internal.example/foo?param=Value&Pet=dog")
+            .body(())
+            .unwrap();
+        // Use builder headers + our map
+        let mut req = req;
+        *req.headers_mut() = headers;
+
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let components = vec![
+            ComponentIdentifier::new("@method"),
+            ComponentIdentifier::new("@authority"),
+            ComponentIdentifier::new("@path"),
+            ComponentIdentifier::new("content-digest"),
+            ComponentIdentifier::new("content-type"),
+            ComponentIdentifier::new("content-length"),
+            ComponentIdentifier::new("forwarded"),
+        ];
+        let parameters = SignatureParameters {
+            created: Some(1618884480),
+            expires: Some(1618884540),
+            keyid: Some("test-key-rsa".into()),
+            alg: Some("rsa-v1_5-sha256".into()),
+            ..Default::default()
+        };
+
+        let base = build_signature_base(&ctx, &components, &parameters).unwrap();
+        let expected = "\
+\"@method\": POST\n\
+\"@authority\": origin.host.internal.example\n\
+\"@path\": /foo\n\
+\"content-digest\": sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:\n\
+\"content-type\": application/json\n\
+\"content-length\": 18\n\
+\"forwarded\": for=192.0.2.123;host=example.com;proto=https\n\
+\"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\" \"forwarded\");created=1618884480;expires=1618884540;alg=\"rsa-v1_5-sha256\";keyid=\"test-key-rsa\"";
+
+        assert_eq!(base, expected);
+    }
+}

--- a/rama-http/src/layer/message_signature/base.rs
+++ b/rama-http/src/layer/message_signature/base.rs
@@ -7,7 +7,8 @@ use rama_http_headers::{SignatureInput, serialize_signature_params_value};
 use std::fmt;
 
 use super::component::{
-    ComponentContext, ComponentError, resolve_component_value, serialize_component_identifier,
+    ComponentContext, ComponentError, component_identity_key, resolve_component_value,
+    serialize_component_identifier,
 };
 
 /// Error building a signature base.
@@ -46,13 +47,14 @@ pub fn build_signature_base(
     components: &[ComponentIdentifier],
     parameters: &SignatureParameters,
 ) -> Result<String, SignatureBaseError> {
-    // Dedup check: each component identifier (name + params) must appear once
+    // Dedup: component identifiers that differ only by parameter order are duplicates.
     let mut seen = Vec::new();
     for c in components {
-        let key = serialize_component_identifier(c);
+        let key = component_identity_key(c);
         if seen.iter().any(|s| s == &key) {
             return Err(SignatureBaseError::new(format!(
-                "duplicate component identifier: {key}"
+                "duplicate component identifier: {}",
+                serialize_component_identifier(c)
             )));
         }
         seen.push(key);
@@ -61,11 +63,7 @@ pub fn build_signature_base(
     let mut lines = Vec::with_capacity(components.len() + 1);
     for c in components {
         let value = resolve_component_value(ctx, c)?;
-        if value.contains('\n') {
-            return Err(SignatureBaseError::new(
-                "component value must not contain newline",
-            ));
-        }
+        validate_component_value_ascii(&value)?;
         let id = serialize_component_identifier(c);
         lines.push(format!("{id}: {value}"));
     }
@@ -75,15 +73,48 @@ pub fn build_signature_base(
         parameters: parameters.clone(),
     };
     let params_line = build_signature_params_line(&params);
+    validate_component_value_ascii(&params_line)?;
     lines.push(format!("\"@signature-params\": {params_line}"));
 
-    Ok(lines.join("\n"))
+    let base = lines.join("\n");
+    validate_signature_base_ascii(&base)?;
+    Ok(base)
+}
+
+fn validate_component_value_ascii(value: &str) -> Result<(), SignatureBaseError> {
+    if value.contains('\n') || value.contains('\r') {
+        return Err(SignatureBaseError::new(
+            "component value must not contain CR or LF",
+        ));
+    }
+    if !value.is_ascii() {
+        return Err(SignatureBaseError::new(
+            "component value must be ASCII",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_signature_base_ascii(base: &str) -> Result<(), SignatureBaseError> {
+    if !base.is_ascii() {
+        return Err(SignatureBaseError::new(
+            "signature base must be ASCII",
+        ));
+    }
+    // Printable ASCII + LF separators between lines (already joined with \n)
+    for b in base.bytes() {
+        if b != b'\n' && !(0x20..=0x7e).contains(&b) {
+            return Err(SignatureBaseError::new(
+                "signature base contains non-printable ASCII",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Serialize the `@signature-params` component value (Inner List + params).
 #[must_use]
 pub fn build_signature_params_line(params: &SignatureParams) -> String {
-    // Re-export path: use the same serialization as Signature-Input member values
     serialize_signature_params_value(params)
 }
 
@@ -108,6 +139,7 @@ pub fn signature_input_for_label(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rama_http_headers::util::structured_fields::{ParameterValue, Parameters};
     use rama_http_types::{HeaderMap, HeaderValue, Method, Request};
 
     /// RFC 9421 §4.3 proxy signature-base example (without content-digest body specifics).
@@ -136,7 +168,6 @@ mod tests {
             .uri("https://origin.host.internal.example/foo?param=Value&Pet=dog")
             .body(())
             .unwrap();
-        // Use builder headers + our map
         let mut req = req;
         *req.headers_mut() = headers;
 
@@ -150,13 +181,11 @@ mod tests {
             ComponentIdentifier::new("content-length"),
             ComponentIdentifier::new("forwarded"),
         ];
-        let parameters = SignatureParameters {
-            created: Some(1618884480),
-            expires: Some(1618884540),
-            keyid: Some("test-key-rsa".into()),
-            alg: Some("rsa-v1_5-sha256".into()),
-            ..Default::default()
-        };
+        let mut parameters = SignatureParameters::new();
+        parameters.created = Some(1618884480);
+        parameters.expires = Some(1618884540);
+        parameters.keyid = Some("test-key-rsa".into());
+        parameters.alg = Some("rsa-v1_5-sha256".into());
 
         let base = build_signature_base(&ctx, &components, &parameters).unwrap();
         let expected = "\
@@ -170,5 +199,36 @@ mod tests {
 \"@signature-params\": (\"@method\" \"@authority\" \"@path\" \"content-digest\" \"content-type\" \"content-length\" \"forwarded\");created=1618884480;expires=1618884540;alg=\"rsa-v1_5-sha256\";keyid=\"test-key-rsa\"";
 
         assert_eq!(base, expected);
+    }
+
+    #[test]
+    fn duplicate_components_param_order_independent() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header(
+                "content-digest",
+                "sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:",
+            )
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let a = ComponentIdentifier::new("content-digest").with_parameters(
+            Parameters::new()
+                .with("sf", ParameterValue::Boolean(true))
+                .with("key", ParameterValue::String("sha-256".into())),
+        );
+        let b = ComponentIdentifier::new("content-digest").with_parameters(
+            Parameters::new()
+                .with("key", ParameterValue::String("sha-256".into()))
+                .with("sf", ParameterValue::Boolean(true)),
+        );
+        let err = build_signature_base(
+            &ctx,
+            &[a, b],
+            &SignatureParameters::default(),
+        )
+        .unwrap_err();
+        assert!(err.message.contains("duplicate"));
     }
 }

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -3,8 +3,8 @@
 use rama_core::bytes::BytesMut;
 use rama_http_headers::signature_input::ComponentIdentifier;
 use rama_http_headers::util::structured_fields::{
-    Dictionary, DictionaryMember, ParameterValue, parse_dictionary, parse_item, parse_list,
-    serialize_dictionary, serialize_item_value, serialize_list,
+    DictionaryMember, ParameterValue, parse_dictionary, parse_item, parse_list,
+    serialize_dictionary, serialize_inner_list_value, serialize_item_value, serialize_list,
 };
 use rama_http_types::{HeaderMap, HeaderName, Method, StatusCode};
 use rama_net::address::HostRef;
@@ -658,18 +658,8 @@ fn trim_http_ows(s: &str) -> &str {
 
 fn serialize_dictionary_member(member: &DictionaryMember) -> String {
     match member {
-        DictionaryMember::Item(item) => {
-            let mut dict = Dictionary::new();
-            dict.insert("_", DictionaryMember::Item(item.clone()));
-            let full = serialize_dictionary(&dict);
-            full.strip_prefix("_=").unwrap_or(&full).to_owned()
-        }
-        DictionaryMember::InnerList(list) => {
-            let mut dict = Dictionary::new();
-            dict.insert("_", DictionaryMember::InnerList(list.clone()));
-            let full = serialize_dictionary(&dict);
-            full.strip_prefix("_=").unwrap_or(&full).to_owned()
-        }
+        DictionaryMember::Item(item) => serialize_item_value(item),
+        DictionaryMember::InnerList(list) => serialize_inner_list_value(list),
     }
 }
 
@@ -994,6 +984,21 @@ mod tests {
             resolve_component_value(&ctx, &ComponentIdentifier::new("@target-uri")).unwrap(),
             "https://example.com/foo?bar=1"
         );
+    }
+
+    #[test]
+    fn key_boolean_true_serializes_as_sf_boolean() {
+        // RFC 9421 §2.1.2: boolean-true dictionary members serialize as `?1` with ;key.
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("example-dict", "a=1, d")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("example-dict")
+            .with_parameters(Parameters::new().with("key", ParameterValue::String("d".into())));
+        assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "?1");
     }
 
     #[test]

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -19,6 +19,27 @@ pub enum MessageKind {
     Response,
 }
 
+/// Expected Structured Fields type for `;sf` serialization (RFC 9421 §2.1.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructuredFieldType {
+    Dictionary,
+    List,
+    Item,
+}
+
+/// Resolve the application-known SF type for a field name.
+///
+/// RFC 9421 requires the application to know the field type when using `;sf`.
+/// Unknown fields must not guess between Dictionary/List/Item.
+pub fn known_structured_field_type(field_name: &str) -> Option<StructuredFieldType> {
+    match field_name {
+        "content-digest" | "repr-digest" | "accept-digest" | "signature" | "signature-input" => {
+            Some(StructuredFieldType::Dictionary)
+        }
+        _ => None,
+    }
+}
+
 /// Context needed to resolve component values from an HTTP message.
 #[derive(Debug, Clone)]
 pub struct ComponentContext<'a> {
@@ -30,6 +51,8 @@ pub struct ComponentContext<'a> {
     pub trailers: Option<&'a HeaderMap>,
     /// Scheme used when reconstructing `@target-uri` for origin-form requests.
     pub scheme_hint: Option<&'a str>,
+    /// Optional overrides for `;sf` field types (field name → type).
+    pub sf_types: Option<&'a ahash::HashMap<String, StructuredFieldType>>,
     /// Related request headers/uri/method when resolving `req` components on a response.
     pub related_request: Option<Box<Self>>,
 }
@@ -45,6 +68,7 @@ impl<'a> ComponentContext<'a> {
             headers,
             trailers: None,
             scheme_hint: None,
+            sf_types: None,
             related_request: None,
         }
     }
@@ -59,6 +83,7 @@ impl<'a> ComponentContext<'a> {
             headers,
             trailers: None,
             scheme_hint: None,
+            sf_types: None,
             related_request: None,
         }
     }
@@ -78,6 +103,15 @@ impl<'a> ComponentContext<'a> {
     #[must_use]
     pub fn with_scheme_hint(mut self, scheme: &'a str) -> Self {
         self.scheme_hint = Some(scheme);
+        self
+    }
+
+    #[must_use]
+    pub fn with_sf_types(
+        mut self,
+        sf_types: &'a ahash::HashMap<String, StructuredFieldType>,
+    ) -> Self {
+        self.sf_types = Some(sf_types);
         self
     }
 }
@@ -530,8 +564,17 @@ fn resolve_field(
             })?;
             return Ok(serialize_dictionary_member(member));
         }
-        // Strict SF serialization — fail closed if the field is not a known SF type.
-        return serialize_strict_sf(&combined).map_err(|e| {
+        // Strict SF serialization — require application-known field type (RFC 9421 §2.1.1).
+        let sf_type = ctx
+            .sf_types
+            .and_then(|m| m.get(name).copied())
+            .or_else(|| known_structured_field_type(name))
+            .ok_or_else(|| {
+                ComponentError::new(format!(
+                    ";sf requires a known structured field type for {name}"
+                ))
+            })?;
+        return serialize_strict_sf(&combined, sf_type).map_err(|e| {
             ComponentError::new(format!("field {name} is not a valid structured field: {e}"))
         });
     }
@@ -571,17 +614,21 @@ fn canonicalize_field_value_bytes(raw: &[u8]) -> Result<Vec<u8>, ComponentError>
     Ok(normalized[start..end].to_vec())
 }
 
-fn serialize_strict_sf(combined: &str) -> Result<String, String> {
-    if let Ok(dict) = parse_dictionary(combined) {
-        return Ok(serialize_dictionary(&dict));
+fn serialize_strict_sf(combined: &str, sf_type: StructuredFieldType) -> Result<String, String> {
+    match sf_type {
+        StructuredFieldType::Dictionary => {
+            let dict = parse_dictionary(combined).map_err(|e| e.to_string())?;
+            Ok(serialize_dictionary(&dict))
+        }
+        StructuredFieldType::List => {
+            let list = parse_list(combined).map_err(|e| e.to_string())?;
+            Ok(serialize_list(&list))
+        }
+        StructuredFieldType::Item => {
+            let item = parse_item(combined).map_err(|e| e.to_string())?;
+            Ok(serialize_item_value(&item))
+        }
     }
-    if let Ok(list) = parse_list(combined) {
-        return Ok(serialize_list(&list));
-    }
-    if let Ok(item) = parse_item(combined) {
-        return Ok(serialize_item_value(&item));
-    }
-    Err("not a dictionary, list, or item".into())
 }
 
 fn combine_field_values(map: &HeaderMap, name: &HeaderName) -> Result<String, ComponentError> {
@@ -766,6 +813,13 @@ mod tests {
         let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
         let id = ComponentIdentifier::new("x-plain")
             .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
+        // Unknown field type: fail closed without guessing.
+        resolve_component_value(&ctx, &id).unwrap_err();
+
+        use ahash::{HashMap, HashMapExt as _};
+        let mut types = HashMap::new();
+        types.insert("x-plain".into(), StructuredFieldType::Item);
+        let ctx = ctx.with_sf_types(&types);
         resolve_component_value(&ctx, &id).unwrap_err();
     }
 
@@ -777,10 +831,31 @@ mod tests {
             .header("example", "1.50")
             .body(())
             .unwrap();
-        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        use ahash::{HashMap, HashMapExt as _};
+        let mut types = HashMap::new();
+        types.insert("example".into(), StructuredFieldType::Item);
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers())
+            .with_sf_types(&types);
         let id = ComponentIdentifier::new("example")
             .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
         assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "1.5");
+    }
+
+    #[test]
+    fn sf_known_builtin_content_digest() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("content-digest", "sha-256=:YQ==:")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("content-digest")
+            .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
+        assert_eq!(
+            resolve_component_value(&ctx, &id).unwrap(),
+            "sha-256=:YQ==:"
+        );
     }
 
     #[test]

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -1,12 +1,16 @@
 //! HTTP message component identifiers and canonicalization (RFC 9421 §2).
 
+use rama_core::bytes::BytesMut;
 use rama_http_headers::signature_input::ComponentIdentifier;
 use rama_http_headers::util::structured_fields::{
-    Dictionary, DictionaryMember, ParameterValue, parse_dictionary, serialize_dictionary,
+    Dictionary, DictionaryMember, ParameterValue, parse_dictionary, parse_item, parse_list,
+    serialize_dictionary, serialize_item_value, serialize_list,
 };
 use rama_http_types::{HeaderMap, HeaderName, Method, StatusCode};
+use rama_net::address::HostRef;
 use rama_net::uri::Uri;
 use std::fmt;
+use std::net::IpAddr;
 
 /// Whether the target message is a request or a response.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -24,6 +28,8 @@ pub struct ComponentContext<'a> {
     pub status: Option<StatusCode>,
     pub headers: &'a HeaderMap,
     pub trailers: Option<&'a HeaderMap>,
+    /// Scheme used when reconstructing `@target-uri` for origin-form requests.
+    pub scheme_hint: Option<&'a str>,
     /// Related request headers/uri/method when resolving `req` components on a response.
     pub related_request: Option<Box<Self>>,
 }
@@ -38,6 +44,7 @@ impl<'a> ComponentContext<'a> {
             status: None,
             headers,
             trailers: None,
+            scheme_hint: None,
             related_request: None,
         }
     }
@@ -51,6 +58,7 @@ impl<'a> ComponentContext<'a> {
             status: Some(status),
             headers,
             trailers: None,
+            scheme_hint: None,
             related_request: None,
         }
     }
@@ -64,6 +72,12 @@ impl<'a> ComponentContext<'a> {
     #[must_use]
     pub fn with_trailers(mut self, trailers: &'a HeaderMap) -> Self {
         self.trailers = Some(trailers);
+        self
+    }
+
+    #[must_use]
+    pub fn with_scheme_hint(mut self, scheme: &'a str) -> Self {
+        self.scheme_hint = Some(scheme);
         self
     }
 }
@@ -95,6 +109,8 @@ pub fn resolve_component_value(
     ctx: &ComponentContext<'_>,
     id: &ComponentIdentifier,
 ) -> Result<String, ComponentError> {
+    validate_component_parameters(id)?;
+
     let use_req = id
         .parameters
         .get("req")
@@ -118,20 +134,65 @@ pub fn resolve_component_value(
     }
 }
 
+/// Reject unknown / inapplicable component parameters (RFC 9421 §2.5).
+fn validate_component_parameters(id: &ComponentIdentifier) -> Result<(), ComponentError> {
+    let is_derived = id.name.starts_with('@');
+    for p in &id.parameters.params {
+        match p.name.as_str() {
+            "req" => {
+                if !matches!(p.value, ParameterValue::Boolean(true)) {
+                    return Err(ComponentError::new(";req must be a boolean true flag"));
+                }
+            }
+            "sf" | "bs" | "tr" => {
+                if is_derived {
+                    return Err(ComponentError::new(format!(
+                        "derived component {} must not have ;{}",
+                        id.name, p.name
+                    )));
+                }
+                if !matches!(p.value, ParameterValue::Boolean(true)) {
+                    return Err(ComponentError::new(format!(
+                        ";{} must be a boolean true flag",
+                        p.name
+                    )));
+                }
+            }
+            "key" => {
+                if is_derived {
+                    return Err(ComponentError::new(format!(
+                        "derived component {} must not have ;key",
+                        id.name
+                    )));
+                }
+                if !matches!(p.value, ParameterValue::String(_)) {
+                    return Err(ComponentError::new(";key requires a string value"));
+                }
+            }
+            "name" => {
+                if id.name != "@query-param" {
+                    return Err(ComponentError::new(
+                        ";name is only valid on @query-param",
+                    ));
+                }
+                if !matches!(p.value, ParameterValue::String(_)) {
+                    return Err(ComponentError::new(";name requires a string value"));
+                }
+            }
+            other => {
+                return Err(ComponentError::new(format!(
+                    "unknown component parameter: {other}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn resolve_derived(
     ctx: &ComponentContext<'_>,
     id: &ComponentIdentifier,
 ) -> Result<String, ComponentError> {
-    // Derived components must not carry sf/bs/tr
-    for forbidden in ["sf", "bs", "tr"] {
-        if id.parameters.get(forbidden).is_some() {
-            return Err(ComponentError::new(format!(
-                "derived component {} must not have ;{forbidden}",
-                id.name
-            )));
-        }
-    }
-
     match id.name.as_str() {
         "@method" => {
             let method = ctx
@@ -139,79 +200,44 @@ fn resolve_derived(
                 .ok_or_else(|| ComponentError::new("@method requires a request"))?;
             Ok(method.as_str().to_owned())
         }
-        "@authority" => {
-            let uri = ctx
-                .uri
-                .ok_or_else(|| ComponentError::new("@authority requires a request URI"))?;
-            let authority = uri
-                .authority()
-                .map(|a| a.to_string().to_ascii_lowercase())
-                .or_else(|| {
-                    ctx.headers
-                        .get(rama_http_types::header::HOST)
-                        .and_then(|v| v.to_str().ok())
-                        .map(|s| s.to_ascii_lowercase())
-                })
-                .ok_or_else(|| ComponentError::new("@authority not available"))?;
-            Ok(authority)
-        }
+        "@authority" => authority_value(ctx),
         "@scheme" => {
             let uri = ctx
                 .uri
                 .ok_or_else(|| ComponentError::new("@scheme requires a request URI"))?;
             let scheme = uri
                 .scheme_str()
+                .or(ctx.scheme_hint)
                 .ok_or_else(|| ComponentError::new("@scheme not available"))?
                 .to_ascii_lowercase();
             Ok(scheme)
         }
-        "@target-uri" => {
-            let uri = ctx
-                .uri
-                .ok_or_else(|| ComponentError::new("@target-uri requires a request URI"))?;
-            Ok(uri.to_string())
-        }
-        "@request-target" => {
-            let uri = ctx
-                .uri
-                .ok_or_else(|| ComponentError::new("@request-target requires a request URI"))?;
-            let path = uri.path_or_root();
-            match uri.query() {
-                Some(q) => Ok(format!("{path}?{}", q.as_encoded_str())),
-                None => Ok(path.into_owned()),
-            }
-        }
+        "@target-uri" => target_uri_value(ctx),
+        "@request-target" => request_target_value(ctx),
         "@path" => {
             let uri = ctx
                 .uri
                 .ok_or_else(|| ComponentError::new("@path requires a request URI"))?;
+            if uri.is_asterisk() {
+                return Err(ComponentError::new("@path is not available for asterisk-form"));
+            }
             Ok(uri.path_or_root().into_owned())
         }
         "@query" => {
             let uri = ctx
                 .uri
                 .ok_or_else(|| ComponentError::new("@query requires a request URI"))?;
+            if uri.is_asterisk() {
+                return Err(ComponentError::new(
+                    "@query is not available for asterisk-form",
+                ));
+            }
             match uri.query() {
                 Some(q) => Ok(format!("?{}", q.as_encoded_str())),
                 None => Ok("?".to_owned()),
             }
         }
-        "@query-param" => {
-            let name = match id.parameters.get("name") {
-                Some(ParameterValue::String(s)) => s.clone(),
-                _ => {
-                    return Err(ComponentError::new(
-                        "@query-param requires ;name=\"...\" parameter",
-                    ));
-                }
-            };
-            let uri = ctx
-                .uri
-                .ok_or_else(|| ComponentError::new("@query-param requires a request URI"))?;
-            uri.first_query_value(name.as_str())
-                .map(|v| v.into_owned())
-                .ok_or_else(|| ComponentError::new(format!("@query-param name={name} not found")))
-        }
+        "@query-param" => query_param_value(ctx, id),
         "@status" => {
             let status = ctx
                 .status
@@ -226,6 +252,197 @@ fn resolve_derived(
         ))),
     }
 }
+
+fn authority_value(ctx: &ComponentContext<'_>) -> Result<String, ComponentError> {
+    let uri = ctx
+        .uri
+        .ok_or_else(|| ComponentError::new("@authority requires a request URI"))?;
+
+    if let Some(auth) = uri.authority() {
+        return Ok(format_authority_host_port(
+            auth.host(),
+            auth.port_u16(),
+            uri.scheme().and_then(|s| s.default_port()),
+        ));
+    }
+
+    let host = ctx
+        .headers
+        .get(rama_http_types::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| ComponentError::new("@authority not available"))?;
+    Ok(strip_default_port_from_host_header(
+        host,
+        uri.scheme()
+            .and_then(|s| s.default_port())
+            .or_else(|| {
+                ctx.scheme_hint.and_then(|s| match s.to_ascii_lowercase().as_str() {
+                    "http" | "ws" => Some(80),
+                    "https" | "wss" => Some(443),
+                    _ => None,
+                })
+            }),
+    )
+    .to_ascii_lowercase())
+}
+
+fn format_authority_host_port(
+    host: HostRef<'_>,
+    port: Option<u16>,
+    default_port: Option<u16>,
+) -> String {
+    let host = match host {
+        HostRef::Address(IpAddr::V6(ip)) => format!("[{ip}]"),
+        other => other.to_string(),
+    }
+    .to_ascii_lowercase();
+    match (port, default_port) {
+        (Some(p), Some(d)) if p == d => host,
+        (Some(p), _) => format!("{host}:{p}"),
+        (None, _) => host,
+    }
+}
+
+fn strip_default_port_from_host_header(host: &str, default_port: Option<u16>) -> String {
+    let Some(default_port) = default_port else {
+        return host.to_owned();
+    };
+    // IPv6 Host headers are `[addr]:port` or `[addr]`
+    if let Some(bracket_end) = host.find(']') {
+        let rest = &host[bracket_end + 1..];
+        if let Some(p) = rest.strip_prefix(':')
+            && p.parse::<u16>().ok() == Some(default_port)
+        {
+            return host[..=bracket_end].to_owned();
+        }
+        return host.to_owned();
+    }
+    if let Some((name, port)) = host.rsplit_once(':')
+        && !name.is_empty()
+        && port.parse::<u16>().ok() == Some(default_port)
+    {
+        return name.to_owned();
+    }
+    host.to_owned()
+}
+
+fn request_target_value(ctx: &ComponentContext<'_>) -> Result<String, ComponentError> {
+    let uri = ctx
+        .uri
+        .ok_or_else(|| ComponentError::new("@request-target requires a request URI"))?;
+    if uri.is_asterisk() {
+        return Ok("*".to_owned());
+    }
+    let mut buf = BytesMut::new();
+    if uri.scheme().is_some() {
+        uri.write_http_absolute_form(&mut buf)
+            .map_err(|e| ComponentError::new(format!("@request-target absolute-form: {e}")))?;
+    } else if uri.authority().is_some() && uri.is_path_empty() && uri.query().is_none() {
+        // CONNECT authority-form
+        uri.write_http_authority_form(&mut buf)
+            .map_err(|e| ComponentError::new(format!("@request-target authority-form: {e}")))?;
+    } else {
+        uri.write_http_origin_form(&mut buf)
+            .map_err(|e| ComponentError::new(format!("@request-target origin-form: {e}")))?;
+    }
+    String::from_utf8(buf.to_vec())
+        .map_err(|_err| ComponentError::new("@request-target is not UTF-8"))
+}
+
+fn target_uri_value(ctx: &ComponentContext<'_>) -> Result<String, ComponentError> {
+    let uri = ctx
+        .uri
+        .ok_or_else(|| ComponentError::new("@target-uri requires a request URI"))?;
+    if uri.is_asterisk() {
+        return Err(ComponentError::new(
+            "@target-uri is not available for asterisk-form",
+        ));
+    }
+    if uri.scheme().is_some() {
+        let mut buf = BytesMut::new();
+        uri.write_http_absolute_form(&mut buf)
+            .map_err(|e| ComponentError::new(format!("@target-uri: {e}")))?;
+        return String::from_utf8(buf.to_vec())
+            .map_err(|_err| ComponentError::new("@target-uri is not UTF-8"));
+    }
+
+    let scheme = ctx
+        .scheme_hint
+        .ok_or_else(|| {
+            ComponentError::new(
+                "@target-uri requires an absolute URI or a scheme_hint for origin-form",
+            )
+        })?
+        .to_ascii_lowercase();
+    let authority = authority_value(ctx)?;
+    let mut buf = BytesMut::new();
+    uri.write_http_origin_form(&mut buf)
+        .map_err(|e| ComponentError::new(format!("@target-uri path: {e}")))?;
+    let path_query = String::from_utf8(buf.to_vec())
+        .map_err(|_err| ComponentError::new("@target-uri path is not UTF-8"))?;
+    Ok(format!("{scheme}://{authority}{path_query}"))
+}
+
+fn query_param_value(
+    ctx: &ComponentContext<'_>,
+    id: &ComponentIdentifier,
+) -> Result<String, ComponentError> {
+    let name = match id.parameters.get("name") {
+        Some(ParameterValue::String(s)) => s.clone(),
+        _ => {
+            return Err(ComponentError::new(
+                "@query-param requires ;name=\"...\" parameter",
+            ));
+        }
+    };
+    let uri = ctx
+        .uri
+        .ok_or_else(|| ComponentError::new("@query-param requires a request URI"))?;
+    let query = uri
+        .query()
+        .ok_or_else(|| ComponentError::new("@query-param: request has no query"))?;
+
+    // Match after form-decoding both the identifier name and query names.
+    let mut matches = query
+        .pairs()
+        .filter(|p| p.name_decoded() == name)
+        .collect::<Vec<_>>();
+    if matches.is_empty() {
+        return Err(ComponentError::new(format!(
+            "@query-param name={name} not found"
+        )));
+    }
+    if matches.len() > 1 {
+        return Err(ComponentError::new(format!(
+            "@query-param name={name} appears more than once"
+        )));
+    }
+    let value = matches
+        .pop()
+        .and_then(|p| p.value_decoded())
+        .unwrap_or_default();
+    Ok(form_urlencoded_percent_encode(&value))
+}
+
+/// application/x-www-form-urlencoded percent-encode with space as `%20` (RFC 9421 §2.2.8).
+fn form_urlencoded_percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &b in input.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'*' | b'-' | b'.' | b'_' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push(char::from(HEX[(b >> 4) as usize]));
+                out.push(char::from(HEX[(b & 0xf) as usize]));
+            }
+        }
+    }
+    out
+}
+
+const HEX: &[u8; 16] = b"0123456789ABCDEF";
 
 fn resolve_field(
     ctx: &ComponentContext<'_>,
@@ -269,7 +486,6 @@ fn resolve_field(
         .map_err(|_err| ComponentError::new("invalid field name"))?;
 
     if use_bs {
-        // Byte-sequence wrap each field value, serialize as SF List of byte sequences
         let values: Vec<_> = map.get_all(&header_name).iter().collect();
         if values.is_empty() {
             return Err(ComponentError::new(format!("field {name} not present")));
@@ -288,10 +504,8 @@ fn resolve_field(
     }
 
     if use_sf || key.is_some() {
-        // Combine field values and parse as Structured Field
         let combined = combine_field_values(map, &header_name)?;
         if let Some(key_name) = key {
-            // Dictionary member lookup
             let dict = parse_dictionary(&combined).map_err(|e| {
                 ComponentError::new(format!("field {name} is not a valid SF dictionary: {e}"))
             })?;
@@ -300,15 +514,26 @@ fn resolve_field(
             })?;
             return Ok(serialize_dictionary_member(member));
         }
-        // Strict SF serialization: re-parse and re-serialize dictionary (most common for Content-Digest)
-        if let Ok(dict) = parse_dictionary(&combined) {
-            return Ok(serialize_dictionary(&dict));
-        }
-        // Fallback: return combined as-is if not a dictionary (lists etc. — subset limitation)
-        return Ok(combined);
+        // Strict SF serialization — fail closed if the field is not a known SF type.
+        return serialize_strict_sf(&combined).map_err(|e| {
+            ComponentError::new(format!("field {name} is not a valid structured field: {e}"))
+        });
     }
 
     combine_field_values(map, &header_name)
+}
+
+fn serialize_strict_sf(combined: &str) -> Result<String, String> {
+    if let Ok(dict) = parse_dictionary(combined) {
+        return Ok(serialize_dictionary(&dict));
+    }
+    if let Ok(list) = parse_list(combined) {
+        return Ok(serialize_list(&list));
+    }
+    if let Ok(item) = parse_item(combined) {
+        return Ok(serialize_item_value(&item));
+    }
+    Err("not a dictionary, list, or item".into())
 }
 
 fn combine_field_values(map: &HeaderMap, name: &HeaderName) -> Result<String, ComponentError> {
@@ -354,10 +579,45 @@ pub fn serialize_component_identifier(id: &ComponentIdentifier) -> String {
     id.serialize_identifier()
 }
 
+/// Identity key for duplicate detection: name + parameters ignoring parameter order.
+pub fn component_identity_key(id: &ComponentIdentifier) -> String {
+    let mut params: Vec<_> = id
+        .parameters
+        .params
+        .iter()
+        .map(|p| {
+            let mut s = p.name.clone();
+            s.push('=');
+            match &p.value {
+                ParameterValue::Boolean(true) => s.push('1'),
+                ParameterValue::Boolean(false) => s.push('0'),
+                ParameterValue::String(v) => {
+                    s.push('"');
+                    s.push_str(v);
+                    s.push('"');
+                }
+                ParameterValue::Token(v) => s.push_str(v),
+                ParameterValue::Integer(n) => s.push_str(&n.to_string()),
+                ParameterValue::ByteSequence(b) => {
+                    use base64::Engine as _;
+                    s.push(':');
+                    s.push_str(&base64::engine::general_purpose::STANDARD.encode(b));
+                    s.push(':');
+                }
+            }
+            s
+        })
+        .collect();
+    params.sort();
+    format!("{}|{}", id.name.to_ascii_lowercase(), params.join("&"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rama_http_headers::util::structured_fields::Parameters;
     use rama_http_types::{Method, Request};
+    use rama_net::uri::Uri;
 
     #[test]
     fn derived_method_path_authority_query() {
@@ -387,6 +647,109 @@ mod tests {
     }
 
     #[test]
+    fn authority_strips_default_https_port() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com:443/foo")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@authority")).unwrap(),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn query_param_rejects_duplicates_and_reencodes() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/?Pet=dog&Pet=cat")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("@query-param").with_parameters(
+            Parameters::new().with("name", ParameterValue::String("Pet".into())),
+        );
+        assert!(resolve_component_value(&ctx, &id).is_err());
+
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/?q=a+b")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("@query-param").with_parameters(
+            Parameters::new().with("name", ParameterValue::String("q".into())),
+        );
+        assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "a%20b");
+    }
+
+    #[test]
+    fn sf_fails_closed_on_non_sf() {
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("x-plain", "not; a = structured field!!!")
+            .body(())
+            .unwrap();
+        let _ = &mut req;
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("x-plain")
+            .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
+        assert!(resolve_component_value(&ctx, &id).is_err());
+    }
+
+    #[test]
+    fn unknown_component_param_errors() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("@method")
+            .with_parameters(Parameters::new().with("foo", ParameterValue::Boolean(true)));
+        assert!(resolve_component_value(&ctx, &id).is_err());
+    }
+
+    #[test]
+    fn request_target_asterisk_and_authority_form() {
+        let uri = Uri::from_static("*");
+        let headers = HeaderMap::new();
+        let method = Method::OPTIONS;
+        let ctx = ComponentContext::for_request(&method, &uri, &headers);
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@request-target")).unwrap(),
+            "*"
+        );
+
+        let uri = Uri::parse_authority_form("example.com:443").unwrap();
+        let method = Method::CONNECT;
+        let ctx = ComponentContext::for_request(&method, &uri, &headers);
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@request-target")).unwrap(),
+            "example.com:443"
+        );
+    }
+
+    #[test]
+    fn target_uri_from_origin_form_with_scheme_hint() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/foo?bar=1")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers())
+            .with_scheme_hint("https");
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@target-uri")).unwrap(),
+            "https://example.com/foo?bar=1"
+        );
+    }
+
+    #[test]
     fn field_combine() {
         let mut req = Request::builder()
             .method(Method::GET)
@@ -403,5 +766,20 @@ mod tests {
             resolve_component_value(&ctx, &ComponentIdentifier::new("cache-control")).unwrap(),
             "max-age=60, must-revalidate"
         );
+    }
+
+    #[test]
+    fn component_identity_ignores_param_order() {
+        let a = ComponentIdentifier::new("digest").with_parameters(
+            Parameters::new()
+                .with("sf", ParameterValue::Boolean(true))
+                .with("key", ParameterValue::String("sha-256".into())),
+        );
+        let b = ComponentIdentifier::new("digest").with_parameters(
+            Parameters::new()
+                .with("key", ParameterValue::String("sha-256".into()))
+                .with("sf", ParameterValue::Boolean(true)),
+        );
+        assert_eq!(component_identity_key(&a), component_identity_key(&b));
     }
 }

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -117,6 +117,11 @@ pub fn resolve_component_value(
         .is_some_and(|v| matches!(v, ParameterValue::Boolean(true)));
 
     if use_req {
+        if ctx.kind == MessageKind::Request {
+            return Err(ComponentError::new(
+                ";req is not allowed when signing or verifying a request",
+            ));
+        }
         let related = ctx
             .related_request
             .as_deref()
@@ -171,9 +176,7 @@ fn validate_component_parameters(id: &ComponentIdentifier) -> Result<(), Compone
             }
             "name" => {
                 if id.name != "@query-param" {
-                    return Err(ComponentError::new(
-                        ";name is only valid on @query-param",
-                    ));
+                    return Err(ComponentError::new(";name is only valid on @query-param"));
                 }
                 if !matches!(p.value, ParameterValue::String(_)) {
                     return Err(ComponentError::new(";name requires a string value"));
@@ -219,7 +222,9 @@ fn resolve_derived(
                 .uri
                 .ok_or_else(|| ComponentError::new("@path requires a request URI"))?;
             if uri.is_asterisk() {
-                return Err(ComponentError::new("@path is not available for asterisk-form"));
+                return Err(ComponentError::new(
+                    "@path is not available for asterisk-form",
+                ));
             }
             Ok(uri.path_or_root().into_owned())
         }
@@ -273,15 +278,14 @@ fn authority_value(ctx: &ComponentContext<'_>) -> Result<String, ComponentError>
         .ok_or_else(|| ComponentError::new("@authority not available"))?;
     Ok(strip_default_port_from_host_header(
         host,
-        uri.scheme()
-            .and_then(|s| s.default_port())
-            .or_else(|| {
-                ctx.scheme_hint.and_then(|s| match s.to_ascii_lowercase().as_str() {
+        uri.scheme().and_then(|s| s.default_port()).or_else(|| {
+            ctx.scheme_hint
+                .and_then(|s| match s.to_ascii_lowercase().as_str() {
                     "http" | "ws" => Some(80),
                     "https" | "wss" => Some(443),
                     _ => None,
                 })
-            }),
+        }),
     )
     .to_ascii_lowercase())
 }
@@ -448,7 +452,13 @@ fn resolve_field(
     ctx: &ComponentContext<'_>,
     id: &ComponentIdentifier,
 ) -> Result<String, ComponentError> {
-    let name = id.name.to_ascii_lowercase();
+    // RFC 9421 §2.1: field component names MUST be lowercase in the signature base.
+    if id.name != id.name.to_ascii_lowercase() {
+        return Err(ComponentError::new(
+            "field component names must be lowercase",
+        ));
+    }
+    let name = id.name.as_str();
     if name.starts_with('@') {
         return Err(ComponentError::new("field names must not start with @"));
     }
@@ -470,8 +480,13 @@ fn resolve_field(
         _ => None,
     };
 
-    if use_sf && use_bs {
-        return Err(ComponentError::new(";sf and ;bs are mutually exclusive"));
+    if use_bs && (use_sf || key.is_some()) {
+        return Err(ComponentError::new(
+            ";bs is mutually exclusive with ;sf and ;key",
+        ));
+    }
+    if use_sf && key.is_none() {
+        // ;sf alone is fine; ;key without ;sf is also allowed for dictionary lookup
     }
 
     let map = if use_tr {
@@ -495,9 +510,10 @@ fn resolve_field(
             if i > 0 {
                 out.push_str(", ");
             }
+            let canonical = canonicalize_field_value_bytes(v.as_bytes())?;
             out.push(':');
             use base64::Engine as _;
-            out.push_str(&base64::engine::general_purpose::STANDARD.encode(v.as_bytes()));
+            out.push_str(&base64::engine::general_purpose::STANDARD.encode(canonical));
             out.push(':');
         }
         return Ok(out);
@@ -521,6 +537,38 @@ fn resolve_field(
     }
 
     combine_field_values(map, &header_name)
+}
+
+/// RFC 9421 §2.1.3: strip leading/trailing whitespace and collapse obs-fold to SP.
+fn canonicalize_field_value_bytes(raw: &[u8]) -> Result<Vec<u8>, ComponentError> {
+    // Collapse obs-fold (CR LF 1*(SP / HTAB)) to a single SP.
+    let mut normalized = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        if i + 2 < raw.len()
+            && raw[i] == b'\r'
+            && raw[i + 1] == b'\n'
+            && matches!(raw[i + 2], b' ' | b'\t')
+        {
+            normalized.push(b' ');
+            i += 3;
+            while i < raw.len() && matches!(raw[i], b' ' | b'\t') {
+                i += 1;
+            }
+            continue;
+        }
+        normalized.push(raw[i]);
+        i += 1;
+    }
+    let start = normalized
+        .iter()
+        .position(|b| !matches!(b, b' ' | b'\t'))
+        .unwrap_or(normalized.len());
+    let end = normalized
+        .iter()
+        .rposition(|b| !matches!(b, b' ' | b'\t'))
+        .map_or(start, |p| p + 1);
+    Ok(normalized[start..end].to_vec())
 }
 
 fn serialize_strict_sf(combined: &str) -> Result<String, String> {
@@ -598,11 +646,34 @@ pub fn component_identity_key(id: &ComponentIdentifier) -> String {
                 }
                 ParameterValue::Token(v) => s.push_str(v),
                 ParameterValue::Integer(n) => s.push_str(&n.to_string()),
+                ParameterValue::Decimal {
+                    negative,
+                    integer,
+                    fraction,
+                    fraction_digits,
+                } => {
+                    if *negative {
+                        s.push('-');
+                    }
+                    s.push_str(&integer.to_string());
+                    s.push('.');
+                    let width = usize::from(*fraction_digits);
+                    s.push_str(&format!("{fraction:0width$}"));
+                }
                 ParameterValue::ByteSequence(b) => {
                     use base64::Engine as _;
                     s.push(':');
                     s.push_str(&base64::engine::general_purpose::STANDARD.encode(b));
                     s.push(':');
+                }
+                ParameterValue::Date(n) => {
+                    s.push('@');
+                    s.push_str(&n.to_string());
+                }
+                ParameterValue::DisplayString(v) => {
+                    s.push_str("%\"");
+                    s.push_str(v);
+                    s.push('"');
                 }
             }
             s
@@ -668,10 +739,9 @@ mod tests {
             .body(())
             .unwrap();
         let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
-        let id = ComponentIdentifier::new("@query-param").with_parameters(
-            Parameters::new().with("name", ParameterValue::String("Pet".into())),
-        );
-        assert!(resolve_component_value(&ctx, &id).is_err());
+        let id = ComponentIdentifier::new("@query-param")
+            .with_parameters(Parameters::new().with("name", ParameterValue::String("Pet".into())));
+        resolve_component_value(&ctx, &id).unwrap_err();
 
         let req = Request::builder()
             .method(Method::GET)
@@ -679,9 +749,8 @@ mod tests {
             .body(())
             .unwrap();
         let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
-        let id = ComponentIdentifier::new("@query-param").with_parameters(
-            Parameters::new().with("name", ParameterValue::String("q".into())),
-        );
+        let id = ComponentIdentifier::new("@query-param")
+            .with_parameters(Parameters::new().with("name", ParameterValue::String("q".into())));
         assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "a%20b");
     }
 
@@ -697,7 +766,76 @@ mod tests {
         let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
         let id = ComponentIdentifier::new("x-plain")
             .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
-        assert!(resolve_component_value(&ctx, &id).is_err());
+        resolve_component_value(&ctx, &id).unwrap_err();
+    }
+
+    #[test]
+    fn sf_decimal_round_trips() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("example", "1.50")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("example")
+            .with_parameters(Parameters::new().with("sf", ParameterValue::Boolean(true)));
+        assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "1.5");
+    }
+
+    #[test]
+    fn reject_uppercase_field_component_name() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("content-type", "application/json")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        resolve_component_value(&ctx, &ComponentIdentifier::new("Content-Type")).unwrap_err();
+    }
+
+    #[test]
+    fn reject_bs_with_key_and_req_on_request() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("x-bin", " value ")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("x-bin").with_parameters(
+            Parameters::new()
+                .with("bs", ParameterValue::Boolean(true))
+                .with("key", ParameterValue::String("a".into())),
+        );
+        resolve_component_value(&ctx, &id).unwrap_err();
+
+        let id = ComponentIdentifier::new("@method")
+            .with_parameters(Parameters::new().with("req", ParameterValue::Boolean(true)));
+        // Related context alone is not enough — request kind forbids ;req.
+        let related = ctx.clone();
+        let ctx = ctx.with_related_request(related);
+        resolve_component_value(&ctx, &id).unwrap_err();
+    }
+
+    #[test]
+    fn bs_strips_whitespace() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("x-bin", " value ")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("x-bin")
+            .with_parameters(Parameters::new().with("bs", ParameterValue::Boolean(true)));
+        use base64::Engine as _;
+        let expected = format!(
+            ":{}:",
+            base64::engine::general_purpose::STANDARD.encode(b"value")
+        );
+        assert_eq!(resolve_component_value(&ctx, &id).unwrap(), expected);
     }
 
     #[test]
@@ -710,7 +848,7 @@ mod tests {
         let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
         let id = ComponentIdentifier::new("@method")
             .with_parameters(Parameters::new().with("foo", ParameterValue::Boolean(true)));
-        assert!(resolve_component_value(&ctx, &id).is_err());
+        resolve_component_value(&ctx, &id).unwrap_err();
     }
 
     #[test]

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -635,20 +635,25 @@ fn combine_field_values(map: &HeaderMap, name: &HeaderName) -> Result<String, Co
     let first = values
         .next()
         .ok_or_else(|| ComponentError::new(format!("field {name} not present")))?;
-    let mut out = first
-        .to_str()
-        .map_err(|_err| ComponentError::new("field value is not ASCII"))?
-        .trim()
-        .to_owned();
+    let mut out = trim_http_ows(
+        first
+            .to_str()
+            .map_err(|_err| ComponentError::new("field value is not ASCII"))?,
+    )
+    .to_owned();
     for v in values {
         out.push_str(", ");
-        out.push_str(
+        out.push_str(trim_http_ows(
             v.to_str()
-                .map_err(|_err| ComponentError::new("field value is not ASCII"))?
-                .trim(),
-        );
+                .map_err(|_err| ComponentError::new("field value is not ASCII"))?,
+        ));
     }
     Ok(out)
+}
+
+/// Strip leading/trailing SP / HTAB only (RFC 9110 OWS), not Unicode whitespace.
+fn trim_http_ows(s: &str) -> &str {
+    s.trim_matches(|c| c == ' ' || c == '\t')
 }
 
 fn serialize_dictionary_member(member: &DictionaryMember) -> String {

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -396,22 +396,20 @@ fn target_uri_value(ctx: &ComponentContext<'_>) -> Result<String, ComponentError
             "@target-uri is not available for asterisk-form",
         ));
     }
-    if uri.scheme().is_some() {
-        let mut buf = BytesMut::new();
-        uri.write_http_absolute_form(&mut buf)
-            .map_err(|e| ComponentError::new(format!("@target-uri: {e}")))?;
-        return String::from_utf8(buf.to_vec())
-            .map_err(|_err| ComponentError::new("@target-uri is not UTF-8"));
-    }
 
-    let scheme = ctx
-        .scheme_hint
-        .ok_or_else(|| {
-            ComponentError::new(
-                "@target-uri requires an absolute URI or a scheme_hint for origin-form",
-            )
-        })?
-        .to_ascii_lowercase();
+    // Assemble target URI from normalized scheme + @authority + origin-form path/query
+    // so absolute-form and origin-form (+ scheme_hint) produce the same component value.
+    let scheme = if let Some(scheme) = uri.scheme() {
+        scheme.as_str().to_ascii_lowercase()
+    } else {
+        ctx.scheme_hint
+            .ok_or_else(|| {
+                ComponentError::new(
+                    "@target-uri requires an absolute URI or a scheme_hint for origin-form",
+                )
+            })?
+            .to_ascii_lowercase()
+    };
     let authority = authority_value(ctx)?;
     let mut buf = BytesMut::new();
     uri.write_http_origin_form(&mut buf)
@@ -440,10 +438,11 @@ fn query_param_value(
         .query()
         .ok_or_else(|| ComponentError::new("@query-param: request has no query"))?;
 
-    // Match after form-decoding both the identifier name and query names.
+    // RFC 9421 §2.2.8: `name` is the encoded nameString; match against re-encoded
+    // query names (not decoded equality, which breaks non-ASCII examples).
     let mut matches = query
         .pairs()
-        .filter(|p| p.name_decoded() == name)
+        .filter(|p| form_urlencoded_percent_encode(&p.name_decoded()) == name)
         .collect::<Vec<_>>();
     if matches.is_empty() {
         return Err(ComponentError::new(format!(
@@ -799,6 +798,36 @@ mod tests {
         let id = ComponentIdentifier::new("@query-param")
             .with_parameters(Parameters::new().with("name", ParameterValue::String("q".into())));
         assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "a%20b");
+    }
+
+    #[test]
+    fn query_param_matches_encoded_name() {
+        // RFC 9421 §2.2.8 example: name parameter is the encoded nameString.
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/?fa%C3%A7ade%22%3A%20=something")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        let id = ComponentIdentifier::new("@query-param").with_parameters(Parameters::new().with(
+            "name",
+            ParameterValue::String("fa%C3%A7ade%22%3A%20".into()),
+        ));
+        assert_eq!(resolve_component_value(&ctx, &id).unwrap(), "something");
+    }
+
+    #[test]
+    fn target_uri_normalizes_absolute_form() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("HTTPS://WWW.EXAMPLE.COM:443/path?param=value")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@target-uri")).unwrap(),
+            "https://www.example.com/path?param=value"
+        );
     }
 
     #[test]

--- a/rama-http/src/layer/message_signature/component.rs
+++ b/rama-http/src/layer/message_signature/component.rs
@@ -1,0 +1,407 @@
+//! HTTP message component identifiers and canonicalization (RFC 9421 §2).
+
+use rama_http_headers::signature_input::ComponentIdentifier;
+use rama_http_headers::util::structured_fields::{
+    Dictionary, DictionaryMember, ParameterValue, parse_dictionary, serialize_dictionary,
+};
+use rama_http_types::{HeaderMap, HeaderName, Method, StatusCode};
+use rama_net::uri::Uri;
+use std::fmt;
+
+/// Whether the target message is a request or a response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageKind {
+    Request,
+    Response,
+}
+
+/// Context needed to resolve component values from an HTTP message.
+#[derive(Debug, Clone)]
+pub struct ComponentContext<'a> {
+    pub kind: MessageKind,
+    pub method: Option<&'a Method>,
+    pub uri: Option<&'a Uri>,
+    pub status: Option<StatusCode>,
+    pub headers: &'a HeaderMap,
+    pub trailers: Option<&'a HeaderMap>,
+    /// Related request headers/uri/method when resolving `req` components on a response.
+    pub related_request: Option<Box<Self>>,
+}
+
+impl<'a> ComponentContext<'a> {
+    #[must_use]
+    pub fn for_request(method: &'a Method, uri: &'a Uri, headers: &'a HeaderMap) -> Self {
+        Self {
+            kind: MessageKind::Request,
+            method: Some(method),
+            uri: Some(uri),
+            status: None,
+            headers,
+            trailers: None,
+            related_request: None,
+        }
+    }
+
+    #[must_use]
+    pub fn for_response(status: StatusCode, headers: &'a HeaderMap) -> Self {
+        Self {
+            kind: MessageKind::Response,
+            method: None,
+            uri: None,
+            status: Some(status),
+            headers,
+            trailers: None,
+            related_request: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_related_request(mut self, related: Self) -> Self {
+        self.related_request = Some(Box::new(related));
+        self
+    }
+
+    #[must_use]
+    pub fn with_trailers(mut self, trailers: &'a HeaderMap) -> Self {
+        self.trailers = Some(trailers);
+        self
+    }
+}
+
+/// Error resolving a component value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentError {
+    pub message: String,
+}
+
+impl ComponentError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ComponentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "component error: {}", self.message)
+    }
+}
+
+impl std::error::Error for ComponentError {}
+
+/// Resolve the canonical component value for a covered component identifier.
+pub fn resolve_component_value(
+    ctx: &ComponentContext<'_>,
+    id: &ComponentIdentifier,
+) -> Result<String, ComponentError> {
+    let use_req = id
+        .parameters
+        .get("req")
+        .is_some_and(|v| matches!(v, ParameterValue::Boolean(true)));
+
+    if use_req {
+        let related = ctx
+            .related_request
+            .as_deref()
+            .ok_or_else(|| ComponentError::new("req parameter requires related request context"))?;
+        // Strip `req` when resolving against the related request
+        let mut stripped = id.clone();
+        stripped.parameters.params.retain(|p| p.name != "req");
+        return resolve_component_value(related, &stripped);
+    }
+
+    if id.name.starts_with('@') {
+        resolve_derived(ctx, id)
+    } else {
+        resolve_field(ctx, id)
+    }
+}
+
+fn resolve_derived(
+    ctx: &ComponentContext<'_>,
+    id: &ComponentIdentifier,
+) -> Result<String, ComponentError> {
+    // Derived components must not carry sf/bs/tr
+    for forbidden in ["sf", "bs", "tr"] {
+        if id.parameters.get(forbidden).is_some() {
+            return Err(ComponentError::new(format!(
+                "derived component {} must not have ;{forbidden}",
+                id.name
+            )));
+        }
+    }
+
+    match id.name.as_str() {
+        "@method" => {
+            let method = ctx
+                .method
+                .ok_or_else(|| ComponentError::new("@method requires a request"))?;
+            Ok(method.as_str().to_owned())
+        }
+        "@authority" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@authority requires a request URI"))?;
+            let authority = uri
+                .authority()
+                .map(|a| a.to_string().to_ascii_lowercase())
+                .or_else(|| {
+                    ctx.headers
+                        .get(rama_http_types::header::HOST)
+                        .and_then(|v| v.to_str().ok())
+                        .map(|s| s.to_ascii_lowercase())
+                })
+                .ok_or_else(|| ComponentError::new("@authority not available"))?;
+            Ok(authority)
+        }
+        "@scheme" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@scheme requires a request URI"))?;
+            let scheme = uri
+                .scheme_str()
+                .ok_or_else(|| ComponentError::new("@scheme not available"))?
+                .to_ascii_lowercase();
+            Ok(scheme)
+        }
+        "@target-uri" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@target-uri requires a request URI"))?;
+            Ok(uri.to_string())
+        }
+        "@request-target" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@request-target requires a request URI"))?;
+            let path = uri.path_or_root();
+            match uri.query() {
+                Some(q) => Ok(format!("{path}?{}", q.as_encoded_str())),
+                None => Ok(path.into_owned()),
+            }
+        }
+        "@path" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@path requires a request URI"))?;
+            Ok(uri.path_or_root().into_owned())
+        }
+        "@query" => {
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@query requires a request URI"))?;
+            match uri.query() {
+                Some(q) => Ok(format!("?{}", q.as_encoded_str())),
+                None => Ok("?".to_owned()),
+            }
+        }
+        "@query-param" => {
+            let name = match id.parameters.get("name") {
+                Some(ParameterValue::String(s)) => s.clone(),
+                _ => {
+                    return Err(ComponentError::new(
+                        "@query-param requires ;name=\"...\" parameter",
+                    ));
+                }
+            };
+            let uri = ctx
+                .uri
+                .ok_or_else(|| ComponentError::new("@query-param requires a request URI"))?;
+            uri.first_query_value(name.as_str())
+                .map(|v| v.into_owned())
+                .ok_or_else(|| ComponentError::new(format!("@query-param name={name} not found")))
+        }
+        "@status" => {
+            let status = ctx
+                .status
+                .ok_or_else(|| ComponentError::new("@status requires a response"))?;
+            Ok(status.as_u16().to_string())
+        }
+        "@signature-params" => Err(ComponentError::new(
+            "@signature-params is produced by base assembly, not resolved as a covered component",
+        )),
+        other => Err(ComponentError::new(format!(
+            "unsupported derived component: {other}"
+        ))),
+    }
+}
+
+fn resolve_field(
+    ctx: &ComponentContext<'_>,
+    id: &ComponentIdentifier,
+) -> Result<String, ComponentError> {
+    let name = id.name.to_ascii_lowercase();
+    if name.starts_with('@') {
+        return Err(ComponentError::new("field names must not start with @"));
+    }
+
+    let use_tr = id
+        .parameters
+        .get("tr")
+        .is_some_and(|v| matches!(v, ParameterValue::Boolean(true)));
+    let use_sf = id
+        .parameters
+        .get("sf")
+        .is_some_and(|v| matches!(v, ParameterValue::Boolean(true)));
+    let use_bs = id
+        .parameters
+        .get("bs")
+        .is_some_and(|v| matches!(v, ParameterValue::Boolean(true)));
+    let key = match id.parameters.get("key") {
+        Some(ParameterValue::String(s)) => Some(s.as_str()),
+        _ => None,
+    };
+
+    if use_sf && use_bs {
+        return Err(ComponentError::new(";sf and ;bs are mutually exclusive"));
+    }
+
+    let map = if use_tr {
+        ctx.trailers.ok_or_else(|| {
+            ComponentError::new(format!("trailer field {name} requested but no trailers"))
+        })?
+    } else {
+        ctx.headers
+    };
+
+    let header_name = HeaderName::from_bytes(name.as_bytes())
+        .map_err(|_err| ComponentError::new("invalid field name"))?;
+
+    if use_bs {
+        // Byte-sequence wrap each field value, serialize as SF List of byte sequences
+        let values: Vec<_> = map.get_all(&header_name).iter().collect();
+        if values.is_empty() {
+            return Err(ComponentError::new(format!("field {name} not present")));
+        }
+        let mut out = String::new();
+        for (i, v) in values.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            out.push(':');
+            use base64::Engine as _;
+            out.push_str(&base64::engine::general_purpose::STANDARD.encode(v.as_bytes()));
+            out.push(':');
+        }
+        return Ok(out);
+    }
+
+    if use_sf || key.is_some() {
+        // Combine field values and parse as Structured Field
+        let combined = combine_field_values(map, &header_name)?;
+        if let Some(key_name) = key {
+            // Dictionary member lookup
+            let dict = parse_dictionary(&combined).map_err(|e| {
+                ComponentError::new(format!("field {name} is not a valid SF dictionary: {e}"))
+            })?;
+            let member = dict.get(key_name).ok_or_else(|| {
+                ComponentError::new(format!("dictionary key {key_name} not found"))
+            })?;
+            return Ok(serialize_dictionary_member(member));
+        }
+        // Strict SF serialization: re-parse and re-serialize dictionary (most common for Content-Digest)
+        if let Ok(dict) = parse_dictionary(&combined) {
+            return Ok(serialize_dictionary(&dict));
+        }
+        // Fallback: return combined as-is if not a dictionary (lists etc. — subset limitation)
+        return Ok(combined);
+    }
+
+    combine_field_values(map, &header_name)
+}
+
+fn combine_field_values(map: &HeaderMap, name: &HeaderName) -> Result<String, ComponentError> {
+    let mut values = map.get_all(name).iter();
+    let first = values
+        .next()
+        .ok_or_else(|| ComponentError::new(format!("field {name} not present")))?;
+    let mut out = first
+        .to_str()
+        .map_err(|_err| ComponentError::new("field value is not ASCII"))?
+        .trim()
+        .to_owned();
+    for v in values {
+        out.push_str(", ");
+        out.push_str(
+            v.to_str()
+                .map_err(|_err| ComponentError::new("field value is not ASCII"))?
+                .trim(),
+        );
+    }
+    Ok(out)
+}
+
+fn serialize_dictionary_member(member: &DictionaryMember) -> String {
+    match member {
+        DictionaryMember::Item(item) => {
+            let mut dict = Dictionary::new();
+            dict.insert("_", DictionaryMember::Item(item.clone()));
+            let full = serialize_dictionary(&dict);
+            full.strip_prefix("_=").unwrap_or(&full).to_owned()
+        }
+        DictionaryMember::InnerList(list) => {
+            let mut dict = Dictionary::new();
+            dict.insert("_", DictionaryMember::InnerList(list.clone()));
+            let full = serialize_dictionary(&dict);
+            full.strip_prefix("_=").unwrap_or(&full).to_owned()
+        }
+    }
+}
+
+/// Serialize a component identifier for the signature base left-hand side.
+pub fn serialize_component_identifier(id: &ComponentIdentifier) -> String {
+    id.serialize_identifier()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rama_http_types::{Method, Request};
+
+    #[test]
+    fn derived_method_path_authority_query() {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/foo?param=Value&Pet=dog")
+            .body(())
+            .unwrap();
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@method")).unwrap(),
+            "POST"
+        );
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@authority")).unwrap(),
+            "example.com"
+        );
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@path")).unwrap(),
+            "/foo"
+        );
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("@query")).unwrap(),
+            "?param=Value&Pet=dog"
+        );
+    }
+
+    #[test]
+    fn field_combine() {
+        let mut req = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/")
+            .header("host", "example.com")
+            .body(())
+            .unwrap();
+        req.headers_mut()
+            .append("cache-control", "max-age=60".parse().unwrap());
+        req.headers_mut()
+            .append("cache-control", "must-revalidate".parse().unwrap());
+        let ctx = ComponentContext::for_request(req.method(), req.uri(), req.headers());
+        assert_eq!(
+            resolve_component_value(&ctx, &ComponentIdentifier::new("cache-control")).unwrap(),
+            "max-age=60, must-revalidate"
+        );
+    }
+}

--- a/rama-http/src/layer/message_signature/mod.rs
+++ b/rama-http/src/layer/message_signature/mod.rs
@@ -8,7 +8,8 @@ pub mod component;
 
 #[doc(inline)]
 pub use base::{
-    SignatureBaseError, build_signature_base, build_signature_params_line, signature_input_for_label,
+    SignatureBaseError, build_signature_base, build_signature_params_line,
+    signature_input_for_label,
 };
 #[doc(inline)]
 pub use component::{

--- a/rama-http/src/layer/message_signature/mod.rs
+++ b/rama-http/src/layer/message_signature/mod.rs
@@ -13,6 +13,6 @@ pub use base::{
 };
 #[doc(inline)]
 pub use component::{
-    ComponentContext, ComponentError, MessageKind, resolve_component_value,
-    serialize_component_identifier,
+    ComponentContext, ComponentError, MessageKind, StructuredFieldType,
+    known_structured_field_type, resolve_component_value, serialize_component_identifier,
 };

--- a/rama-http/src/layer/message_signature/mod.rs
+++ b/rama-http/src/layer/message_signature/mod.rs
@@ -1,0 +1,17 @@
+//! HTTP Message Signatures (RFC 9421) — component extraction and signature base.
+//!
+//! Sign/verify/proxy layers are available behind the `message-signature` feature
+//! in follow-up PRs.
+
+pub mod base;
+pub mod component;
+
+#[doc(inline)]
+pub use base::{
+    SignatureBaseError, build_signature_base, build_signature_params_line, signature_input_for_label,
+};
+#[doc(inline)]
+pub use component::{
+    ComponentContext, ComponentError, MessageKind, resolve_component_value,
+    serialize_component_identifier,
+};

--- a/rama-http/src/layer/mod.rs
+++ b/rama-http/src/layer/mod.rs
@@ -36,6 +36,7 @@ pub mod into_response;
 pub mod map_request_body;
 pub mod map_response_body;
 pub mod match_redirect;
+pub mod message_signature;
 pub mod normalize_path;
 pub mod propagate_headers;
 pub mod proxy_auth;


### PR DESCRIPTION
Part 1/3 of #1082 (HTTP Message Signatures).

Adds the shared foundation for RFC 9421 without sign/verify/proxy layers yet:

- Minimal Structured Fields (RFC 9651) subset for dictionaries/lists/items/parameters
- Typed `Signature` / `Signature-Input` headers (plus header name constants)
- Component extraction and signature-base construction (`@method`, `@authority`, `@target-uri`, `@query-param`, field params `;sf` / `;bs` / `;key` / `;req`, etc.)
- Fail-closed canonicalization aligned with the RFCs (typed `;sf`, encoded query-param names, normalized `@target-uri`, Display String encoding, `;key` boolean-true as `?1`)

Focused checks that passed on this branch:

- `cargo test -p rama-http-headers --lib structured_fields`
- `cargo test -p rama-http --lib message_signature`
- `cargo clippy -p rama-http-headers -p rama-http --lib -- -D warnings`
- `cargo fmt` clean for the touched crates

Follow-ups:
- #1084: Content-Digest + crypto adapters + sign/verify layers (`message-signature`)
- #1085: proxy/intermediary append layers

cc @GlenDC @soundofspace