### PR TITLE
feat: use systemd-resolved (varlink) for linux dns when available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ version = "0.3.1"
 dependencies = [
  "ahash",
  "arc-swap",
+ "base64 0.23.0",
  "bindgen",
  "dial9-tokio-telemetry",
  "dial9-trace-format",
@@ -3652,8 +3653,11 @@ dependencies = [
  "pin-project-lite",
  "rama-core",
  "rama-net",
+ "rama-unix",
  "rama-utils",
  "rand 0.10.2",
+ "serde",
+ "serde_json",
  "tokio",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -467,7 +467,12 @@ http = [
 # committing to client, proxy or server specifics: those feature-gate
 # their own extra requirements (e.g. `EasyHttpWebClient` also needs
 # `tcp` + `dns`) on top of this.
-http-backend = ["http", "dep:rama-http-backend", "dep:rama-http-core", "dep:tokio"]
+http-backend = [
+    "http",
+    "dep:rama-http-backend",
+    "dep:rama-http-core",
+    "dep:tokio",
+]
 http-full = [
     "http-backend",
     # `EasyHttpWebClient` (see `http::client`) needs these on top of

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -467,12 +467,7 @@ http = [
 # committing to client, proxy or server specifics: those feature-gate
 # their own extra requirements (e.g. `EasyHttpWebClient` also needs
 # `tcp` + `dns`) on top of this.
-http-backend = [
-    "http",
-    "dep:rama-http-backend",
-    "dep:rama-http-core",
-    "dep:tokio",
-]
+http-backend = ["http", "dep:rama-http-backend", "dep:rama-http-core", "dep:tokio"]
 http-full = [
     "http-backend",
     # `EasyHttpWebClient` (see `http::client`) needs these on top of

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -120,9 +120,16 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "dns_txt_rr"
+path = "fuzz_targets/dns_txt_rr.rs"
+test = false
+doc = false
+bench = false
+
 [dependencies]
 libfuzzer-sys = { workspace = true, features = ["arbitrary-derive"] }
-rama = { path = "../", features = ["ua", "http", "net", "html"] }
+rama = { path = "../", features = ["dns", "ua", "http", "net", "html"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 

--- a/fuzz/fuzz_targets/dns_txt_rr.rs
+++ b/fuzz/fuzz_targets/dns_txt_rr.rs
@@ -1,0 +1,20 @@
+//! Fuzz target for the systemd-resolved varlink backend's raw RR parser
+//! (`rama-dns/src/client/systemd_resolved_wire.rs`).
+//!
+//! `ResolveRecord` replies carry each resource record as RFC 1035 wire bytes
+//! (the base64 `raw` field). The parser walks the owner name, the
+//! type/class/TTL/rdlen header and the TXT character-string segments. On any
+//! malformed input it must return a typed `Malformed` verdict (mapped to a
+//! transport failure upstream) — never panic, never read out of bounds,
+//! never hang. The hook additionally asserts that every yielded TXT segment
+//! derives from within the input buffer.
+//!
+//! Run with:
+//!     cargo +nightly fuzz run dns_txt_rr -- -max_len=4096
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    rama::dns::client::fuzzing::parse_txt_rr(data);
+});

--- a/justfile
+++ b/justfile
@@ -309,6 +309,12 @@ fuzz-http-header-map:
 fuzz-http-header-map-60s:
     cargo +nightly fuzz run http_header_map -- -max_len=131072 -max_total_time=60
 
+fuzz-dns-txt-rr:
+    cargo +nightly fuzz run dns_txt_rr -- -max_len=4096
+
+fuzz-dns-txt-rr-60s:
+    cargo +nightly fuzz run dns_txt_rr -- -max_len=4096 -max_total_time=60
+
 fuzz-h2-main:
     # cargo install honggfuzz
     cd rama-http-core/tests/h2-fuzz && \

--- a/rama-dns/Cargo.toml
+++ b/rama-dns/Cargo.toml
@@ -52,7 +52,11 @@ rand = { workspace = true }
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+base64 = { workspace = true }
 libc = { workspace = true }
+rama-unix = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_NetworkManagement_Dns"] }
@@ -63,6 +67,13 @@ bindgen = { workspace = true }
 [dev-dependencies]
 ahash = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
+
+# the systemd-resolved varlink client also builds under test on other unixes
+[target.'cfg(all(target_family = "unix", not(target_os = "linux")))'.dev-dependencies]
+base64 = { workspace = true }
+rama-unix = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -509,6 +509,10 @@ fn lookup_txt_uncached_stream(
 
 /// Serve the lookup via systemd-resolved when a usable answer comes back,
 /// and stream from the native libc backend otherwise.
+///
+/// The native fallback deliberately runs with its own full timeout: during
+/// the short window before the breaker trips on a wedged daemon, a slow
+/// success beats failing queries at the configured deadline.
 fn resolved_first_stream<T, F, N, S>(
     varlink: Option<F>,
     native: N,

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -1,5 +1,10 @@
 //! Linux-native DNS resolver.
 //!
+//! When systemd-resolved's varlink socket is reachable, lookups are served
+//! through it first — fully async, no blocking-pool worker — falling back to
+//! the libc paths below per query and whenever the daemon is unavailable
+//! (see [`super::systemd_resolved`]).
+//!
 //! On targets with `res_nsearch` support, `A` / `AAAA` / `TXT` lookups are
 //! backed by the native resolver stub. `res_nsearch` (not `res_nquery`) is
 //! used so the resolver walks the `search` list from `/etc/resolv.conf` and
@@ -30,7 +35,10 @@ use rama_utils::{
     str::arcstr::ArcStr,
 };
 
-use super::resolver::{DnsAddressResolver, DnsResolver, DnsTxtResolver};
+use super::{
+    resolver::{DnsAddressResolver, DnsResolver, DnsTxtResolver},
+    systemd_resolved::{self, ResolvedLookup, SystemdResolved},
+};
 
 mod cache;
 
@@ -70,6 +78,8 @@ pub struct LinuxDnsResolverBuilder {
     negative_cache_ttl: Duration,
     cache_capacity: u64,
     response_buffer_size: usize,
+    systemd_resolved: bool,
+    systemd_resolved_config: systemd_resolved::Config,
 }
 
 impl Default for LinuxDnsResolverBuilder {
@@ -80,6 +90,8 @@ impl Default for LinuxDnsResolverBuilder {
             negative_cache_ttl: DEFAULT_NEGATIVE_CACHE_TTL,
             cache_capacity: DEFAULT_CACHE_CAPACITY,
             response_buffer_size: DEFAULT_RESPONSE_BUFFER_SIZE,
+            systemd_resolved: true,
+            systemd_resolved_config: systemd_resolved::Config::default(),
         }
     }
 }
@@ -126,6 +138,52 @@ impl LinuxDnsResolverBuilder {
         }
     }
 
+    generate_set_and_with! {
+        /// Route lookups through systemd-resolved's varlink API when its
+        /// socket is reachable (default: enabled), falling back to the libc
+        /// paths per query and whenever the daemon is unavailable.
+        pub fn systemd_resolved(mut self, enabled: bool) -> Self {
+            self.systemd_resolved = enabled;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// How often an unavailable systemd-resolved is re-probed.
+        pub fn systemd_resolved_reprobe_interval(mut self, interval: Duration) -> Self {
+            self.systemd_resolved_config.reprobe_interval = interval;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Consecutive transport failures before systemd-resolved is marked
+        /// unavailable. Resolution answers (incl. negative ones) never count.
+        pub fn systemd_resolved_breaker_threshold(mut self, threshold: u32) -> Self {
+            self.systemd_resolved_config.breaker_threshold = threshold;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Connect timeout for the systemd-resolved varlink socket. A healthy
+        /// local daemon accepts near-instantly.
+        pub fn systemd_resolved_connect_timeout(mut self, timeout: Duration) -> Self {
+            self.systemd_resolved_config.connect_timeout = timeout;
+            self
+        }
+    }
+
+    generate_set_and_with! {
+        /// Maximum in-flight systemd-resolved queries. Keep below resolved's
+        /// varlink server default of 128 connections per UID, a budget shared
+        /// with every other same-UID client (e.g. `nss-resolve`).
+        pub fn systemd_resolved_max_concurrency(mut self, max: usize) -> Self {
+            self.systemd_resolved_config.max_concurrency = max;
+            self
+        }
+    }
+
     #[must_use]
     pub fn build(self) -> LinuxDnsResolver {
         LinuxDnsResolver {
@@ -139,6 +197,9 @@ impl LinuxDnsResolverBuilder {
                 self.cache_ttl,
                 self.negative_cache_ttl,
             )),
+            systemd_resolved: self
+                .systemd_resolved
+                .then(|| Arc::new(SystemdResolved::new(self.systemd_resolved_config))),
         }
     }
 }
@@ -152,6 +213,7 @@ pub struct LinuxDnsResolver {
     cache_capacity: u64,
     response_buffer_size: usize,
     cache: Arc<cache::LinuxDnsCache>,
+    systemd_resolved: Option<Arc<SystemdResolved>>,
 }
 
 impl Default for LinuxDnsResolver {
@@ -191,6 +253,11 @@ impl LinuxDnsResolver {
         self.response_buffer_size
     }
 
+    #[must_use]
+    pub fn systemd_resolved_enabled(&self) -> bool {
+        self.systemd_resolved.is_some()
+    }
+
     generate_set_and_with! {
         pub fn timeout(mut self, timeout: Duration) -> Self {
             self.timeout = timeout;
@@ -212,6 +279,7 @@ impl DnsAddressResolver for LinuxDnsResolver {
         domain: Domain,
     ) -> impl Stream<Item = Result<Ipv4Addr, Self::Error>> + Send + '_ {
         let response_buffer_size = self.response_buffer_size;
+        let resolved = self.systemd_resolved.clone();
         lookup_cached_stream(
             domain,
             self.timeout,
@@ -220,7 +288,7 @@ impl DnsAddressResolver for LinuxDnsResolver {
             move |cache, domain| cache.get_ipv4(domain),
             move |cache, domain, values, ttl| cache.insert_ipv4(domain, values, ttl),
             move |domain, timeout| {
-                lookup_ipv4_uncached_stream(domain, timeout, response_buffer_size)
+                lookup_ipv4_uncached_stream(resolved, domain, timeout, response_buffer_size)
             },
         )
     }
@@ -230,6 +298,7 @@ impl DnsAddressResolver for LinuxDnsResolver {
         domain: Domain,
     ) -> impl Stream<Item = Result<Ipv6Addr, Self::Error>> + Send + '_ {
         let response_buffer_size = self.response_buffer_size;
+        let resolved = self.systemd_resolved.clone();
         lookup_cached_stream(
             domain,
             self.timeout,
@@ -238,7 +307,7 @@ impl DnsAddressResolver for LinuxDnsResolver {
             move |cache, domain| cache.get_ipv6(domain),
             move |cache, domain, values, ttl| cache.insert_ipv6(domain, values, ttl),
             move |domain, timeout| {
-                lookup_ipv6_uncached_stream(domain, timeout, response_buffer_size)
+                lookup_ipv6_uncached_stream(resolved, domain, timeout, response_buffer_size)
             },
         )
     }
@@ -252,6 +321,7 @@ impl DnsTxtResolver for LinuxDnsResolver {
         domain: Domain,
     ) -> impl Stream<Item = Result<Bytes, Self::Error>> + Send + '_ {
         let response_buffer_size = self.response_buffer_size;
+        let resolved = self.systemd_resolved.clone();
         lookup_cached_stream(
             domain,
             self.timeout,
@@ -260,7 +330,7 @@ impl DnsTxtResolver for LinuxDnsResolver {
             move |cache, domain| cache.get_txt(domain),
             move |cache, domain, values, ttl| cache.insert_txt(domain, values, ttl),
             move |domain, timeout| {
-                lookup_txt_uncached_stream(domain, timeout, response_buffer_size)
+                lookup_txt_uncached_stream(resolved, domain, timeout, response_buffer_size)
             },
         )
     }
@@ -271,31 +341,16 @@ impl DnsResolver for LinuxDnsResolver {}
 /// Events emitted by uncached lookup streams.
 ///
 /// `AuthoritativeNegative` is only emitted by backends that can distinguish
-/// "the zone says there is no such record" (the `res_nsearch` path) from
-/// "this lookup returned nothing for unrelated reasons" (the legacy
-/// `getaddrinfo` path, where `AI_ADDRCONFIG` can suppress whole families
-/// based on local interface state). Only the former is safe to cache as a
-/// negative entry.
+/// "the zone says there is no such record" (the `res_nsearch` and
+/// systemd-resolved paths) from "this lookup returned nothing for unrelated
+/// reasons" (the legacy `getaddrinfo` path, where `AI_ADDRCONFIG` can
+/// suppress whole families based on local interface state). Only the former
+/// is safe to cache as a negative entry, and only with a SOA-derived TTL —
+/// systemd-resolved negatives carry none (the daemon does its own RFC 2308
+/// negative caching), so they end up uncached here.
 pub(super) enum LookupEvent<T> {
     Record(T, u32),
-    // Only constructed by the `res_nsearch` backend (glibc / BSDs). The
-    // legacy `getaddrinfo` fallback (used on e.g. musl) cannot distinguish
-    // authoritative DNS negatives from local-policy empties — see
-    // `legacy.rs` — so it never emits this variant. The `cfg_attr` only
-    // applies the lint expectation on the exact targets where the variant
-    // is dead, so `expect` is fulfilled there and absent elsewhere.
-    #[cfg_attr(
-        not(any(
-            all(target_os = "linux", target_env = "gnu"),
-            target_os = "freebsd",
-            target_os = "openbsd",
-            target_os = "netbsd",
-        )),
-        expect(dead_code, reason = "only constructed by the res_nsearch backend")
-    )]
-    AuthoritativeNegative {
-        soa_ttl: Option<u32>,
-    },
+    AuthoritativeNegative { soa_ttl: Option<u32> },
 }
 
 /// Lookup a domain and produce a stream that is cached on succes. If a
@@ -396,13 +451,101 @@ where
     })
 }
 
+fn lookup_ipv4_uncached_stream(
+    resolved: Option<Arc<SystemdResolved>>,
+    domain: Domain,
+    timeout: Duration,
+    response_buffer_size: usize,
+) -> impl Stream<Item = Result<LookupEvent<Ipv4Addr>, BoxError>> + Send {
+    let varlink = resolved.map(|resolved| {
+        let domain = domain.clone();
+        async move { resolved.lookup_ipv4(&domain, timeout).await }
+    });
+    resolved_first_stream(varlink, move || {
+        native_lookup_ipv4_stream(domain, timeout, response_buffer_size)
+    })
+}
+
+fn lookup_ipv6_uncached_stream(
+    resolved: Option<Arc<SystemdResolved>>,
+    domain: Domain,
+    timeout: Duration,
+    response_buffer_size: usize,
+) -> impl Stream<Item = Result<LookupEvent<Ipv6Addr>, BoxError>> + Send {
+    let varlink = resolved.map(|resolved| {
+        let domain = domain.clone();
+        async move { resolved.lookup_ipv6(&domain, timeout).await }
+    });
+    resolved_first_stream(varlink, move || {
+        native_lookup_ipv6_stream(domain, timeout, response_buffer_size)
+    })
+}
+
+fn lookup_txt_uncached_stream(
+    resolved: Option<Arc<SystemdResolved>>,
+    domain: Domain,
+    timeout: Duration,
+    response_buffer_size: usize,
+) -> impl Stream<Item = Result<LookupEvent<Bytes>, BoxError>> + Send {
+    let varlink = resolved.map(|resolved| {
+        let domain = domain.clone();
+        async move { resolved.lookup_txt(&domain, timeout).await }
+    });
+    resolved_first_stream(varlink, move || {
+        native_lookup_txt_stream(domain, timeout, response_buffer_size)
+    })
+}
+
+/// Serve the lookup via systemd-resolved when a usable answer comes back,
+/// and stream from the native libc backend otherwise.
+fn resolved_first_stream<T, F, N, S>(
+    varlink: Option<F>,
+    native: N,
+) -> impl Stream<Item = Result<LookupEvent<T>, BoxError>> + Send
+where
+    T: Send + 'static,
+    F: Future<Output = ResolvedLookup<T>> + Send + 'static,
+    N: FnOnce() -> S + Send + 'static,
+    S: Stream<Item = Result<LookupEvent<T>, BoxError>> + Send,
+{
+    stream_fn(async move |mut yielder| {
+        if let Some(varlink) = varlink {
+            match varlink.await {
+                ResolvedLookup::Records(records) => {
+                    for (value, ttl) in records {
+                        yielder
+                            .yield_item(Ok(LookupEvent::Record(value, ttl)))
+                            .await;
+                    }
+                    return;
+                }
+                ResolvedLookup::Negative => {
+                    yielder
+                        .yield_item(Ok(LookupEvent::AuthoritativeNegative { soa_ttl: None }))
+                        .await;
+                    return;
+                }
+                ResolvedLookup::Failed(err) => {
+                    yielder.yield_item(Err(err)).await;
+                    return;
+                }
+                ResolvedLookup::Unavailable => {}
+            }
+        }
+        let mut native = std::pin::pin!(native());
+        while let Some(item) = native.next().await {
+            yielder.yield_item(item).await;
+        }
+    })
+}
+
 #[cfg(any(
     all(target_os = "linux", target_env = "gnu"),
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
 ))]
-fn lookup_ipv4_uncached_stream(
+fn native_lookup_ipv4_stream(
     domain: Domain,
     timeout: Duration,
     response_buffer_size: usize,
@@ -416,7 +559,7 @@ fn lookup_ipv4_uncached_stream(
     target_os = "openbsd",
     target_os = "netbsd",
 )))]
-fn lookup_ipv4_uncached_stream(
+fn native_lookup_ipv4_stream(
     domain: Domain,
     timeout: Duration,
     _response_buffer_size: usize,
@@ -430,7 +573,7 @@ fn lookup_ipv4_uncached_stream(
     target_os = "openbsd",
     target_os = "netbsd",
 ))]
-fn lookup_ipv6_uncached_stream(
+fn native_lookup_ipv6_stream(
     domain: Domain,
     timeout: Duration,
     response_buffer_size: usize,
@@ -444,7 +587,7 @@ fn lookup_ipv6_uncached_stream(
     target_os = "openbsd",
     target_os = "netbsd",
 )))]
