### PR TITLE
fix(cli): treat `resolve` as a known subcommand in default-send fallback

### DIFF
--- a/rama-cli/src/main.rs
+++ b/rama-cli/src/main.rs
@@ -53,6 +53,24 @@ enum CliCommands {
     Probe(cmd::probe::ProbeCommand),
 }
 
+/// Root arguments that must surface their own clap error rather than falling
+/// back to the implicit `send` command. Every [`CliCommands`] subcommand has to
+/// be listed here; `all_subcommands_are_known_root_args` enforces that.
+const KNOWN_ROOT_ARGS: [&str; 8] = [
+    "-V",
+    "--version",
+    "-h",
+    "--help",
+    "resolve",
+    "send",
+    "serve",
+    "probe",
+];
+
+fn is_known_root_arg(arg: &str) -> bool {
+    KNOWN_ROOT_ARGS.contains(&arg.trim())
+}
+
 #[tokio::main]
 async fn main() {
     #[expect(
@@ -87,10 +105,7 @@ async fn main() {
             _ => {
                 if std::env::args()
                     .nth(1)
-                    .map(|s| {
-                        ["-V", "--version", "-h", "--help", "send", "serve", "probe"]
-                            .contains(&s.trim())
-                    })
+                    .map(|s| is_known_root_arg(&s))
                     .unwrap_or_default()
                 {
                     err.exit()
@@ -116,5 +131,33 @@ async fn main() {
             .map(|err| err.code)
             .unwrap_or(1);
         std::process::exit(exit_code);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `resolve` was missing from `KNOWN_ROOT_ARGS`, so `rama resolve <bad args>`
+    /// fell through to the implicit `send` command instead of reporting the
+    /// resolve error. Derive the expectation from clap so the list cannot drift
+    /// again when a subcommand is added.
+    #[test]
+    fn all_subcommands_are_known_root_args() {
+        use clap::CommandFactory;
+
+        for sub in Cli::command().get_subcommands() {
+            let name = sub.get_name();
+            assert!(
+                is_known_root_arg(name),
+                "subcommand `{name}` is missing from KNOWN_ROOT_ARGS"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_root_args_fall_back_to_send() {
+        assert!(!is_known_root_arg("https://example.com"));
+        assert!(!is_known_root_arg("--header"));
     }
 }


### PR DESCRIPTION
Closes #1089

## What

`rama` falls back to the implicit `send` command when the first argument is not a recognised subcommand. `resolve` was missing from that guard list, so `rama resolve <bad args>` was re-parsed as `send` and reported an error about `send` rather than the resolve error clap had already produced.

`resolve` was the only `CliCommands` variant missing from the list.

## How

- Extract the guard list into `KNOWN_ROOT_ARGS` with an `is_known_root_arg` helper, and add `"resolve"`.
- Add a test that derives the expectation from clap's own subcommand list (`Cli::command().get_subcommands()`), so adding a subcommand without updating the guard list now fails a test instead of silently misrouting.

I verified the test actually catches the bug by removing `"resolve"` again:

```
thread 'tests::all_subcommands_are_known_root_args' panicked at rama-cli/src/main.rs:150:13:
subcommand `resolve` is missing from KNOWN_ROOT_ARGS
```

## Testing

```
cargo test -p rama-cli --bin rama     # 52 passed, 0 failed
cargo fmt -p rama-cli -- --check      # clean
cargo clippy -p rama-cli --bin rama --all-targets   # clean
```

I understand these changes in full and can respond to review comments. AI assistance was used in preparing this change; I have reviewed every line.