-fn lookup_ipv6_uncached_stream(
+fn native_lookup_ipv6_stream(
     domain: Domain,
     timeout: Duration,
     _response_buffer_size: usize,
@@ -458,7 +601,7 @@ fn lookup_ipv6_uncached_stream(
     target_os = "openbsd",
     target_os = "netbsd",
 ))]
-fn lookup_txt_uncached_stream(
+fn native_lookup_txt_stream(
     domain: Domain,
     timeout: Duration,
     response_buffer_size: usize,
@@ -472,7 +615,7 @@ fn lookup_txt_uncached_stream(
     target_os = "openbsd",
     target_os = "netbsd",
 )))]
-fn lookup_txt_uncached_stream(
+fn native_lookup_txt_stream(
     _domain: Domain,
     _timeout: Duration,
     _response_buffer_size: usize,
@@ -517,13 +660,20 @@ static_str_error! {
 
 #[cfg(test)]
 mod tests {
-    use super::{LookupEvent, cache, lookup_cached_stream};
+    use super::{LookupEvent, ResolvedLookup, cache, lookup_cached_stream, resolved_first_stream};
     use rama_core::{
         error::{BoxError, BoxErrorExt as _},
         futures::{Stream, StreamExt as _, stream},
     };
     use rama_net::address::Domain;
-    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
+    use std::{
+        net::Ipv4Addr,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        time::Duration,
+    };
 
     fn test_cache() -> Arc<cache::LinuxDnsCache> {
         Arc::new(cache::LinuxDnsCache::new(
@@ -635,6 +785,104 @@ mod tests {
             cached_ipv4(&cache, &domain).is_none(),
             "a failed lookup must not be cached",
         );
+    }
+
+    fn tracked_native(
+        called: &Arc<AtomicBool>,
+    ) -> impl FnOnce() -> stream::Iter<std::vec::IntoIter<Result<LookupEvent<Ipv4Addr>, BoxError>>>
+    + Send
+    + 'static {
+        let called = called.clone();
+        move || {
+            called.store(true, Ordering::SeqCst);
+            stream::iter(vec![Ok(LookupEvent::Record(Ipv4Addr::new(9, 9, 9, 9), 30))])
+        }
+    }
+
+    #[tokio::test]
+    async fn resolved_records_short_circuit_native() {
+        let native_called = Arc::new(AtomicBool::new(false));
+        let items: Vec<_> = resolved_first_stream(
+            Some(std::future::ready(ResolvedLookup::Records(vec![(
+                Ipv4Addr::new(1, 2, 3, 4),
+                60,
+            )]))),
+            tracked_native(&native_called),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(items.len(), 1);
+        assert!(
+            matches!(items[0], Ok(LookupEvent::Record(addr, 60)) if addr == Ipv4Addr::new(1, 2, 3, 4)),
+        );
+        assert!(!native_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn resolved_negative_yields_authoritative_event() {
+        let native_called = Arc::new(AtomicBool::new(false));
+        let items: Vec<_> = resolved_first_stream(
+            Some(std::future::ready(ResolvedLookup::<Ipv4Addr>::Negative)),
+            tracked_native(&native_called),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items[0],
+            Ok(LookupEvent::AuthoritativeNegative { soa_ttl: None }),
+        ));
+        assert!(!native_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn resolved_failure_is_surfaced() {
+        let native_called = Arc::new(AtomicBool::new(false));
+        let items: Vec<_> = resolved_first_stream(
+            Some(std::future::ready(ResolvedLookup::<Ipv4Addr>::Failed(
+                BoxError::from_static_str("nope"),
+            ))),
+            tracked_native(&native_called),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(items.len(), 1);
+        assert!(matches!(items[0], Err(ref err) if err.to_string() == "nope"));
+        assert!(!native_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn resolved_unavailable_falls_back_to_native() {
+        let native_called = Arc::new(AtomicBool::new(false));
+        let items: Vec<_> = resolved_first_stream(
+            Some(std::future::ready(ResolvedLookup::<Ipv4Addr>::Unavailable)),
+            tracked_native(&native_called),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(items.len(), 1);
+        assert!(
+            matches!(items[0], Ok(LookupEvent::Record(addr, 30)) if addr == Ipv4Addr::new(9, 9, 9, 9)),
+        );
+        assert!(native_called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn disabled_resolved_uses_native() {
+        let native_called = Arc::new(AtomicBool::new(false));
+        let items: Vec<_> = resolved_first_stream(
+            None::<std::future::Ready<ResolvedLookup<Ipv4Addr>>>,
+            tracked_native(&native_called),
+        )
+        .collect()
+        .await;
+
+        assert_eq!(items.len(), 1);
+        assert!(native_called.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -19,7 +19,7 @@ use std::{
     ffi::CString,
     fmt, fs,
     net::{Ipv4Addr, Ipv6Addr},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
@@ -159,9 +159,12 @@ impl LinuxDnsResolverBuilder {
         /// finding a live systemd-resolved socket is insufficient: the daemon
         /// may maintain a secondary DNS view that is not the process's system
         /// resolver. Explicitly enabling the backend also opts into
-        /// systemd-resolved's name semantics: names containing a dot are
-        /// treated as fully qualified instead of following libc's `ndots`
-        /// search expansion.
+        /// systemd-resolved's name semantics for address lookups: names
+        /// containing a dot are treated as fully qualified instead of
+        /// following libc's `ndots` search expansion. TXT lookups keep the
+        /// libc `search` behavior — a negative answer for a relative name is
+        /// retried through the native backend; only a positive as-is answer
+        /// can shadow a search-list candidate under `ndots` larger than one.
         pub fn systemd_resolved(mut self, enabled: bool) -> Self {
             self.systemd_resolved = enabled;
             self
@@ -236,11 +239,18 @@ impl LinuxDnsResolverBuilder {
 }
 
 fn systemd_resolved_selected_by_nss() -> bool {
-    cfg!(target_env = "gnu")
-        && fs::read_to_string(NSSWITCH_CONF_PATH)
-            .is_ok_and(|contents| nsswitch_hosts_selects_resolve(&contents))
+    // process-lifetime snapshot: resolvers are built freely and the
+    // builder flag overrides whenever runtime control is needed
+    static SELECTED: OnceLock<bool> = OnceLock::new();
+    *SELECTED.get_or_init(|| {
+        cfg!(target_env = "gnu")
+            && fs::read_to_string(NSSWITCH_CONF_PATH)
+                .is_ok_and(|contents| nsswitch_hosts_selects_resolve(&contents))
+    })
 }
 
+// assumes the stock `resolve [!UNAVAIL=return] dns` line, where negative
+// answers are final — matching this backend's own short-circuit on them
 fn nsswitch_hosts_selects_resolve(contents: &str) -> bool {
     for raw_line in contents.lines() {
         let line = raw_line

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -802,6 +802,19 @@ mod tests {
         );
     }
 
+    #[test]
+    fn builder_settings_propagate() {
+        let resolver = super::LinuxDnsResolver::builder()
+            .with_timeout(Duration::from_secs(9))
+            .with_systemd_resolved(false)
+            .build();
+        assert_eq!(resolver.timeout(), Duration::from_secs(9));
+        assert!(!resolver.systemd_resolved_enabled());
+
+        let resolver = super::LinuxDnsResolver::new();
+        assert!(resolver.systemd_resolved_enabled());
+    }
+
     fn tracked_native(
         called: &Arc<AtomicBool>,
     ) -> impl FnOnce() -> stream::Iter<std::vec::IntoIter<Result<LookupEvent<Ipv4Addr>, BoxError>>>

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -1,9 +1,10 @@
 //! Linux-native DNS resolver.
 //!
-//! When systemd-resolved's varlink socket is reachable, lookups are served
-//! through it first — fully async, no blocking-pool worker — falling back to
-//! the libc paths below per query and whenever the daemon is unavailable
-//! (see [`super::systemd_resolved`]).
+//! When the host selects `nss-resolve`, lookups are served through
+//! systemd-resolved's varlink socket first — fully async, no blocking-pool
+//! worker — falling back to the libc paths below per query and whenever the
+//! daemon is unavailable (see [`super::systemd_resolved`]). The builder may
+//! explicitly enable or disable this path regardless of the NSS configuration.
 //!
 //! On targets with `res_nsearch` support, `A` / `AAAA` / `TXT` lookups are
 //! backed by the native resolver stub. `res_nsearch` (not `res_nquery`) is
@@ -16,7 +17,7 @@
 
 use std::{
     ffi::CString,
-    fmt,
+    fmt, fs,
     net::{Ipv4Addr, Ipv6Addr},
     sync::Arc,
     time::Duration,
@@ -69,6 +70,7 @@ const DEFAULT_CACHE_CAPACITY: u64 = 65_536;
 /// what most TCP-fallback paths advertise via EDNS0 and keeps the per-query
 /// allocation in the blocking thread modest.
 const DEFAULT_RESPONSE_BUFFER_SIZE: usize = kib(16);
+const NSSWITCH_CONF_PATH: &str = "/etc/nsswitch.conf";
 
 #[derive(Debug, Clone)]
 /// Used to build a [`LinuxDnsResolver`] instance.
@@ -90,7 +92,10 @@ impl Default for LinuxDnsResolverBuilder {
             negative_cache_ttl: DEFAULT_NEGATIVE_CACHE_TTL,
             cache_capacity: DEFAULT_CACHE_CAPACITY,
             response_buffer_size: DEFAULT_RESPONSE_BUFFER_SIZE,
-            systemd_resolved: true,
+            // A running daemon may only be maintained as a secondary DNS
+            // view. Use it automatically only when NSS actually selects
+            // nss-resolve; callers can still opt in explicitly below.
+            systemd_resolved: systemd_resolved_selected_by_nss(),
             systemd_resolved_config: systemd_resolved::Config::default(),
         }
     }
@@ -98,6 +103,12 @@ impl Default for LinuxDnsResolverBuilder {
 
 impl LinuxDnsResolverBuilder {
     generate_set_and_with! {
+        /// Timeout for each DNS backend attempt.
+        ///
+        /// If a systemd-resolved transport attempt consumes this budget and
+        /// falls back to the native backend, that fallback receives a fresh
+        /// budget. During the short pre-breaker window, total lookup latency
+        /// can therefore approach twice this value.
         pub fn timeout(mut self, timeout: Duration) -> Self {
             self.timeout = timeout;
             self
@@ -139,9 +150,18 @@ impl LinuxDnsResolverBuilder {
     }
 
     generate_set_and_with! {
-        /// Route lookups through systemd-resolved's varlink API when its
-        /// socket is reachable (default: enabled), falling back to the libc
-        /// paths per query and whenever the daemon is unavailable.
+        /// Force whether lookups route through systemd-resolved's varlink API,
+        /// falling back to the libc paths per query and whenever the daemon is
+        /// unavailable.
+        ///
+        /// By default this is enabled automatically only when the host's
+        /// `hosts:` NSS configuration selects `resolve` before `dns`. Merely
+        /// finding a live systemd-resolved socket is insufficient: the daemon
+        /// may maintain a secondary DNS view that is not the process's system
+        /// resolver. Explicitly enabling the backend also opts into
+        /// systemd-resolved's name semantics: names containing a dot are
+        /// treated as fully qualified instead of following libc's `ndots`
+        /// search expansion.
         pub fn systemd_resolved(mut self, enabled: bool) -> Self {
             self.systemd_resolved = enabled;
             self
@@ -215,6 +235,39 @@ impl LinuxDnsResolverBuilder {
     }
 }
 
+fn systemd_resolved_selected_by_nss() -> bool {
+    cfg!(target_env = "gnu")
+        && fs::read_to_string(NSSWITCH_CONF_PATH)
+            .is_ok_and(|contents| nsswitch_hosts_selects_resolve(&contents))
+}
+
+fn nsswitch_hosts_selects_resolve(contents: &str) -> bool {
+    for raw_line in contents.lines() {
+        let line = raw_line
+            .split_once('#')
+            .map_or(raw_line, |(before_comment, _)| before_comment)
+            .trim();
+        let Some((database, sources)) = line.split_once(':') else {
+            continue;
+        };
+        if database.trim() != "hosts" {
+            continue;
+        }
+
+        let mut resolve_index = None;
+        let mut dns_index = None;
+        for (index, source) in sources.split_ascii_whitespace().enumerate() {
+            match source {
+                "resolve" => resolve_index.get_or_insert(index),
+                "dns" => dns_index.get_or_insert(index),
+                _ => continue,
+            };
+        }
+        return resolve_index.is_some_and(|resolve| dns_index.is_none_or(|dns| resolve < dns));
+    }
+    false
+}
+
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct LinuxDnsResolver {
@@ -270,6 +323,10 @@ impl LinuxDnsResolver {
     }
 
     generate_set_and_with! {
+        /// Set the timeout for each DNS backend attempt.
+        ///
+        /// See [`LinuxDnsResolverBuilder::timeout`] for fallback latency
+        /// semantics.
         pub fn timeout(mut self, timeout: Duration) -> Self {
             self.timeout = timeout;
             self
@@ -811,8 +868,30 @@ mod tests {
         assert_eq!(resolver.timeout(), Duration::from_secs(9));
         assert!(!resolver.systemd_resolved_enabled());
 
-        let resolver = super::LinuxDnsResolver::new();
+        let resolver = super::LinuxDnsResolver::builder()
+            .with_systemd_resolved(true)
+            .build();
         assert!(resolver.systemd_resolved_enabled());
+    }
+
+    #[test]
+    fn nsswitch_auto_detection_requires_resolve_before_dns() {
+        assert!(super::nsswitch_hosts_selects_resolve(
+            "passwd: files\nhosts: files resolve [!UNAVAIL=return] dns\n"
+        ));
+        assert!(super::nsswitch_hosts_selects_resolve(
+            "hosts: files resolve # dns resolve in a comment does not count\n"
+        ));
+
+        assert!(!super::nsswitch_hosts_selects_resolve(
+            "hosts: files dns resolve\n"
+        ));
+        assert!(!super::nsswitch_hosts_selects_resolve(
+            "hosts: files mdns4_minimal [NOTFOUND=return] dns\n"
+        ));
+        assert!(!super::nsswitch_hosts_selects_resolve(
+            "# hosts: resolve\npasswd: files\n"
+        ));
     }
 
     fn tracked_native(

--- a/rama-dns/src/client/linux/mod.rs
+++ b/rama-dns/src/client/linux/mod.rs
@@ -184,6 +184,17 @@ impl LinuxDnsResolverBuilder {
         }
     }
 
+    generate_set_and_with! {
+        /// Cache TTL for address records resolved via systemd-resolved, whose
+        /// replies carry no per-record TTLs. Keep short: the daemon's own
+        /// TTL-accurate cache sits underneath. Zero means "unknown", falling
+        /// back to the full [`Self::cache_ttl`] bound.
+        pub fn systemd_resolved_hostname_cache_ttl(mut self, ttl: Duration) -> Self {
+            self.systemd_resolved_config.hostname_ttl = ttl;
+            self
+        }
+    }
+
     #[must_use]
     pub fn build(self) -> LinuxDnsResolver {
         LinuxDnsResolver {

--- a/rama-dns/src/client/mod.rs
+++ b/rama-dns/src/client/mod.rs
@@ -41,6 +41,27 @@ pub type NativeDnsResolver = WindowsDnsResolver;
 #[cfg(any(target_os = "linux", all(test, target_family = "unix")))]
 mod systemd_resolved;
 
+// dependency-free wire parsing, split out from the varlink client so the
+// fuzz target below can compile it on any host without the linux-only deps
+mod systemd_resolved_wire;
+
+#[doc(hidden)]
+pub mod fuzzing {
+    /// Fuzz hook for the resolved wire-format RR parser: must never panic,
+    /// and every TXT segment must derive from within the input buffer.
+    /// Returns the TXT ttl + segment count, `None` for non-TXT verdicts.
+    pub fn parse_txt_rr(raw: &[u8]) -> Option<(u32, usize)> {
+        match super::systemd_resolved_wire::parse_txt_rr(raw) {
+            super::systemd_resolved_wire::RrParse::Txt { ttl, segments } => {
+                let total: usize = segments.iter().map(|segment| segment.len() + 1).sum();
+                assert!(total <= raw.len(), "TXT segments exceed input buffer");
+                Some((ttl, segments.len()))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]

--- a/rama-dns/src/client/mod.rs
+++ b/rama-dns/src/client/mod.rs
@@ -36,6 +36,11 @@ pub use self::windows::WindowsDnsResolver;
 #[cfg_attr(docsrs, doc(cfg(target_os = "windows")))]
 pub type NativeDnsResolver = WindowsDnsResolver;
 
+// also compiled under test on any unix so the varlink client and its
+// availability state machine are exercised on non-linux dev hosts
+#[cfg(any(target_os = "linux", all(test, target_family = "unix")))]
+mod systemd_resolved;
+
 #[cfg(target_os = "linux")]
 mod linux;
 #[cfg(target_os = "linux")]

--- a/rama-dns/src/client/mod.rs
+++ b/rama-dns/src/client/mod.rs
@@ -60,6 +60,21 @@ pub mod fuzzing {
             _ => None,
         }
     }
+
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn hook_reports_txt_verdicts() {
+            // owner "a" | TXT IN ttl=7 rdlen=4 | rdata: "hi" + one empty segment
+            let mut raw = vec![1, b'a', 0, 0, 16, 0, 1, 0, 0, 0, 7, 0, 4, 2, b'h', b'i', 0];
+            assert_eq!(super::parse_txt_rr(&raw), Some((7, 2)));
+
+            raw[3..5].copy_from_slice(&5_u16.to_be_bytes()); // CNAME: not txt
+            assert_eq!(super::parse_txt_rr(&raw), None);
+
+            assert_eq!(super::parse_txt_rr(&[0xC0]), None); // malformed
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -12,8 +12,11 @@
 //! not implement — a `MethodNotFound` reply pins TXT to the native backend
 //! without affecting address lookups. `ResolveRecord` applies no
 //! search-domain expansion, so single-label TXT names route to the native
-//! backend directly; multi-label relative names relying on `search` still
-//! behave differently than `res_nsearch` would.
+//! backend directly and only rooted names treat a negative answer as
+//! authoritative: a relative name that comes back negative is retried
+//! natively so the resolv.conf search list still applies. Remaining
+//! divergence from `res_nsearch`: a positive as-is answer wins even where
+//! `ndots` would have preferred a search-list candidate.
 
 use std::{
     fmt,
@@ -23,13 +26,17 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use parking_lot::Mutex;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use rama_core::{bytes::Bytes, error::BoxError, telemetry::tracing};
+use rama_core::{
+    bytes::Bytes,
+    error::{BoxError, BoxErrorExt as _, ErrorExt as _},
+    telemetry::tracing,
+};
 use rama_net::address::Domain;
 use rama_unix::client::default_unix_connect;
 use rama_utils::{octets::kib, str::arcstr::ArcStr};
@@ -37,6 +44,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _},
     sync::Semaphore,
+    time::Instant,
 };
 
 pub(super) const DEFAULT_SOCKET_PATH: &str = "/run/systemd/resolve/io.systemd.Resolve";
@@ -128,8 +136,8 @@ pub(super) enum ResolvedLookup<T> {
     Records(Vec<(T, u32)>),
     /// Authoritative "no such record" answer.
     Negative,
-    /// Resolution failed upstream: surface it; falling back would re-ask the
-    /// same daemon through its slower 127.0.0.53 stub.
+    /// Resolution failed upstream: surface it; falling back would usually
+    /// re-ask the same daemon through its slower 127.0.0.53 stub.
     Failed(BoxError),
     /// resolved is not usable for this lookup; use the native backend.
     Unavailable,
@@ -222,20 +230,26 @@ impl SystemdResolved {
         timeout: Duration,
     ) -> ResolvedLookup<Bytes> {
         let name = wire_name(domain);
-        // ResolveRecord never applies resolv.conf search domains; keep
-        // single-label names on the native path where that expansion happens
+        // fast path: single-label names always need the search list, which
+        // ResolveRecord never applies — skip the guaranteed-useless roundtrip
         if !name.contains('.') {
             return ResolvedLookup::Unavailable;
         }
+        // only a rooted name may treat a negative answer as authoritative;
+        // relative ones are retried natively so the search list applies
+        let rooted = domain.is_fqdn();
         let Some(claim) = self.claim() else {
             return ResolvedLookup::Unavailable;
         };
+        // read after claim(): its recovery-reprobe arm resets this pin
         if !self.txt_supported.load(Ordering::Acquire) {
+            // the daemon never saw a query: hand back any probe slot
+            self.report_transport_failure(claim, FailureKind::Overload);
             return ResolvedLookup::Unavailable;
         }
         let this = self.clone();
         join(tokio::spawn(async move {
-            this.record_query(claim, name, timeout).await
+            this.record_query(claim, name, rooted, timeout).await
         }))
         .await
     }
@@ -289,7 +303,7 @@ impl SystemdResolved {
             Err(err) => {
                 return self.transport_failed(
                     claim,
-                    TransportFailure::soft(format!("invalid ResolveHostname reply: {err}")),
+                    TransportFailure::soft(err.context("invalid ResolveHostname reply")),
                 );
             }
         };
@@ -322,6 +336,7 @@ impl SystemdResolved {
         self: Arc<Self>,
         claim: Claim,
         name: String,
+        rooted: bool,
         timeout: Duration,
     ) -> ResolvedLookup<Bytes> {
         let envelope = match self
@@ -340,6 +355,12 @@ impl SystemdResolved {
             Err(failure) => return self.transport_failed(claim, failure),
         };
         if let Some(error) = envelope.error.as_deref() {
+            if !rooted && error == ERROR_NO_SUCH_RR {
+                // not authoritative for a relative name: the native backend
+                // may still resolve it through the resolv.conf search list
+                self.report_success(claim);
+                return ResolvedLookup::Unavailable;
+            }
             return self.classify_reply_error(claim, error, true);
         }
         let reply = match serde_json::from_value::<RecordReply>(envelope.parameters) {
@@ -347,7 +368,7 @@ impl SystemdResolved {
             Err(err) => {
                 return self.transport_failed(
                     claim,
-                    TransportFailure::soft(format!("invalid ResolveRecord reply: {err}")),
+                    TransportFailure::soft(err.context("invalid ResolveRecord reply")),
                 );
             }
         };
@@ -417,7 +438,10 @@ impl SystemdResolved {
         if error.starts_with(VARLINK_ERROR_PREFIX) {
             return self.transport_failed(
                 claim,
-                TransportFailure::soft(format!("varlink protocol error: {error}")),
+                TransportFailure::soft(
+                    BoxError::from_static_str("varlink protocol error")
+                        .context_str_field("error", error),
+                ),
             );
         }
         self.report_success(claim);
@@ -529,28 +553,26 @@ impl SystemdResolved {
         let permit = match tokio::time::timeout(timeout, self.permits.acquire()).await {
             Ok(Ok(permit)) => permit,
             Ok(Err(err)) => {
-                return Err(TransportFailure::soft(format!(
-                    "varlink semaphore closed: {err}"
-                )));
+                return Err(TransportFailure::soft(
+                    err.context("varlink semaphore closed"),
+                ));
             }
             Err(_) => {
-                return Err(TransportFailure::overload(format!(
-                    "no varlink slot within {timeout:?}"
-                )));
+                return Err(TransportFailure::overload(no_slot_error(timeout)));
             }
         };
         let remaining = timeout.saturating_sub(started.elapsed());
         if remaining.is_zero() {
-            return Err(TransportFailure::overload(format!(
-                "no varlink slot within {timeout:?}"
-            )));
+            return Err(TransportFailure::overload(no_slot_error(timeout)));
         }
         let result =
             match tokio::time::timeout(remaining, self.call_inner(method, parameters)).await {
                 Ok(result) => result,
-                Err(_) => Err(TransportFailure::soft(format!(
-                    "{method} timed out after {timeout:?}"
-                ))),
+                Err(_) => Err(TransportFailure::soft(
+                    BoxError::from_static_str("varlink call timed out")
+                        .context_field("method", method)
+                        .context_debug_field("timeout", timeout),
+                )),
             };
         drop(permit);
         result
@@ -571,20 +593,20 @@ impl SystemdResolved {
             // immediate connect errors (missing socket, refused) are unambiguous
             Ok(Err(err)) => return Err(TransportFailure::hard(err)),
             Err(_) => {
-                return Err(TransportFailure::soft(format!(
-                    "connect timed out after {:?}",
-                    self.config.connect_timeout
-                )));
+                return Err(TransportFailure::soft(
+                    BoxError::from_static_str("varlink connect timed out")
+                        .context_debug_field("timeout", self.config.connect_timeout),
+                ));
             }
         };
 
         let mut frame = serde_json::to_vec(&Call { method, parameters })
-            .map_err(|err| TransportFailure::soft(format!("encode varlink call: {err}")))?;
+            .map_err(|err| TransportFailure::soft(err.context("encode varlink call")))?;
         frame.push(0);
         stream
             .write_all(&frame)
             .await
-            .map_err(|err| TransportFailure::soft(format!("write varlink call: {err}")))?;
+            .map_err(|err| TransportFailure::soft(err.context("write varlink call")))?;
 
         let mut buf = Vec::with_capacity(1024);
         let mut scanned = 0;
@@ -592,7 +614,7 @@ impl SystemdResolved {
             let n = stream
                 .read_buf(&mut buf)
                 .await
-                .map_err(|err| TransportFailure::soft(format!("read varlink reply: {err}")))?;
+                .map_err(|err| TransportFailure::soft(err.context("read varlink reply")))?;
             if n == 0 {
                 return Err(TransportFailure::soft(
                     "connection closed before varlink reply",
@@ -604,7 +626,7 @@ impl SystemdResolved {
                     return Err(TransportFailure::soft("varlink reply exceeds size bound"));
                 }
                 return serde_json::from_slice(frame)
-                    .map_err(|err| TransportFailure::soft(format!("decode varlink reply: {err}")));
+                    .map_err(|err| TransportFailure::soft(err.context("decode varlink reply")));
             }
             scanned = buf.len();
             if buf.len() > MAX_REPLY_SIZE {
@@ -663,6 +685,11 @@ fn mark_unavailable(state: &mut Availability) -> bool {
 
 fn wire_name(domain: &Domain) -> String {
     domain.as_str().trim_end_matches('.').to_owned()
+}
+
+fn no_slot_error(timeout: Duration) -> BoxError {
+    BoxError::from_static_str("no varlink slot within the lookup deadline")
+        .context_debug_field("timeout", timeout)
 }
 
 /// Positive sub-second TTLs round up to one second so they cannot collapse
@@ -1402,35 +1429,25 @@ mod tests {
         );
     }
 
-    #[test]
-    fn stale_probe_claim_is_reclaimed() {
+    #[tokio::test(start_paused = true)]
+    async fn stale_probe_claim_is_reclaimed() {
         let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
         let original = resolved.claim().expect("probe claim");
         assert!(original.probe_generation.is_some());
         assert!(resolved.claim().is_none(), "fresh probe is not reclaimable");
 
-        resolved.state.lock().phase = Phase::Probing {
-            since: Instant::now()
-                .checked_sub(PROBE_STALE + Duration::from_secs(1))
-                .expect("clock predates the probe stale bound"),
-            generation: original.probe_generation.expect("probe generation"),
-        };
+        tokio::time::advance(PROBE_STALE + Duration::from_secs(1)).await;
         let replacement = resolved.claim().expect("stale probe reclaimed");
         assert!(replacement.probe_generation.is_some());
         assert_ne!(replacement.probe_generation, original.probe_generation);
     }
 
-    #[test]
-    fn superseded_probe_reports_do_not_reset_or_flip_replacement() {
+    #[tokio::test(start_paused = true)]
+    async fn superseded_probe_reports_do_not_reset_or_flip_replacement() {
         let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
         let original = resolved.claim().expect("probe claim");
-        let original_generation = original.probe_generation.expect("probe generation");
-        resolved.state.lock().phase = Phase::Probing {
-            since: Instant::now()
-                .checked_sub(PROBE_STALE + Duration::from_secs(1))
-                .expect("clock predates the probe stale bound"),
-            generation: original_generation,
-        };
+        assert!(original.probe_generation.is_some());
+        tokio::time::advance(PROBE_STALE + Duration::from_secs(1)).await;
         let replacement = resolved.claim().expect("replacement probe");
 
         resolved.report_transport_failure(original, FailureKind::Overload);
@@ -1536,6 +1553,9 @@ mod tests {
         // rdata segment length pointing past the buffer
         let mut raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &[200]);
         assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
+        // TXT rdata must carry at least one character-string
+        raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &[]);
+        assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
         // rdlen pointing past the buffer
         raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &txt_rdata(&[b"ok"]));
         raw.truncate(raw.len() - 1);
@@ -1578,6 +1598,30 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
         assert_eq!(server.connections(), 1);
+    }
+
+    #[tokio::test]
+    async fn relative_txt_negative_falls_back_without_authority() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(error_reply(ERROR_NO_SUCH_RR))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved.lookup_txt(&domain(), Duration::from_secs(1)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(server.connections(), 1, "the daemon is still asked first");
+        assert_available(&resolved);
+    }
+
+    #[tokio::test]
+    async fn rooted_txt_negative_is_authoritative() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(error_reply(ERROR_NO_SUCH_RR))]);
+        let resolved = resolver(server.path.clone());
+        let rooted: Domain = "example.com.".try_into().expect("valid domain");
+        assert!(matches!(
+            resolved.lookup_txt(&rooted, Duration::from_secs(1)).await,
+            ResolvedLookup::Negative,
+        ));
+        assert_available(&resolved);
     }
 
     #[tokio::test]

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -53,8 +53,7 @@ const VARLINK_ERROR_PREFIX: &str = "org.varlink.";
 const AF_INET: i64 = 2;
 const AF_INET6: i64 = 10;
 
-const DNS_CLASS_IN: u16 = 1;
-const DNS_TYPE_TXT: u16 = 16;
+use super::systemd_resolved_wire::{DNS_CLASS_IN, DNS_TYPE_TXT, RrParse, parse_txt_rr};
 
 /// A probe claim older than this is assumed orphaned and may be re-claimed.
 const PROBE_STALE: Duration = Duration::from_secs(15);
@@ -686,61 +685,6 @@ struct RecordReply {
 #[derive(Deserialize)]
 struct RecordEntry {
     raw: String,
-}
-
-enum RrParse {
-    Txt { ttl: u32, segments: Vec<Bytes> },
-    Other,
-    Malformed,
-}
-
-/// Parse one wire-format RR as produced by `ResolveRecord`'s `raw` field.
-/// Owner names are standalone here, so compression pointers cannot be
-/// resolved and are treated as malformed.
-fn parse_txt_rr(raw: &[u8]) -> RrParse {
-    let Some(mut offset) = skip_uncompressed_name(raw) else {
-        return RrParse::Malformed;
-    };
-    let Some(header) = raw.get(offset..offset + 10) else {
-        return RrParse::Malformed;
-    };
-    let rtype = u16::from_be_bytes([header[0], header[1]]);
-    let class = u16::from_be_bytes([header[2], header[3]]);
-    let ttl = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
-    let rdlen = u16::from_be_bytes([header[8], header[9]]) as usize;
-    offset += 10;
-    let Some(rdata) = raw.get(offset..offset + rdlen) else {
-        return RrParse::Malformed;
-    };
-    if rtype != DNS_TYPE_TXT || class != DNS_CLASS_IN {
-        return RrParse::Other;
-    }
-    let mut segments = Vec::new();
-    let mut cursor = 0;
-    while cursor < rdata.len() {
-        let len = rdata[cursor] as usize;
-        cursor += 1;
-        let Some(segment) = rdata.get(cursor..cursor + len) else {
-            return RrParse::Malformed;
-        };
-        segments.push(Bytes::copy_from_slice(segment));
-        cursor += len;
-    }
-    RrParse::Txt { ttl, segments }
-}
-
-fn skip_uncompressed_name(raw: &[u8]) -> Option<usize> {
-    let mut offset = 0;
-    loop {
-        let len = *raw.get(offset)?;
-        if len == 0 {
-            return Some(offset + 1);
-        }
-        if len & 0xC0 != 0 {
-            return None;
-        }
-        offset += 1 + len as usize;
-    }
 }
 
 #[derive(Debug)]
@@ -1388,6 +1332,38 @@ mod tests {
     }
 
     #[test]
+    fn stale_probe_claim_is_reclaimed() {
+        let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
+        assert!(resolved.claim().expect("probe claim").probing);
+        assert!(resolved.claim().is_none(), "fresh probe is not reclaimable");
+
+        resolved.state.lock().phase = Phase::Probing {
+            since: Instant::now()
+                .checked_sub(PROBE_STALE + Duration::from_secs(1))
+                .expect("clock predates the probe stale bound"),
+        };
+        assert!(resolved.claim().expect("stale probe reclaimed").probing);
+    }
+
+    #[test]
+    fn overload_does_not_reset_foreign_probe() {
+        let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
+        let probe = resolved.claim().expect("probe claim");
+
+        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Overload);
+        assert!(
+            matches!(phase(&resolved), Phase::Probing { .. }),
+            "a non-probing overload must not reset someone else's probe",
+        );
+
+        resolved.report_transport_failure(probe, FailureKind::Overload);
+        assert!(
+            matches!(phase(&resolved), Phase::Untested),
+            "the probing claim's own overload frees the probe slot",
+        );
+    }
+
+    #[test]
     fn zero_reprobe_interval_reprobes_immediately() {
         let mut config = test_config("/nonexistent".into());
         config.reprobe_interval = Duration::ZERO;
@@ -1543,12 +1519,30 @@ mod tests {
         assert_unavailable(&resolved);
     }
 
+    /// Valid hostname reply padded to exactly `target_len` JSON bytes.
+    fn padded_hostname_frame(target_len: usize) -> Vec<u8> {
+        let build = |pad: String| {
+            serde_json::to_vec(&json!({
+                "parameters": {
+                    "addresses": [{ "family": 2, "address": [1, 2, 3, 4] }],
+                    "pad": pad,
+                },
+            }))
+            .expect("serialize padded reply")
+        };
+        let overhead = build(String::new()).len();
+        let mut raw = build("a".repeat(target_len - overhead));
+        assert_eq!(raw.len(), target_len);
+        raw.push(0);
+        raw
+    }
+
     #[tokio::test]
     async fn oversized_reply_is_transport_failure() {
-        let pad = "a".repeat(MAX_REPLY_SIZE);
-        let mut raw = format!(r#"{{"parameters":{{"pad":"{pad}"}}}}"#).into_bytes();
-        raw.push(0);
-        let server = FakeResolved::spawn(vec![Behavior::RawReply(raw)]);
+        // an otherwise perfectly valid reply: only the size bound may reject it
+        let server = FakeResolved::spawn(vec![Behavior::RawReply(padded_hostname_frame(
+            MAX_REPLY_SIZE + 1,
+        ))]);
         let resolved = resolver(server.path.clone());
         assert!(matches!(
             resolved
@@ -1557,6 +1551,40 @@ mod tests {
             ResolvedLookup::Unavailable,
         ));
         assert_unavailable(&resolved);
+    }
+
+    #[tokio::test]
+    async fn reply_at_size_bound_is_accepted() {
+        let server = FakeResolved::spawn(vec![Behavior::RawReply(padded_hostname_frame(
+            MAX_REPLY_SIZE,
+        ))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+    }
+
+    #[tokio::test]
+    async fn txt_resolution_errors_surface_without_pinning() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(error_reply(
+            "io.systemd.Resolve.QueryTimedOut",
+        ))]);
+        let resolved = resolver(server.path.clone());
+        match resolved.lookup_txt(&domain(), Duration::from_secs(1)).await {
+            ResolvedLookup::Failed(err) => {
+                assert!(err.to_string().contains("QueryTimedOut"), "got: {err}")
+            }
+            _ => panic!("expected failed lookup"),
+        }
+        // only MethodNotFound may pin txt to the native backend
+        match resolved.lookup_txt(&domain(), Duration::from_secs(1)).await {
+            ResolvedLookup::Failed(_) => {}
+            _ => panic!("expected failed lookup"),
+        }
+        assert_eq!(server.connections(), 2);
     }
 
     #[tokio::test]

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -1,0 +1,1326 @@
+//! systemd-resolved varlink backend for the Linux DNS resolver.
+//!
+//! Speaks the native `io.systemd.Resolve` API (JSON frames terminated by a
+//! NUL byte, one call per connection) over the daemon's unix socket — the
+//! same transport glibc's `nss-resolve` module uses. Unlike the libc paths
+//! this is fully async: no blocking-pool worker is held and timeouts cancel
+//! the query.
+//!
+//! Address lookups use `ResolveHostname` for `getaddrinfo` parity (search
+//! domains, `/etc/hosts`, synthesized names, CNAME chasing). TXT lookups use
+//! `ResolveRecord` (raw wire-format RRs, real TTLs), which older daemons do
+//! not implement — a `MethodNotFound` reply pins TXT to the native backend
+//! without affecting address lookups.
+
+use std::{
+    fmt,
+    net::{Ipv4Addr, Ipv6Addr},
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use rama_core::{bytes::Bytes, error::BoxError, telemetry::tracing};
+use rama_net::address::Domain;
+use rama_unix::client::default_unix_connect;
+use rama_utils::{octets::kib, str::arcstr::ArcStr};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::{AsyncReadExt as _, AsyncWriteExt as _},
+    sync::Semaphore,
+};
+
+pub(super) const DEFAULT_SOCKET_PATH: &str = "/run/systemd/resolve/io.systemd.Resolve";
+
+const METHOD_RESOLVE_HOSTNAME: &str = "io.systemd.Resolve.ResolveHostname";
+const METHOD_RESOLVE_RECORD: &str = "io.systemd.Resolve.ResolveRecord";
+const ERROR_NO_SUCH_RR: &str = "io.systemd.Resolve.NoSuchResourceRecord";
+const ERROR_METHOD_NOT_FOUND: &str = "org.varlink.service.MethodNotFound";
+/// Errors in this namespace are varlink protocol failures, not resolution answers.
+const VARLINK_ERROR_PREFIX: &str = "org.varlink.";
+
+// The daemon is always Linux; these are its wire values regardless of the
+// compilation host (this module also builds on other unixes for tests).
+const AF_INET: i64 = 2;
+const AF_INET6: i64 = 10;
+
+const DNS_CLASS_IN: u16 = 1;
+const DNS_TYPE_TXT: u16 = 16;
+
+/// A probe claim older than this is assumed orphaned and may be re-claimed.
+const PROBE_STALE: Duration = Duration::from_secs(15);
+/// Replies are per-query record sets; anything bigger is a broken peer.
+const MAX_REPLY_SIZE: usize = kib(256);
+
+#[derive(Debug, Clone)]
+pub(super) struct Config {
+    pub(super) socket_path: PathBuf,
+    pub(super) connect_timeout: Duration,
+    pub(super) reprobe_interval: Duration,
+    pub(super) breaker_threshold: u32,
+    pub(super) max_concurrency: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            socket_path: DEFAULT_SOCKET_PATH.into(),
+            // a healthy local daemon accepts near-instantly; anything slower
+            // is backlogged and should feed the breaker quickly
+            connect_timeout: Duration::from_secs(1),
+            reprobe_interval: Duration::from_secs(30),
+            breaker_threshold: 4,
+            // stays below resolved's varlink server default of 128 connections
+            // per UID, a budget shared with other same-UID clients (nss-resolve)
+            max_concurrency: 112,
+        }
+    }
+}
+
+const UNTESTED: u8 = 0;
+const PROBING: u8 = 1;
+const AVAILABLE: u8 = 2;
+const UNAVAILABLE: u8 = 3;
+
+/// Lock-free availability tracking: the first lookup doubles as the probe
+/// (single-flight via CAS), transport failures feed a consecutive-failure
+/// breaker, and an unavailable daemon is re-probed at most once per
+/// [`Config::reprobe_interval`]. Lookups never wait on a probe: whoever does
+/// not hold the claim reports [`ResolvedLookup::Unavailable`] so the caller
+/// uses the native backend instead.
+#[derive(Debug)]
+pub(super) struct SystemdResolved {
+    config: Config,
+    epoch: Instant,
+    state: AtomicU8,
+    /// ms since `epoch`: probe claim time while probing, flip time while unavailable
+    stamp: AtomicU64,
+    failures: AtomicU32,
+    txt_supported: AtomicBool,
+    permits: Semaphore,
+}
+
+pub(super) enum ResolvedLookup<T> {
+    /// Records with their DNS TTL in seconds (`0` = unknown).
+    Records(Vec<(T, u32)>),
+    /// Authoritative "no such record" answer.
+    Negative,
+    /// Resolution failed upstream: surface it; falling back would re-ask the
+    /// same daemon through its slower 127.0.0.53 stub.
+    Failed(BoxError),
+    /// resolved is not usable for this lookup; use the native backend.
+    Unavailable,
+}
+
+#[derive(Clone, Copy)]
+struct Claim {
+    probing: bool,
+}
+
+struct TransportFailure {
+    hard: bool,
+    error: BoxError,
+}
+
+impl TransportFailure {
+    fn soft(error: impl Into<BoxError>) -> Self {
+        Self {
+            hard: false,
+            error: error.into(),
+        }
+    }
+
+    fn hard(error: impl Into<BoxError>) -> Self {
+        Self {
+            hard: true,
+            error: error.into(),
+        }
+    }
+}
+
+impl SystemdResolved {
+    pub(super) fn new(config: Config) -> Self {
+        let permits = Semaphore::new(config.max_concurrency.max(1));
+        Self {
+            config,
+            epoch: Instant::now(),
+            state: AtomicU8::new(UNTESTED),
+            stamp: AtomicU64::new(0),
+            failures: AtomicU32::new(0),
+            txt_supported: AtomicBool::new(true),
+            permits,
+        }
+    }
+
+    pub(super) async fn lookup_ipv4(
+        self: &Arc<Self>,
+        domain: &Domain,
+        timeout: Duration,
+    ) -> ResolvedLookup<Ipv4Addr> {
+        self.lookup_hostname(domain, AF_INET, timeout, |raw| {
+            <[u8; 4]>::try_from(raw).ok().map(Ipv4Addr::from)
+        })
+        .await
+    }
+
+    pub(super) async fn lookup_ipv6(
+        self: &Arc<Self>,
+        domain: &Domain,
+        timeout: Duration,
+    ) -> ResolvedLookup<Ipv6Addr> {
+        self.lookup_hostname(domain, AF_INET6, timeout, |raw| {
+            <[u8; 16]>::try_from(raw).ok().map(Ipv6Addr::from)
+        })
+        .await
+    }
+
+    pub(super) async fn lookup_txt(
+        self: &Arc<Self>,
+        domain: &Domain,
+        timeout: Duration,
+    ) -> ResolvedLookup<Bytes> {
+        if !self.txt_supported.load(Ordering::Acquire) {
+            return ResolvedLookup::Unavailable;
+        }
+        let Some(claim) = self.claim() else {
+            return ResolvedLookup::Unavailable;
+        };
+        let this = self.clone();
+        let name = wire_name(domain);
+        join(tokio::spawn(async move {
+            this.record_query(claim, name, timeout).await
+        }))
+        .await
+    }
+
+    async fn lookup_hostname<T: Send + 'static>(
+        self: &Arc<Self>,
+        domain: &Domain,
+        family: i64,
+        timeout: Duration,
+        decode: fn(&[u8]) -> Option<T>,
+    ) -> ResolvedLookup<T> {
+        let Some(claim) = self.claim() else {
+            return ResolvedLookup::Unavailable;
+        };
+        let this = self.clone();
+        let name = wire_name(domain);
+        join(tokio::spawn(async move {
+            this.hostname_query(claim, name, family, timeout, decode)
+                .await
+        }))
+        .await
+    }
+
+    async fn hostname_query<T>(
+        self: Arc<Self>,
+        claim: Claim,
+        name: String,
+        family: i64,
+        timeout: Duration,
+        decode: fn(&[u8]) -> Option<T>,
+    ) -> ResolvedLookup<T> {
+        let envelope = match self
+            .call(
+                METHOD_RESOLVE_HOSTNAME,
+                &HostnameParams {
+                    name: &name,
+                    family,
+                },
+                timeout,
+            )
+            .await
+        {
+            Ok(envelope) => envelope,
+            Err(failure) => return self.transport_failed(claim, failure),
+        };
+        if let Some(error) = envelope.error.as_deref() {
+            return self.classify_reply_error(claim, error, false);
+        }
+        match serde_json::from_value::<HostnameReply>(envelope.parameters) {
+            Ok(reply) => {
+                self.report_success();
+                ResolvedLookup::Records(
+                    reply
+                        .addresses
+                        .into_iter()
+                        .filter(|entry| entry.family == family)
+                        .filter_map(|entry| decode(&entry.address).map(|value| (value, 0)))
+                        .collect(),
+                )
+            }
+            Err(err) => self.transport_failed(
+                claim,
+                TransportFailure::soft(format!("invalid ResolveHostname reply: {err}")),
+            ),
+        }
+    }
+
+    async fn record_query(
+        self: Arc<Self>,
+        claim: Claim,
+        name: String,
+        timeout: Duration,
+    ) -> ResolvedLookup<Bytes> {
+        let envelope = match self
+            .call(
+                METHOD_RESOLVE_RECORD,
+                &RecordParams {
+                    name: &name,
+                    r#type: DNS_TYPE_TXT,
+                    class: DNS_CLASS_IN,
+                },
+                timeout,
+            )
+            .await
+        {
+            Ok(envelope) => envelope,
+            Err(failure) => return self.transport_failed(claim, failure),
+        };
+        if let Some(error) = envelope.error.as_deref() {
+            return self.classify_reply_error(claim, error, true);
+        }
+        let reply = match serde_json::from_value::<RecordReply>(envelope.parameters) {
+            Ok(reply) => reply,
+            Err(err) => {
+                return self.transport_failed(
+                    claim,
+                    TransportFailure::soft(format!("invalid ResolveRecord reply: {err}")),
+                );
+            }
+        };
+        let mut records = Vec::new();
+        for entry in &reply.rrs {
+            let Ok(raw) = BASE64.decode(&entry.raw) else {
+                return self.transport_failed(
+                    claim,
+                    TransportFailure::soft("invalid base64 rr in ResolveRecord reply"),
+                );
+            };
+            match parse_txt_rr(&raw) {
+                RrParse::Txt { ttl, segments } => {
+                    records.extend(segments.into_iter().map(|segment| (segment, ttl)));
+                }
+                // e.g. CNAME chain entries included alongside the target RRset
+                RrParse::Other => {}
+                RrParse::Malformed => {
+                    return self.transport_failed(
+                        claim,
+                        TransportFailure::soft("malformed rr in ResolveRecord reply"),
+                    );
+                }
+            }
+        }
+        self.report_success();
+        if records.is_empty() {
+            ResolvedLookup::Negative
+        } else {
+            ResolvedLookup::Records(records)
+        }
+    }
+
+    fn classify_reply_error<T>(
+        &self,
+        claim: Claim,
+        error: &str,
+        record_query: bool,
+    ) -> ResolvedLookup<T> {
+        if error == ERROR_NO_SUCH_RR {
+            self.report_success();
+            return ResolvedLookup::Negative;
+        }
+        if record_query && error == ERROR_METHOD_NOT_FOUND {
+            // daemon reachable but too old for ResolveRecord: pin TXT to the
+            // native backend, address lookups keep flowing
+            self.report_success();
+            self.txt_supported.store(false, Ordering::Release);
+            tracing::debug!(
+                "dns::systemd-resolved: ResolveRecord not implemented; txt lookups use the native backend"
+            );
+            return ResolvedLookup::Unavailable;
+        }
+        if error.starts_with(VARLINK_ERROR_PREFIX) {
+            return self.transport_failed(
+                claim,
+                TransportFailure::soft(format!("varlink protocol error: {error}")),
+            );
+        }
+        self.report_success();
+        ResolvedLookup::Failed(
+            SystemdResolvedError::message(format!("systemd-resolved lookup failed: {error}"))
+                .into(),
+        )
+    }
+
+    fn transport_failed<T>(&self, claim: Claim, failure: TransportFailure) -> ResolvedLookup<T> {
+        let TransportFailure { hard, error } = failure;
+        tracing::debug!(
+            err = %error,
+            hard,
+            "dns::systemd-resolved: transport failure",
+        );
+        self.report_transport_failure(claim, hard);
+        ResolvedLookup::Unavailable
+    }
+
+    fn claim(&self) -> Option<Claim> {
+        let now = self.now_ms();
+        match self.state.load(Ordering::Acquire) {
+            AVAILABLE => Some(Claim { probing: false }),
+            UNTESTED => self
+                .state
+                .compare_exchange(UNTESTED, PROBING, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+                .then(|| {
+                    self.stamp.store(now, Ordering::Release);
+                    Claim { probing: true }
+                }),
+            PROBING => {
+                let stamped = self.stamp.load(Ordering::Acquire);
+                (now.saturating_sub(stamped) > ms(PROBE_STALE)
+                    && self
+                        .stamp
+                        .compare_exchange(stamped, now, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok())
+                .then_some(Claim { probing: true })
+            }
+            _ => {
+                let stamped = self.stamp.load(Ordering::Acquire);
+                if now.saturating_sub(stamped) >= ms(self.config.reprobe_interval)
+                    && self
+                        .stamp
+                        .compare_exchange(stamped, now, Ordering::AcqRel, Ordering::Acquire)
+                        .is_ok()
+                {
+                    self.state.store(PROBING, Ordering::Release);
+                    Some(Claim { probing: true })
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn report_success(&self) {
+        self.failures.store(0, Ordering::Release);
+        if self.state.swap(AVAILABLE, Ordering::AcqRel) != AVAILABLE {
+            tracing::debug!("dns::systemd-resolved: available");
+        }
+    }
+
+    fn report_transport_failure(&self, claim: Claim, hard: bool) {
+        if claim.probing || hard {
+            self.mark_unavailable();
+            return;
+        }
+        if self.failures.fetch_add(1, Ordering::AcqRel) + 1 >= self.config.breaker_threshold {
+            self.mark_unavailable();
+        }
+    }
+
+    fn mark_unavailable(&self) {
+        self.failures.store(0, Ordering::Release);
+        self.stamp.store(self.now_ms(), Ordering::Release);
+        if self.state.swap(UNAVAILABLE, Ordering::AcqRel) != UNAVAILABLE {
+            tracing::debug!(
+                reprobe_interval = ?self.config.reprobe_interval,
+                "dns::systemd-resolved: unavailable; lookups use the native backend",
+            );
+        }
+    }
+
+    fn now_ms(&self) -> u64 {
+        u64::try_from(self.epoch.elapsed().as_millis()).unwrap_or(u64::MAX)
+    }
+
+    async fn call<P: Serialize>(
+        &self,
+        method: &'static str,
+        parameters: &P,
+        timeout: Duration,
+    ) -> Result<Envelope, TransportFailure> {
+        match tokio::time::timeout(timeout, self.call_inner(method, parameters)).await {
+            Ok(result) => result,
+            Err(_) => Err(TransportFailure::soft(format!(
+                "{method} timed out after {timeout:?}"
+            ))),
+        }
+    }
+
+    async fn call_inner<P: Serialize>(
+        &self,
+        method: &'static str,
+        parameters: &P,
+    ) -> Result<Envelope, TransportFailure> {
+        let _permit =
+            self.permits.acquire().await.map_err(|err| {
+                TransportFailure::soft(format!("varlink semaphore closed: {err}"))
+            })?;
+
+        let (mut stream, _info) = match tokio::time::timeout(
+            self.config.connect_timeout,
+            default_unix_connect(self.config.socket_path.clone()),
+        )
+        .await
+        {
+            Ok(Ok(connection)) => connection,
+            // immediate connect errors (missing socket, refused) are unambiguous
+            Ok(Err(err)) => return Err(TransportFailure::hard(err)),
+            Err(_) => {
+                return Err(TransportFailure::soft(format!(
+                    "connect timed out after {:?}",
+                    self.config.connect_timeout
+                )));
+            }
+        };
+
+        let mut frame = serde_json::to_vec(&Call { method, parameters })
+            .map_err(|err| TransportFailure::soft(format!("encode varlink call: {err}")))?;
+        frame.push(0);
+        stream
+            .write_all(&frame)
+            .await
+            .map_err(|err| TransportFailure::soft(format!("write varlink call: {err}")))?;
+
+        let mut buf = Vec::with_capacity(1024);
+        let mut scanned = 0;
+        loop {
+            let n = stream
+                .read_buf(&mut buf)
+                .await
+                .map_err(|err| TransportFailure::soft(format!("read varlink reply: {err}")))?;
+            if n == 0 {
+                return Err(TransportFailure::soft(
+                    "connection closed before varlink reply",
+                ));
+            }
+            if let Some(pos) = buf[scanned..].iter().position(|byte| *byte == 0) {
+                let frame = &buf[..scanned + pos];
+                return serde_json::from_slice(frame)
+                    .map_err(|err| TransportFailure::soft(format!("decode varlink reply: {err}")));
+            }
+            scanned = buf.len();
+            if buf.len() > MAX_REPLY_SIZE {
+                return Err(TransportFailure::soft("varlink reply exceeds size bound"));
+            }
+        }
+    }
+}
+
+/// Detached task so a dropped consumer (e.g. `race_connect`) can never orphan
+/// a probe claim or lose breaker accounting.
+async fn join<T>(task: tokio::task::JoinHandle<ResolvedLookup<T>>) -> ResolvedLookup<T> {
+    match task.await {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            tracing::debug!(%err, "dns::systemd-resolved: lookup task failed to join");
+            ResolvedLookup::Unavailable
+        }
+    }
+}
+
+fn wire_name(domain: &Domain) -> String {
+    domain.as_str().trim_end_matches('.').to_owned()
+}
+
+fn ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[derive(Serialize)]
+struct Call<'a, P> {
+    method: &'static str,
+    parameters: &'a P,
+}
+
+#[derive(Serialize)]
+struct HostnameParams<'a> {
+    name: &'a str,
+    family: i64,
+}
+
+#[derive(Serialize)]
+struct RecordParams<'a> {
+    name: &'a str,
+    #[serde(rename = "type")]
+    r#type: u16,
+    class: u16,
+}
+
+#[derive(Deserialize)]
+struct Envelope {
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default)]
+    parameters: serde_json::Value,
+}
+
+#[derive(Deserialize)]
+struct HostnameReply {
+    #[serde(default)]
+    addresses: Vec<AddressEntry>,
+}
+
+#[derive(Deserialize)]
+struct AddressEntry {
+    family: i64,
+    address: Vec<u8>,
+}
+
+#[derive(Deserialize)]
+struct RecordReply {
+    #[serde(default)]
+    rrs: Vec<RecordEntry>,
+}
+
+#[derive(Deserialize)]
+struct RecordEntry {
+    raw: String,
+}
+
+enum RrParse {
+    Txt { ttl: u32, segments: Vec<Bytes> },
+    Other,
+    Malformed,
+}
+
+/// Parse one wire-format RR as produced by `ResolveRecord`'s `raw` field.
+/// Owner names are standalone here, so compression pointers cannot be
+/// resolved and are treated as malformed.
+fn parse_txt_rr(raw: &[u8]) -> RrParse {
+    let Some(mut offset) = skip_uncompressed_name(raw) else {
+        return RrParse::Malformed;
+    };
+    let Some(header) = raw.get(offset..offset + 10) else {
+        return RrParse::Malformed;
+    };
+    let rtype = u16::from_be_bytes([header[0], header[1]]);
+    let class = u16::from_be_bytes([header[2], header[3]]);
+    let ttl = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
+    let rdlen = u16::from_be_bytes([header[8], header[9]]) as usize;
+    offset += 10;
+    let Some(rdata) = raw.get(offset..offset + rdlen) else {
+        return RrParse::Malformed;
+    };
+    if rtype != DNS_TYPE_TXT || class != DNS_CLASS_IN {
+        return RrParse::Other;
+    }
+    let mut segments = Vec::new();
+    let mut cursor = 0;
+    while cursor < rdata.len() {
+        let len = rdata[cursor] as usize;
+        cursor += 1;
+        let Some(segment) = rdata.get(cursor..cursor + len) else {
+            return RrParse::Malformed;
+        };
+        segments.push(Bytes::copy_from_slice(segment));
+        cursor += len;
+    }
+    RrParse::Txt { ttl, segments }
+}
+
+fn skip_uncompressed_name(raw: &[u8]) -> Option<usize> {
+    let mut offset = 0;
+    loop {
+        let len = *raw.get(offset)?;
+        if len == 0 {
+            return Some(offset + 1);
+        }
+        if len & 0xC0 != 0 {
+            return None;
+        }
+        offset += 1 + len as usize;
+    }
+}
+
+#[derive(Debug)]
+struct SystemdResolvedError(ArcStr);
+
+impl SystemdResolvedError {
+    fn message(message: impl Into<ArcStr>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl fmt::Display for SystemdResolvedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SystemdResolvedError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::net::UnixListener;
+
+    static SOCKET_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    fn test_socket_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "rama-dns-rvl-{}-{}.sock",
+            std::process::id(),
+            SOCKET_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    #[derive(Clone)]
+    enum Behavior {
+        Reply(serde_json::Value),
+        RawReply(Vec<u8>),
+        ChunkedReply(serde_json::Value),
+        DelayedReply(Duration, serde_json::Value),
+        CloseImmediately,
+        Hang,
+    }
+
+    struct FakeResolved {
+        path: PathBuf,
+        connections: Arc<AtomicUsize>,
+        concurrent_peak: Arc<AtomicUsize>,
+        handle: tokio::task::JoinHandle<()>,
+    }
+
+    impl FakeResolved {
+        fn spawn(behaviors: Vec<Behavior>) -> Self {
+            Self::spawn_at(test_socket_path(), behaviors)
+        }
+
+        fn spawn_at(path: PathBuf, behaviors: Vec<Behavior>) -> Self {
+            _ = std::fs::remove_file(&path);
+            let listener = UnixListener::bind(&path).expect("bind fake resolved socket");
+            let connections = Arc::new(AtomicUsize::new(0));
+            let concurrent_peak = Arc::new(AtomicUsize::new(0));
+            let conn_count = connections.clone();
+            let peak = concurrent_peak.clone();
+            let handle = tokio::spawn(async move {
+                let live = Arc::new(AtomicUsize::new(0));
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let index = conn_count.fetch_add(1, Ordering::SeqCst);
+                    let behavior = behaviors
+                        .get(index)
+                        .or_else(|| behaviors.last())
+                        .cloned()
+                        .expect("at least one behavior");
+                    let live = live.clone();
+                    let peak = peak.clone();
+                    tokio::spawn(async move {
+                        let current = live.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(current, Ordering::SeqCst);
+                        serve_connection(stream, behavior).await;
+                        live.fetch_sub(1, Ordering::SeqCst);
+                    });
+                }
+            });
+            Self {
+                path,
+                connections,
+                concurrent_peak,
+                handle,
+            }
+        }
+
+        fn connections(&self) -> usize {
+            self.connections.load(Ordering::SeqCst)
+        }
+    }
+
+    impl Drop for FakeResolved {
+        fn drop(&mut self) {
+            self.handle.abort();
+            _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    async fn serve_connection(mut stream: tokio::net::UnixStream, behavior: Behavior) {
+        let mut buf = Vec::new();
+        loop {
+            let Ok(n) = stream.read_buf(&mut buf).await else {
+                return;
+            };
+            if n == 0 || buf.contains(&0) {
+                break;
+            }
+        }
+        match behavior {
+            Behavior::CloseImmediately => {}
+            Behavior::Hang => tokio::time::sleep(Duration::from_secs(60)).await,
+            Behavior::RawReply(raw) => {
+                _ = stream.write_all(&raw).await;
+            }
+            Behavior::ChunkedReply(reply) => {
+                let mut frame = serde_json::to_vec(&reply).expect("serialize reply");
+                frame.push(0);
+                let split = frame.len() / 2;
+                _ = stream.write_all(&frame[..split]).await;
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                _ = stream.write_all(&frame[split..]).await;
+            }
+            Behavior::DelayedReply(delay, reply) => {
+                tokio::time::sleep(delay).await;
+                write_reply(&mut stream, &reply).await;
+            }
+            Behavior::Reply(reply) => write_reply(&mut stream, &reply).await,
+        }
+    }
+
+    async fn write_reply(stream: &mut tokio::net::UnixStream, reply: &serde_json::Value) {
+        let mut frame = serde_json::to_vec(reply).expect("serialize reply");
+        frame.push(0);
+        _ = stream.write_all(&frame).await;
+    }
+
+    fn test_config(path: PathBuf) -> Config {
+        Config {
+            socket_path: path,
+            connect_timeout: Duration::from_millis(250),
+            reprobe_interval: Duration::from_secs(60),
+            breaker_threshold: 2,
+            max_concurrency: 8,
+        }
+    }
+
+    fn resolver(path: PathBuf) -> Arc<SystemdResolved> {
+        Arc::new(SystemdResolved::new(test_config(path)))
+    }
+
+    fn domain() -> Domain {
+        "example.com".try_into().expect("valid domain")
+    }
+
+    fn hostname_reply(addresses: &serde_json::Value) -> serde_json::Value {
+        json!({ "parameters": { "addresses": addresses, "name": "example.com", "flags": 1 } })
+    }
+
+    fn error_reply(id: &str) -> serde_json::Value {
+        json!({ "error": id, "parameters": {} })
+    }
+
+    fn build_rr(labels: &[&str], rtype: u16, ttl: u32, rdata: &[u8]) -> Vec<u8> {
+        let mut raw = Vec::new();
+        for label in labels {
+            raw.push(u8::try_from(label.len()).expect("short label"));
+            raw.extend_from_slice(label.as_bytes());
+        }
+        raw.push(0);
+        raw.extend_from_slice(&rtype.to_be_bytes());
+        raw.extend_from_slice(&DNS_CLASS_IN.to_be_bytes());
+        raw.extend_from_slice(&ttl.to_be_bytes());
+        raw.extend_from_slice(
+            &u16::try_from(rdata.len())
+                .expect("short rdata")
+                .to_be_bytes(),
+        );
+        raw.extend_from_slice(rdata);
+        raw
+    }
+
+    fn txt_rdata(segments: &[&[u8]]) -> Vec<u8> {
+        let mut rdata = Vec::new();
+        for segment in segments {
+            rdata.push(u8::try_from(segment.len()).expect("short segment"));
+            rdata.extend_from_slice(segment);
+        }
+        rdata
+    }
+
+    #[tokio::test]
+    async fn resolve_hostname_returns_matching_family_records() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(hostname_reply(&json!([
+            { "ifindex": 2, "family": 2, "address": [93, 184, 216, 34] },
+            { "family": 10, "address": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] },
+            { "family": 2, "address": [10, 0, 0, 1] },
+        ])))]);
+        let resolved = resolver(server.path.clone());
+        match resolved
+            .lookup_ipv4(&domain(), Duration::from_secs(2))
+            .await
+        {
+            ResolvedLookup::Records(records) => assert_eq!(
+                records,
+                vec![
+                    (Ipv4Addr::new(93, 184, 216, 34), 0),
+                    (Ipv4Addr::new(10, 0, 0, 1), 0),
+                ],
+            ),
+            _ => panic!("expected records"),
+        }
+        assert_eq!(server.connections(), 1);
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn resolve_hostname_ipv6() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(hostname_reply(&json!([
+            { "family": 10, "address": [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] },
+        ])))]);
+        let resolved = resolver(server.path.clone());
+        match resolved
+            .lookup_ipv6(&domain(), Duration::from_secs(2))
+            .await
+        {
+            ResolvedLookup::Records(records) => assert_eq!(
+                records,
+                vec![("2001:db8::1".parse::<Ipv6Addr>().expect("valid ipv6"), 0)],
+            ),
+            _ => panic!("expected records"),
+        }
+    }
+
+    #[tokio::test]
+    async fn no_such_record_is_negative_and_keeps_backend_available() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(error_reply(ERROR_NO_SUCH_RR))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Negative,
+        ));
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Negative,
+        ));
+        assert_eq!(
+            server.connections(),
+            2,
+            "negatives must keep routing via varlink"
+        );
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn resolution_errors_surface_without_fallback() {
+        let server = FakeResolved::spawn(vec![
+            Behavior::Reply(hostname_reply(
+                &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+            )),
+            Behavior::Reply(error_reply("io.systemd.Resolve.QueryTimedOut")),
+        ]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+        match resolved
+            .lookup_ipv4(&domain(), Duration::from_secs(2))
+            .await
+        {
+            ResolvedLookup::Failed(err) => {
+                assert!(err.to_string().contains("QueryTimedOut"), "got: {err}")
+            }
+            _ => panic!("expected failed lookup"),
+        }
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_eq!(resolved.failures.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_socket_flips_unavailable_and_skips_daemon() {
+        let path = test_socket_path();
+        let resolved = resolver(path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+
+        // a daemon appearing now is not contacted before the re-probe interval
+        let server =
+            FakeResolved::spawn_at(path, vec![Behavior::Reply(hostname_reply(&json!([])))]);
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(server.connections(), 0);
+    }
+
+    #[tokio::test]
+    async fn reprobe_recovers_after_interval() {
+        let path = test_socket_path();
+        let mut config = test_config(path.clone());
+        config.reprobe_interval = Duration::from_millis(50);
+        let resolved = Arc::new(SystemdResolved::new(config));
+
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+
+        let server = FakeResolved::spawn_at(
+            path,
+            vec![Behavior::Reply(hostname_reply(
+                &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+            ))],
+        );
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+        assert_eq!(server.connections(), 1);
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn probe_is_single_flight() {
+        let server = FakeResolved::spawn(vec![Behavior::DelayedReply(
+            Duration::from_millis(300),
+            hostname_reply(&json!([{ "family": 2, "address": [1, 2, 3, 4] }])),
+        )]);
+        let resolved = resolver(server.path.clone());
+
+        let prober = {
+            let resolved = resolved.clone();
+            tokio::spawn(async move {
+                resolved
+                    .lookup_ipv4(&domain(), Duration::from_secs(2))
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // while the probe is in flight, other lookups fall back immediately
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert!(matches!(
+            resolved
+                .lookup_ipv6(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(server.connections(), 1);
+
+        assert!(matches!(
+            prober.await.expect("probe task"),
+            ResolvedLookup::Records(_),
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn breaker_trips_after_consecutive_soft_failures() {
+        let server = FakeResolved::spawn(vec![
+            Behavior::Reply(hostname_reply(
+                &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+            )),
+            Behavior::CloseImmediately,
+            Behavior::CloseImmediately,
+        ]);
+        let resolved = resolver(server.path.clone());
+
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(
+            resolved.state.load(Ordering::SeqCst),
+            AVAILABLE,
+            "one failure below the threshold must not trip the breaker",
+        );
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(
+            server.connections(),
+            3,
+            "tripped breaker must skip the daemon"
+        );
+    }
+
+    #[tokio::test]
+    async fn hard_failure_flips_immediately() {
+        let path = test_socket_path();
+        let mut config = test_config(path.clone());
+        config.breaker_threshold = 100;
+        let resolved = Arc::new(SystemdResolved::new(config));
+
+        let server = FakeResolved::spawn_at(
+            path,
+            vec![Behavior::Reply(hostname_reply(
+                &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+            ))],
+        );
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+
+        drop(server); // socket file removed: connect now fails hard
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn txt_records_parse_raw_wire_format() {
+        let cname = build_rr(&["example", "com"], 5, 60, &[0]);
+        let txt = build_rr(
+            &["example", "com"],
+            DNS_TYPE_TXT,
+            123,
+            &txt_rdata(&[b"hello", b"world"]),
+        );
+        let server = FakeResolved::spawn(vec![Behavior::Reply(json!({
+            "parameters": {
+                "rrs": [
+                    { "raw": BASE64.encode(&cname) },
+                    { "ifindex": 2, "raw": BASE64.encode(&txt) },
+                ],
+                "flags": 0,
+            },
+        }))]);
+        let resolved = resolver(server.path.clone());
+        match resolved.lookup_txt(&domain(), Duration::from_secs(2)).await {
+            ResolvedLookup::Records(records) => assert_eq!(
+                records,
+                vec![
+                    (Bytes::from_static(b"hello"), 123),
+                    (Bytes::from_static(b"world"), 123),
+                ],
+            ),
+            _ => panic!("expected records"),
+        }
+    }
+
+    #[tokio::test]
+    async fn txt_method_not_found_pins_native_backend() {
+        let server = FakeResolved::spawn(vec![
+            Behavior::Reply(error_reply(ERROR_METHOD_NOT_FOUND)),
+            Behavior::Reply(hostname_reply(
+                &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+            )),
+        ]);
+        let resolved = resolver(server.path.clone());
+
+        assert!(matches!(
+            resolved.lookup_txt(&domain(), Duration::from_secs(1)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+
+        // sticky: no further daemon roundtrip for txt
+        assert!(matches!(
+            resolved.lookup_txt(&domain(), Duration::from_secs(1)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(server.connections(), 1);
+
+        // address lookups keep flowing
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+        assert_eq!(server.connections(), 2);
+    }
+
+    #[tokio::test]
+    async fn hung_daemon_times_out_and_flips_unavailable() {
+        let server = FakeResolved::spawn(vec![Behavior::Hang]);
+        let resolved = resolver(server.path.clone());
+        let started = Instant::now();
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_millis(100))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn garbage_reply_is_transport_failure() {
+        let server = FakeResolved::spawn(vec![Behavior::RawReply(b"not json\0".to_vec())]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn reply_split_across_writes_is_reassembled() {
+        let server = FakeResolved::spawn(vec![Behavior::ChunkedReply(hostname_reply(
+            &json!([{ "family": 2, "address": [1, 2, 3, 4] }]),
+        ))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+    }
+
+    #[tokio::test]
+    async fn concurrency_is_capped() {
+        let path = test_socket_path();
+        let mut config = test_config(path.clone());
+        config.max_concurrency = 1;
+        let resolved = Arc::new(SystemdResolved::new(config));
+
+        let good = hostname_reply(&json!([{ "family": 2, "address": [1, 2, 3, 4] }]));
+        let server = FakeResolved::spawn_at(
+            path,
+            vec![
+                Behavior::Reply(good.clone()),
+                Behavior::DelayedReply(Duration::from_millis(150), good.clone()),
+                Behavior::DelayedReply(Duration::from_millis(150), good),
+            ],
+        );
+
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+
+        let domain = domain();
+        let (a, b) = tokio::join!(
+            resolved.lookup_ipv4(&domain, Duration::from_secs(2)),
+            resolved.lookup_ipv4(&domain, Duration::from_secs(2)),
+        );
+        assert!(matches!(a, ResolvedLookup::Records(_)));
+        assert!(matches!(b, ResolvedLookup::Records(_)));
+        assert!(
+            server.concurrent_peak.load(Ordering::SeqCst) <= 1,
+            "semaphore must serialize daemon connections",
+        );
+    }
+
+    #[test]
+    fn claim_state_machine() {
+        let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
+
+        let claim = resolved.claim().expect("first claim probes");
+        assert!(claim.probing);
+        assert!(resolved.claim().is_none(), "probe is single-flight");
+
+        resolved.report_success();
+        assert!(!resolved.claim().expect("available").probing);
+
+        resolved.report_transport_failure(Claim { probing: false }, false);
+        assert!(
+            resolved.claim().is_some(),
+            "below the breaker threshold the backend stays available",
+        );
+        resolved.report_transport_failure(Claim { probing: false }, false);
+        assert!(
+            resolved.claim().is_none(),
+            "breaker tripped, reprobe not due"
+        );
+    }
+
+    #[test]
+    fn zero_reprobe_interval_reprobes_immediately() {
+        let mut config = test_config("/nonexistent".into());
+        config.reprobe_interval = Duration::ZERO;
+        let resolved = SystemdResolved::new(config);
+
+        let claim = resolved.claim().expect("probe claim");
+        resolved.report_transport_failure(claim, true);
+        assert!(resolved.claim().expect("immediate reprobe").probing);
+    }
+
+    #[test]
+    fn parse_txt_rr_multi_segment() {
+        let raw = build_rr(
+            &["example", "com"],
+            DNS_TYPE_TXT,
+            300,
+            &txt_rdata(&[b"v=spf1 -all", b""]),
+        );
+        match parse_txt_rr(&raw) {
+            RrParse::Txt { ttl, segments } => {
+                assert_eq!(ttl, 300);
+                assert_eq!(
+                    segments,
+                    vec![Bytes::from_static(b"v=spf1 -all"), Bytes::new()],
+                );
+            }
+            _ => panic!("expected txt"),
+        }
+    }
+
+    #[test]
+    fn parse_txt_rr_skips_other_types() {
+        let raw = build_rr(&["example", "com"], 5, 300, &[0]);
+        assert!(matches!(parse_txt_rr(&raw), RrParse::Other));
+    }
+
+    #[test]
+    fn parse_txt_rr_rejects_malformed() {
+        // truncated header
+        assert!(matches!(parse_txt_rr(&[0, 0, 16]), RrParse::Malformed));
+        // compression pointer in the owner name
+        assert!(matches!(
+            parse_txt_rr(&[0xC0, 0x0C, 0, 16]),
+            RrParse::Malformed
+        ));
+        // rdata segment length pointing past the buffer
+        let mut raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &[200]);
+        assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
+        // rdlen pointing past the buffer
+        raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &txt_rdata(&[b"ok"]));
+        raw.truncate(raw.len() - 1);
+        assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
+    }
+}

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -10,7 +10,10 @@
 //! domains, `/etc/hosts`, synthesized names, CNAME chasing). TXT lookups use
 //! `ResolveRecord` (raw wire-format RRs, real TTLs), which older daemons do
 //! not implement — a `MethodNotFound` reply pins TXT to the native backend
-//! without affecting address lookups.
+//! without affecting address lookups. `ResolveRecord` applies no
+//! search-domain expansion, so single-label TXT names route to the native
+//! backend directly; multi-label relative names relying on `search` still
+//! behave differently than `res_nsearch` would.
 
 use std::{
     fmt,
@@ -18,10 +21,12 @@ use std::{
     path::PathBuf,
     sync::{
         Arc,
-        atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, Ordering},
+        atomic::{AtomicBool, Ordering},
     },
     time::{Duration, Instant},
 };
+
+use parking_lot::Mutex;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use rama_core::{bytes::Bytes, error::BoxError, telemetry::tracing};
@@ -85,25 +90,33 @@ impl Default for Config {
     }
 }
 
-const UNTESTED: u8 = 0;
-const PROBING: u8 = 1;
-const AVAILABLE: u8 = 2;
-const UNAVAILABLE: u8 = 3;
+#[derive(Debug, Clone, Copy)]
+enum Phase {
+    Untested,
+    Probing { since: Instant },
+    Available,
+    Unavailable { since: Instant },
+}
 
-/// Lock-free availability tracking: the first lookup doubles as the probe
-/// (single-flight via CAS), transport failures feed a consecutive-failure
-/// breaker, and an unavailable daemon is re-probed at most once per
+#[derive(Debug)]
+struct Availability {
+    phase: Phase,
+    /// consecutive soft transport failures while available
+    failures: u32,
+}
+
+/// Availability tracking: the first lookup doubles as the probe
+/// (single-flight), transport failures feed a consecutive-failure breaker,
+/// and an unavailable daemon is re-probed at most once per
 /// [`Config::reprobe_interval`]. Lookups never wait on a probe: whoever does
 /// not hold the claim reports [`ResolvedLookup::Unavailable`] so the caller
-/// uses the native backend instead.
+/// uses the native backend instead. Transitions go through one mutex (its
+/// critical sections are a few loads/stores) so a success and a concurrent
+/// failure can never interleave into a wrong breaker verdict.
 #[derive(Debug)]
 pub(super) struct SystemdResolved {
     config: Config,
-    epoch: Instant,
-    state: AtomicU8,
-    /// ms since `epoch`: probe claim time while probing, flip time while unavailable
-    stamp: AtomicU64,
-    failures: AtomicU32,
+    state: Mutex<Availability>,
     txt_supported: AtomicBool,
     permits: Semaphore,
 }
@@ -125,22 +138,40 @@ struct Claim {
     probing: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FailureKind {
+    /// Unambiguous daemon absence (missing socket, refused): flip immediately.
+    Hard,
+    /// Daemon misbehavior or timeout mid-exchange: feeds the breaker.
+    Soft,
+    /// Local saturation (no permit within the deadline): the daemon never saw
+    /// the query, so it must neither feed the breaker nor hold a probe slot.
+    Overload,
+}
+
 struct TransportFailure {
-    hard: bool,
+    kind: FailureKind,
     error: BoxError,
 }
 
 impl TransportFailure {
     fn soft(error: impl Into<BoxError>) -> Self {
         Self {
-            hard: false,
+            kind: FailureKind::Soft,
             error: error.into(),
         }
     }
 
     fn hard(error: impl Into<BoxError>) -> Self {
         Self {
-            hard: true,
+            kind: FailureKind::Hard,
+            error: error.into(),
+        }
+    }
+
+    fn overload(error: impl Into<BoxError>) -> Self {
+        Self {
+            kind: FailureKind::Overload,
             error: error.into(),
         }
     }
@@ -151,10 +182,10 @@ impl SystemdResolved {
         let permits = Semaphore::new(config.max_concurrency.max(1));
         Self {
             config,
-            epoch: Instant::now(),
-            state: AtomicU8::new(UNTESTED),
-            stamp: AtomicU64::new(0),
-            failures: AtomicU32::new(0),
+            state: Mutex::new(Availability {
+                phase: Phase::Untested,
+                failures: 0,
+            }),
             txt_supported: AtomicBool::new(true),
             permits,
         }
@@ -190,11 +221,16 @@ impl SystemdResolved {
         if !self.txt_supported.load(Ordering::Acquire) {
             return ResolvedLookup::Unavailable;
         }
+        let name = wire_name(domain);
+        // ResolveRecord never applies resolv.conf search domains; keep
+        // single-label names on the native path where that expansion happens
+        if !name.contains('.') {
+            return ResolvedLookup::Unavailable;
+        }
         let Some(claim) = self.claim() else {
             return ResolvedLookup::Unavailable;
         };
         let this = self.clone();
-        let name = wire_name(domain);
         join(tokio::spawn(async move {
             this.record_query(claim, name, timeout).await
         }))
@@ -245,24 +281,38 @@ impl SystemdResolved {
         if let Some(error) = envelope.error.as_deref() {
             return self.classify_reply_error(claim, error, false);
         }
-        match serde_json::from_value::<HostnameReply>(envelope.parameters) {
-            Ok(reply) => {
-                self.report_success();
-                let ttl = u32::try_from(self.config.hostname_ttl.as_secs()).unwrap_or(u32::MAX);
-                ResolvedLookup::Records(
-                    reply
-                        .addresses
-                        .into_iter()
-                        .filter(|entry| entry.family == family)
-                        .filter_map(|entry| decode(&entry.address).map(|value| (value, ttl)))
-                        .collect(),
-                )
+        let reply = match serde_json::from_value::<HostnameReply>(envelope.parameters) {
+            Ok(reply) => reply,
+            Err(err) => {
+                return self.transport_failed(
+                    claim,
+                    TransportFailure::soft(format!("invalid ResolveHostname reply: {err}")),
+                );
             }
-            Err(err) => self.transport_failed(
-                claim,
-                TransportFailure::soft(format!("invalid ResolveHostname reply: {err}")),
-            ),
+        };
+        let ttl = hostname_cache_ttl_secs(self.config.hostname_ttl);
+        let mut records = Vec::with_capacity(reply.addresses.len());
+        for entry in reply.addresses {
+            if entry.family != family {
+                continue;
+            }
+            let Some(value) = decode(&entry.address) else {
+                return self.transport_failed(
+                    claim,
+                    TransportFailure::soft("invalid address payload in ResolveHostname reply"),
+                );
+            };
+            records.push((value, ttl));
         }
+        if records.is_empty() {
+            // a correct daemon answers NoSuchResourceRecord instead
+            return self.transport_failed(
+                claim,
+                TransportFailure::soft("empty ResolveHostname success reply"),
+            );
+        }
+        self.report_success();
+        ResolvedLookup::Records(records)
     }
 
     async fn record_query(
@@ -298,6 +348,13 @@ impl SystemdResolved {
                 );
             }
         };
+        if reply.rrs.is_empty() {
+            // a correct daemon answers NoSuchResourceRecord instead
+            return self.transport_failed(
+                claim,
+                TransportFailure::soft("empty ResolveRecord success reply"),
+            );
+        }
         let mut records = Vec::new();
         for entry in &reply.rrs {
             let Ok(raw) = BASE64.decode(&entry.raw) else {
@@ -362,84 +419,90 @@ impl SystemdResolved {
     }
 
     fn transport_failed<T>(&self, claim: Claim, failure: TransportFailure) -> ResolvedLookup<T> {
-        let TransportFailure { hard, error } = failure;
+        let TransportFailure { kind, error } = failure;
         tracing::debug!(
             err = %error,
-            hard,
+            ?kind,
             "dns::systemd-resolved: transport failure",
         );
-        self.report_transport_failure(claim, hard);
+        self.report_transport_failure(claim, kind);
         ResolvedLookup::Unavailable
     }
 
     fn claim(&self) -> Option<Claim> {
-        let now = self.now_ms();
-        match self.state.load(Ordering::Acquire) {
-            AVAILABLE => Some(Claim { probing: false }),
-            UNTESTED => self
-                .state
-                .compare_exchange(UNTESTED, PROBING, Ordering::AcqRel, Ordering::Acquire)
-                .is_ok()
-                .then(|| {
-                    self.stamp.store(now, Ordering::Release);
-                    Claim { probing: true }
-                }),
-            PROBING => {
-                let stamped = self.stamp.load(Ordering::Acquire);
-                (now.saturating_sub(stamped) > ms(PROBE_STALE)
-                    && self
-                        .stamp
-                        .compare_exchange(stamped, now, Ordering::AcqRel, Ordering::Acquire)
-                        .is_ok())
-                .then_some(Claim { probing: true })
+        let mut state = self.state.lock();
+        match state.phase {
+            Phase::Available => Some(Claim { probing: false }),
+            Phase::Untested => {
+                state.phase = Phase::Probing {
+                    since: Instant::now(),
+                };
+                Some(Claim { probing: true })
             }
-            _ => {
-                let stamped = self.stamp.load(Ordering::Acquire);
-                if now.saturating_sub(stamped) >= ms(self.config.reprobe_interval)
-                    && self
-                        .stamp
-                        .compare_exchange(stamped, now, Ordering::AcqRel, Ordering::Acquire)
-                        .is_ok()
-                {
-                    self.state.store(PROBING, Ordering::Release);
-                    Some(Claim { probing: true })
-                } else {
-                    None
-                }
+            // a probe claim older than the stale bound is assumed orphaned
+            // (its task died without reporting) and may be re-claimed
+            Phase::Probing { since } => (since.elapsed() > PROBE_STALE).then(|| {
+                state.phase = Phase::Probing {
+                    since: Instant::now(),
+                };
+                Claim { probing: true }
+            }),
+            Phase::Unavailable { since } => {
+                (since.elapsed() >= self.config.reprobe_interval).then(|| {
+                    state.phase = Phase::Probing {
+                        since: Instant::now(),
+                    };
+                    Claim { probing: true }
+                })
             }
         }
     }
 
     fn report_success(&self) {
-        self.failures.store(0, Ordering::Release);
-        if self.state.swap(AVAILABLE, Ordering::AcqRel) != AVAILABLE {
+        let became_available = {
+            let mut state = self.state.lock();
+            state.failures = 0;
+            !matches!(
+                std::mem::replace(&mut state.phase, Phase::Available),
+                Phase::Available,
+            )
+        };
+        if became_available {
             tracing::debug!("dns::systemd-resolved: available");
         }
     }
 
-    fn report_transport_failure(&self, claim: Claim, hard: bool) {
-        if claim.probing || hard {
-            self.mark_unavailable();
-            return;
-        }
-        if self.failures.fetch_add(1, Ordering::AcqRel) + 1 >= self.config.breaker_threshold {
-            self.mark_unavailable();
-        }
-    }
-
-    fn mark_unavailable(&self) {
-        self.failures.store(0, Ordering::Release);
-        self.stamp.store(self.now_ms(), Ordering::Release);
-        if self.state.swap(UNAVAILABLE, Ordering::AcqRel) != UNAVAILABLE {
+    fn report_transport_failure(&self, claim: Claim, kind: FailureKind) {
+        let flipped = {
+            let mut state = self.state.lock();
+            match kind {
+                FailureKind::Overload => {
+                    if claim.probing && matches!(state.phase, Phase::Probing { .. }) {
+                        state.phase = Phase::Untested;
+                    }
+                    false
+                }
+                FailureKind::Hard => mark_unavailable(&mut state),
+                FailureKind::Soft => {
+                    if claim.probing {
+                        mark_unavailable(&mut state)
+                    } else {
+                        state.failures += 1;
+                        if state.failures >= self.config.breaker_threshold {
+                            mark_unavailable(&mut state)
+                        } else {
+                            false
+                        }
+                    }
+                }
+            }
+        };
+        if flipped {
             tracing::debug!(
                 reprobe_interval = ?self.config.reprobe_interval,
                 "dns::systemd-resolved: unavailable; lookups use the native backend",
             );
         }
-    }
-
-    fn now_ms(&self) -> u64 {
-        u64::try_from(self.epoch.elapsed().as_millis()).unwrap_or(u64::MAX)
     }
 
     async fn call<P: Serialize>(
@@ -448,12 +511,35 @@ impl SystemdResolved {
         parameters: &P,
         timeout: Duration,
     ) -> Result<Envelope, TransportFailure> {
-        match tokio::time::timeout(timeout, self.call_inner(method, parameters)).await {
-            Ok(result) => result,
-            Err(_) => Err(TransportFailure::soft(format!(
-                "{method} timed out after {timeout:?}"
-            ))),
+        let started = Instant::now();
+        let permit = match tokio::time::timeout(timeout, self.permits.acquire()).await {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(err)) => {
+                return Err(TransportFailure::soft(format!(
+                    "varlink semaphore closed: {err}"
+                )));
+            }
+            Err(_) => {
+                return Err(TransportFailure::overload(format!(
+                    "no varlink slot within {timeout:?}"
+                )));
+            }
+        };
+        let remaining = timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            return Err(TransportFailure::overload(format!(
+                "no varlink slot within {timeout:?}"
+            )));
         }
+        let result =
+            match tokio::time::timeout(remaining, self.call_inner(method, parameters)).await {
+                Ok(result) => result,
+                Err(_) => Err(TransportFailure::soft(format!(
+                    "{method} timed out after {timeout:?}"
+                ))),
+            };
+        drop(permit);
+        result
     }
 
     async fn call_inner<P: Serialize>(
@@ -461,11 +547,6 @@ impl SystemdResolved {
         method: &'static str,
         parameters: &P,
     ) -> Result<Envelope, TransportFailure> {
-        let _permit =
-            self.permits.acquire().await.map_err(|err| {
-                TransportFailure::soft(format!("varlink semaphore closed: {err}"))
-            })?;
-
         let (mut stream, _info) = match tokio::time::timeout(
             self.config.connect_timeout,
             default_unix_connect(self.config.socket_path.clone()),
@@ -505,6 +586,9 @@ impl SystemdResolved {
             }
             if let Some(pos) = buf[scanned..].iter().position(|byte| *byte == 0) {
                 let frame = &buf[..scanned + pos];
+                if frame.len() > MAX_REPLY_SIZE {
+                    return Err(TransportFailure::soft("varlink reply exceeds size bound"));
+                }
                 return serde_json::from_slice(frame)
                     .map_err(|err| TransportFailure::soft(format!("decode varlink reply: {err}")));
             }
@@ -528,12 +612,31 @@ async fn join<T>(task: tokio::task::JoinHandle<ResolvedLookup<T>>) -> ResolvedLo
     }
 }
 
+fn mark_unavailable(state: &mut Availability) -> bool {
+    state.failures = 0;
+    !matches!(
+        std::mem::replace(
+            &mut state.phase,
+            Phase::Unavailable {
+                since: Instant::now(),
+            },
+        ),
+        Phase::Unavailable { .. },
+    )
+}
+
 fn wire_name(domain: &Domain) -> String {
     domain.as_str().trim_end_matches('.').to_owned()
 }
 
-fn ms(duration: Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+/// Positive sub-second TTLs round up to one second so they cannot collapse
+/// into `0`, which the cache layer treats as "unknown".
+fn hostname_cache_ttl_secs(ttl: Duration) -> u32 {
+    if ttl.is_zero() {
+        0
+    } else {
+        u32::try_from(ttl.as_secs().max(1)).unwrap_or(u32::MAX)
+    }
 }
 
 #[derive(Serialize)]
@@ -566,7 +669,6 @@ struct Envelope {
 
 #[derive(Deserialize)]
 struct HostnameReply {
-    #[serde(default)]
     addresses: Vec<AddressEntry>,
 }
 
@@ -578,7 +680,6 @@ struct AddressEntry {
 
 #[derive(Deserialize)]
 struct RecordReply {
-    #[serde(default)]
     rrs: Vec<RecordEntry>,
 }
 
@@ -804,6 +905,18 @@ mod tests {
         "example.com".try_into().expect("valid domain")
     }
 
+    fn phase(resolved: &SystemdResolved) -> Phase {
+        resolved.state.lock().phase
+    }
+
+    fn assert_available(resolved: &SystemdResolved) {
+        assert!(matches!(phase(resolved), Phase::Available));
+    }
+
+    fn assert_unavailable(resolved: &SystemdResolved) {
+        assert!(matches!(phase(resolved), Phase::Unavailable { .. }));
+    }
+
     fn hostname_reply(addresses: &serde_json::Value) -> serde_json::Value {
         json!({ "parameters": { "addresses": addresses, "name": "example.com", "flags": 1 } })
     }
@@ -862,7 +975,7 @@ mod tests {
             _ => panic!("expected records"),
         }
         assert_eq!(server.connections(), 1);
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_available(&resolved);
     }
 
     #[tokio::test]
@@ -904,7 +1017,7 @@ mod tests {
             2,
             "negatives must keep routing via varlink"
         );
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_available(&resolved);
     }
 
     #[tokio::test]
@@ -931,8 +1044,8 @@ mod tests {
             }
             _ => panic!("expected failed lookup"),
         }
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
-        assert_eq!(resolved.failures.load(Ordering::SeqCst), 0);
+        assert_available(&resolved);
+        assert_eq!(resolved.state.lock().failures, 0);
     }
 
     #[tokio::test]
@@ -945,7 +1058,7 @@ mod tests {
                 .await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+        assert_unavailable(&resolved);
 
         // a daemon appearing now is not contacted before the re-probe interval
         let server =
@@ -987,7 +1100,7 @@ mod tests {
             ResolvedLookup::Records(_),
         ));
         assert_eq!(server.connections(), 1);
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_available(&resolved);
     }
 
     #[tokio::test]
@@ -1027,7 +1140,7 @@ mod tests {
             prober.await.expect("probe task"),
             ResolvedLookup::Records(_),
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_available(&resolved);
     }
 
     #[tokio::test]
@@ -1053,9 +1166,8 @@ mod tests {
                 .await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(
-            resolved.state.load(Ordering::SeqCst),
-            AVAILABLE,
+        assert!(
+            matches!(phase(&resolved), Phase::Available),
             "one failure below the threshold must not trip the breaker",
         );
         assert!(matches!(
@@ -1064,7 +1176,7 @@ mod tests {
                 .await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+        assert_unavailable(&resolved);
 
         assert!(matches!(
             resolved
@@ -1106,7 +1218,7 @@ mod tests {
                 .await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+        assert_unavailable(&resolved);
     }
 
     #[tokio::test]
@@ -1154,7 +1266,7 @@ mod tests {
             resolved.lookup_txt(&domain(), Duration::from_secs(1)).await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), AVAILABLE);
+        assert_available(&resolved);
 
         // sticky: no further daemon roundtrip for txt
         assert!(matches!(
@@ -1185,7 +1297,7 @@ mod tests {
             ResolvedLookup::Unavailable,
         ));
         assert!(started.elapsed() < Duration::from_secs(1));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+        assert_unavailable(&resolved);
     }
 
     #[tokio::test]
@@ -1198,7 +1310,7 @@ mod tests {
                 .await,
             ResolvedLookup::Unavailable,
         ));
-        assert_eq!(resolved.state.load(Ordering::SeqCst), UNAVAILABLE);
+        assert_unavailable(&resolved);
     }
 
     #[tokio::test]
@@ -1263,12 +1375,12 @@ mod tests {
         resolved.report_success();
         assert!(!resolved.claim().expect("available").probing);
 
-        resolved.report_transport_failure(Claim { probing: false }, false);
+        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Soft);
         assert!(
             resolved.claim().is_some(),
             "below the breaker threshold the backend stays available",
         );
-        resolved.report_transport_failure(Claim { probing: false }, false);
+        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Soft);
         assert!(
             resolved.claim().is_none(),
             "breaker tripped, reprobe not due"
@@ -1282,7 +1394,7 @@ mod tests {
         let resolved = SystemdResolved::new(config);
 
         let claim = resolved.claim().expect("probe claim");
-        resolved.report_transport_failure(claim, true);
+        resolved.report_transport_failure(claim, FailureKind::Hard);
         assert!(resolved.claim().expect("immediate reprobe").probing);
     }
 
@@ -1328,5 +1440,172 @@ mod tests {
         raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &txt_rdata(&[b"ok"]));
         raw.truncate(raw.len() - 1);
         assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
+    }
+
+    #[test]
+    fn hostname_cache_ttl_rounds_up_subsecond() {
+        assert_eq!(hostname_cache_ttl_secs(Duration::ZERO), 0);
+        assert_eq!(hostname_cache_ttl_secs(Duration::from_millis(500)), 1);
+        assert_eq!(hostname_cache_ttl_secs(Duration::from_secs(15)), 15);
+    }
+
+    #[tokio::test]
+    async fn dropped_consumer_probe_still_settles_state() {
+        let server = FakeResolved::spawn(vec![Behavior::DelayedReply(
+            Duration::from_millis(150),
+            hostname_reply(&json!([{ "family": 2, "address": [1, 2, 3, 4] }])),
+        )]);
+        let resolved = resolver(server.path.clone());
+
+        let lookup = {
+            let resolved = resolved.clone();
+            tokio::spawn(async move {
+                resolved
+                    .lookup_ipv4(&domain(), Duration::from_secs(2))
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        lookup.abort(); // consumer gone mid-probe; the detached query task lives on
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !matches!(phase(&resolved), Phase::Available) {
+            assert!(Instant::now() < deadline, "probe never settled state");
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        assert_eq!(server.connections(), 1);
+    }
+
+    #[tokio::test]
+    async fn single_label_txt_stays_on_native_backend() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(error_reply(ERROR_NO_SUCH_RR))]);
+        let resolved = resolver(server.path.clone());
+        let single: Domain = "printer".try_into().expect("valid domain");
+        assert!(matches!(
+            resolved.lookup_txt(&single, Duration::from_secs(1)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_eq!(
+            server.connections(),
+            0,
+            "search-domain candidates must be left to res_nsearch",
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_addresses_field_is_transport_failure() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(json!({ "parameters": {} }))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_unavailable(&resolved);
+    }
+
+    #[tokio::test]
+    async fn invalid_address_length_is_transport_failure() {
+        let server = FakeResolved::spawn(vec![Behavior::Reply(hostname_reply(&json!([
+            { "family": 2, "address": [1, 2, 3, 4, 5] },
+        ])))]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_unavailable(&resolved);
+    }
+
+    #[tokio::test]
+    async fn empty_success_replies_are_transport_failures() {
+        let server = FakeResolved::spawn(vec![
+            Behavior::Reply(hostname_reply(&json!([]))),
+            Behavior::Reply(json!({ "parameters": { "rrs": [], "flags": 0 } })),
+        ]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(1))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_unavailable(&resolved);
+
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved.lookup_txt(&domain(), Duration::from_secs(1)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_unavailable(&resolved);
+    }
+
+    #[tokio::test]
+    async fn oversized_reply_is_transport_failure() {
+        let pad = "a".repeat(MAX_REPLY_SIZE);
+        let mut raw = format!(r#"{{"parameters":{{"pad":"{pad}"}}}}"#).into_bytes();
+        raw.push(0);
+        let server = FakeResolved::spawn(vec![Behavior::RawReply(raw)]);
+        let resolved = resolver(server.path.clone());
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_unavailable(&resolved);
+    }
+
+    #[tokio::test]
+    async fn queue_timeout_does_not_feed_breaker() {
+        let path = test_socket_path();
+        let mut config = test_config(path.clone());
+        config.max_concurrency = 1;
+        config.breaker_threshold = 1; // any counted soft failure would flip
+        let resolved = Arc::new(SystemdResolved::new(config));
+
+        let good = hostname_reply(&json!([{ "family": 2, "address": [1, 2, 3, 4] }]));
+        let server = FakeResolved::spawn_at(
+            path,
+            vec![
+                Behavior::Reply(good.clone()),
+                Behavior::DelayedReply(Duration::from_millis(300), good),
+            ],
+        );
+
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_secs(2))
+                .await,
+            ResolvedLookup::Records(_),
+        ));
+
+        // occupy the single permit, then let another lookup expire in the queue
+        let slow = {
+            let resolved = resolved.clone();
+            tokio::spawn(async move {
+                resolved
+                    .lookup_ipv4(&domain(), Duration::from_secs(2))
+                    .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(matches!(
+            resolved
+                .lookup_ipv4(&domain(), Duration::from_millis(100))
+                .await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_available(&resolved);
+        assert_eq!(resolved.state.lock().failures, 0, "overload must not count");
+
+        assert!(matches!(
+            slow.await.expect("slow lookup"),
+            ResolvedLookup::Records(_),
+        ));
+        assert_eq!(server.connections(), 2);
     }
 }

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -92,7 +92,7 @@ impl Default for Config {
 #[derive(Debug, Clone, Copy)]
 enum Phase {
     Untested,
-    Probing { since: Instant },
+    Probing { since: Instant, generation: u64 },
     Available,
     Unavailable { since: Instant },
 }
@@ -102,6 +102,9 @@ struct Availability {
     phase: Phase,
     /// consecutive soft transport failures while available
     failures: u32,
+    /// Monotonic identity for probe ownership. Reports from a probe that was
+    /// reclaimed after [`PROBE_STALE`] must not overwrite its successor.
+    next_probe_generation: u64,
 }
 
 /// Availability tracking: the first lookup doubles as the probe
@@ -134,7 +137,7 @@ pub(super) enum ResolvedLookup<T> {
 
 #[derive(Clone, Copy)]
 struct Claim {
-    probing: bool,
+    probe_generation: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -184,6 +187,7 @@ impl SystemdResolved {
             state: Mutex::new(Availability {
                 phase: Phase::Untested,
                 failures: 0,
+                next_probe_generation: 0,
             }),
             txt_supported: AtomicBool::new(true),
             permits,
@@ -217,9 +221,6 @@ impl SystemdResolved {
         domain: &Domain,
         timeout: Duration,
     ) -> ResolvedLookup<Bytes> {
-        if !self.txt_supported.load(Ordering::Acquire) {
-            return ResolvedLookup::Unavailable;
-        }
         let name = wire_name(domain);
         // ResolveRecord never applies resolv.conf search domains; keep
         // single-label names on the native path where that expansion happens
@@ -229,6 +230,9 @@ impl SystemdResolved {
         let Some(claim) = self.claim() else {
             return ResolvedLookup::Unavailable;
         };
+        if !self.txt_supported.load(Ordering::Acquire) {
+            return ResolvedLookup::Unavailable;
+        }
         let this = self.clone();
         join(tokio::spawn(async move {
             this.record_query(claim, name, timeout).await
@@ -310,7 +314,7 @@ impl SystemdResolved {
                 TransportFailure::soft("empty ResolveHostname success reply"),
             );
         }
-        self.report_success();
+        self.report_success(claim);
         ResolvedLookup::Records(records)
     }
 
@@ -376,10 +380,15 @@ impl SystemdResolved {
                 }
             }
         }
-        self.report_success();
         if records.is_empty() {
-            ResolvedLookup::Negative
+            // A successful ResolveRecord reply should contain the requested
+            // RRset. If it only contains ancillary records (for example a
+            // CNAME chain), let the native backend decide instead of turning
+            // an incomplete daemon reply into an authoritative negative.
+            self.report_success(claim);
+            ResolvedLookup::Unavailable
         } else {
+            self.report_success(claim);
             ResolvedLookup::Records(records)
         }
     }
@@ -391,17 +400,18 @@ impl SystemdResolved {
         record_query: bool,
     ) -> ResolvedLookup<T> {
         if error == ERROR_NO_SUCH_RR {
-            self.report_success();
+            self.report_success(claim);
             return ResolvedLookup::Negative;
         }
         if record_query && error == ERROR_METHOD_NOT_FOUND {
             // daemon reachable but too old for ResolveRecord: pin TXT to the
             // native backend, address lookups keep flowing
-            self.report_success();
-            self.txt_supported.store(false, Ordering::Release);
-            tracing::debug!(
-                "dns::systemd-resolved: ResolveRecord not implemented; txt lookups use the native backend"
-            );
+            if self.report_success(claim) {
+                self.txt_supported.store(false, Ordering::Release);
+                tracing::debug!(
+                    "dns::systemd-resolved: ResolveRecord not implemented; txt lookups use the native backend"
+                );
+            }
             return ResolvedLookup::Unavailable;
         }
         if error.starts_with(VARLINK_ERROR_PREFIX) {
@@ -410,7 +420,7 @@ impl SystemdResolved {
                 TransportFailure::soft(format!("varlink protocol error: {error}")),
             );
         }
-        self.report_success();
+        self.report_success(claim);
         ResolvedLookup::Failed(
             SystemdResolvedError::message(format!("systemd-resolved lookup failed: {error}"))
                 .into(),
@@ -431,35 +441,36 @@ impl SystemdResolved {
     fn claim(&self) -> Option<Claim> {
         let mut state = self.state.lock();
         match state.phase {
-            Phase::Available => Some(Claim { probing: false }),
-            Phase::Untested => {
-                state.phase = Phase::Probing {
-                    since: Instant::now(),
-                };
-                Some(Claim { probing: true })
-            }
+            Phase::Available => Some(Claim {
+                probe_generation: None,
+            }),
+            Phase::Untested => Some(begin_probe(&mut state)),
             // a probe claim older than the stale bound is assumed orphaned
             // (its task died without reporting) and may be re-claimed
-            Phase::Probing { since } => (since.elapsed() > PROBE_STALE).then(|| {
-                state.phase = Phase::Probing {
-                    since: Instant::now(),
-                };
-                Claim { probing: true }
-            }),
+            Phase::Probing { since, .. } => {
+                (since.elapsed() > PROBE_STALE).then(|| begin_probe(&mut state))
+            }
             Phase::Unavailable { since } => {
                 (since.elapsed() >= self.config.reprobe_interval).then(|| {
-                    state.phase = Phase::Probing {
-                        since: Instant::now(),
-                    };
-                    Claim { probing: true }
+                    // A daemon replacement may implement methods that the
+                    // previous instance did not. Re-test TXT support whenever
+                    // transport recovery starts a new probe generation.
+                    self.txt_supported.store(true, Ordering::Release);
+                    begin_probe(&mut state)
                 })
             }
         }
     }
 
-    fn report_success(&self) {
+    /// Report a successful exchange, returning whether this claim still owns
+    /// the state transition. Callers must guard claim-specific side effects
+    /// (such as capability pins) with the result.
+    fn report_success(&self, claim: Claim) -> bool {
         let became_available = {
             let mut state = self.state.lock();
+            if !claim_is_current(&state, claim) {
+                return false;
+            }
             state.failures = 0;
             !matches!(
                 std::mem::replace(&mut state.phase, Phase::Available),
@@ -469,21 +480,25 @@ impl SystemdResolved {
         if became_available {
             tracing::debug!("dns::systemd-resolved: available");
         }
+        true
     }
 
     fn report_transport_failure(&self, claim: Claim, kind: FailureKind) {
         let flipped = {
             let mut state = self.state.lock();
+            if !claim_is_current(&state, claim) {
+                return;
+            }
             match kind {
                 FailureKind::Overload => {
-                    if claim.probing && matches!(state.phase, Phase::Probing { .. }) {
+                    if claim.probe_generation.is_some() {
                         state.phase = Phase::Untested;
                     }
                     false
                 }
                 FailureKind::Hard => mark_unavailable(&mut state),
                 FailureKind::Soft => {
-                    if claim.probing {
+                    if claim.probe_generation.is_some() {
                         mark_unavailable(&mut state)
                     } else {
                         state.failures += 1;
@@ -596,6 +611,28 @@ impl SystemdResolved {
                 return Err(TransportFailure::soft("varlink reply exceeds size bound"));
             }
         }
+    }
+}
+
+fn begin_probe(state: &mut Availability) -> Claim {
+    let generation = state.next_probe_generation;
+    state.next_probe_generation = state.next_probe_generation.wrapping_add(1);
+    state.phase = Phase::Probing {
+        since: Instant::now(),
+        generation,
+    };
+    Claim {
+        probe_generation: Some(generation),
+    }
+}
+
+fn claim_is_current(state: &Availability, claim: Claim) -> bool {
+    match claim.probe_generation {
+        None => true,
+        Some(claim_generation) => matches!(
+            state.phase,
+            Phase::Probing { generation, .. } if generation == claim_generation
+        ),
     }
 }
 
@@ -1197,6 +1234,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cname_only_record_reply_falls_back_without_tripping_backend() {
+        let cname = build_rr(&["example", "com"], 5, 60, &[0]);
+        let server = FakeResolved::spawn(vec![Behavior::Reply(json!({
+            "parameters": {
+                "rrs": [{ "raw": BASE64.encode(&cname) }],
+                "flags": 0,
+            },
+        }))]);
+        let resolved = resolver(server.path.clone());
+
+        assert!(matches!(
+            resolved.lookup_txt(&domain(), Duration::from_secs(2)).await,
+            ResolvedLookup::Unavailable,
+        ));
+        assert_available(&resolved);
+    }
+
+    #[tokio::test]
     async fn txt_method_not_found_pins_native_backend() {
         let server = FakeResolved::spawn(vec![
             Behavior::Reply(error_reply(ERROR_METHOD_NOT_FOUND)),
@@ -1313,18 +1368,34 @@ mod tests {
         let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
 
         let claim = resolved.claim().expect("first claim probes");
-        assert!(claim.probing);
+        assert!(claim.probe_generation.is_some());
         assert!(resolved.claim().is_none(), "probe is single-flight");
 
-        resolved.report_success();
-        assert!(!resolved.claim().expect("available").probing);
+        resolved.report_success(claim);
+        assert!(
+            resolved
+                .claim()
+                .expect("available")
+                .probe_generation
+                .is_none()
+        );
 
-        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Soft);
+        resolved.report_transport_failure(
+            Claim {
+                probe_generation: None,
+            },
+            FailureKind::Soft,
+        );
         assert!(
             resolved.claim().is_some(),
             "below the breaker threshold the backend stays available",
         );
-        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Soft);
+        resolved.report_transport_failure(
+            Claim {
+                probe_generation: None,
+            },
+            FailureKind::Soft,
+        );
         assert!(
             resolved.claim().is_none(),
             "breaker tripped, reprobe not due"
@@ -1334,33 +1405,58 @@ mod tests {
     #[test]
     fn stale_probe_claim_is_reclaimed() {
         let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
-        assert!(resolved.claim().expect("probe claim").probing);
+        let original = resolved.claim().expect("probe claim");
+        assert!(original.probe_generation.is_some());
         assert!(resolved.claim().is_none(), "fresh probe is not reclaimable");
 
         resolved.state.lock().phase = Phase::Probing {
             since: Instant::now()
                 .checked_sub(PROBE_STALE + Duration::from_secs(1))
                 .expect("clock predates the probe stale bound"),
+            generation: original.probe_generation.expect("probe generation"),
         };
-        assert!(resolved.claim().expect("stale probe reclaimed").probing);
+        let replacement = resolved.claim().expect("stale probe reclaimed");
+        assert!(replacement.probe_generation.is_some());
+        assert_ne!(replacement.probe_generation, original.probe_generation);
     }
 
     #[test]
-    fn overload_does_not_reset_foreign_probe() {
+    fn superseded_probe_reports_do_not_reset_or_flip_replacement() {
         let resolved = SystemdResolved::new(test_config("/nonexistent".into()));
-        let probe = resolved.claim().expect("probe claim");
+        let original = resolved.claim().expect("probe claim");
+        let original_generation = original.probe_generation.expect("probe generation");
+        resolved.state.lock().phase = Phase::Probing {
+            since: Instant::now()
+                .checked_sub(PROBE_STALE + Duration::from_secs(1))
+                .expect("clock predates the probe stale bound"),
+            generation: original_generation,
+        };
+        let replacement = resolved.claim().expect("replacement probe");
 
-        resolved.report_transport_failure(Claim { probing: false }, FailureKind::Overload);
+        resolved.report_transport_failure(original, FailureKind::Overload);
         assert!(
-            matches!(phase(&resolved), Phase::Probing { .. }),
-            "a non-probing overload must not reset someone else's probe",
+            claim_is_current(&resolved.state.lock(), replacement),
+            "an old overload must not reset the replacement probe",
         );
 
-        resolved.report_transport_failure(probe, FailureKind::Overload);
+        resolved.report_transport_failure(original, FailureKind::Hard);
         assert!(
-            matches!(phase(&resolved), Phase::Untested),
-            "the probing claim's own overload frees the probe slot",
+            claim_is_current(&resolved.state.lock(), replacement),
+            "an old failure must not mark a recovered daemon unavailable",
         );
+        assert!(matches!(
+            resolved.classify_reply_error::<Bytes>(original, ERROR_METHOD_NOT_FOUND, true),
+            ResolvedLookup::Unavailable,
+        ));
+        assert!(
+            resolved.txt_supported.load(Ordering::Acquire),
+            "a superseded probe must not pin capabilities on its replacement",
+        );
+
+        resolved.report_success(replacement);
+        assert_available(&resolved);
+        resolved.report_transport_failure(original, FailureKind::Soft);
+        assert_available(&resolved);
     }
 
     #[test]
@@ -1371,7 +1467,35 @@ mod tests {
 
         let claim = resolved.claim().expect("probe claim");
         resolved.report_transport_failure(claim, FailureKind::Hard);
-        assert!(resolved.claim().expect("immediate reprobe").probing);
+        assert!(
+            resolved
+                .claim()
+                .expect("immediate reprobe")
+                .probe_generation
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn recovery_probe_rechecks_pinned_txt_capability() {
+        let mut config = test_config("/nonexistent".into());
+        config.reprobe_interval = Duration::ZERO;
+        let resolved = SystemdResolved::new(config);
+
+        let initial = resolved.claim().expect("initial probe");
+        resolved.report_success(initial);
+        resolved.txt_supported.store(false, Ordering::Release);
+        resolved.report_transport_failure(
+            Claim {
+                probe_generation: None,
+            },
+            FailureKind::Hard,
+        );
+        assert!(!resolved.txt_supported.load(Ordering::Acquire));
+
+        let reprobe = resolved.claim().expect("recovery probe");
+        assert!(reprobe.probe_generation.is_some());
+        assert!(resolved.txt_supported.load(Ordering::Acquire));
     }
 
     #[test]
@@ -1415,6 +1539,10 @@ mod tests {
         // rdlen pointing past the buffer
         raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &txt_rdata(&[b"ok"]));
         raw.truncate(raw.len() - 1);
+        assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
+        // bytes after the declared rdata are not part of a standalone RR
+        raw = build_rr(&["example", "com"], DNS_TYPE_TXT, 60, &txt_rdata(&[b"ok"]));
+        raw.push(0);
         assert!(matches!(parse_txt_rr(&raw), RrParse::Malformed));
     }
 

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -63,6 +63,7 @@ pub(super) struct Config {
     pub(super) reprobe_interval: Duration,
     pub(super) breaker_threshold: u32,
     pub(super) max_concurrency: usize,
+    pub(super) hostname_ttl: Duration,
 }
 
 impl Default for Config {
@@ -77,6 +78,9 @@ impl Default for Config {
             // stays below resolved's varlink server default of 128 connections
             // per UID, a budget shared with other same-UID clients (nss-resolve)
             max_concurrency: 112,
+            // ResolveHostname replies carry no TTLs; keep our cache entries
+            // short so the daemon's own TTL-accurate cache stays authoritative
+            hostname_ttl: Duration::from_secs(15),
         }
     }
 }
@@ -244,12 +248,13 @@ impl SystemdResolved {
         match serde_json::from_value::<HostnameReply>(envelope.parameters) {
             Ok(reply) => {
                 self.report_success();
+                let ttl = u32::try_from(self.config.hostname_ttl.as_secs()).unwrap_or(u32::MAX);
                 ResolvedLookup::Records(
                     reply
                         .addresses
                         .into_iter()
                         .filter(|entry| entry.family == family)
-                        .filter_map(|entry| decode(&entry.address).map(|value| (value, 0)))
+                        .filter_map(|entry| decode(&entry.address).map(|value| (value, ttl)))
                         .collect(),
                 )
             }
@@ -787,6 +792,7 @@ mod tests {
             reprobe_interval: Duration::from_secs(60),
             breaker_threshold: 2,
             max_concurrency: 8,
+            hostname_ttl: Duration::from_secs(15),
         }
     }
 
@@ -849,8 +855,8 @@ mod tests {
             ResolvedLookup::Records(records) => assert_eq!(
                 records,
                 vec![
-                    (Ipv4Addr::new(93, 184, 216, 34), 0),
-                    (Ipv4Addr::new(10, 0, 0, 1), 0),
+                    (Ipv4Addr::new(93, 184, 216, 34), 15),
+                    (Ipv4Addr::new(10, 0, 0, 1), 15),
                 ],
             ),
             _ => panic!("expected records"),
@@ -871,7 +877,7 @@ mod tests {
         {
             ResolvedLookup::Records(records) => assert_eq!(
                 records,
-                vec![("2001:db8::1".parse::<Ipv6Addr>().expect("valid ipv6"), 0)],
+                vec![("2001:db8::1".parse::<Ipv6Addr>().expect("valid ipv6"), 15)],
             ),
             _ => panic!("expected records"),
         }

--- a/rama-dns/src/client/systemd_resolved_wire.rs
+++ b/rama-dns/src/client/systemd_resolved_wire.rs
@@ -1,0 +1,63 @@
+//! RFC 1035 wire-format parsing for the systemd-resolved varlink backend:
+//! `ResolveRecord` replies carry each resource record as raw wire bytes.
+//! Dependency-free on purpose so fuzz builds can compile it on any host.
+
+use rama_core::bytes::Bytes;
+
+pub(super) const DNS_CLASS_IN: u16 = 1;
+pub(super) const DNS_TYPE_TXT: u16 = 16;
+
+pub(super) enum RrParse {
+    Txt { ttl: u32, segments: Vec<Bytes> },
+    Other,
+    Malformed,
+}
+
+/// Parse one wire-format RR as produced by `ResolveRecord`'s `raw` field.
+/// Owner names are standalone here, so compression pointers cannot be
+/// resolved and are treated as malformed.
+pub(super) fn parse_txt_rr(raw: &[u8]) -> RrParse {
+    let Some(mut offset) = skip_uncompressed_name(raw) else {
+        return RrParse::Malformed;
+    };
+    let Some(header) = raw.get(offset..offset + 10) else {
+        return RrParse::Malformed;
+    };
+    let rtype = u16::from_be_bytes([header[0], header[1]]);
+    let class = u16::from_be_bytes([header[2], header[3]]);
+    let ttl = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
+    let rdlen = u16::from_be_bytes([header[8], header[9]]) as usize;
+    offset += 10;
+    let Some(rdata) = raw.get(offset..offset + rdlen) else {
+        return RrParse::Malformed;
+    };
+    if rtype != DNS_TYPE_TXT || class != DNS_CLASS_IN {
+        return RrParse::Other;
+    }
+    let mut segments = Vec::new();
+    let mut cursor = 0;
+    while cursor < rdata.len() {
+        let len = rdata[cursor] as usize;
+        cursor += 1;
+        let Some(segment) = rdata.get(cursor..cursor + len) else {
+            return RrParse::Malformed;
+        };
+        segments.push(Bytes::copy_from_slice(segment));
+        cursor += len;
+    }
+    RrParse::Txt { ttl, segments }
+}
+
+fn skip_uncompressed_name(raw: &[u8]) -> Option<usize> {
+    let mut offset = 0;
+    loop {
+        let len = *raw.get(offset)?;
+        if len == 0 {
+            return Some(offset + 1);
+        }
+        if len & 0xC0 != 0 {
+            return None;
+        }
+        offset += 1 + len as usize;
+    }
+}

--- a/rama-dns/src/client/systemd_resolved_wire.rs
+++ b/rama-dns/src/client/systemd_resolved_wire.rs
@@ -20,15 +20,24 @@ pub(super) fn parse_txt_rr(raw: &[u8]) -> RrParse {
     let Some(mut offset) = skip_uncompressed_name(raw) else {
         return RrParse::Malformed;
     };
-    let Some(header) = raw.get(offset..offset + 10) else {
+    let Some(header_end) = offset.checked_add(10) else {
+        return RrParse::Malformed;
+    };
+    let Some(header) = raw.get(offset..header_end) else {
         return RrParse::Malformed;
     };
     let rtype = u16::from_be_bytes([header[0], header[1]]);
     let class = u16::from_be_bytes([header[2], header[3]]);
     let ttl = u32::from_be_bytes([header[4], header[5], header[6], header[7]]);
     let rdlen = u16::from_be_bytes([header[8], header[9]]) as usize;
-    offset += 10;
-    let Some(rdata) = raw.get(offset..offset + rdlen) else {
+    offset = header_end;
+    let Some(rdata_end) = offset.checked_add(rdlen) else {
+        return RrParse::Malformed;
+    };
+    if rdata_end != raw.len() {
+        return RrParse::Malformed;
+    }
+    let Some(rdata) = raw.get(offset..rdata_end) else {
         return RrParse::Malformed;
     };
     if rtype != DNS_TYPE_TXT || class != DNS_CLASS_IN {

--- a/rama-dns/src/client/systemd_resolved_wire.rs
+++ b/rama-dns/src/client/systemd_resolved_wire.rs
@@ -43,6 +43,10 @@ pub(super) fn parse_txt_rr(raw: &[u8]) -> RrParse {
     if rtype != DNS_TYPE_TXT || class != DNS_CLASS_IN {
         return RrParse::Other;
     }
+    if rdata.is_empty() {
+        // RFC 1035 §3.3.14: TXT rdata is one or more character-strings
+        return RrParse::Malformed;
+    }
     let mut segments = Vec::new();
     let mut cursor = 0;
     while cursor < rdata.len() {

--- a/rama-dns/src/lib.rs
+++ b/rama-dns/src/lib.rs
@@ -31,14 +31,16 @@
 //! are fully asynchronous and scale naturally — no tokio blocking-pool
 //! traffic.
 //!
-//! `LinuxDnsResolver` (via `res_nsearch` / `getaddrinfo`) and
-//! [`client::TokioDnsResolver`] (via `getaddrinfo`) are different: each
-//! lookup occupies a tokio blocking-pool thread for the duration of the
-//! libc call. Under sustained high-concurrency DNS load (typical for
-//! forward proxies) that pool can become a bottleneck. For such
-//! workloads prefer the pure-Rust `client::HickoryDnsResolver` (gated
-//! behind the `hickory` feature), which speaks DNS directly over async
-//! UDP/TCP and gives finer control over caching and upstream selection.
+//! On Linux, `LinuxDnsResolver` first tries systemd-resolved's varlink
+//! socket, which is likewise fully asynchronous. Where that daemon is not
+//! running it falls back to `res_nsearch` / `getaddrinfo`, and there — as
+//! with [`client::TokioDnsResolver`] (via `getaddrinfo`) — each lookup
+//! occupies a tokio blocking-pool thread for the duration of the libc
+//! call. Under sustained high-concurrency DNS load (typical for forward
+//! proxies) that pool can become a bottleneck. For such workloads prefer
+//! the pure-Rust `client::HickoryDnsResolver` (gated behind the `hickory`
+//! feature), which speaks DNS directly over async UDP/TCP and gives finer
+//! control over caching and upstream selection.
 //!
 //! ## Global DNS resolver
 //!

--- a/rama-dns/src/lib.rs
+++ b/rama-dns/src/lib.rs
@@ -31,16 +31,18 @@
 //! are fully asynchronous and scale naturally — no tokio blocking-pool
 //! traffic.
 //!
-//! On Linux, `LinuxDnsResolver` first tries systemd-resolved's varlink
-//! socket, which is likewise fully asynchronous. Where that daemon is not
-//! running it falls back to `res_nsearch` / `getaddrinfo`, and there — as
-//! with [`client::TokioDnsResolver`] (via `getaddrinfo`) — each lookup
-//! occupies a tokio blocking-pool thread for the duration of the libc
+//! On Linux hosts whose NSS configuration selects `nss-resolve`,
+//! `LinuxDnsResolver` first tries systemd-resolved's varlink socket, which is
+//! likewise fully asynchronous. This path can also be enabled or disabled
+//! explicitly through `LinuxDnsResolver::builder()`. Where the daemon is not
+//! selected or available it falls back to `res_nsearch` / `getaddrinfo`, and
+//! there — as with [`client::TokioDnsResolver`] (via `getaddrinfo`) — each
+//! lookup occupies a tokio blocking-pool thread for the duration of the libc
 //! call. Under sustained high-concurrency DNS load (typical for forward
-//! proxies) that pool can become a bottleneck. For such workloads prefer
-//! the pure-Rust `client::HickoryDnsResolver` (gated behind the `hickory`
-//! feature), which speaks DNS directly over async UDP/TCP and gives finer
-//! control over caching and upstream selection.
+//! proxies) that pool can become a bottleneck. For such workloads prefer the
+//! pure-Rust `client::HickoryDnsResolver` (gated behind the `hickory` feature),
+//! which speaks DNS directly over async UDP/TCP and gives finer control over
+//! caching and upstream selection.
 //!
 //! ## Global DNS resolver
 //!


### PR DESCRIPTION
linux dns lookups now go through the systemd-resolved varlink socket if it's there, fully async so no more blocking pool threads. falls back per query to the old res_nsearch/getaddrinfo path. txt uses ResolveRecord, also added a fuzz target for the rr parsing.

based on feedback from some attendees at the copenhagen rust meetup where we introduced rama from core concepts up to advanced network stacks. cc @soundofspace