### PR TITLE
add streaming HTTP body capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4373,6 +4373,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "nom 8.0.0",
+ "parking_lot",
  "pin-project-lite",
  "quickcheck",
  "rama-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,9 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "castaway"
@@ -4380,6 +4383,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
+ "serde_test",
  "sha2 0.11.0",
  "sync_wrapper",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4083,10 +4083,8 @@ version = "0.3.1"
 dependencies = [
  "ahash",
  "base64 0.23.1",
- "bytes",
  "clap",
  "escargot",
- "futures",
  "indexmap",
  "itertools 0.15.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ boa_engine = { version = "0.21", features = ["annex-b"] }
 boa_gc = "0.21"
 brotli = "8"
 byteorder = "1.5"
-bytes = "1"
+bytes = { version = "1", default-features = false, features = ["serde"] }
 cc = "1"
 clap = { version = "4.6", features = ["derive", "unstable-v5", "wrap_help"] }
 compression-codecs = "0.4"
@@ -542,7 +542,7 @@ dial9 = [
 [dependencies]
 ahash = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
-bytes = { workspace = true, optional = true }
+bytes = { workspace = true, features = ["std"], optional = true }
 hex = { workspace = true, optional = true }
 pin-project-lite = { workspace = true, optional = true }
 rama-core = { workspace = true }
@@ -595,7 +595,7 @@ rustversion = { workspace = true }
 cc = { workspace = true }
 
 [dev-dependencies]
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["std"] }
 divan = { workspace = true }
 escargot = { workspace = true }
 flate2 = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -505,9 +505,7 @@ net-apple-xpc = ["rama/net-apple-xpc"]
 [dependencies]
 ahash = { workspace = true }
 base64 = { workspace = true }
-bytes = { workspace = true, features = ["std"] }
 clap = { workspace = true }
-futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 itoa = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -505,7 +505,7 @@ net-apple-xpc = ["rama/net-apple-xpc"]
 [dependencies]
 ahash = { workspace = true }
 base64 = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["std"] }
 clap = { workspace = true }
 futures = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }

--- a/examples/src/http_key_value_store.rs
+++ b/examples/src/http_key_value_store.rs
@@ -99,9 +99,9 @@ struct AppState {
 }
 
 #[derive(Debug, Clone, Default)]
-struct Db(Arc<RwLock<HashMap<String, bytes::Bytes>>>);
+struct Db(Arc<RwLock<HashMap<String, rama::bytes::Bytes>>>);
 
-impl_deref!(Db: Arc<RwLock<HashMap<String, bytes::Bytes>>>);
+impl_deref!(Db: Arc<RwLock<HashMap<String, rama::bytes::Bytes>>>);
 
 #[derive(Debug, Deserialize)]
 struct ItemParam {
@@ -183,7 +183,7 @@ async fn main() {
                         .with_post("/items", async |State(db): State<Db>, Json(dict): Json<HashMap<String, String>>| {
                             let mut db = db.write().await;
                             for (k, v) in dict {
-                                db.insert(k, bytes::Bytes::from(v));
+                                db.insert(k, rama::bytes::Bytes::from(v));
                             }
                             StatusCode::OK
                         })

--- a/examples/tests/integration/tls_boring_dynamic_certs.rs
+++ b/examples/tests/integration/tls_boring_dynamic_certs.rs
@@ -117,7 +117,7 @@ fn map_internal_client_error<E, Body>(
 ) -> Result<Response, rama::error::BoxError>
 where
     E: Into<rama::error::BoxError>,
-    Body: StreamingBody<Data = bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+    Body: StreamingBody<Data = rama::bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
 {
     match result {
         Ok(response) => Ok(response.map(rama::http::Body::new)),

--- a/examples/tests/integration/tls_rustls_dynamic_certs.rs
+++ b/examples/tests/integration/tls_rustls_dynamic_certs.rs
@@ -117,7 +117,7 @@ fn map_internal_client_error<E, Body>(
 ) -> Result<Response, rama::error::BoxError>
 where
     E: Into<rama::error::BoxError>,
-    Body: StreamingBody<Data = bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+    Body: StreamingBody<Data = rama::bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
 {
     match result {
         Ok(response) => Ok(response.map(rama::http::Body::new)),

--- a/examples/tests/integration/tls_rustls_dynamic_config.rs
+++ b/examples/tests/integration/tls_rustls_dynamic_config.rs
@@ -137,7 +137,7 @@ fn map_internal_client_error<E, Body>(
 ) -> Result<Response, rama::error::BoxError>
 where
     E: Into<rama::error::BoxError>,
-    Body: StreamingBody<Data = bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+    Body: StreamingBody<Data = rama::bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
 {
     match result {
         Ok(response) => Ok(response.map(rama::http::Body::new)),

--- a/examples/tests/integration/utils/mod.rs
+++ b/examples/tests/integration/utils/mod.rs
@@ -358,7 +358,7 @@ fn map_internal_client_error<E, Body>(
 ) -> Result<Response, rama::error::BoxError>
 where
     E: Into<rama::error::BoxError>,
-    Body: StreamingBody<Data = bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+    Body: StreamingBody<Data = rama::bytes::Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
 {
     match result {
         Ok(response) => Ok(response.map(rama::http::Body::new)),

--- a/rama-core/Cargo.toml
+++ b/rama-core/Cargo.toml
@@ -59,7 +59,7 @@ dial9 = ["std", "dep:dial9-tokio-telemetry", "dep:dial9-trace-format"]
 [dependencies]
 ahash = { workspace = true, optional = true }
 asynk-strim = { workspace = true }
-bytes = { version = "1", default-features = false }
+bytes = { workspace = true }
 dial9-tokio-telemetry = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }

--- a/rama-http-types/Cargo.toml
+++ b/rama-http-types/Cargo.toml
@@ -29,7 +29,7 @@ default = []
 tls = ["dep:rama-tls", "rama-tls/http"]
 
 [dependencies]
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["std"] }
 const_format = { workspace = true }
 fnv = { workspace = true }
 futures-core = { workspace = true }
@@ -57,6 +57,7 @@ tokio = { workspace = true, features = ["macros", "io-std", "sync"] }
 futures-util = { workspace = true }
 quickcheck = { workspace = true }
 rand = { workspace = true }
+serde_test = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [lints]

--- a/rama-http-types/Cargo.toml
+++ b/rama-http-types/Cargo.toml
@@ -40,6 +40,7 @@ memchr = { workspace = true }
 mime = { workspace = true }
 mime_guess = { workspace = true }
 nom = { workspace = true }
+parking_lot = { workspace = true }
 pin-project-lite = { workspace = true }
 rama-core = { workspace = true, features = ["std"] }
 rama-json = { workspace = true }

--- a/rama-http-types/src/body/capture.rs
+++ b/rama-http-types/src/body/capture.rs
@@ -223,13 +223,14 @@ where
                 ready!(future.as_mut().poll(cx));
                 *this.pending.get_mut() = None;
 
-                assert!(
-                    this.pending_output.is_some(),
-                    "a capture future always has a pending output"
-                );
-                let Some(output) = this.pending_output.take() else {
-                    return Poll::Ready(None);
-                };
+                #[expect(
+                    clippy::expect_used,
+                    reason = "missing output means the CaptureBody state machine is invalid"
+                )]
+                let output = this
+                    .pending_output
+                    .take()
+                    .expect("a capture future always has a pending output");
                 match output {
                     PendingOutput::Frame(frame) => return Poll::Ready(Some(Ok(frame))),
                     PendingOutput::Error(error) => {

--- a/rama-http-types/src/body/capture.rs
+++ b/rama-http-types/src/body/capture.rs
@@ -1,0 +1,909 @@
+use parking_lot::Mutex;
+use pin_project_lite::pin_project;
+use rama_core::bytes::{Bytes, BytesMut};
+use std::{
+    fmt,
+    future::{Future, ready},
+    pin::Pin,
+    task::{Context, Poll, ready},
+};
+use sync_wrapper::SyncWrapper;
+use tokio::sync::oneshot;
+
+use super::{Body, Frame, SizeHint, StreamingBody};
+use crate::HeaderMap;
+
+/// How an observed body stream terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CaptureOutcome {
+    /// The body returned its normal end-of-stream marker.
+    Complete,
+    /// The body yielded an error.
+    Error,
+    /// The wrapper was dropped before observing a normal end or error.
+    ///
+    /// This does not necessarily imply missing bytes: a consumer can stop
+    /// polling after receiving all expected data without polling the terminal
+    /// `None`. A custom sink can also record a frame before its future finishes,
+    /// even if cancellation prevents that frame from reaching the downstream
+    /// consumer.
+    Aborted,
+}
+
+/// An owned event emitted while a body streams.
+///
+/// Data frames contain a reference-counted clone of the original [`Bytes`].
+/// The original frame continues downstream unchanged after the capture sink's
+/// future completes.
+#[derive(Clone, Debug)]
+pub enum BodyCaptureEvent {
+    /// A data or trailers frame.
+    Frame(Frame<Bytes>),
+    /// The capture reached a normal end or observed an error.
+    ///
+    /// Error outcomes intentionally carry no error value so events remain
+    /// cloneable without constraining the wrapped body's error type.
+    End(CaptureOutcome),
+}
+
+/// Asynchronously observes owned body events.
+///
+/// The future returned by [`capture`](Self::capture) is polled before the
+/// original frame or terminal state is forwarded. Implementations therefore
+/// choose their own flow-control policy: they can perform work directly, await
+/// a bounded queue, enqueue without waiting, or return immediately.
+pub trait BodyCaptureSink: Send + Sync + 'static {
+    /// Capture one body event.
+    ///
+    /// The returned future must own everything it needs because it can outlive
+    /// the borrow of `self`.
+    fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static;
+
+    /// Notify the sink synchronously when the body is abandoned.
+    ///
+    /// Destructors cannot await. Implementations that need asynchronous work
+    /// can perform a non-blocking send or arrange for their own guard to finish
+    /// that work.
+    fn aborted(&self) {}
+}
+
+impl<F, Fut> BodyCaptureSink for F
+where
+    F: Fn(BodyCaptureEvent) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+        self(event)
+    }
+}
+
+impl BodyCaptureSink for tokio::sync::mpsc::Sender<BodyCaptureEvent> {
+    fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+        let sender = self.clone();
+        async move {
+            drop(sender.send(event).await);
+        }
+    }
+
+    fn aborted(&self) {
+        // Drop cannot wait for bounded capacity. Consumers that require a
+        // guaranteed abort outcome should provide a sink with its own guard.
+        drop(self.try_send(BodyCaptureEvent::End(CaptureOutcome::Aborted)));
+    }
+}
+
+impl BodyCaptureSink for tokio::sync::mpsc::UnboundedSender<BodyCaptureEvent> {
+    fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+        let result = self.send(event);
+        async move {
+            drop(result);
+        }
+    }
+
+    fn aborted(&self) {
+        drop(self.send(BodyCaptureEvent::End(CaptureOutcome::Aborted)));
+    }
+}
+
+type CaptureFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+
+enum PendingOutput<E> {
+    Frame(Frame<Bytes>),
+    Error(E),
+    End,
+}
+
+struct CaptureGuard<S: BodyCaptureSink> {
+    sink: S,
+    finished: bool,
+}
+
+impl<S: BodyCaptureSink> CaptureGuard<S> {
+    fn finish(&mut self) {
+        self.finished = true;
+    }
+}
+
+impl<S: BodyCaptureSink> Drop for CaptureGuard<S> {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.sink.aborted();
+        }
+    }
+}
+
+pin_project! {
+    /// A body that asynchronously sends an owned copy of each frame to a sink.
+    ///
+    /// At most one original frame and its reference-counted capture copy are
+    /// retained while the sink future is pending. No whole-body buffering or
+    /// internal channel is used.
+    #[must_use = "a captured body does nothing unless polled"]
+    pub struct CaptureBody<B, S>
+    where
+        B: StreamingBody<Data = Bytes>,
+        S: BodyCaptureSink,
+    {
+        #[pin]
+        inner: B,
+        guard: CaptureGuard<S>,
+        pending: SyncWrapper<Option<CaptureFuture>>,
+        pending_output: Option<PendingOutput<B::Error>>,
+    }
+}
+
+impl<B, S> CaptureBody<B, S>
+where
+    B: StreamingBody<Data = Bytes>,
+    S: BodyCaptureSink,
+{
+    /// Wrap a body with an asynchronous capture sink.
+    pub fn new(inner: B, sink: S) -> Self {
+        Self {
+            inner,
+            guard: CaptureGuard {
+                sink,
+                finished: false,
+            },
+            pending: SyncWrapper::new(None),
+            pending_output: None,
+        }
+    }
+
+    /// Return a reference to the wrapped body.
+    pub const fn get_ref(&self) -> &B {
+        &self.inner
+    }
+
+    /// Return a mutable reference to the wrapped body.
+    pub fn get_mut(&mut self) -> &mut B {
+        &mut self.inner
+    }
+
+    /// Return a pinned mutable reference to the wrapped body.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut B> {
+        self.project().inner
+    }
+
+    /// Consume the wrapper and return the inner body.
+    ///
+    /// The sink receives [`BodyCaptureSink::aborted`].
+    pub fn into_inner(self) -> B {
+        self.inner
+    }
+}
+
+impl<B> CaptureBody<B, BufferedBodyCapture>
+where
+    B: StreamingBody<Data = Bytes>,
+{
+    /// Wrap a body and retain a bounded or unlimited copy in memory.
+    pub fn buffered(inner: B, limit: CaptureLimit) -> (Self, CaptureHandle) {
+        let (sink, handle) = BufferedBodyCapture::new(limit);
+        (Self::new(inner, sink), handle)
+    }
+}
+
+impl<B, S> StreamingBody for CaptureBody<B, S>
+where
+    B: StreamingBody<Data = Bytes>,
+    S: BodyCaptureSink,
+{
+    type Data = Bytes;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let mut this = self.project();
+
+        loop {
+            if let Some(future) = this.pending.get_mut().as_mut() {
+                ready!(future.as_mut().poll(cx));
+                *this.pending.get_mut() = None;
+
+                assert!(
+                    this.pending_output.is_some(),
+                    "a capture future always has a pending output"
+                );
+                let Some(output) = this.pending_output.take() else {
+                    return Poll::Ready(None);
+                };
+                match output {
+                    PendingOutput::Frame(frame) => return Poll::Ready(Some(Ok(frame))),
+                    PendingOutput::Error(error) => {
+                        this.guard.finish();
+                        return Poll::Ready(Some(Err(error)));
+                    }
+                    PendingOutput::End => {
+                        this.guard.finish();
+                        return Poll::Ready(None);
+                    }
+                }
+            }
+
+            if this.guard.finished {
+                return this.inner.poll_frame(cx);
+            }
+
+            match this.inner.as_mut().poll_frame(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Ok(frame))) => {
+                    let future = this
+                        .guard
+                        .sink
+                        .capture(BodyCaptureEvent::Frame(frame.clone()));
+                    *this.pending.get_mut() = Some(Box::pin(future));
+                    *this.pending_output = Some(PendingOutput::Frame(frame));
+                }
+                Poll::Ready(Some(Err(error))) => {
+                    let future = this
+                        .guard
+                        .sink
+                        .capture(BodyCaptureEvent::End(CaptureOutcome::Error));
+                    *this.pending.get_mut() = Some(Box::pin(future));
+                    *this.pending_output = Some(PendingOutput::Error(error));
+                }
+                Poll::Ready(None) => {
+                    let future = this
+                        .guard
+                        .sink
+                        .capture(BodyCaptureEvent::End(CaptureOutcome::Complete));
+                    *this.pending.get_mut() = Some(Box::pin(future));
+                    *this.pending_output = Some(PendingOutput::End);
+                }
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.guard.finished && self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        let pending = match &self.pending_output {
+            Some(PendingOutput::Frame(frame)) => frame
+                .data_ref()
+                .map_or(0, |data| u64::try_from(data.len()).unwrap_or(u64::MAX)),
+            _ => 0,
+        };
+        self.inner.size_hint() + SizeHint::with_exact(pending)
+    }
+}
+
+impl<B, S> fmt::Debug for CaptureBody<B, S>
+where
+    B: StreamingBody<Data = Bytes> + fmt::Debug,
+    S: BodyCaptureSink,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CaptureBody")
+            .field("inner", &self.inner)
+            .field("sink", &std::any::type_name::<S>())
+            .field("capture_pending", &self.pending_output.is_some())
+            .field("finished", &self.guard.finished)
+            .finish()
+    }
+}
+
+/// Maximum number of body bytes retained by a [`BufferedBodyCapture`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CaptureLimit(Option<usize>);
+
+impl CaptureLimit {
+    /// Retain at most `max_bytes`.
+    #[must_use]
+    pub const fn max_bytes(max_bytes: usize) -> Self {
+        Self(Some(max_bytes))
+    }
+
+    /// Retain the complete body without a size bound.
+    #[must_use]
+    pub const fn unlimited() -> Self {
+        Self(None)
+    }
+
+    /// Return the configured byte limit, or `None` for an unlimited capture.
+    #[must_use]
+    pub const fn get(self) -> Option<usize> {
+        self.0
+    }
+}
+
+impl From<usize> for CaptureLimit {
+    fn from(value: usize) -> Self {
+        Self::max_bytes(value)
+    }
+}
+
+/// The final output produced by [`BufferedBodyCapture`].
+#[derive(Debug)]
+pub struct CapturedBody {
+    bytes: Bytes,
+    trailers: Option<HeaderMap>,
+    outcome: CaptureOutcome,
+    total_bytes: u64,
+    truncated: bool,
+}
+
+impl CapturedBody {
+    /// Return the retained body bytes.
+    #[must_use]
+    pub const fn bytes(&self) -> &Bytes {
+        &self.bytes
+    }
+
+    /// Return all observed trailer fields.
+    ///
+    /// The byte limit applies only to data frames; trailer storage is not
+    /// bounded. Fields from multiple trailer frames are merged in observation
+    /// order using [`HeaderMap::extend`].
+    #[must_use]
+    pub const fn trailers(&self) -> Option<&HeaderMap> {
+        self.trailers.as_ref()
+    }
+
+    /// Return how the stream terminated.
+    #[must_use]
+    pub const fn outcome(&self) -> CaptureOutcome {
+        self.outcome
+    }
+
+    /// Return the total number of data bytes observed.
+    #[must_use]
+    pub const fn total_bytes(&self) -> u64 {
+        self.total_bytes
+    }
+
+    /// Return whether bytes were omitted because the capture limit was hit.
+    #[must_use]
+    pub const fn is_truncated(&self) -> bool {
+        self.truncated
+    }
+
+    /// Consume the capture and return its retained bytes and trailers.
+    #[must_use]
+    pub fn into_parts(self) -> (Bytes, Option<HeaderMap>) {
+        (self.bytes, self.trailers)
+    }
+
+    /// Rebuild a forwardable body from the retained bytes and trailers.
+    pub fn into_body(self) -> Body {
+        let (bytes, trailers) = self.into_parts();
+        match trailers {
+            Some(trailers) => Body::from(bytes).with_trailer_headers(trailers),
+            None => Body::from(bytes),
+        }
+    }
+}
+
+/// Returned if a buffered capture producer disappears without finalizing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CaptureCanceled;
+
+impl fmt::Display for CaptureCanceled {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("body capture producer was canceled")
+    }
+}
+
+impl std::error::Error for CaptureCanceled {}
+
+/// An exactly-once completion handle for a [`BufferedBodyCapture`].
+#[derive(Debug)]
+#[must_use = "drop the handle explicitly if the buffered body is not needed"]
+pub struct CaptureHandle {
+    receiver: oneshot::Receiver<CapturedBody>,
+}
+
+impl CaptureHandle {
+    /// Wait until the body completes, errors, or is dropped early.
+    pub async fn wait(self) -> Result<CapturedBody, CaptureCanceled> {
+        self.receiver.await.map_err(|_error| CaptureCanceled)
+    }
+}
+
+struct BufferState {
+    bytes: BytesMut,
+    trailers: Option<HeaderMap>,
+    limit: CaptureLimit,
+    total_bytes: u64,
+    truncated: bool,
+    sender: Option<oneshot::Sender<CapturedBody>>,
+}
+
+impl BufferState {
+    fn is_observed(&mut self) -> bool {
+        if self.sender.as_ref().is_some_and(oneshot::Sender::is_closed) {
+            self.sender = None;
+            self.bytes.clear();
+            self.trailers = None;
+        }
+        self.sender.is_some()
+    }
+
+    fn observe_frame(&mut self, frame: Frame<Bytes>) {
+        if !self.is_observed() {
+            return;
+        }
+
+        match frame.into_data() {
+            Ok(data) => {
+                self.total_bytes = self
+                    .total_bytes
+                    .saturating_add(u64::try_from(data.len()).unwrap_or(u64::MAX));
+                let remaining = self
+                    .limit
+                    .get()
+                    .map_or(data.len(), |limit| limit.saturating_sub(self.bytes.len()));
+                let take = remaining.min(data.len());
+                self.bytes.extend_from_slice(&data[..take]);
+                self.truncated |= take < data.len();
+            }
+            Err(frame) => {
+                if let Ok(trailers) = frame.into_trailers() {
+                    if let Some(current) = &mut self.trailers {
+                        current.extend(trailers);
+                    } else {
+                        self.trailers = Some(trailers);
+                    }
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self, outcome: CaptureOutcome) {
+        let Some(sender) = self.sender.take() else {
+            return;
+        };
+        let captured = CapturedBody {
+            bytes: std::mem::take(&mut self.bytes).freeze(),
+            trailers: self.trailers.take(),
+            outcome,
+            total_bytes: self.total_bytes,
+            truncated: self.truncated,
+        };
+        drop(sender.send(captured));
+    }
+}
+
+impl Drop for BufferState {
+    fn drop(&mut self) {
+        self.finish(CaptureOutcome::Aborted);
+    }
+}
+
+/// A capture sink that retains body data and trailers in memory.
+///
+/// The associated [`CaptureHandle`] resolves exactly once with the buffered
+/// body and its terminal outcome. This is an explicit collection utility on
+/// top of streaming [`CaptureBody`], rather than part of the forwarding path.
+pub struct BufferedBodyCapture {
+    state: Mutex<BufferState>,
+}
+
+impl BufferedBodyCapture {
+    /// Create a buffered sink and its exactly-once completion handle.
+    pub fn new(limit: CaptureLimit) -> (Self, CaptureHandle) {
+        let (sender, receiver) = oneshot::channel();
+        (
+            Self {
+                state: Mutex::new(BufferState {
+                    bytes: BytesMut::new(),
+                    trailers: None,
+                    limit,
+                    total_bytes: 0,
+                    truncated: false,
+                    sender: Some(sender),
+                }),
+            },
+            CaptureHandle { receiver },
+        )
+    }
+
+    fn state(&self) -> parking_lot::MutexGuard<'_, BufferState> {
+        self.state.lock()
+    }
+}
+
+impl BodyCaptureSink for BufferedBodyCapture {
+    fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+        let mut state = self.state();
+        match event {
+            BodyCaptureEvent::Frame(frame) => state.observe_frame(frame),
+            BodyCaptureEvent::End(outcome) => state.finish(outcome),
+        }
+        ready(())
+    }
+
+    fn aborted(&self) {
+        self.state().finish(CaptureOutcome::Aborted);
+    }
+}
+
+impl fmt::Debug for BufferedBodyCapture {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state();
+        f.debug_struct("BufferedBodyCapture")
+            .field("limit", &state.limit)
+            .field("captured_bytes", &state.bytes.len())
+            .field("total_bytes", &state.total_bytes)
+            .field("truncated", &state.truncated)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        io,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use rama_core::bytes::Bytes;
+
+    use super::*;
+    use crate::body::util::{BodyExt as _, StreamBody};
+
+    async fn wait_for_capture(handle: CaptureHandle) -> CapturedBody {
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle.wait())
+            .await
+            .expect("capture should finish promptly")
+            .expect("capture producer should finalize")
+    }
+
+    #[tokio::test]
+    async fn sink_future_applies_backpressure_before_forwarding() {
+        let gate = Arc::new(tokio::sync::Notify::new());
+        let sink_gate = Arc::clone(&gate);
+        let sink = move |event: BodyCaptureEvent| {
+            let gate = Arc::clone(&sink_gate);
+            async move {
+                if matches!(event, BodyCaptureEvent::Frame(_)) {
+                    gate.notified().await;
+                }
+            }
+        };
+        let mut body = CaptureBody::new(Body::from("held"), sink);
+        let mut frame = Box::pin(body.frame());
+
+        tokio::time::timeout(std::time::Duration::ZERO, &mut frame)
+            .await
+            .expect_err("the frame must wait for its capture future");
+        drop(frame);
+        assert_eq!(body.size_hint().exact(), Some(4));
+        assert!(!body.is_end_stream());
+        gate.notify_one();
+        assert_eq!(
+            body.frame().await.unwrap().unwrap().into_data().unwrap(),
+            Bytes::from_static(b"held")
+        );
+    }
+
+    #[tokio::test]
+    async fn channel_sinks_report_abort_when_capacity_is_available() {
+        let (bounded, mut bounded_events) = tokio::sync::mpsc::channel(1);
+        bounded.aborted();
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), bounded_events.recv())
+                .await
+                .expect("bounded abort should arrive promptly"),
+            Some(BodyCaptureEvent::End(CaptureOutcome::Aborted))
+        ));
+
+        let (unbounded, mut unbounded_events) = tokio::sync::mpsc::unbounded_channel();
+        unbounded.aborted();
+        assert!(matches!(
+            tokio::time::timeout(std::time::Duration::from_secs(1), unbounded_events.recv())
+                .await
+                .expect("unbounded abort should arrive promptly"),
+            Some(BodyCaptureEvent::End(CaptureOutcome::Aborted))
+        ));
+    }
+
+    #[tokio::test]
+    async fn bounded_channel_drops_abort_notification_when_full() {
+        let (bounded, mut events) = tokio::sync::mpsc::channel(1);
+        bounded
+            .send(BodyCaptureEvent::Frame(Frame::data(Bytes::from_static(
+                b"queued",
+            ))))
+            .await
+            .unwrap();
+
+        bounded.aborted();
+        drop(bounded);
+
+        assert!(matches!(
+            events.recv().await,
+            Some(BodyCaptureEvent::Frame(_))
+        ));
+        assert!(events.recv().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn buffered_capture_forwards_frames_and_finishes_once() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-finished", "yes".parse().unwrap());
+        let source = StreamBody::new(rama_core::futures::stream::iter([
+            Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"hello"))),
+            Ok(Frame::data(Bytes::from_static(b" world"))),
+            Ok(Frame::trailers(trailers.clone())),
+        ]));
+        let (mut body, handle) = CaptureBody::buffered(source, CaptureLimit::max_bytes(7));
+
+        let mut forwarded = Vec::new();
+        while let Some(frame) = body.frame().await {
+            let frame = frame.unwrap();
+            if let Some(data) = frame.data_ref() {
+                forwarded.extend_from_slice(data);
+            } else {
+                assert_eq!(frame.trailers_ref().unwrap(), &trailers);
+            }
+        }
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(forwarded, b"hello world");
+        assert_eq!(captured.bytes(), &Bytes::from_static(b"hello w"));
+        assert_eq!(captured.trailers(), Some(&trailers));
+        assert_eq!(captured.outcome(), CaptureOutcome::Complete);
+        assert_eq!(captured.total_bytes(), 11);
+        assert!(captured.is_truncated());
+    }
+
+    #[tokio::test]
+    async fn zero_byte_limit_records_length_without_retaining_data() {
+        let (body, handle) =
+            CaptureBody::buffered(Body::from("not retained"), CaptureLimit::max_bytes(0));
+        body.collect().await.unwrap();
+
+        let captured = wait_for_capture(handle).await;
+        assert!(captured.bytes().is_empty());
+        assert_eq!(captured.total_bytes(), 12);
+        assert!(captured.is_truncated());
+        assert_eq!(captured.outcome(), CaptureOutcome::Complete);
+    }
+
+    #[tokio::test]
+    async fn buffered_capture_reports_error_and_partial_body() {
+        let source = StreamBody::new(rama_core::futures::stream::iter([
+            Ok(Frame::data(Bytes::from_static(b"before"))),
+            Err(io::Error::other("broken body")),
+        ]));
+        let (mut body, handle) = CaptureBody::buffered(source, CaptureLimit::unlimited());
+
+        assert_eq!(
+            body.frame().await.unwrap().unwrap().into_data().unwrap(),
+            Bytes::from_static(b"before")
+        );
+        assert_eq!(
+            body.frame().await.unwrap().unwrap_err().to_string(),
+            "broken body"
+        );
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(captured.bytes(), &Bytes::from_static(b"before"));
+        assert_eq!(captured.outcome(), CaptureOutcome::Error);
+    }
+
+    #[tokio::test]
+    async fn unlimited_buffer_can_rebuild_data_and_trailers() {
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-finished", "yes".parse().unwrap());
+        let source = StreamBody::new(rama_core::futures::stream::iter([
+            Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"complete"))),
+            Ok(Frame::trailers(trailers.clone())),
+        ]));
+        let (body, handle) = CaptureBody::buffered(source, CaptureLimit::unlimited());
+        body.collect().await.unwrap();
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(captured.outcome(), CaptureOutcome::Complete);
+        assert!(!captured.is_truncated());
+        let rebuilt = captured.into_body().collect().await.unwrap();
+        assert_eq!(rebuilt.trailers(), Some(&trailers));
+        assert_eq!(rebuilt.to_bytes(), Bytes::from_static(b"complete"));
+    }
+
+    #[tokio::test]
+    async fn dropping_buffer_handle_stops_retaining_frames() {
+        let (sink, handle) = BufferedBodyCapture::new(CaptureLimit::unlimited());
+        drop(handle);
+        sink.capture(BodyCaptureEvent::Frame(Frame::data(Bytes::from_static(
+            b"ignored",
+        ))))
+        .await;
+
+        let state = sink.state();
+        assert!(state.sender.is_none());
+        assert!(state.bytes.is_empty());
+        assert_eq!(state.total_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_buffer_sink_reports_abort() {
+        let (sink, handle) = BufferedBodyCapture::new(CaptureLimit::unlimited());
+        drop(sink);
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(captured.outcome(), CaptureOutcome::Aborted);
+    }
+
+    #[tokio::test]
+    async fn explicit_buffer_abort_finishes_before_the_sink_is_dropped() {
+        let (sink, handle) = BufferedBodyCapture::new(CaptureLimit::unlimited());
+        sink.aborted();
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(captured.outcome(), CaptureOutcome::Aborted);
+        drop(sink);
+    }
+
+    #[tokio::test]
+    async fn buffered_capture_reports_abort_once() {
+        let source = StreamBody::new(rama_core::futures::stream::iter([
+            Ok::<_, Infallible>(Frame::data(Bytes::from_static(b"first"))),
+            Ok(Frame::data(Bytes::from_static(b"second"))),
+        ]));
+        let (mut body, handle) = CaptureBody::buffered(source, CaptureLimit::unlimited());
+        assert_eq!(
+            body.frame().await.unwrap().unwrap().into_data().unwrap(),
+            Bytes::from_static(b"first")
+        );
+        drop(body);
+
+        let captured = wait_for_capture(handle).await;
+        assert_eq!(captured.bytes(), &Bytes::from_static(b"first"));
+        assert_eq!(captured.outcome(), CaptureOutcome::Aborted);
+    }
+
+    struct PendingSink {
+        events: tokio::sync::mpsc::UnboundedSender<BodyCaptureEvent>,
+        aborts: Arc<AtomicUsize>,
+    }
+
+    impl BodyCaptureSink for PendingSink {
+        fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+            self.events.send(event).unwrap();
+            std::future::pending()
+        }
+
+        fn aborted(&self) {
+            self.aborts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn dropping_while_sink_is_pending_reports_abort_without_forwarding() {
+        let (events, mut captured) = tokio::sync::mpsc::unbounded_channel();
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let mut body = CaptureBody::new(
+            Body::from("captured first"),
+            PendingSink {
+                events,
+                aborts: Arc::clone(&aborts),
+            },
+        );
+        let mut frame = Box::pin(body.frame());
+
+        tokio::time::timeout(std::time::Duration::ZERO, &mut frame)
+            .await
+            .expect_err("the sink future should remain pending");
+        drop(frame);
+        assert!(matches!(
+            captured.recv().await,
+            Some(BodyCaptureEvent::Frame(_))
+        ));
+        drop(body);
+        assert_eq!(aborts.load(Ordering::Relaxed), 1);
+    }
+
+    struct AbortSink(Arc<AtomicUsize>);
+
+    impl BodyCaptureSink for AbortSink {
+        fn capture(&self, _event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+            ready(())
+        }
+
+        fn aborted(&self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn into_inner_notifies_sink_of_abort() {
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let body = CaptureBody::new(Body::from("body"), AbortSink(Arc::clone(&aborted)));
+        let _inner = body.into_inner();
+        assert_eq!(aborted.load(Ordering::Relaxed), 1);
+    }
+
+    struct CompletionSink {
+        endings: Arc<AtomicUsize>,
+        aborts: Arc<AtomicUsize>,
+    }
+
+    impl BodyCaptureSink for CompletionSink {
+        fn capture(&self, event: BodyCaptureEvent) -> impl Future<Output = ()> + Send + 'static {
+            if matches!(event, BodyCaptureEvent::End(CaptureOutcome::Complete)) {
+                self.endings.fetch_add(1, Ordering::Relaxed);
+            }
+            ready(())
+        }
+
+        fn aborted(&self) {
+            self.aborts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    #[tokio::test]
+    async fn normal_completion_finishes_once_without_abort() {
+        let endings = Arc::new(AtomicUsize::new(0));
+        let aborts = Arc::new(AtomicUsize::new(0));
+        let mut body = CaptureBody::new(
+            Body::empty(),
+            CompletionSink {
+                endings: Arc::clone(&endings),
+                aborts: Arc::clone(&aborts),
+            },
+        );
+
+        assert!(body.frame().await.is_none());
+        assert!(body.is_end_stream());
+        drop(body);
+
+        assert_eq!(endings.load(Ordering::Relaxed), 1);
+        assert_eq!(aborts.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn delegates_stream_metadata_without_hiding_pending_completion() {
+        let (body, handle) = CaptureBody::buffered(Body::from("abc"), CaptureLimit::unlimited());
+        assert!(!body.is_end_stream());
+        assert_eq!(body.size_hint().exact(), Some(3));
+        drop(handle);
+
+        let (body, handle) = CaptureBody::buffered(Body::empty(), CaptureLimit::unlimited());
+        assert!(!body.is_end_stream());
+        assert_eq!(body.size_hint().exact(), Some(0));
+        drop(handle);
+    }
+
+    #[test]
+    fn capture_debug_and_canceled_display_are_informative() {
+        let (sink, handle) = BufferedBodyCapture::new(CaptureLimit::max_bytes(8));
+        assert!(format!("{sink:?}").contains("BufferedBodyCapture"));
+        let body = CaptureBody::new(Body::empty(), sink);
+        assert!(format!("{body:?}").contains("CaptureBody"));
+        assert_eq!(
+            CaptureCanceled.to_string(),
+            "body capture producer was canceled"
+        );
+        drop(handle);
+    }
+}

--- a/rama-http-types/src/body/http_body/frame.rs
+++ b/rama-http-types/src/body/http_body/frame.rs
@@ -1,12 +1,12 @@
 use crate::HeaderMap;
 
 /// A frame of any kind related to an HTTP stream (body).
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Frame<T> {
     kind: Kind<T>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 enum Kind<T> {
     // The first two variants are "inlined" since they are undoubtedly
     // the most common. This saves us from having to allocate a

--- a/rama-http-types/src/body/http_body_util/mod.rs
+++ b/rama-http-types/src/body/http_body_util/mod.rs
@@ -88,6 +88,29 @@ pub trait BodyExt: crate::body::http_body::Body {
         combinators::InspectFrame::new(self, f)
     }
 
+    /// Forward this byte body while asynchronously sending owned frame copies to a sink.
+    fn capture<S>(self, sink: S) -> crate::body::CaptureBody<Self, S>
+    where
+        Self: Sized + crate::body::http_body::Body<Data = bytes::Bytes>,
+        S: crate::body::BodyCaptureSink,
+    {
+        crate::body::CaptureBody::new(self, sink)
+    }
+
+    /// Forward this byte body while retaining a bounded or unlimited copy in memory.
+    fn capture_buffered(
+        self,
+        limit: crate::body::CaptureLimit,
+    ) -> (
+        crate::body::CaptureBody<Self, crate::body::BufferedBodyCapture>,
+        crate::body::CaptureHandle,
+    )
+    where
+        Self: Sized + crate::body::http_body::Body<Data = bytes::Bytes>,
+    {
+        crate::body::CaptureBody::buffered(self, limit)
+    }
+
     /// Maps this body's error value to a different value.
     fn map_err<F, E>(self, f: F) -> MapErr<Self, F>
     where
@@ -224,6 +247,38 @@ pub trait BodyExt: crate::body::http_body::Body {
     }
 
     /// Turn this body into [`BodyStream`].
+    ///
+    /// This can be combined with stream combinators to observe each frame or
+    /// error asynchronously without changing it. The observer is awaited before
+    /// the item is yielded, so it naturally applies backpressure without
+    /// blocking an executor thread or cloning the frame:
+    ///
+    /// ```
+    /// use rama_core::futures::StreamExt as _;
+    /// use rama_http_types::body::{Body, Frame, util::{BodyExt, StreamBody}};
+    ///
+    /// async fn observe<D, E>(_item: &Result<Frame<D>, E>) {}
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let body = Body::from("hello");
+    /// let body = StreamBody::new(body.into_stream().then(|item| async move {
+    ///     observe(&item).await;
+    ///     item
+    /// }));
+    ///
+    /// let collected = BodyExt::collect(body).await.unwrap();
+    /// assert_eq!(collected.to_bytes(), "hello");
+    /// # }
+    /// ```
+    ///
+    /// Stream combinators observe yielded items, not the normal end marker
+    /// (`None`). Use an appropriate body or layer lifecycle hook when normal
+    /// end-of-stream must also be observed. Converting the resulting stream
+    /// back with [`StreamBody`] does not preserve the original body's
+    /// [`SizeHint`](crate::body::http_body::SizeHint) or early
+    /// [`Body::is_end_stream`](crate::body::http_body::Body::is_end_stream)
+    /// indication.
     fn into_stream(self) -> BodyStream<Self>
     where
         Self: Sized,

--- a/rama-http-types/src/body/mod.rs
+++ b/rama-http-types/src/body/mod.rs
@@ -53,6 +53,12 @@ pub use guarded::GuardedBody;
 mod optional;
 pub use optional::OptionalBody;
 
+mod capture;
+pub use capture::{
+    BodyCaptureEvent, BodyCaptureSink, BufferedBodyCapture, CaptureBody, CaptureCanceled,
+    CaptureHandle, CaptureLimit, CaptureOutcome, CapturedBody,
+};
+
 // Implementations copied over from http-body but addapted to work with our Requests/Response types
 
 impl<B: StreamingBody> StreamingBody for crate::Request<B> {
@@ -178,6 +184,38 @@ impl Body {
         F: FnOnce() + Send + Sync + 'static,
     {
         Self::new(OnDropBody::new(self.0, on_drop))
+    }
+
+    /// Forward this body while asynchronously sending owned frame copies to a sink.
+    pub fn capture<S>(self, sink: S) -> Self
+    where
+        S: BodyCaptureSink,
+    {
+        Self::new(CaptureBody::new(self.0, sink))
+    }
+
+    /// Forward this body while retaining a bounded or unlimited copy in memory.
+    ///
+    /// The returned handle resolves exactly once after the forwarding body
+    /// completes, errors, or is dropped:
+    ///
+    /// ```
+    /// use rama_http_types::{Body, CaptureLimit, CaptureOutcome, body::util::BodyExt as _};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let (body, capture) = Body::from("hello").capture_buffered(CaptureLimit::max_bytes(1024));
+    /// body.collect().await.unwrap();
+    ///
+    /// let captured = capture.wait().await.unwrap();
+    /// assert_eq!(captured.bytes(), "hello");
+    /// assert_eq!(captured.outcome(), CaptureOutcome::Complete);
+    /// assert!(!captured.is_truncated());
+    /// # }
+    /// ```
+    pub fn capture_buffered(self, limit: CaptureLimit) -> (Self, CaptureHandle) {
+        let (body, handle) = CaptureBody::buffered(self.0, limit);
+        (Self::new(body), handle)
     }
 
     /// Attach a headermap as trailer headers to this body.
@@ -408,4 +446,23 @@ where
 fn test_try_downcast() {
     assert_eq!(try_downcast::<i32, _>(5_u32), Err(5_u32));
     assert_eq!(try_downcast::<i32, _>(5_i32), Ok(5_i32));
+}
+
+#[tokio::test]
+async fn capture_convenience_forwards_and_observes_body() {
+    let (sink, mut events) = tokio::sync::mpsc::unbounded_channel();
+    let forwarded = Body::from("captured").capture(sink);
+
+    assert_eq!(
+        forwarded.collect().await.unwrap().to_bytes(),
+        Bytes::from_static(b"captured")
+    );
+    let BodyCaptureEvent::Frame(frame) = events.recv().await.unwrap() else {
+        panic!("the first capture event must contain the data frame");
+    };
+    assert_eq!(frame.into_data().unwrap(), Bytes::from_static(b"captured"));
+    assert!(matches!(
+        events.recv().await,
+        Some(BodyCaptureEvent::End(CaptureOutcome::Complete))
+    ));
 }

--- a/rama-http-types/src/header/map.rs
+++ b/rama-http-types/src/header/map.rs
@@ -2418,14 +2418,9 @@ impl serde::Serialize for HeaderMap<HeaderValue> {
     where
         S: serde::Serializer,
     {
-        let headers: Result<Vec<_>, _> = self
-            .ordered_iter()
-            .map(|(name, value)| {
-                let value = value.to_str().map_err(serde::ser::Error::custom)?;
-                Ok::<_, S::Error>((name, value.to_owned()))
-            })
-            .collect();
-        headers?.serialize(serializer)
+        self.ordered_iter()
+            .collect::<Vec<_>>()
+            .serialize(serializer)
     }
 }
 
@@ -2434,16 +2429,8 @@ impl<'de> serde::Deserialize<'de> for HeaderMap<HeaderValue> {
     where
         D: serde::Deserializer<'de>,
     {
-        let headers = <Vec<(HeaderName, std::borrow::Cow<'de, str>)>>::deserialize(deserializer)?;
-        headers
-            .into_iter()
-            .map(|(name, value)| {
-                Ok::<_, D::Error>((
-                    name,
-                    HeaderValue::from_str(&value).map_err(serde::de::Error::custom)?,
-                ))
-            })
-            .collect()
+        Vec::<(HeaderName, HeaderValue)>::deserialize(deserializer)
+            .map(|headers| headers.into_iter().collect())
     }
 }
 

--- a/rama-http-types/src/header/name.rs
+++ b/rama-http-types/src/header/name.rs
@@ -1636,7 +1636,7 @@ impl serde::Serialize for HeaderName {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 

--- a/rama-http-types/src/header/value.rs
+++ b/rama-http-types/src/header/value.rs
@@ -18,6 +18,10 @@ use crate::header::name::HeaderName;
 /// To handle this, the `HeaderValue` is usable as a type and can be compared
 /// with strings and implements `Debug`. A `to_str` fn is provided that returns
 /// an `Err` if the header value contains non visible ascii characters.
+///
+/// Its human-readable Serde form is a string when possible and a byte sequence
+/// otherwise. The sensitivity marker controls diagnostics and compression, not
+/// wire data, and is intentionally not preserved by Serde.
 #[derive(Clone)]
 pub struct HeaderValue {
     inner: Bytes,
@@ -728,6 +732,98 @@ where
     #[inline]
     fn partial_cmp(&self, other: &&T) -> Option<cmp::Ordering> {
         self.partial_cmp(*other)
+    }
+}
+
+impl serde::Serialize for HeaderValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self.to_str() {
+            Ok(value) if serializer.is_human_readable() => serializer.serialize_str(value),
+            _ => serializer.serialize_bytes(self.as_bytes()),
+        }
+    }
+}
+
+/// Human-readable formats must support `deserialize_any` because textual
+/// values deserialize from strings while opaque values deserialize from byte
+/// sequences. Formats that represent `serialize_bytes` as text cannot retain
+/// that distinction and are not suitable for lossless opaque header values.
+impl<'de> serde::Deserialize<'de> for HeaderValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct HeaderValueVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for HeaderValueVisitor {
+            type Value = HeaderValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a valid HTTP header value as text or bytes")
+            }
+
+            fn visit_borrowed_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HeaderValue::from_bytes(value.as_bytes()).map_err(E::custom)
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_borrowed_str(value)
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HeaderValue::from_maybe_shared(value).map_err(E::custom)
+            }
+
+            fn visit_borrowed_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HeaderValue::from_bytes(value).map_err(E::custom)
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_borrowed_bytes(value)
+            }
+
+            fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HeaderValue::from_maybe_shared(value).map_err(E::custom)
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::SeqAccess<'de>,
+            {
+                let mut bytes = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                while let Some(byte) = seq.next_element()? {
+                    bytes.push(byte);
+                }
+                self.visit_byte_buf(bytes)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_any(HeaderValueVisitor)
+        } else {
+            deserializer.deserialize_bytes(HeaderValueVisitor)
+        }
     }
 }
 

--- a/rama-http-types/src/lib.rs
+++ b/rama-http-types/src/lib.rs
@@ -23,7 +23,9 @@ use rama_net::uri::Uri;
 
 pub mod body;
 pub use body::{
-    Body, BodyDataStream, BodyExtractExt, BodyLimit, InfiniteReader, StreamingBody, sse,
+    Body, BodyCaptureEvent, BodyCaptureSink, BodyDataStream, BodyExtractExt, BodyLimit,
+    BufferedBodyCapture, CaptureBody, CaptureCanceled, CaptureHandle, CaptureLimit, CaptureOutcome,
+    CapturedBody, InfiniteReader, StreamingBody, sse,
 };
 
 pub mod request;

--- a/rama-http-types/src/method.rs
+++ b/rama-http-types/src/method.rs
@@ -213,6 +213,13 @@ impl AsRef<str> for Method {
     }
 }
 
+// Methods are tokens, so their canonical Serde representation is the exact
+// token text. This also preserves extension methods without an allocation on
+// serialization.
+use rama_utils::macros::serde_str::impl_serde_str;
+
+impl_serde_str!(as_str Method);
+
 impl Ord for Method {
     #[inline]
     fn cmp(&self, other: &Method) -> std::cmp::Ordering {

--- a/rama-http-types/src/request.rs
+++ b/rama-http-types/src/request.rs
@@ -13,6 +13,10 @@ use rama_utils::macros::generate_set_and_with;
 /// For example, the body could be `Vec<u8>`, a `Stream` of byte chunks, or a
 /// value that has been deserialized.
 ///
+/// The Serde representation contains `method`, `uri`, `version`, `headers`,
+/// and `body`. Typed [`Extensions`] are process-local values and are
+/// intentionally omitted. Deserializing therefore creates empty extensions.
+///
 /// # Examples
 ///
 /// Creating a `Request` to send
@@ -116,6 +120,106 @@ pub struct Parts {
 
     /// The request's extensions
     pub extensions: Extensions,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename = "RequestParts")]
+struct RequestPartsSerde {
+    method: Method,
+    uri: String,
+    version: Version,
+    headers: HeaderMap<HeaderValue>,
+}
+
+impl serde::Serialize for Parts {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct as _;
+
+        let mut state = serializer.serialize_struct("RequestParts", 4)?;
+        state.serialize_field("method", &self.method)?;
+        state.serialize_field("uri", &self.uri)?;
+        state.serialize_field("version", &self.version)?;
+        state.serialize_field("headers", &self.headers)?;
+        state.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Parts {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = RequestPartsSerde::deserialize(deserializer)?;
+        let uri =
+            deserialize_request_uri(&repr.method, &repr.uri).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            method: repr.method,
+            uri,
+            version: repr.version,
+            headers: repr.headers,
+            extensions: Extensions::new(),
+        })
+    }
+}
+
+impl<T: serde::Serialize> serde::Serialize for Request<T> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct as _;
+
+        let mut state = serializer.serialize_struct("Request", 5)?;
+        state.serialize_field("method", &self.head.method)?;
+        state.serialize_field("uri", &self.head.uri)?;
+        state.serialize_field("version", &self.head.version)?;
+        state.serialize_field("headers", &self.head.headers)?;
+        state.serialize_field("body", &self.body)?;
+        state.end()
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename = "Request")]
+struct RequestSerde<T> {
+    method: Method,
+    uri: String,
+    version: Version,
+    headers: HeaderMap<HeaderValue>,
+    body: T,
+}
+
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Request<T> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = RequestSerde::deserialize(deserializer)?;
+        let uri =
+            deserialize_request_uri(&repr.method, &repr.uri).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            head: Parts {
+                method: repr.method,
+                uri,
+                version: repr.version,
+                headers: repr.headers,
+                extensions: Extensions::new(),
+            },
+            body: repr.body,
+        })
+    }
+}
+
+fn deserialize_request_uri(method: &Method, value: &str) -> Result<Uri> {
+    if method == Method::CONNECT {
+        Uri::parse_authority_form(value).or_else(|_| Uri::parse_reference(value))
+    } else {
+        Uri::parse_reference(value)
+    }
+    .map_err(Into::into)
 }
 
 impl ExtensionsRef for Parts {

--- a/rama-http-types/src/response.rs
+++ b/rama-http-types/src/response.rs
@@ -17,6 +17,10 @@ use rama_utils::macros::generate_set_and_with;
 /// For example, the body could be `Vec<u8>`, a `Stream` of byte chunks, or a
 /// value that has been deserialized.
 ///
+/// The Serde representation contains `status`, `version`, `headers`, and
+/// `body`. Typed [`Extensions`] are process-local values and are intentionally
+/// omitted. Deserializing therefore creates empty extensions.
+///
 /// Typically you'll work with responses on the client side as the result of
 /// sending a `Request` and on the server you'll be generating a `Response` to
 /// send back to the client.
@@ -134,6 +138,87 @@ pub struct Parts {
 
     /// The response's extensions
     pub extensions: Extensions,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename = "ResponseParts")]
+struct ResponsePartsSerde {
+    status: StatusCode,
+    version: Version,
+    headers: HeaderMap<HeaderValue>,
+}
+
+impl serde::Serialize for Parts {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct as _;
+
+        let mut state = serializer.serialize_struct("ResponseParts", 3)?;
+        state.serialize_field("status", &self.status)?;
+        state.serialize_field("version", &self.version)?;
+        state.serialize_field("headers", &self.headers)?;
+        state.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Parts {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = ResponsePartsSerde::deserialize(deserializer)?;
+        Ok(Self {
+            status: repr.status,
+            version: repr.version,
+            headers: repr.headers,
+            extensions: Extensions::new(),
+        })
+    }
+}
+
+impl<T: serde::Serialize> serde::Serialize for Response<T> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct as _;
+
+        let mut state = serializer.serialize_struct("Response", 4)?;
+        state.serialize_field("status", &self.head.status)?;
+        state.serialize_field("version", &self.head.version)?;
+        state.serialize_field("headers", &self.head.headers)?;
+        state.serialize_field("body", &self.body)?;
+        state.end()
+    }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename = "Response")]
+struct ResponseSerde<T> {
+    status: StatusCode,
+    version: Version,
+    headers: HeaderMap<HeaderValue>,
+    body: T,
+}
+
+impl<'de, T: serde::Deserialize<'de>> serde::Deserialize<'de> for Response<T> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let repr = ResponseSerde::deserialize(deserializer)?;
+        Ok(Self {
+            head: Parts {
+                status: repr.status,
+                version: repr.version,
+                headers: repr.headers,
+                extensions: Extensions::new(),
+            },
+            body: repr.body,
+        })
+    }
 }
 
 impl ExtensionsRef for Parts {

--- a/rama-http-types/src/status.rs
+++ b/rama-http-types/src/status.rs
@@ -559,6 +559,25 @@ impl fmt::Display for InvalidStatusCode {
 
 impl Error for InvalidStatusCode {}
 
+impl serde::Serialize for StatusCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u16(self.as_u16())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StatusCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = <u16 as serde::Deserialize>::deserialize(deserializer)?;
+        Self::from_u16(value).map_err(serde::de::Error::custom)
+    }
+}
+
 // A string of packed 3-ASCII-digit status code values for the supported range
 // of [100, 999] (900 codes, 2700 bytes).
 const CODE_DIGITS: &str = "\

--- a/rama-http-types/tests/serde.rs
+++ b/rama-http-types/tests/serde.rs
@@ -1,0 +1,242 @@
+use bytes::Bytes;
+use rama_core::extensions::{Extension, ExtensionsRef as _};
+use rama_http_types::{
+    HeaderMap, HeaderValue, Method, Request, Response, StatusCode, Version, request, response,
+};
+use serde_test::{Configure, Token, assert_tokens};
+
+#[derive(Debug, Extension)]
+struct ProcessLocal;
+
+#[derive(Debug)]
+struct ComparableRequest(Request<()>);
+
+impl PartialEq for ComparableRequest {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.method() == other.0.method()
+            && self.0.uri() == other.0.uri()
+            && self.0.version() == other.0.version()
+            && self.0.headers() == other.0.headers()
+    }
+}
+
+impl serde::Serialize for ComparableRequest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(&self.0, serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ComparableRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        serde::Deserialize::deserialize(deserializer).map(Self)
+    }
+}
+
+#[test]
+fn bytes_roundtrip_through_serde() {
+    let bytes = Bytes::from_static(&[0, 0x80, 0xff]);
+    let json = serde_json::to_string(&bytes).unwrap();
+    assert_eq!(json, "[0,128,255]");
+    assert_eq!(serde_json::from_str::<Bytes>(&json).unwrap(), bytes);
+}
+
+#[test]
+fn leaf_types_use_stable_json_representations() {
+    assert_eq!(serde_json::to_string(&Method::PATCH).unwrap(), r#""PATCH""#);
+    assert_eq!(
+        serde_json::to_string(&StatusCode::IM_A_TEAPOT).unwrap(),
+        "418"
+    );
+    assert_eq!(
+        serde_json::to_string(&Version::HTTP_2).unwrap(),
+        r#""HTTP/2.0""#
+    );
+
+    assert_eq!(
+        serde_json::from_str::<Method>(r#""CUSTOM""#).unwrap(),
+        "CUSTOM"
+    );
+    assert_eq!(
+        serde_json::from_str::<StatusCode>("599").unwrap(),
+        StatusCode::from_u16(599).unwrap()
+    );
+    assert_eq!(
+        serde_json::from_str::<Version>(r#""2""#).unwrap(),
+        Version::HTTP_2
+    );
+
+    serde_json::from_str::<Method>(r#""""#).unwrap_err();
+    serde_json::from_str::<StatusCode>("99").unwrap_err();
+    serde_json::from_str::<Version>(r#""HTTP/4""#).unwrap_err();
+}
+
+#[test]
+fn header_value_json_is_readable_when_text_and_lossless_when_opaque() {
+    let text = HeaderValue::from_static("text value");
+    assert_eq!(serde_json::to_string(&text).unwrap(), r#""text value""#);
+    assert_eq!(
+        serde_json::from_str::<HeaderValue>(r#""text value""#).unwrap(),
+        text
+    );
+
+    let opaque = HeaderValue::from_bytes(&[0x80, b' ', 0xff]).unwrap();
+    let json = serde_json::to_string(&opaque).unwrap();
+    assert_eq!(json, "[128,32,255]");
+    assert_eq!(serde_json::from_str::<HeaderValue>(&json).unwrap(), opaque);
+
+    serde_json::from_str::<HeaderValue>("[10]").unwrap_err();
+    let error = serde_json::from_str::<HeaderValue>("{}").unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("a valid HTTP header value as text or bytes")
+    );
+}
+
+#[test]
+fn header_value_uses_bytes_in_non_human_readable_formats() {
+    assert_tokens(
+        &HeaderValue::from_static("text value").compact(),
+        &[Token::BorrowedBytes(b"text value")],
+    );
+}
+
+#[test]
+fn header_map_roundtrip_preserves_order_duplicates_casing_and_bytes() {
+    let mut headers = HeaderMap::new();
+    headers.append("X-First", HeaderValue::from_static("one"));
+    headers.append("x-second", HeaderValue::from_bytes(&[0x80]).unwrap());
+    headers.append("X-FIRST", HeaderValue::from_static("two"));
+
+    let json = serde_json::to_string(&headers).unwrap();
+    let decoded: HeaderMap = serde_json::from_str(&json).unwrap();
+    let actual = decoded
+        .ordered_iter()
+        .map(|(name, value)| (name.to_string(), value.as_bytes().to_vec()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        actual,
+        [
+            ("X-First".to_owned(), b"one".to_vec()),
+            ("x-second".to_owned(), vec![0x80]),
+            ("X-FIRST".to_owned(), b"two".to_vec()),
+        ]
+    );
+}
+
+#[test]
+fn aggregate_types_roundtrip_in_non_human_readable_formats() {
+    let request = ComparableRequest(Request::builder().uri("/resource").body(()).unwrap());
+    assert_tokens(
+        &request.compact(),
+        &[
+            Token::Struct {
+                name: "Request",
+                len: 5,
+            },
+            Token::Str("method"),
+            Token::Str("GET"),
+            Token::Str("uri"),
+            Token::Str("/resource"),
+            Token::Str("version"),
+            Token::Str("HTTP/1.1"),
+            Token::Str("headers"),
+            Token::Seq { len: Some(0) },
+            Token::SeqEnd,
+            Token::Str("body"),
+            Token::Unit,
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn invalid_header_name_is_rejected_during_map_deserialization() {
+    let error = serde_json::from_str::<HeaderMap>(r#"[["bad name","value"]]"#).unwrap_err();
+    assert!(error.to_string().contains("invalid HTTP header name"));
+}
+
+#[test]
+fn request_and_parts_roundtrip_omit_process_local_extensions() {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("https://example.com/upload?q=1")
+        .version(Version::HTTP_2)
+        .header("X-Text", "hello")
+        .header("X-Opaque", HeaderValue::from_bytes(&[0x80]).unwrap())
+        .extension(ProcessLocal)
+        .body(vec![1_u8, 2, 3])
+        .unwrap();
+
+    let json = serde_json::to_string(&request).unwrap();
+    assert!(!json.contains("ProcessLocal"));
+    let decoded: Request<Vec<u8>> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.method(), Method::POST);
+    assert_eq!(decoded.uri().as_str(), "https://example.com/upload?q=1");
+    assert_eq!(decoded.version(), Version::HTTP_2);
+    assert_eq!(decoded.headers()["x-opaque"].as_bytes(), &[0x80]);
+    assert_eq!(decoded.body(), &[1, 2, 3]);
+    assert!(!decoded.extensions().contains::<ProcessLocal>());
+
+    let (parts, _) = decoded.into_parts();
+    let parts_json = serde_json::to_string(&parts).unwrap();
+    let decoded_parts: request::Parts = serde_json::from_str(&parts_json).unwrap();
+    assert_eq!(decoded_parts.method, Method::POST);
+    assert!(!decoded_parts.extensions.contains::<ProcessLocal>());
+}
+
+#[test]
+fn request_roundtrip_preserves_connect_authority_and_relative_references() {
+    let connect = Request::builder()
+        .method(Method::CONNECT)
+        .uri(rama_net::uri::Uri::parse_authority_form("example.com:443").unwrap())
+        .body(())
+        .unwrap();
+    let json = serde_json::to_string(&connect).unwrap();
+    let decoded: Request<()> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.uri().to_string(), "example.com:443");
+    assert!(decoded.uri().scheme().is_none());
+    assert_eq!(decoded.uri().host().unwrap().to_string(), "example.com");
+    assert_eq!(decoded.uri().port().as_u16(), Some(443));
+
+    let relative = Request::builder()
+        .uri(rama_net::uri::Uri::parse_reference("../asset?q=1#part").unwrap())
+        .body(())
+        .unwrap();
+    let json = serde_json::to_string(&relative).unwrap();
+    let decoded: Request<()> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.uri().to_string(), "../asset?q=1#part");
+}
+
+#[test]
+fn response_and_parts_roundtrip_omit_process_local_extensions() {
+    let response = Response::builder()
+        .status(StatusCode::CREATED)
+        .version(Version::HTTP_11)
+        .header("X-Result", "created")
+        .extension(ProcessLocal)
+        .body("ok".to_owned())
+        .unwrap();
+
+    let json = serde_json::to_string(&response).unwrap();
+    assert!(!json.contains("ProcessLocal"));
+    let decoded: Response<String> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.status(), StatusCode::CREATED);
+    assert_eq!(decoded.version(), Version::HTTP_11);
+    assert_eq!(decoded.headers()["x-result"], "created");
+    assert_eq!(decoded.body(), "ok");
+    assert!(!decoded.extensions().contains::<ProcessLocal>());
+
+    let (parts, _) = decoded.into_parts();
+    let parts_json = serde_json::to_string(&parts).unwrap();
+    let decoded_parts: response::Parts = serde_json::from_str(&parts_json).unwrap();
+    assert_eq!(decoded_parts.status, StatusCode::CREATED);
+    assert!(!decoded_parts.extensions.contains::<ProcessLocal>());
+}

--- a/rama-http-types/tests/serde.rs
+++ b/rama-http-types/tests/serde.rs
@@ -193,7 +193,7 @@ fn request_and_parts_roundtrip_omit_process_local_extensions() {
 }
 
 #[test]
-fn request_roundtrip_preserves_connect_authority_and_relative_references() {
+fn request_roundtrip_preserves_all_request_target_forms() {
     let connect = Request::builder()
         .method(Method::CONNECT)
         .uri(rama_net::uri::Uri::parse_authority_form("example.com:443").unwrap())
@@ -205,6 +205,26 @@ fn request_roundtrip_preserves_connect_authority_and_relative_references() {
     assert!(decoded.uri().scheme().is_none());
     assert_eq!(decoded.uri().host().unwrap().to_string(), "example.com");
     assert_eq!(decoded.uri().port().as_u16(), Some(443));
+
+    let connect_reference = Request::builder()
+        .method(Method::CONNECT)
+        .uri(rama_net::uri::Uri::parse_reference("/tunnel").unwrap())
+        .body(())
+        .unwrap();
+    let json = serde_json::to_string(&connect_reference).unwrap();
+    let decoded: Request<()> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.method(), Method::CONNECT);
+    assert_eq!(decoded.uri().to_string(), "/tunnel");
+
+    let options = Request::builder()
+        .method(Method::OPTIONS)
+        .uri(rama_net::uri::Uri::parse_reference("*").unwrap())
+        .body(())
+        .unwrap();
+    let json = serde_json::to_string(&options).unwrap();
+    let decoded: Request<()> = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded.method(), Method::OPTIONS);
+    assert_eq!(decoded.uri().to_string(), "*");
 
     let relative = Request::builder()
         .uri(rama_net::uri::Uri::parse_reference("../asset?q=1#part").unwrap())

--- a/rama-http/src/io/mod.rs
+++ b/rama-http/src/io/mod.rs
@@ -5,15 +5,18 @@ use rama_core::bytes::Bytes;
 use rama_core::error::{BoxError, ErrorContext as _};
 use rama_http_types::Version;
 use rama_utils::fmt::try_format_into;
+use std::future::poll_fn;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 mod request;
 #[doc(inline)]
 pub use request::write_http_request;
+pub(crate) use request::write_http_request_streaming;
 
 mod response;
 #[doc(inline)]
 pub use response::write_http_response;
+pub(crate) use response::write_http_response_streaming;
 
 pub mod upgrade;
 
@@ -79,4 +82,31 @@ where
     } else {
         Body::new(body)
     })
+}
+
+/// Stream `body` into `w` without retaining a second complete copy.
+pub(crate) async fn write_http1_body_streaming<W, B>(
+    w: &mut W,
+    body: B,
+    write_body: bool,
+) -> Result<(), BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    if !write_body {
+        return Ok(());
+    }
+
+    w.write_all(b"\r\n").await?;
+    let mut body = Box::pin(body);
+    while let Some(frame) = poll_fn(|cx| body.as_mut().poll_frame(cx)).await {
+        let frame = frame.map_err(Into::into)?;
+        if let Ok(data) = frame.into_data()
+            && !data.is_empty()
+        {
+            w.write_all(&data).await?;
+        }
+    }
+    Ok(())
 }

--- a/rama-http/src/io/request.rs
+++ b/rama-http/src/io/request.rs
@@ -1,4 +1,4 @@
-use crate::{Request, StreamingBody};
+use crate::{Body, Request, StreamingBody};
 use rama_core::{bytes::Bytes, error::BoxError};
 use rama_http_types::proto::h2::{PseudoHeader, PseudoHeaderOrder};
 use rama_utils::fmt::try_format_into;
@@ -10,6 +10,34 @@ pub async fn write_http_request<W, B>(
     req: Request<B>,
     write_headers: bool,
     write_body: bool,
+) -> Result<Request, BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    write_http_request_inner(w, req, write_headers, write_body, true).await
+}
+
+pub(crate) async fn write_http_request_streaming<W, B>(
+    w: &mut W,
+    req: Request<B>,
+    write_headers: bool,
+    write_body: bool,
+) -> Result<(), BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    drop(write_http_request_inner(w, req, write_headers, write_body, false).await?);
+    Ok(())
+}
+
+async fn write_http_request_inner<W, B>(
+    w: &mut W,
+    req: Request<B>,
+    write_headers: bool,
+    write_body: bool,
+    retain_body: bool,
 ) -> Result<Request, BoxError>
 where
     W: AsyncWrite + Unpin + Send + Sync + 'static,
@@ -80,7 +108,12 @@ where
         super::write_http1_header_map(w, &mut parts.headers, parts.version, &mut line).await?;
     }
 
-    let body = super::write_http1_body(w, body, write_body).await?;
+    let body = if retain_body {
+        super::write_http1_body(w, body, write_body).await?
+    } else {
+        super::write_http1_body_streaming(w, body, write_body).await?;
+        Body::empty()
+    };
 
     let req = Request::from_parts(parts, body);
     Ok(req)
@@ -164,5 +197,21 @@ mod tests {
             req,
             "POST / HTTP/1.1\r\ncontent-type: text/plain\r\nuser-agent: test/0\r\n\r\nhello"
         );
+    }
+
+    #[tokio::test]
+    async fn streaming_writer_writes_request_body() {
+        let mut buf = Vec::new();
+        let req = Request::builder()
+            .method("POST")
+            .uri("http://example.com")
+            .body(Body::from("streamed"))
+            .unwrap();
+
+        write_http_request_streaming(&mut buf, req, false, true)
+            .await
+            .unwrap();
+
+        assert_eq!(buf, b"\r\nstreamed");
     }
 }

--- a/rama-http/src/io/response.rs
+++ b/rama-http/src/io/response.rs
@@ -1,4 +1,4 @@
-use crate::{Response, StreamingBody};
+use crate::{Body, Response, StreamingBody};
 use rama_core::{bytes::Bytes, error::BoxError};
 use rama_http_types::proto::h2::{PseudoHeader, PseudoHeaderOrder};
 use rama_utils::fmt::try_format_into;
@@ -10,6 +10,34 @@ pub async fn write_http_response<W, B>(
     res: Response<B>,
     write_headers: bool,
     write_body: bool,
+) -> Result<Response, BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    write_http_response_inner(w, res, write_headers, write_body, true).await
+}
+
+pub(crate) async fn write_http_response_streaming<W, B>(
+    w: &mut W,
+    res: Response<B>,
+    write_headers: bool,
+    write_body: bool,
+) -> Result<(), BoxError>
+where
+    W: AsyncWrite + Unpin + Send + Sync + 'static,
+    B: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    drop(write_http_response_inner(w, res, write_headers, write_body, false).await?);
+    Ok(())
+}
+
+async fn write_http_response_inner<W, B>(
+    w: &mut W,
+    res: Response<B>,
+    write_headers: bool,
+    write_body: bool,
+    retain_body: bool,
 ) -> Result<Response, BoxError>
 where
     W: AsyncWrite + Unpin + Send + Sync + 'static,
@@ -73,7 +101,12 @@ where
         super::write_http1_header_map(w, &mut parts.headers, parts.version, &mut line).await?;
     }
 
-    let body = super::write_http1_body(w, body, write_body).await?;
+    let body = if retain_body {
+        super::write_http1_body(w, body, write_body).await?
+    } else {
+        super::write_http1_body_streaming(w, body, write_body).await?;
+        Body::empty()
+    };
 
     let req = Response::from_parts(parts, body);
     Ok(req)
@@ -81,8 +114,45 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{convert::Infallible, time::Duration};
+
+    use rama_core::futures::stream;
+    use tokio::io::AsyncReadExt as _;
+
     use super::*;
     use crate::Body;
+
+    #[tokio::test]
+    async fn streaming_writer_emits_chunks_before_end_of_stream() {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let stream = stream::unfold(receiver, |mut receiver| async move {
+            receiver.recv().await.map(|item| (item, receiver))
+        });
+        let response = Response::new(Body::from_stream(stream));
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        let write = tokio::spawn(async move {
+            write_http_response_streaming(&mut writer, response, false, true)
+                .await
+                .unwrap();
+        });
+
+        sender
+            .send(Ok::<_, Infallible>(Bytes::from_static(b"first")))
+            .unwrap();
+        let mut first = [0; 7];
+        tokio::time::timeout(Duration::from_secs(1), reader.read_exact(&mut first))
+            .await
+            .expect("the first chunk should be written before end-of-stream")
+            .unwrap();
+        assert_eq!(&first, b"\r\nfirst");
+
+        sender.send(Ok(Bytes::from_static(b"second"))).unwrap();
+        drop(sender);
+        let mut second = [0; 6];
+        reader.read_exact(&mut second).await.unwrap();
+        assert_eq!(&second, b"second");
+        write.await.unwrap();
+    }
 
     #[tokio::test]
     async fn test_write_response_ok() {

--- a/rama-http/src/layer/body_capture.rs
+++ b/rama-http/src/layer/body_capture.rs
@@ -1,0 +1,432 @@
+//! Asynchronous streaming request and response body capture.
+//!
+//! [`BodyCaptureLayer`] creates a dedicated [`BodyCaptureSink`] for each
+//! selected HTTP message. Each sink receives owned frame copies while the
+//! original body continues downstream.
+
+use std::{fmt, future::Future};
+
+use rama_core::{Layer, Service, bytes::Bytes, error::BoxError};
+use rama_http_types::{
+    Body, BodyCaptureSink, CaptureBody, Request, Response, StreamingBody, body::util::BodyExt as _,
+    request, response,
+};
+use rama_utils::macros::define_inner_service_accessors;
+
+/// The HTTP head associated with a captured body stream.
+#[derive(Clone)]
+pub enum CapturedHead {
+    /// An inbound request head.
+    Request(request::Parts),
+    /// An outbound response head.
+    Response(response::Parts),
+}
+
+impl fmt::Debug for CapturedHead {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(parts) => f.debug_tuple("Request").field(parts).finish(),
+            Self::Response(parts) => f.debug_tuple("Response").field(parts).finish(),
+        }
+    }
+}
+
+/// Creates a dedicated streaming capture sink for an HTTP message.
+///
+/// Returning `None` skips body capture for that message. The factory future is
+/// awaited after the HTTP head is available and before its body starts flowing.
+pub trait MakeBodyCaptureSink: Send + Sync + 'static {
+    /// The per-message capture sink.
+    type Sink: BodyCaptureSink;
+
+    /// Create a capture sink from the request or response head.
+    fn make_sink(&self, head: CapturedHead)
+    -> impl Future<Output = Option<Self::Sink>> + Send + '_;
+}
+
+impl<F, Fut, S> MakeBodyCaptureSink for F
+where
+    F: Fn(CapturedHead) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Option<S>> + Send + 'static,
+    S: BodyCaptureSink,
+{
+    type Sink = S;
+
+    fn make_sink(
+        &self,
+        head: CapturedHead,
+    ) -> impl Future<Output = Option<Self::Sink>> + Send + '_ {
+        self(head)
+    }
+}
+
+/// Layer that captures request bodies, response bodies, or both while they
+/// continue streaming through the service.
+#[derive(Clone)]
+pub struct BodyCaptureLayer<M> {
+    make_sink: M,
+    capture_request: bool,
+    capture_response: bool,
+}
+
+impl<M> BodyCaptureLayer<M> {
+    /// Capture request bodies.
+    #[must_use]
+    pub const fn request(make_sink: M) -> Self {
+        Self {
+            make_sink,
+            capture_request: true,
+            capture_response: false,
+        }
+    }
+
+    /// Capture response bodies.
+    #[must_use]
+    pub const fn response(make_sink: M) -> Self {
+        Self {
+            make_sink,
+            capture_request: false,
+            capture_response: true,
+        }
+    }
+
+    /// Capture request and response bodies.
+    #[must_use]
+    pub const fn bidirectional(make_sink: M) -> Self {
+        Self {
+            make_sink,
+            capture_request: true,
+            capture_response: true,
+        }
+    }
+
+    /// Return the capture sink factory.
+    #[must_use]
+    pub const fn make_sink(&self) -> &M {
+        &self.make_sink
+    }
+
+    /// Return whether request capture is enabled.
+    #[must_use]
+    pub const fn captures_requests(&self) -> bool {
+        self.capture_request
+    }
+
+    /// Return whether response capture is enabled.
+    #[must_use]
+    pub const fn captures_responses(&self) -> bool {
+        self.capture_response
+    }
+}
+
+impl<M: fmt::Debug> fmt::Debug for BodyCaptureLayer<M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BodyCaptureLayer")
+            .field("make_sink", &self.make_sink)
+            .field("capture_request", &self.capture_request)
+            .field("capture_response", &self.capture_response)
+            .finish()
+    }
+}
+
+impl<M, S> Layer<S> for BodyCaptureLayer<M>
+where
+    M: Clone,
+{
+    type Service = BodyCaptureService<M, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BodyCaptureService {
+            inner,
+            make_sink: self.make_sink.clone(),
+            capture_request: self.capture_request,
+            capture_response: self.capture_response,
+        }
+    }
+
+    fn into_layer(self, inner: S) -> Self::Service {
+        BodyCaptureService {
+            inner,
+            make_sink: self.make_sink,
+            capture_request: self.capture_request,
+            capture_response: self.capture_response,
+        }
+    }
+}
+
+/// Service produced by [`BodyCaptureLayer`].
+#[derive(Clone)]
+pub struct BodyCaptureService<M, S> {
+    inner: S,
+    make_sink: M,
+    capture_request: bool,
+    capture_response: bool,
+}
+
+impl<M, S> BodyCaptureService<M, S> {
+    /// Create a service that captures request and response bodies.
+    #[must_use]
+    pub const fn bidirectional(inner: S, make_sink: M) -> Self {
+        Self {
+            inner,
+            make_sink,
+            capture_request: true,
+            capture_response: true,
+        }
+    }
+
+    define_inner_service_accessors!();
+}
+
+impl<M: fmt::Debug, S: fmt::Debug> fmt::Debug for BodyCaptureService<M, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BodyCaptureService")
+            .field("inner", &self.inner)
+            .field("make_sink", &self.make_sink)
+            .field("capture_request", &self.capture_request)
+            .field("capture_response", &self.capture_response)
+            .finish()
+    }
+}
+
+impl<M, S, ReqBody, ResBody> Service<Request<ReqBody>> for BodyCaptureService<M, S>
+where
+    M: MakeBodyCaptureSink,
+    S: Service<Request<Body>, Output = Response<ResBody>>,
+    ReqBody: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+    ResBody: StreamingBody<Data = Bytes, Error: Into<BoxError>> + Send + Sync + 'static,
+{
+    type Output = Response<Body>;
+    type Error = S::Error;
+
+    async fn serve(&self, request: Request<ReqBody>) -> Result<Self::Output, Self::Error> {
+        let request = if self.capture_request {
+            let (parts, body) = request.into_parts();
+            let body = match self
+                .make_sink
+                .make_sink(CapturedHead::Request(parts.clone()))
+                .await
+            {
+                Some(sink) => Body::new(CaptureBody::new(body.map_err(Into::into), sink)),
+                None => Body::new(body),
+            };
+            Request::from_parts(parts, body)
+        } else {
+            request.map(Body::new)
+        };
+
+        let response = self.inner.serve(request).await?;
+        Ok(if self.capture_response {
+            let (parts, body) = response.into_parts();
+            let body = match self
+                .make_sink
+                .make_sink(CapturedHead::Response(parts.clone()))
+                .await
+            {
+                Some(sink) => Body::new(CaptureBody::new(body.map_err(Into::into), sink)),
+                None => Body::new(body),
+            };
+            Response::from_parts(parts, body)
+        } else {
+            response.map(Body::new)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use rama_core::{Layer as _, Service as _, futures::StreamExt as _, service::service_fn};
+    use rama_http_types::{
+        BodyCaptureEvent, CaptureOutcome, StatusCode, body::Frame, body::util::BodyExt as _,
+    };
+
+    use super::*;
+
+    type Capture = (
+        CapturedHead,
+        tokio::sync::mpsc::UnboundedReceiver<BodyCaptureEvent>,
+    );
+
+    async fn recv<T>(receiver: &mut tokio::sync::mpsc::UnboundedReceiver<T>) -> T {
+        tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("capture should arrive promptly")
+            .expect("capture channel should remain open")
+    }
+
+    #[tokio::test]
+    async fn bidirectional_capture_streams_both_messages() {
+        let request_polls = Arc::new(AtomicUsize::new(0));
+        let polled = Arc::clone(&request_polls);
+        let request_body = Body::from_stream(
+            rama_core::futures::stream::iter([
+                Ok::<_, Infallible>(Bytes::from_static(b"request ")),
+                Ok(Bytes::from_static(b"body")),
+            ])
+            .inspect(move |_| {
+                polled.fetch_add(1, Ordering::Relaxed);
+            }),
+        );
+
+        let (captures, mut captured) = tokio::sync::mpsc::unbounded_channel::<Capture>();
+        let make_sink = move |head| {
+            let captures = captures.clone();
+            async move {
+                let (events, receiver) = tokio::sync::mpsc::unbounded_channel();
+                captures.send((head, receiver)).unwrap();
+                Some(events)
+            }
+        };
+        let layer = BodyCaptureLayer::bidirectional(make_sink);
+        let service_polls = Arc::clone(&request_polls);
+        let service = layer.into_layer(service_fn(move |request: Request<Body>| {
+            let request_polls = Arc::clone(&service_polls);
+            async move {
+                assert_eq!(request_polls.load(Ordering::Relaxed), 0);
+                assert_eq!(
+                    request.into_body().collect().await.unwrap().to_bytes(),
+                    Bytes::from_static(b"request body")
+                );
+                Ok::<_, Infallible>(
+                    Response::builder()
+                        .status(StatusCode::CREATED)
+                        .body(Body::from("response body"))
+                        .unwrap(),
+                )
+            }
+        }));
+
+        let response = service
+            .serve(
+                Request::builder()
+                    .method("POST")
+                    .uri("https://example.com/")
+                    .body(request_body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let (head, mut request_events) = recv(&mut captured).await;
+        assert!(matches!(head, CapturedHead::Request(ref parts) if parts.method == "POST"));
+        let mut request_bytes = Vec::new();
+        loop {
+            let event = recv(&mut request_events).await;
+            match event {
+                BodyCaptureEvent::Frame(frame) => {
+                    if let Ok(data) = frame.into_data() {
+                        request_bytes.extend_from_slice(&data);
+                    }
+                }
+                BodyCaptureEvent::End(outcome) => {
+                    assert_eq!(outcome, CaptureOutcome::Complete);
+                    break;
+                }
+            }
+        }
+        assert_eq!(request_bytes, b"request body");
+
+        let (head, mut response_events) = recv(&mut captured).await;
+        assert!(
+            matches!(head, CapturedHead::Response(ref parts) if parts.status == StatusCode::CREATED)
+        );
+        response_events.try_recv().unwrap_err();
+
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            Bytes::from_static(b"response body")
+        );
+        let BodyCaptureEvent::Frame(frame) = recv(&mut response_events).await else {
+            panic!("expected a captured response frame");
+        };
+        assert_eq!(
+            frame.into_data().unwrap(),
+            Bytes::from_static(b"response body")
+        );
+        assert!(matches!(
+            recv(&mut response_events).await,
+            BodyCaptureEvent::End(CaptureOutcome::Complete)
+        ));
+    }
+
+    #[tokio::test]
+    async fn factory_can_skip_capture_from_the_head() {
+        let make_sink = |head| async move {
+            match head {
+                CapturedHead::Request(parts) if parts.method == "GET" => None,
+                _ => Some(|_event: BodyCaptureEvent| async {}),
+            }
+        };
+        let service = BodyCaptureLayer::request(make_sink).into_layer(service_fn(
+            |request: Request<Body>| async move {
+                request.into_body().collect().await.unwrap();
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            },
+        ));
+
+        service
+            .serve(
+                Request::builder()
+                    .method("GET")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn frame_is_cloneable_when_its_data_is_cloneable() {
+        let frame = Frame::data(Bytes::from_static(b"shared"));
+        assert_eq!(
+            frame.clone().into_data().unwrap(),
+            frame.into_data().unwrap()
+        );
+    }
+
+    #[test]
+    fn constructors_and_debug_report_capture_directions() {
+        let request = BodyCaptureLayer::request("factory");
+        assert_eq!(request.make_sink(), &"factory");
+        assert!(request.captures_requests());
+        assert!(!request.captures_responses());
+        assert!(format!("{request:?}").contains("BodyCaptureLayer"));
+
+        let response = BodyCaptureLayer::response("factory");
+        assert!(!response.captures_requests());
+        assert!(response.captures_responses());
+
+        let both = BodyCaptureLayer::bidirectional("factory");
+        assert!(both.captures_requests());
+        assert!(both.captures_responses());
+
+        let service = BodyCaptureService::bidirectional("inner", "factory");
+        assert!(format!("{service:?}").contains("BodyCaptureService"));
+
+        let (request_parts, ()) = Request::builder()
+            .method("POST")
+            .body(())
+            .unwrap()
+            .into_parts();
+        let request_head = format!("{:?}", CapturedHead::Request(request_parts));
+        assert!(request_head.starts_with("Request("));
+        assert!(request_head.contains("POST"));
+
+        let (response_parts, ()) = Response::builder()
+            .status(StatusCode::CREATED)
+            .body(())
+            .unwrap()
+            .into_parts();
+        let response_head = format!("{:?}", CapturedHead::Response(response_parts));
+        assert!(response_head.starts_with("Response("));
+        assert!(response_head.contains("201"));
+    }
+}

--- a/rama-http/src/layer/mod.rs
+++ b/rama-http/src/layer/mod.rs
@@ -17,6 +17,7 @@
 //! [`Service`]: rama_core::Service
 
 pub mod auth;
+pub mod body_capture;
 pub mod body_limit;
 pub mod catch_panic;
 pub mod classify;

--- a/rama-http/src/layer/traffic_writer/file.rs
+++ b/rama-http/src/layer/traffic_writer/file.rs
@@ -1,5 +1,9 @@
-use super::{RequestWriter, ResponseWriter, WriterMode, write_headers_body_flags};
+use super::{
+    RequestWriter, ResponseWriter, TrafficWriterId, WriterMode, ensure_traffic_writer_id,
+    write_headers_body_flags,
+};
 use crate::{Request, Response, io::write_http_request_streaming};
+use rama_core::extensions::ExtensionsRef as _;
 use rama_core::telemetry::tracing;
 use rama_utils::fs::{CreatedFilePermissions, OpenOptions, is_reserved_device_name};
 use rama_utils::time::unix_timestamp_millis;
@@ -11,7 +15,6 @@ use std::{
     sync::Arc,
 };
 use tokio::io::{AsyncWriteExt as _, BufWriter};
-use uuid::Uuid;
 
 const MAX_PREFIX_LEN: usize = 32;
 const MAX_METHOD_LEN: usize = 16;
@@ -29,6 +32,8 @@ const CREATE_ATTEMPTS: usize = 8;
 /// Raw URIs are never included because they can contain secrets, path
 /// separators, platform-specific characters, or unbounded input. A short URI
 /// fingerprint is included for diagnostics instead.
+/// Request and response files captured for the same HTTP exchange contain the
+/// same UUID, regardless of request/response writer layer order.
 ///
 /// Files are created without overwriting existing paths. On Unix, newly
 /// created files receive owner-only read/write permissions before the process
@@ -104,10 +109,10 @@ impl PerMessageFileWriter {
 
     async fn open_unique(
         &self,
-        name: impl Fn() -> String,
+        name: impl Fn(usize) -> String,
     ) -> io::Result<(BufWriter<tokio::fs::File>, PathBuf)> {
-        for _ in 0..CREATE_ATTEMPTS {
-            let filename = name();
+        for attempt in 0..CREATE_ATTEMPTS {
+            let filename = name(attempt);
             if !is_portable_filename(&filename) {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
@@ -148,8 +153,19 @@ impl RequestWriter for PerMessageFileWriter {
 
         let method = portable_method(request.method().as_str());
         let uri_fingerprint = fingerprint(request.uri());
+        let traffic_writer_id = ensure_traffic_writer_id(request.extensions());
+        let timestamp = unix_timestamp_millis();
         let opened = self
-            .open_unique(|| request_filename(&self.prefix, &method, uri_fingerprint))
+            .open_unique(|attempt| {
+                request_filename(
+                    &self.prefix,
+                    timestamp,
+                    &method,
+                    uri_fingerprint,
+                    traffic_writer_id,
+                    attempt,
+                )
+            })
             .await;
         let (mut file, path) = match opened {
             Ok(value) => value,
@@ -179,8 +195,12 @@ impl ResponseWriter for PerMessageFileWriter {
         }
 
         let status = response.status().as_u16();
+        let traffic_writer_id = ensure_traffic_writer_id(response.extensions());
+        let timestamp = unix_timestamp_millis();
         let opened = self
-            .open_unique(|| response_filename(&self.prefix, status))
+            .open_unique(|attempt| {
+                response_filename(&self.prefix, timestamp, status, traffic_writer_id, attempt)
+            })
             .await;
         let (mut file, path) = match opened {
             Ok(value) => value,
@@ -244,20 +264,35 @@ fn fingerprint(value: impl Hash) -> u64 {
     hasher.finish()
 }
 
-fn request_filename(prefix: &str, method: &str, uri_fingerprint: u64) -> String {
-    format!(
-        "{prefix}-{}-request-{method}-{uri_fingerprint:016x}-{}.http",
-        unix_timestamp_millis(),
-        Uuid::new_v4().simple(),
-    )
+fn request_filename(
+    prefix: &str,
+    timestamp: i64,
+    method: &str,
+    uri_fingerprint: u64,
+    traffic_writer_id: TrafficWriterId,
+    attempt: usize,
+) -> String {
+    let id = traffic_writer_id.0.simple();
+    if attempt == 0 {
+        format!("{prefix}-{timestamp}-request-{method}-{uri_fingerprint:016x}-{id}.http")
+    } else {
+        format!("{prefix}-{timestamp}-request-{method}-{uri_fingerprint:016x}-{id}-{attempt}.http")
+    }
 }
 
-fn response_filename(prefix: &str, status: u16) -> String {
-    format!(
-        "{prefix}-{}-response-{status}-{}.http",
-        unix_timestamp_millis(),
-        Uuid::new_v4().simple(),
-    )
+fn response_filename(
+    prefix: &str,
+    timestamp: i64,
+    status: u16,
+    traffic_writer_id: TrafficWriterId,
+    attempt: usize,
+) -> String {
+    let id = traffic_writer_id.0.simple();
+    if attempt == 0 {
+        format!("{prefix}-{timestamp}-response-{status}-{id}.http")
+    } else {
+        format!("{prefix}-{timestamp}-response-{status}-{id}-{attempt}.http")
+    }
 }
 
 fn is_portable_filename(filename: &str) -> bool {
@@ -275,6 +310,7 @@ mod tests {
     use super::*;
     use crate::{Body, Method, StatusCode};
     use ahash::{HashSet, HashSetExt as _};
+    use uuid::Uuid;
 
     #[test]
     fn generated_filenames_are_unique_portable_and_bounded() {
@@ -287,9 +323,25 @@ mod tests {
         let mut names = HashSet::new();
 
         for _ in 0..128 {
-            let request =
-                request_filename("portable_prefix-123456789012345", &method, uri_fingerprint);
-            let response = response_filename("portable_prefix-123456789012345", 599);
+            let traffic_writer_id = TrafficWriterId(Uuid::new_v4());
+            let request = request_filename(
+                "portable_prefix-123456789012345",
+                1_700_000_000_000,
+                &method,
+                uri_fingerprint,
+                traffic_writer_id,
+                0,
+            );
+            let response = response_filename(
+                "portable_prefix-123456789012345",
+                1_700_000_000_001,
+                599,
+                traffic_writer_id,
+                0,
+            );
+            let id = traffic_writer_id.0.simple().to_string();
+            assert!(request.contains(&id));
+            assert!(response.contains(&id));
             for filename in [request, response] {
                 assert!(is_portable_filename(&filename));
                 assert!(filename.len() <= MAX_FILE_NAME_LEN);
@@ -298,6 +350,30 @@ mod tests {
                 assert!(names.insert(filename));
             }
         }
+
+        let traffic_writer_id = TrafficWriterId(Uuid::new_v4());
+        let base = request_filename("capture", 1, "GET", 0, traffic_writer_id, 0);
+        let retry = request_filename("capture", 1, "GET", 0, traffic_writer_id, 1);
+        assert_ne!(base, retry);
+        assert!(retry.ends_with(&format!("-{}-1.http", traffic_writer_id.0.simple())));
+        assert!(is_portable_filename(&retry));
+
+        let base = response_filename("capture", 1, 200, traffic_writer_id, 0);
+        let retry = response_filename("capture", 1, 200, traffic_writer_id, 1);
+        assert_ne!(base, retry);
+        assert!(retry.ends_with(&format!("-{}-1.http", traffic_writer_id.0.simple())));
+        assert!(is_portable_filename(&retry));
+
+        let longest = request_filename(
+            "12345678901234567890123456789012",
+            i64::MIN,
+            &method,
+            u64::MAX,
+            traffic_writer_id,
+            CREATE_ATTEMPTS - 1,
+        );
+        assert!(longest.len() <= MAX_FILE_NAME_LEN);
+        assert!(is_portable_filename(&longest));
     }
 
     #[tokio::test]
@@ -341,10 +417,9 @@ mod tests {
         let path = temp.path().join(colliding);
         tokio::fs::write(&path, b"existing").await.unwrap();
 
-        let attempts = std::sync::atomic::AtomicUsize::new(0);
         let (_, created_path) = writer
-            .open_unique(|| {
-                if attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0 {
+            .open_unique(|attempt| {
+                if attempt == 0 {
                     colliding.to_owned()
                 } else {
                     unique.to_owned()
@@ -352,7 +427,6 @@ mod tests {
             })
             .await
             .unwrap();
-        assert_eq!(attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
         assert_eq!(created_path, writer.directory().join(unique));
         assert_eq!(tokio::fs::read(path).await.unwrap(), b"existing");
     }
@@ -371,7 +445,7 @@ mod tests {
 
         let attempts = std::sync::atomic::AtomicUsize::new(0);
         let error = writer
-            .open_unique(|| {
+            .open_unique(|_| {
                 attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 filename.to_owned()
             })
@@ -394,7 +468,7 @@ mod tests {
         tokio::fs::remove_dir(directory).await.unwrap();
 
         let error = writer
-            .open_unique(|| "capture-unique.http".to_owned())
+            .open_unique(|_| "capture-unique.http".to_owned())
             .await
             .unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::NotFound);
@@ -410,7 +484,7 @@ mod tests {
         let overly_long = "x".repeat(MAX_FILE_NAME_LEN + 1);
         for filename in ["../escape.http", "trailing.", overly_long.as_str()] {
             let error = writer
-                .open_unique(|| filename.to_owned())
+                .open_unique(|_| filename.to_owned())
                 .await
                 .unwrap_err();
             assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
@@ -432,31 +506,30 @@ mod tests {
         let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
             .await
             .unwrap();
+        let traffic_writer_id = TrafficWriterId(Uuid::new_v4());
 
         let (first_tx, first_rx) = tokio::sync::mpsc::unbounded_channel();
         let first_body = Body::from_stream(rama_core::futures::stream::unfold(
             first_rx,
             |mut receiver| async move { receiver.recv().await.map(|item| (item, receiver)) },
         ));
+        let first_response = Response::builder()
+            .status(StatusCode::OK)
+            .body(first_body)
+            .unwrap();
+        first_response.extensions().insert(traffic_writer_id);
         let first_writer = writer.clone();
         let first = tokio::spawn(async move {
-            first_writer
-                .write_response(
-                    Response::builder()
-                        .status(StatusCode::OK)
-                        .body(first_body)
-                        .unwrap(),
-                )
-                .await;
+            first_writer.write_response(first_response).await;
         });
-        let second = writer.write_request(
-            Request::builder()
-                .method(Method::POST)
-                .uri("https://example.com/upload?token=secret")
-                .header("x-test", "yes")
-                .body(Body::from("second"))
-                .unwrap(),
-        );
+        let second_request = Request::builder()
+            .method(Method::POST)
+            .uri("https://example.com/upload?token=secret")
+            .header("x-test", "yes")
+            .body(Body::from("second"))
+            .unwrap();
+        second_request.extensions().insert(traffic_writer_id);
+        let second = writer.write_request(second_request);
         first_tx
             .send(Ok::<_, std::convert::Infallible>(
                 rama_core::bytes::Bytes::from_static(b"first"),
@@ -488,6 +561,8 @@ mod tests {
                 && bytes.ends_with(b"\r\nfirst")
         }));
         assert!(files.iter().all(|(name, _)| !name.contains("secret")));
+        let id = traffic_writer_id.0.simple().to_string();
+        assert!(files.iter().all(|(name, _)| name.contains(&id)));
     }
 
     #[tokio::test]

--- a/rama-http/src/layer/traffic_writer/file.rs
+++ b/rama-http/src/layer/traffic_writer/file.rs
@@ -1,0 +1,646 @@
+use super::{RequestWriter, ResponseWriter, WriterMode, write_headers_body_flags};
+use crate::{Request, Response, io::write_http_request_streaming};
+use rama_core::telemetry::tracing;
+use rama_utils::fs::{CreatedFilePermissions, OpenOptions, is_reserved_device_name};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tokio::io::{AsyncWriteExt as _, BufWriter};
+use uuid::Uuid;
+
+const MAX_PREFIX_LEN: usize = 32;
+const MAX_METHOD_LEN: usize = 16;
+const MAX_FILE_NAME_LEN: usize = 160;
+const CREATE_ATTEMPTS: usize = 8;
+
+/// Writes every captured request and response to an independent file.
+///
+/// Independent files allow bodies to stream concurrently without frame
+/// interleaving or cross-message backpressure. Generated filenames use only
+/// portable ASCII characters and are bounded to 160 bytes, comfortably below
+/// the commonly supported 255-byte component limit. The caller-provided
+/// destination can still be rejected by the operating system when the complete
+/// path exceeds a platform-specific path limit.
+/// Raw URIs are never included because they can contain secrets, path
+/// separators, platform-specific characters, or unbounded input. A short URI
+/// fingerprint is included for diagnostics instead.
+///
+/// Files are created without overwriting existing paths. On Unix, newly
+/// created files receive owner-only read/write permissions before the process
+/// umask is applied. The destination directory is canonicalized and every file
+/// open is confined to it.
+#[derive(Clone, Debug)]
+pub struct PerMessageFileWriter {
+    directory: Arc<PathBuf>,
+    prefix: Arc<str>,
+    request_mode: Option<WriterMode>,
+    response_mode: Option<WriterMode>,
+}
+
+impl PerMessageFileWriter {
+    /// Create a per-message file writer, creating `directory` when necessary.
+    ///
+    /// `prefix` must be 1 to 32 ASCII letters, digits, `-`, or `_`. This
+    /// deliberately conservative alphabet is valid in filenames on Unix,
+    /// Windows, and common removable filesystems.
+    pub async fn try_new(
+        directory: impl Into<PathBuf>,
+        prefix: impl AsRef<str>,
+    ) -> io::Result<Self> {
+        let prefix = validate_prefix(prefix.as_ref())?;
+        let directory = directory.into();
+        tokio::fs::create_dir_all(&directory).await?;
+        let directory = tokio::fs::canonicalize(directory).await?;
+        Ok(Self {
+            directory: Arc::new(directory),
+            prefix: Arc::from(prefix),
+            request_mode: Some(WriterMode::All),
+            response_mode: Some(WriterMode::All),
+        })
+    }
+
+    /// Set how request files are written.
+    #[must_use]
+    pub fn with_request_mode(mut self, mode: Option<WriterMode>) -> Self {
+        self.request_mode = mode;
+        self
+    }
+
+    /// Set how response files are written.
+    #[must_use]
+    pub fn with_response_mode(mut self, mode: Option<WriterMode>) -> Self {
+        self.response_mode = mode;
+        self
+    }
+
+    /// Return the canonical destination directory.
+    #[must_use]
+    pub fn directory(&self) -> &Path {
+        self.directory.as_ref()
+    }
+
+    /// Return the portable filename prefix.
+    #[must_use]
+    pub fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    /// Return the configured request writer mode.
+    #[must_use]
+    pub const fn request_mode(&self) -> Option<WriterMode> {
+        self.request_mode
+    }
+
+    /// Return the configured response writer mode.
+    #[must_use]
+    pub const fn response_mode(&self) -> Option<WriterMode> {
+        self.response_mode
+    }
+
+    async fn open_unique(
+        &self,
+        name: impl Fn() -> String,
+    ) -> io::Result<(BufWriter<tokio::fs::File>, PathBuf)> {
+        for _ in 0..CREATE_ATTEMPTS {
+            let filename = name();
+            if !is_portable_filename(&filename) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "generated traffic capture filename is not portable",
+                ));
+            }
+
+            let result = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .created_file_permissions(CreatedFilePermissions::OwnerReadWrite)
+                .jail(self.directory.as_ref())
+                .open(&filename)
+                .await;
+            match result {
+                Ok(file) => {
+                    let path = self.directory.join(filename);
+                    return Ok((BufWriter::new(file), path));
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "failed to allocate a unique traffic capture filename",
+        ))
+    }
+}
+
+impl RequestWriter for PerMessageFileWriter {
+    async fn write_request(&self, request: Request) {
+        let (write_headers, write_body) = write_headers_body_flags(self.request_mode);
+        if !write_headers && !write_body {
+            return;
+        }
+
+        let method = portable_method(request.method().as_str());
+        let uri_fingerprint = fingerprint(request.uri());
+        let opened = self
+            .open_unique(|| request_filename(&self.prefix, &method, uri_fingerprint))
+            .await;
+        let (mut file, path) = match opened {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::error!(%error, "failed to create request capture file");
+                return;
+            }
+        };
+
+        let result = async {
+            write_http_request_streaming(&mut file, request, write_headers, write_body).await?;
+            file.flush().await?;
+            Ok::<_, rama_core::error::BoxError>(())
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::error!(%error, path = %path.display(), "failed to write request capture file");
+        }
+    }
+}
+
+impl ResponseWriter for PerMessageFileWriter {
+    async fn write_response(&self, response: Response) {
+        let (write_headers, write_body) = write_headers_body_flags(self.response_mode);
+        if !write_headers && !write_body {
+            return;
+        }
+
+        let status = response.status().as_u16();
+        let opened = self
+            .open_unique(|| response_filename(&self.prefix, status))
+            .await;
+        let (mut file, path) = match opened {
+            Ok(value) => value,
+            Err(error) => {
+                tracing::error!(%error, "failed to create response capture file");
+                return;
+            }
+        };
+
+        let result = async {
+            crate::io::write_http_response_streaming(
+                &mut file,
+                response,
+                write_headers,
+                write_body,
+            )
+            .await?;
+            file.flush().await?;
+            Ok::<_, rama_core::error::BoxError>(())
+        }
+        .await;
+        if let Err(error) = result {
+            tracing::error!(%error, path = %path.display(), "failed to write response capture file");
+        }
+    }
+}
+
+fn validate_prefix(prefix: &str) -> io::Result<String> {
+    if prefix.is_empty()
+        || prefix.len() > MAX_PREFIX_LEN
+        || !prefix
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        || is_reserved_device_name(prefix)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "traffic capture filename prefix must be 1 to 32 portable ASCII letters, digits, '-' or '_' and not a reserved device name",
+        ));
+    }
+    Ok(prefix.to_owned())
+}
+
+fn portable_method(method: &str) -> String {
+    method
+        .bytes()
+        .take(MAX_METHOD_LEN)
+        .map(|byte| {
+            if byte.is_ascii_alphanumeric() {
+                char::from(byte.to_ascii_uppercase())
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn fingerprint(value: impl Hash) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn unix_timestamp_nanos() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_nanos())
+}
+
+fn request_filename(prefix: &str, method: &str, uri_fingerprint: u64) -> String {
+    format!(
+        "{prefix}-{}-request-{method}-{uri_fingerprint:016x}-{}.http",
+        unix_timestamp_nanos(),
+        Uuid::new_v4().simple(),
+    )
+}
+
+fn response_filename(prefix: &str, status: u16) -> String {
+    format!(
+        "{prefix}-{}-response-{status}-{}.http",
+        unix_timestamp_nanos(),
+        Uuid::new_v4().simple(),
+    )
+}
+
+fn is_portable_filename(filename: &str) -> bool {
+    !filename.is_empty()
+        && filename.len() <= MAX_FILE_NAME_LEN
+        && filename
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+        && !filename.ends_with(['.', ' '])
+        && !is_reserved_device_name(filename)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Body, Method, StatusCode};
+    use ahash::{HashSet, HashSetExt as _};
+
+    #[test]
+    fn generated_filenames_are_unique_portable_and_bounded() {
+        let method = portable_method("CUSTOM/METHOD-THAT-IS-TOO-LONG");
+        assert_eq!(method, "CUSTOM_METHOD_TH");
+        let uri_fingerprint = fingerprint("https://example.com/private/path?access_token=secret");
+        assert_ne!(uri_fingerprint, 0);
+        assert_ne!(uri_fingerprint, 1);
+        assert_ne!(uri_fingerprint, fingerprint("https://example.com/other"));
+        assert!(unix_timestamp_nanos() > 1);
+        let mut names = HashSet::new();
+
+        for _ in 0..128 {
+            let request =
+                request_filename("portable_prefix-123456789012345", &method, uri_fingerprint);
+            let response = response_filename("portable_prefix-123456789012345", 599);
+            for filename in [request, response] {
+                assert!(is_portable_filename(&filename));
+                assert!(filename.len() <= MAX_FILE_NAME_LEN);
+                assert_eq!(Path::new(&filename).components().count(), 1);
+                assert!(!filename.contains("access_token"));
+                assert!(names.insert(filename));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn prefix_validation_is_platform_conservative() {
+        let temp = tempfile::tempdir().unwrap();
+        for prefix in [
+            "",
+            "contains space",
+            "contains.dot",
+            "../escape",
+            r"back\slash",
+            "unicode-λ",
+            "CON",
+            "nul",
+            "123456789012345678901234567890123",
+        ] {
+            let error = PerMessageFileWriter::try_new(temp.path(), prefix)
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput, "{prefix:?}");
+        }
+
+        let writer = PerMessageFileWriter::try_new(temp.path(), "Abc_123-xyz-12345678901234567890")
+            .await
+            .unwrap();
+        assert_eq!(writer.prefix().len(), MAX_PREFIX_LEN);
+        assert_eq!(writer.directory(), temp.path().canonicalize().unwrap());
+    }
+
+    #[tokio::test]
+    async fn unique_creation_never_overwrites_an_existing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "capture")
+            .await
+            .unwrap();
+        let colliding =
+            "capture-1-request-GET-0000000000000000-00000000000000000000000000000000.http";
+        let unique = "capture-2-request-GET-0000000000000000-00000000000000000000000000000000.http";
+        assert!(is_portable_filename(colliding));
+        assert!(is_portable_filename(unique));
+        let path = temp.path().join(colliding);
+        tokio::fs::write(&path, b"existing").await.unwrap();
+
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let (_, created_path) = writer
+            .open_unique(|| {
+                if attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed) == 0 {
+                    colliding.to_owned()
+                } else {
+                    unique.to_owned()
+                }
+            })
+            .await
+            .unwrap();
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(created_path, writer.directory().join(unique));
+        assert_eq!(tokio::fs::read(path).await.unwrap(), b"existing");
+    }
+
+    #[tokio::test]
+    async fn unique_creation_reports_exhausted_collisions() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "capture")
+            .await
+            .unwrap();
+        let filename =
+            "capture-1-request-GET-0000000000000000-00000000000000000000000000000000.http";
+        tokio::fs::write(temp.path().join(filename), b"existing")
+            .await
+            .unwrap();
+
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let error = writer
+            .open_unique(|| {
+                attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                filename.to_owned()
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(
+            attempts.load(std::sync::atomic::Ordering::Relaxed),
+            CREATE_ATTEMPTS
+        );
+    }
+
+    #[tokio::test]
+    async fn unique_creation_propagates_non_collision_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let directory = temp.path().join("removed");
+        let writer = PerMessageFileWriter::try_new(&directory, "capture")
+            .await
+            .unwrap();
+        tokio::fs::remove_dir(directory).await.unwrap();
+
+        let error = writer
+            .open_unique(|| "capture-unique.http".to_owned())
+            .await
+            .unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[tokio::test]
+    async fn unique_creation_rejects_non_portable_generated_names() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "capture")
+            .await
+            .unwrap();
+
+        let overly_long = "x".repeat(MAX_FILE_NAME_LEN + 1);
+        for filename in ["../escape.http", "trailing.", overly_long.as_str()] {
+            let error = writer
+                .open_unique(|| filename.to_owned())
+                .await
+                .unwrap_err();
+            assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        }
+        assert!(
+            tokio::fs::read_dir(temp.path())
+                .await
+                .unwrap()
+                .next_entry()
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn request_and_response_files_stream_independently() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
+            .await
+            .unwrap();
+
+        let (first_tx, first_rx) = tokio::sync::mpsc::unbounded_channel();
+        let first_body = Body::from_stream(rama_core::futures::stream::unfold(
+            first_rx,
+            |mut receiver| async move { receiver.recv().await.map(|item| (item, receiver)) },
+        ));
+        let first_writer = writer.clone();
+        let first = tokio::spawn(async move {
+            first_writer
+                .write_response(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .body(first_body)
+                        .unwrap(),
+                )
+                .await;
+        });
+        let second = writer.write_request(
+            Request::builder()
+                .method(Method::POST)
+                .uri("https://example.com/upload?token=secret")
+                .header("x-test", "yes")
+                .body(Body::from("second"))
+                .unwrap(),
+        );
+        first_tx
+            .send(Ok::<_, std::convert::Infallible>(
+                rama_core::bytes::Bytes::from_static(b"first"),
+            ))
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), second)
+            .await
+            .expect("a separate request file must not wait for a live response");
+        drop(first_tx);
+        first.await.unwrap();
+
+        let mut entries = tokio::fs::read_dir(temp.path()).await.unwrap();
+        let mut files = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            let name = entry.file_name().into_string().unwrap();
+            assert!(is_portable_filename(&name));
+            files.push((name, tokio::fs::read(entry.path()).await.unwrap()));
+        }
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|(name, bytes)| {
+            name.contains("-request-POST-")
+                && bytes.starts_with(b"POST /upload?token=secret HTTP/1.1\r\n")
+                && bytes.ends_with(b"\r\nsecond")
+        }));
+        assert!(files.iter().any(|(name, bytes)| {
+            name.contains("-response-200-")
+                && bytes.starts_with(b"HTTP/1.1 200 OK\r\n")
+                && bytes.ends_with(b"\r\nfirst")
+        }));
+        assert!(files.iter().all(|(name, _)| !name.contains("secret")));
+    }
+
+    #[tokio::test]
+    async fn disabled_request_does_not_create_a_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
+            .await
+            .unwrap()
+            .with_request_mode(None);
+        writer
+            .write_request(Request::new(Body::from("ignored")))
+            .await;
+        assert!(
+            tokio::fs::read_dir(temp.path())
+                .await
+                .unwrap()
+                .next_entry()
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_response_does_not_create_a_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
+            .await
+            .unwrap()
+            .with_response_mode(None);
+        writer
+            .write_response(Response::new(Body::from("ignored")))
+            .await;
+        assert!(
+            tokio::fs::read_dir(temp.path())
+                .await
+                .unwrap()
+                .next_entry()
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn response_headers_mode_creates_a_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
+            .await
+            .unwrap()
+            .with_request_mode(None)
+            .with_response_mode(Some(WriterMode::Headers));
+        writer
+            .write_response(
+                Response::builder()
+                    .status(StatusCode::ACCEPTED)
+                    .header("x-mode", "headers")
+                    .body(Body::from("ignored"))
+                    .unwrap(),
+            )
+            .await;
+
+        let entry = tokio::fs::read_dir(temp.path())
+            .await
+            .unwrap()
+            .next_entry()
+            .await
+            .unwrap()
+            .unwrap();
+        let bytes = tokio::fs::read(entry.path()).await.unwrap();
+        assert!(bytes.starts_with(b"HTTP/1.1 202 Accepted\r\n"));
+        assert!(bytes.ends_with(b"x-mode: headers\r\n"));
+        assert!(!bytes.windows(7).any(|window| window == b"ignored"));
+    }
+
+    #[tokio::test]
+    async fn request_and_response_modes_control_file_contents() {
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "modes")
+            .await
+            .unwrap()
+            .with_request_mode(Some(WriterMode::Headers))
+            .with_response_mode(Some(WriterMode::Body));
+
+        writer
+            .write_request(
+                Request::builder()
+                    .uri("/headers")
+                    .header("x-mode", "headers")
+                    .body(Body::from("not written"))
+                    .unwrap(),
+            )
+            .await;
+        writer
+            .write_response(
+                Response::builder()
+                    .status(StatusCode::CREATED)
+                    .header("x-mode", "not written")
+                    .body(Body::from("body only"))
+                    .unwrap(),
+            )
+            .await;
+
+        let mut entries = tokio::fs::read_dir(temp.path()).await.unwrap();
+        let mut files = Vec::new();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            files.push((
+                entry.file_name().into_string().unwrap(),
+                tokio::fs::read(entry.path()).await.unwrap(),
+            ));
+        }
+        assert_eq!(files.len(), 2);
+        assert!(files.iter().any(|(name, bytes)| {
+            name.contains("-request-GET-")
+                && bytes.starts_with(b"GET /headers HTTP/1.1\r\n")
+                && bytes.ends_with(b"x-mode: headers\r\n")
+                && !bytes.windows(11).any(|window| window == b"not written")
+        }));
+        assert!(
+            files.iter().any(|(name, bytes)| {
+                name.contains("-response-201-") && bytes == b"\r\nbody only"
+            })
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capture_files_are_not_group_or_world_accessible() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::tempdir().unwrap();
+        let writer = PerMessageFileWriter::try_new(temp.path(), "traffic")
+            .await
+            .unwrap();
+        writer
+            .write_response(Response::new(Body::from("private")))
+            .await;
+
+        let entry = tokio::fs::read_dir(temp.path())
+            .await
+            .unwrap()
+            .next_entry()
+            .await
+            .unwrap()
+            .unwrap();
+        let mode = entry.metadata().await.unwrap().permissions().mode();
+        assert_eq!(mode & 0o077, 0);
+    }
+}

--- a/rama-http/src/layer/traffic_writer/file.rs
+++ b/rama-http/src/layer/traffic_writer/file.rs
@@ -2,13 +2,13 @@ use super::{RequestWriter, ResponseWriter, WriterMode, write_headers_body_flags}
 use crate::{Request, Response, io::write_http_request_streaming};
 use rama_core::telemetry::tracing;
 use rama_utils::fs::{CreatedFilePermissions, OpenOptions, is_reserved_device_name};
+use rama_utils::time::unix_timestamp_millis;
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     io,
     path::{Path, PathBuf},
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::io::{AsyncWriteExt as _, BufWriter};
 use uuid::Uuid;
@@ -244,16 +244,10 @@ fn fingerprint(value: impl Hash) -> u64 {
     hasher.finish()
 }
 
-fn unix_timestamp_nanos() -> u128 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0, |duration| duration.as_nanos())
-}
-
 fn request_filename(prefix: &str, method: &str, uri_fingerprint: u64) -> String {
     format!(
         "{prefix}-{}-request-{method}-{uri_fingerprint:016x}-{}.http",
-        unix_timestamp_nanos(),
+        unix_timestamp_millis(),
         Uuid::new_v4().simple(),
     )
 }
@@ -261,7 +255,7 @@ fn request_filename(prefix: &str, method: &str, uri_fingerprint: u64) -> String 
 fn response_filename(prefix: &str, status: u16) -> String {
     format!(
         "{prefix}-{}-response-{status}-{}.http",
-        unix_timestamp_nanos(),
+        unix_timestamp_millis(),
         Uuid::new_v4().simple(),
     )
 }
@@ -290,7 +284,6 @@ mod tests {
         assert_ne!(uri_fingerprint, 0);
         assert_ne!(uri_fingerprint, 1);
         assert_ne!(uri_fingerprint, fingerprint("https://example.com/other"));
-        assert!(unix_timestamp_nanos() > 1);
         let mut names = HashSet::new();
 
         for _ in 0..128 {

--- a/rama-http/src/layer/traffic_writer/file.rs
+++ b/rama-http/src/layer/traffic_writer/file.rs
@@ -8,8 +8,6 @@ use rama_core::telemetry::tracing;
 use rama_utils::fs::{CreatedFilePermissions, OpenOptions, is_reserved_device_name};
 use rama_utils::time::unix_timestamp_millis;
 use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
     io,
     path::{Path, PathBuf},
     sync::Arc,
@@ -30,8 +28,7 @@ const CREATE_ATTEMPTS: usize = 8;
 /// destination can still be rejected by the operating system when the complete
 /// path exceeds a platform-specific path limit.
 /// Raw URIs are never included because they can contain secrets, path
-/// separators, platform-specific characters, or unbounded input. A short URI
-/// fingerprint is included for diagnostics instead.
+/// separators, platform-specific characters, or unbounded input.
 /// Request and response files captured for the same HTTP exchange contain the
 /// same UUID, regardless of request/response writer layer order.
 ///
@@ -152,19 +149,11 @@ impl RequestWriter for PerMessageFileWriter {
         }
 
         let method = portable_method(request.method().as_str());
-        let uri_fingerprint = fingerprint(request.uri());
         let traffic_writer_id = ensure_traffic_writer_id(request.extensions());
         let timestamp = unix_timestamp_millis();
         let opened = self
             .open_unique(|attempt| {
-                request_filename(
-                    &self.prefix,
-                    timestamp,
-                    &method,
-                    uri_fingerprint,
-                    traffic_writer_id,
-                    attempt,
-                )
+                request_filename(&self.prefix, timestamp, &method, traffic_writer_id, attempt)
             })
             .await;
         let (mut file, path) = match opened {
@@ -258,25 +247,18 @@ fn portable_method(method: &str) -> String {
         .collect()
 }
 
-fn fingerprint(value: impl Hash) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
-}
-
 fn request_filename(
     prefix: &str,
     timestamp: i64,
     method: &str,
-    uri_fingerprint: u64,
     traffic_writer_id: TrafficWriterId,
     attempt: usize,
 ) -> String {
     let id = traffic_writer_id.0.simple();
     if attempt == 0 {
-        format!("{prefix}-{timestamp}-request-{method}-{uri_fingerprint:016x}-{id}.http")
+        format!("{prefix}-{timestamp}-request-{method}-{id}.http")
     } else {
-        format!("{prefix}-{timestamp}-request-{method}-{uri_fingerprint:016x}-{id}-{attempt}.http")
+        format!("{prefix}-{timestamp}-request-{method}-{id}-{attempt}.http")
     }
 }
 
@@ -308,18 +290,80 @@ fn is_portable_filename(filename: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Body, Method, StatusCode};
+    use crate::{
+        Body, Method, StatusCode,
+        body::util::BodyExt as _,
+        layer::traffic_writer::{RequestWriterLayer, ResponseWriterLayer},
+    };
     use ahash::{HashSet, HashSetExt as _};
+    use rama_core::{Layer as _, Service as _, rt::Executor, service::service_fn};
+    use std::{convert::Infallible, time::Duration};
     use uuid::Uuid;
+
+    async fn wait_for_exchange_files(directory: &Path) -> Vec<(String, Vec<u8>)> {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let mut entries = tokio::fs::read_dir(directory).await.unwrap();
+                let mut files = Vec::new();
+                while let Some(entry) = entries.next_entry().await.unwrap() {
+                    files.push((
+                        entry.file_name().into_string().unwrap(),
+                        tokio::fs::read(entry.path()).await.unwrap(),
+                    ));
+                }
+                if files.len() == 2
+                    && files
+                        .iter()
+                        .any(|(_, bytes)| bytes.ends_with(b"\r\nrequest-body"))
+                    && files
+                        .iter()
+                        .any(|(_, bytes)| bytes.ends_with(b"\r\nresponse-body"))
+                {
+                    return files;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("request and response capture files should finish")
+    }
+
+    fn assert_exchange_files_share_id(files: &[(String, Vec<u8>)]) {
+        fn id(name: &str) -> &str {
+            name.strip_suffix(".http")
+                .unwrap()
+                .rsplit('-')
+                .next()
+                .unwrap()
+        }
+
+        let request = files
+            .iter()
+            .find(|(name, _)| name.contains("-request-POST-"))
+            .unwrap();
+        let response = files
+            .iter()
+            .find(|(name, _)| name.contains("-response-200-"))
+            .unwrap();
+        let request_id = id(&request.0);
+        let response_id = id(&response.0);
+        assert_eq!(request_id.len(), 32);
+        assert!(request_id.bytes().all(|byte| byte.is_ascii_hexdigit()));
+        assert_eq!(request_id, response_id);
+    }
+
+    async fn consume_request(request: Request) -> Result<Response, Infallible> {
+        assert_eq!(
+            request.into_body().collect().await.unwrap().to_bytes(),
+            "request-body"
+        );
+        Ok(Response::new(Body::from("response-body")))
+    }
 
     #[test]
     fn generated_filenames_are_unique_portable_and_bounded() {
         let method = portable_method("CUSTOM/METHOD-THAT-IS-TOO-LONG");
         assert_eq!(method, "CUSTOM_METHOD_TH");
-        let uri_fingerprint = fingerprint("https://example.com/private/path?access_token=secret");
-        assert_ne!(uri_fingerprint, 0);
-        assert_ne!(uri_fingerprint, 1);
-        assert_ne!(uri_fingerprint, fingerprint("https://example.com/other"));
         let mut names = HashSet::new();
 
         for _ in 0..128 {
@@ -328,7 +372,6 @@ mod tests {
                 "portable_prefix-123456789012345",
                 1_700_000_000_000,
                 &method,
-                uri_fingerprint,
                 traffic_writer_id,
                 0,
             );
@@ -352,8 +395,8 @@ mod tests {
         }
 
         let traffic_writer_id = TrafficWriterId(Uuid::new_v4());
-        let base = request_filename("capture", 1, "GET", 0, traffic_writer_id, 0);
-        let retry = request_filename("capture", 1, "GET", 0, traffic_writer_id, 1);
+        let base = request_filename("capture", 1, "GET", traffic_writer_id, 0);
+        let retry = request_filename("capture", 1, "GET", traffic_writer_id, 1);
         assert_ne!(base, retry);
         assert!(retry.ends_with(&format!("-{}-1.http", traffic_writer_id.0.simple())));
         assert!(is_portable_filename(&retry));
@@ -368,12 +411,95 @@ mod tests {
             "12345678901234567890123456789012",
             i64::MIN,
             &method,
-            u64::MAX,
             traffic_writer_id,
             CREATE_ATTEMPTS - 1,
         );
         assert!(longest.len() <= MAX_FILE_NAME_LEN);
         assert!(is_portable_filename(&longest));
+    }
+
+    #[tokio::test]
+    async fn file_layers_share_exchange_id_with_request_layer_outermost() {
+        let temp = tempfile::tempdir().unwrap();
+        let executor = Executor::new();
+        let request = RequestWriterLayer::file_per_request(
+            &executor,
+            temp.path(),
+            "traffic",
+            Some(WriterMode::All),
+        )
+        .await
+        .unwrap();
+        let response = ResponseWriterLayer::file_per_response(
+            &executor,
+            temp.path(),
+            "traffic",
+            Some(WriterMode::All),
+        )
+        .await
+        .unwrap();
+        let service = request.into_layer(response.into_layer(service_fn(consume_request)));
+
+        let response = service
+            .serve(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/capture")
+                    .body(Body::from("request-body"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            "response-body"
+        );
+        drop(service);
+
+        let files = wait_for_exchange_files(temp.path()).await;
+        assert_exchange_files_share_id(&files);
+    }
+
+    #[tokio::test]
+    async fn file_layers_share_exchange_id_with_response_layer_outermost() {
+        let temp = tempfile::tempdir().unwrap();
+        let executor = Executor::new();
+        let request = RequestWriterLayer::file_per_request(
+            &executor,
+            temp.path(),
+            "traffic",
+            Some(WriterMode::All),
+        )
+        .await
+        .unwrap();
+        let response = ResponseWriterLayer::file_per_response(
+            &executor,
+            temp.path(),
+            "traffic",
+            Some(WriterMode::All),
+        )
+        .await
+        .unwrap();
+        let service = response.into_layer(request.into_layer(service_fn(consume_request)));
+
+        let response = service
+            .serve(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/capture")
+                    .body(Body::from("request-body"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            "response-body"
+        );
+        drop(service);
+
+        let files = wait_for_exchange_files(temp.path()).await;
+        assert_exchange_files_share_id(&files);
     }
 
     #[tokio::test]
@@ -409,9 +535,8 @@ mod tests {
         let writer = PerMessageFileWriter::try_new(temp.path(), "capture")
             .await
             .unwrap();
-        let colliding =
-            "capture-1-request-GET-0000000000000000-00000000000000000000000000000000.http";
-        let unique = "capture-2-request-GET-0000000000000000-00000000000000000000000000000000.http";
+        let colliding = "capture-1-request-GET-00000000000000000000000000000000.http";
+        let unique = "capture-2-request-GET-00000000000000000000000000000000.http";
         assert!(is_portable_filename(colliding));
         assert!(is_portable_filename(unique));
         let path = temp.path().join(colliding);
@@ -437,8 +562,7 @@ mod tests {
         let writer = PerMessageFileWriter::try_new(temp.path(), "capture")
             .await
             .unwrap();
-        let filename =
-            "capture-1-request-GET-0000000000000000-00000000000000000000000000000000.http";
+        let filename = "capture-1-request-GET-00000000000000000000000000000000.http";
         tokio::fs::write(temp.path().join(filename), b"existing")
             .await
             .unwrap();

--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     io::{write_http_request_streaming, write_http_response_streaming},
 };
 use rama_core::{
+    extensions::{Extension, Extensions},
     rt::Executor,
     telemetry::tracing::{self, Instrument},
 };
@@ -28,6 +29,7 @@ use tokio::{
     io::{AsyncWrite, AsyncWriteExt},
     sync::mpsc::{Receiver, Sender, UnboundedSender, channel, unbounded_channel},
 };
+use uuid::Uuid;
 
 mod file;
 #[doc(inline)]
@@ -52,6 +54,15 @@ pub enum WriterMode {
     Headers,
     /// Print only the body of the request / response.
     Body,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct TrafficWriterId(Uuid);
+
+impl Extension for TrafficWriterId {}
+
+fn ensure_traffic_writer_id(extensions: &Extensions) -> TrafficWriterId {
+    *extensions.get_ref_or_insert(|| TrafficWriterId(Uuid::new_v4()))
 }
 
 /// Resolve a [`WriterMode`] into `(write_headers, write_body)` flags.
@@ -476,9 +487,72 @@ pub enum BidirectionalMessage {
 
 #[cfg(test)]
 mod capture_tests {
+    use rama_core::{
+        Layer as _, Service as _, extensions::ExtensionsRef as _, service::service_fn,
+    };
     use rama_http_types::CaptureOutcome;
+    use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
     use super::*;
+
+    #[derive(Clone)]
+    struct IdObserver(UnboundedSender<TrafficWriterId>);
+
+    impl RequestWriter for IdObserver {
+        async fn write_request(&self, request: Request) {
+            self.0
+                .send(*request.extensions().get_ref::<TrafficWriterId>().unwrap())
+                .unwrap();
+        }
+    }
+
+    impl ResponseWriter for IdObserver {
+        async fn write_response(&self, response: Response) {
+            self.0
+                .send(*response.extensions().get_ref::<TrafficWriterId>().unwrap())
+                .unwrap();
+        }
+    }
+
+    async fn assert_matching_ids(mut ids: UnboundedReceiver<TrafficWriterId>) {
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), ids.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let second = tokio::time::timeout(std::time::Duration::from_secs(1), ids.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[tokio::test]
+    async fn request_and_response_writers_share_id_with_request_layer_outermost() {
+        let (sender, ids) = tokio::sync::mpsc::unbounded_channel();
+        let observer = IdObserver(sender);
+        let inner = service_fn(|_request: Request| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        });
+        let service = RequestWriterLayer::new(observer.clone())
+            .into_layer(ResponseWriterLayer::new(observer).into_layer(inner));
+
+        service.serve(Request::new(Body::empty())).await.unwrap();
+        assert_matching_ids(ids).await;
+    }
+
+    #[tokio::test]
+    async fn request_and_response_writers_share_id_with_response_layer_outermost() {
+        let (sender, ids) = tokio::sync::mpsc::unbounded_channel();
+        let observer = IdObserver(sender);
+        let inner = service_fn(|_request: Request| async {
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        });
+        let service = ResponseWriterLayer::new(observer.clone())
+            .into_layer(RequestWriterLayer::new(observer).into_layer(inner));
+
+        service.serve(Request::new(Body::empty())).await.unwrap();
+        assert_matching_ids(ids).await;
+    }
 
     #[tokio::test]
     async fn capture_channel_tracks_stream_completion() {

--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -7,7 +7,10 @@
 //! message therefore applies asynchronous backpressure to later body streams
 //! instead of buffering their complete contents in memory. Use a per-message
 //! writer when messages must be captured concurrently without sharing that
-//! backpressure.
+//! backpressure. In particular, a shared bidirectional body writer can stall a
+//! full-duplex exchange when either peer waits for the other direction to make
+//! progress; use [`PerMessageFileWriter`] or another independent writer for
+//! such traffic.
 
 use crate::body::Frame;
 use crate::{
@@ -491,6 +494,8 @@ mod capture_tests {
         Layer as _, Service as _, extensions::ExtensionsRef as _, service::service_fn,
     };
     use rama_http_types::CaptureOutcome;
+    use std::{io, time::Duration};
+    use tokio::io::AsyncReadExt as _;
     use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
     use super::*;
@@ -552,6 +557,90 @@ mod capture_tests {
 
         service.serve(Request::new(Body::empty())).await.unwrap();
         assert_matching_ids(ids).await;
+    }
+
+    #[tokio::test]
+    async fn last_writer_drains_messages_and_writes_only_the_final_exchange() {
+        let executor = Executor::new();
+        let (output, mut captured) = tokio::io::duplex(512);
+        let writer = BidirectionalWriter::last(
+            &executor,
+            output,
+            Some(WriterMode::All),
+            Some(WriterMode::All),
+        );
+
+        writer
+            .write_request(
+                Request::builder()
+                    .uri("/first")
+                    .body(Body::from("request-one"))
+                    .unwrap(),
+            )
+            .await;
+        writer
+            .write_response(
+                Response::builder()
+                    .status(201)
+                    .body(Body::from("response-one"))
+                    .unwrap(),
+            )
+            .await;
+        writer
+            .write_request(
+                Request::builder()
+                    .uri("/second")
+                    .body(Body::from("request-two"))
+                    .unwrap(),
+            )
+            .await;
+        writer
+            .write_response(
+                Response::builder()
+                    .status(202)
+                    .body(Body::from("response-two"))
+                    .unwrap(),
+            )
+            .await;
+        drop(writer);
+
+        let mut bytes = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), captured.read_to_end(&mut bytes))
+            .await
+            .expect("last writer should flush when its channel closes")
+            .unwrap();
+        assert_eq!(
+            bytes,
+            b"GET /second HTTP/1.1\r\n\r\nrequest-two\r\nHTTP/1.1 202 Accepted\r\n\r\nresponse-two\r\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn last_writer_replaces_a_failed_body_with_an_empty_body() {
+        let executor = Executor::new();
+        let (output, mut captured) = tokio::io::duplex(128);
+        let writer = BidirectionalWriter::last(&executor, output, Some(WriterMode::All), None);
+        let body = Body::from_stream(rama_core::futures::stream::once(async {
+            Err::<rama_core::bytes::Bytes, _>(io::Error::other("body failed"))
+        }));
+
+        writer
+            .write_request(
+                Request::builder()
+                    .method("POST")
+                    .uri("/broken")
+                    .body(body)
+                    .unwrap(),
+            )
+            .await;
+        drop(writer);
+
+        let mut bytes = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), captured.read_to_end(&mut bytes))
+            .await
+            .expect("last writer should recover from a body error")
+            .unwrap();
+        assert_eq!(bytes, b"POST /broken HTTP/1.1\r\n\r\n\r\n");
     }
 
     #[tokio::test]

--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -2,11 +2,12 @@
 //!
 //! Can be useful for cli / debug purposes.
 //!
-//! Built-in writers keep messages ordered through one output task. Their
-//! per-message capture queues are unbounded so a long-lived earlier message
-//! cannot stall unrelated live traffic. If the output falls behind, captured
-//! frames can accumulate in memory; use a custom capture sink when bounded
-//! backpressure or lossy observation is preferable.
+//! Built-in shared writers keep complete messages ordered through one output
+//! task. Each message has capacity for one captured frame; a slow or long-lived
+//! message therefore applies asynchronous backpressure to later body streams
+//! instead of buffering their complete contents in memory. Use a per-message
+//! writer when messages must be captured concurrently without sharing that
+//! backpressure.
 
 use crate::body::Frame;
 use crate::{
@@ -25,8 +26,12 @@ use std::{
 };
 use tokio::{
     io::{AsyncWrite, AsyncWriteExt},
-    sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel},
+    sync::mpsc::{Receiver, Sender, UnboundedSender, channel, unbounded_channel},
 };
+
+mod file;
+#[doc(inline)]
+pub use file::PerMessageFileWriter;
 
 mod request;
 #[doc(inline)]
@@ -60,7 +65,7 @@ pub(super) fn write_headers_body_flags(mode: Option<WriterMode>) -> (bool, bool)
 }
 
 struct CaptureEventBody {
-    receiver: UnboundedReceiver<BodyCaptureEvent>,
+    receiver: Receiver<BodyCaptureEvent>,
     done: bool,
 }
 
@@ -105,12 +110,10 @@ impl StreamingBody for CaptureEventBody {
     }
 }
 
-pub(super) fn capture_body_channel() -> (UnboundedSender<BodyCaptureEvent>, Body) {
-    // Traffic writing is observational and must not stall unrelated live
-    // messages while a single ordered writer is draining an earlier body. A
-    // lagging writer can therefore buffer capture events; consumers that need
-    // bounded backpressure can use CaptureBody with a bounded sink directly.
-    let (sender, receiver) = unbounded_channel();
+pub(super) fn capture_body_channel() -> (Sender<BodyCaptureEvent>, Body) {
+    // A shared writer serializes complete messages. Retain at most one frame
+    // per waiting message and propagate writer backpressure to its live body.
+    let (sender, receiver) = channel(1);
     (
         sender,
         Body::new(CaptureEventBody {
@@ -261,7 +264,12 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
         Self { sender: tx }
     }
 
-    /// Create a new [`BidirectionalWriter`] with a custom writer that only writes the last request and response received.
+    /// Create a new [`BidirectionalWriter`] with a custom writer that only
+    /// writes the last request and response received.
+    ///
+    /// Selected bodies are intentionally buffered in full because output is
+    /// deferred until the channel closes. Do not use body-writing modes here
+    /// for unbounded or attacker-controlled bodies.
     pub fn last<W>(
         executor: &Executor,
         mut writer: W,
@@ -380,7 +388,10 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
         )
     }
 
-    /// Create a new [`BidirectionalWriter`] that prints the last request and response to stdout.
+    /// Create a new [`BidirectionalWriter`] that prints the last request and
+    /// response to stdout.
+    ///
+    /// See [`Self::last`] for its intentional full-body buffering semantics.
     #[must_use]
     pub fn stdout_last(
         executor: &Executor,
@@ -408,7 +419,10 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
         )
     }
 
-    /// Create a new [`BidirectionalWriter`] that prints the last request and responses to stderr.
+    /// Create a new [`BidirectionalWriter`] that prints the last request and
+    /// response to stderr.
+    ///
+    /// See [`Self::last`] for its intentional full-body buffering semantics.
     #[must_use]
     pub fn stderr_last(
         executor: &Executor,
@@ -475,6 +489,7 @@ mod capture_tests {
             .send(BodyCaptureEvent::Frame(Frame::data(
                 rama_core::bytes::Bytes::from_static(b"frame"),
             )))
+            .await
             .unwrap();
         assert_eq!(
             body.frame().await.unwrap().unwrap().into_data().unwrap(),
@@ -484,8 +499,31 @@ mod capture_tests {
 
         sender
             .send(BodyCaptureEvent::End(CaptureOutcome::Complete))
+            .await
             .unwrap();
         assert!(body.frame().await.is_none());
         assert!(body.is_end_stream());
+    }
+
+    #[tokio::test]
+    async fn capture_channel_retains_at_most_one_event() {
+        let (sender, mut body) = capture_body_channel();
+        sender
+            .send(BodyCaptureEvent::Frame(Frame::data(
+                rama_core::bytes::Bytes::from_static(b"frame"),
+            )))
+            .await
+            .unwrap();
+        let mut end = Box::pin(sender.send(BodyCaptureEvent::End(CaptureOutcome::Complete)));
+
+        tokio::time::timeout(std::time::Duration::from_millis(50), &mut end)
+            .await
+            .expect_err("a second event must wait for the body to drain the first");
+        assert_eq!(
+            body.frame().await.unwrap().unwrap().into_data().unwrap(),
+            "frame"
+        );
+        end.await.unwrap();
+        assert!(body.frame().await.is_none());
     }
 }

--- a/rama-http/src/layer/traffic_writer/mod.rs
+++ b/rama-http/src/layer/traffic_writer/mod.rs
@@ -1,18 +1,31 @@
 //! Middleware to write Http traffic in std format.
 //!
 //! Can be useful for cli / debug purposes.
+//!
+//! Built-in writers keep messages ordered through one output task. Their
+//! per-message capture queues are unbounded so a long-lived earlier message
+//! cannot stall unrelated live traffic. If the output falls behind, captured
+//! frames can accumulate in memory; use a custom capture sink when bounded
+//! backpressure or lossy observation is preferable.
 
+use crate::body::Frame;
 use crate::{
-    Request, Response,
-    io::{write_http_request, write_http_response},
+    Body, BodyCaptureEvent, Request, Response, StreamingBody,
+    body::util::BodyExt as _,
+    io::{write_http_request_streaming, write_http_response_streaming},
 };
 use rama_core::{
     rt::Executor,
     telemetry::tracing::{self, Instrument},
 };
+use std::{
+    convert::Infallible,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tokio::{
     io::{AsyncWrite, AsyncWriteExt},
-    sync::mpsc::{Sender, UnboundedSender, channel, unbounded_channel},
+    sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel},
 };
 
 mod request;
@@ -46,6 +59,67 @@ pub(super) fn write_headers_body_flags(mode: Option<WriterMode>) -> (bool, bool)
     }
 }
 
+struct CaptureEventBody {
+    receiver: UnboundedReceiver<BodyCaptureEvent>,
+    done: bool,
+}
+
+impl StreamingBody for CaptureEventBody {
+    type Data = rama_core::bytes::Bytes;
+    type Error = Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        match Pin::new(&mut self.receiver).poll_recv(cx) {
+            Poll::Ready(Some(BodyCaptureEvent::Frame(frame))) => Poll::Ready(Some(Ok(frame))),
+            Poll::Ready(Some(BodyCaptureEvent::End(outcome))) => {
+                match outcome {
+                    crate::CaptureOutcome::Complete => {}
+                    crate::CaptureOutcome::Error | crate::CaptureOutcome::Aborted => {
+                        tracing::warn!(
+                            ?outcome,
+                            "captured HTTP body ended before normal completion"
+                        );
+                    }
+                }
+                self.done = true;
+                Poll::Ready(None)
+            }
+            Poll::Ready(None) => {
+                tracing::warn!("captured HTTP body channel closed without a terminal event");
+                self.done = true;
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.done
+    }
+}
+
+pub(super) fn capture_body_channel() -> (UnboundedSender<BodyCaptureEvent>, Body) {
+    // Traffic writing is observational and must not stall unrelated live
+    // messages while a single ordered writer is draining an earlier body. A
+    // lagging writer can therefore buffer capture events; consumers that need
+    // bounded backpressure can use CaptureBody with a bounded sink directly.
+    let (sender, receiver) = unbounded_channel();
+    (
+        sender,
+        Body::new(CaptureEventBody {
+            receiver,
+            done: false,
+        }),
+    )
+}
+
 /// Drive a bidirectional-writer receive loop: write each request/response to
 /// `$writer` (logging any error), emit a `\r\n` separator between messages, and
 /// flush when the channel closes. Shared by the unbounded and bounded
@@ -57,14 +131,16 @@ macro_rules! drive_bidirectional_writer {
             match msg {
                 BidirectionalMessage::Request(req) => {
                     if let Err(err) =
-                        write_http_request(&mut $writer, req, $req_headers, $req_body).await
+                        write_http_request_streaming(&mut $writer, req, $req_headers, $req_body)
+                            .await
                     {
                         tracing::error!("failed to write http request to writer: {err:?}")
                     }
                 }
                 BidirectionalMessage::Response(res) => {
                     if let Err(err) =
-                        write_http_response(&mut $writer, res, $res_headers, $res_body).await
+                        write_http_response_streaming(&mut $writer, res, $res_headers, $res_body)
+                            .await
                     {
                         tracing::error!("failed to write http response to writer: {err:?}")
                     }
@@ -211,13 +287,41 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
 
                 while let Some(msg) = rx.recv().await {
                     match msg {
-                        BidirectionalMessage::Request(req) => last_request = Some(req),
-                        BidirectionalMessage::Response(res) => last_response = Some(res),
+                        BidirectionalMessage::Request(req) => {
+                            let (parts, body) = req.into_parts();
+                            let body = if write_request_body {
+                                match body.collect().await {
+                                    Ok(body) => Body::from(body.to_bytes()),
+                                    Err(error) => {
+                                        tracing::error!(%error, "failed to buffer last request body");
+                                        Body::empty()
+                                    }
+                                }
+                            } else {
+                                Body::empty()
+                            };
+                            last_request = Some(Request::from_parts(parts, body));
+                        }
+                        BidirectionalMessage::Response(res) => {
+                            let (parts, body) = res.into_parts();
+                            let body = if write_response_body {
+                                match body.collect().await {
+                                    Ok(body) => Body::from(body.to_bytes()),
+                                    Err(error) => {
+                                        tracing::error!(%error, "failed to buffer last response body");
+                                        Body::empty()
+                                    }
+                                }
+                            } else {
+                                Body::empty()
+                            };
+                            last_response = Some(Response::from_parts(parts, body));
+                        }
                     }
                 }
 
                 if let Some(req) = last_request {
-                    if let Err(err) = write_http_request(
+                    if let Err(err) = write_http_request_streaming(
                         &mut writer,
                         req,
                         write_request_headers,
@@ -233,7 +337,7 @@ impl BidirectionalWriter<Sender<BidirectionalMessage>> {
                 }
 
                 if let Some(res) = last_response {
-                    if let Err(err) = write_http_response(
+                    if let Err(err) = write_http_response_streaming(
                         &mut writer,
                         res,
                         write_response_headers,
@@ -354,4 +458,34 @@ pub enum BidirectionalMessage {
     Request(Request),
     /// A response to be written.
     Response(Response),
+}
+
+#[cfg(test)]
+mod capture_tests {
+    use rama_http_types::CaptureOutcome;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn capture_channel_tracks_stream_completion() {
+        let (sender, mut body) = capture_body_channel();
+        assert!(!body.is_end_stream());
+
+        sender
+            .send(BodyCaptureEvent::Frame(Frame::data(
+                rama_core::bytes::Bytes::from_static(b"frame"),
+            )))
+            .unwrap();
+        assert_eq!(
+            body.frame().await.unwrap().unwrap().into_data().unwrap(),
+            "frame"
+        );
+        assert!(!body.is_end_stream());
+
+        sender
+            .send(BodyCaptureEvent::End(CaptureOutcome::Complete))
+            .unwrap();
+        assert!(body.frame().await.is_none());
+        assert!(body.is_end_stream());
+    }
 }

--- a/rama-http/src/layer/traffic_writer/request.rs
+++ b/rama-http/src/layer/traffic_writer/request.rs
@@ -1,4 +1,4 @@
-use super::{WriterMode, capture_body_channel, write_headers_body_flags};
+use super::{PerMessageFileWriter, WriterMode, capture_body_channel, write_headers_body_flags};
 use crate::io::write_http_request_streaming;
 use crate::{Body, Request, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
@@ -8,7 +8,7 @@ use rama_core::rt::Executor;
 use rama_core::telemetry::tracing::{self, Instrument};
 use rama_core::{Layer, Service};
 use rama_http_types::CaptureBody;
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, io, path::PathBuf, sync::Arc};
 use tokio::io::{AsyncWrite, AsyncWriteExt, stderr, stdout};
 use tokio::sync::mpsc::{Sender, UnboundedSender, channel, unbounded_channel};
 
@@ -29,9 +29,9 @@ where
 pub trait RequestWriter: Send + Sync + 'static {
     /// Write the HTTP request while its body is streaming.
     ///
-    /// Implementations should consume or deliberately drop the body while this
-    /// future runs. Retaining it for later allows its unbounded observational
-    /// capture queue to grow until the original request body terminates.
+    /// Implementations must consume or deliberately drop the body while this
+    /// future runs. Retaining it for later applies backpressure once its
+    /// single-frame observational capture queue is full.
     fn write_request(&self, req: Request) -> impl Future<Output = ()> + Send + '_;
 }
 
@@ -136,6 +136,24 @@ impl<S> RequestWriterService<S, UnboundedSender<Request>> {
     #[must_use]
     pub fn stderr_unbounded(inner: S, executor: &Executor, mode: Option<WriterMode>) -> Self {
         Self::writer_unbounded(inner, executor, stderr(), mode)
+    }
+}
+
+impl<S> RequestWriterService<S, PerMessageFileWriter> {
+    /// Create a service that streams every request into a unique file below
+    /// `directory` using the portable filename `prefix`.
+    pub async fn file_per_request(
+        inner: S,
+        executor: &Executor,
+        directory: impl Into<PathBuf>,
+        prefix: impl AsRef<str>,
+        mode: Option<WriterMode>,
+    ) -> io::Result<Self> {
+        let writer = PerMessageFileWriter::try_new(directory, prefix)
+            .await?
+            .with_request_mode(mode)
+            .with_response_mode(None);
+        Ok(Self::new_with_executor(inner, writer, executor.clone()))
     }
 }
 
@@ -332,6 +350,23 @@ impl RequestWriterLayer<UnboundedSender<Request>> {
     }
 }
 
+impl RequestWriterLayer<PerMessageFileWriter> {
+    /// Create a layer that streams every request into a unique file below
+    /// `directory` using the portable filename `prefix`.
+    pub async fn file_per_request(
+        executor: &Executor,
+        directory: impl Into<PathBuf>,
+        prefix: impl AsRef<str>,
+        mode: Option<WriterMode>,
+    ) -> io::Result<Self> {
+        let writer = PerMessageFileWriter::try_new(directory, prefix)
+            .await?
+            .with_request_mode(mode)
+            .with_response_mode(None);
+        Ok(Self::new_with_executor(writer, executor.clone()))
+    }
+}
+
 impl RequestWriterLayer<Sender<Request>> {
     /// Create a new [`RequestWriterLayer`] that prints requests to an [`AsyncWrite`]r
     /// over a bounded channel with a fixed buffer size.
@@ -415,6 +450,34 @@ mod tests {
 
     use super::*;
     use crate::Response;
+
+    #[tokio::test]
+    async fn file_constructors_only_enable_request_capture() {
+        let temp = tempfile::tempdir().unwrap();
+        let executor = Executor::new();
+        let layer = RequestWriterLayer::file_per_request(
+            &executor,
+            temp.path(),
+            "requests",
+            Some(WriterMode::Headers),
+        )
+        .await
+        .unwrap();
+        assert_eq!(layer.writer.request_mode(), Some(WriterMode::Headers));
+        assert_eq!(layer.writer.response_mode(), None);
+
+        let service = RequestWriterService::file_per_request(
+            (),
+            &executor,
+            temp.path(),
+            "requests",
+            Some(WriterMode::Body),
+        )
+        .await
+        .unwrap();
+        assert_eq!(service.writer.request_mode(), Some(WriterMode::Body));
+        assert_eq!(service.writer.response_mode(), None);
+    }
 
     #[tokio::test]
     async fn writer_observes_request_without_collecting_before_inner_service() {

--- a/rama-http/src/layer/traffic_writer/request.rs
+++ b/rama-http/src/layer/traffic_writer/request.rs
@@ -1,13 +1,14 @@
-use super::{WriterMode, write_headers_body_flags};
-use crate::io::write_http_request;
-use crate::{Body, Request, StreamingBody, body::util::BodyExt};
+use super::{WriterMode, capture_body_channel, write_headers_body_flags};
+use crate::io::write_http_request_streaming;
+use crate::{Body, Request, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
 use rama_core::error::{BoxError, ErrorContext as _};
 use rama_core::extensions::{Extension, ExtensionsRef};
 use rama_core::rt::Executor;
 use rama_core::telemetry::tracing::{self, Instrument};
 use rama_core::{Layer, Service};
-use std::fmt::Debug;
+use rama_http_types::CaptureBody;
+use std::{fmt::Debug, sync::Arc};
 use tokio::io::{AsyncWrite, AsyncWriteExt, stderr, stdout};
 use tokio::sync::mpsc::{Sender, UnboundedSender, channel, unbounded_channel};
 
@@ -16,7 +17,7 @@ async fn write_request_entry<W>(writer: &mut W, req: Request, write_headers: boo
 where
     W: AsyncWrite + Unpin + Send + Sync + 'static,
 {
-    if let Err(err) = write_http_request(writer, req, write_headers, write_body).await {
+    if let Err(err) = write_http_request_streaming(writer, req, write_headers, write_body).await {
         tracing::error!("failed to write http request to writer: {err:?}")
     }
     if let Err(err) = writer.write_all(b"\r\n").await {
@@ -26,7 +27,11 @@ where
 
 /// A trait for writing http requests.
 pub trait RequestWriter: Send + Sync + 'static {
-    /// Write the http request.
+    /// Write the HTTP request while its body is streaming.
+    ///
+    /// Implementations should consume or deliberately drop the body while this
+    /// future runs. Retaining it for later allows its unbounded observational
+    /// capture queue to grow until the original request body terminates.
     fn write_request(&self, req: Request) -> impl Future<Output = ()> + Send + '_;
 }
 
@@ -47,16 +52,33 @@ impl DoNotWriteRequest {
 #[derive(Clone)]
 /// Middleware to print Http request in std format.
 ///
+/// Request bodies are observed while they stream to the inner service. The
+/// writer receives an owned body stream and processes frames concurrently.
+///
 /// See the [module docs](super) for more details.
 pub struct RequestWriterService<S, W> {
     inner: S,
-    writer: W,
+    writer: Arc<W>,
+    executor: Executor,
 }
 
 impl<S, W> RequestWriterService<S, W> {
     /// Create a new [`RequestWriterService`] with a custom [`RequestWriter`].
-    pub const fn new(inner: S, writer: W) -> Self {
-        Self { inner, writer }
+    ///
+    /// Use [`Self::new_with_executor`] when streaming writer tasks must
+    /// participate in graceful shutdown.
+    pub fn new(inner: S, writer: W) -> Self {
+        Self::new_with_executor(inner, writer, Executor::new())
+    }
+
+    /// Create a new [`RequestWriterService`] with a custom [`RequestWriter`]
+    /// and executor for streaming writer tasks.
+    pub fn new_with_executor(inner: S, writer: W, executor: Executor) -> Self {
+        Self {
+            inner,
+            writer: Arc::new(writer),
+            executor,
+        }
     }
 }
 
@@ -95,7 +117,11 @@ impl<S> RequestWriterService<S, UnboundedSender<Request>> {
             }
             .instrument(span),
         );
-        Self { writer: tx, inner }
+        Self {
+            writer: Arc::new(tx),
+            inner,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`RequestWriterService`] that prints requests to stdout
@@ -140,7 +166,11 @@ impl<S> RequestWriterService<S, Sender<Request>> {
             }
             .instrument(span),
         );
-        Self { writer: tx, inner }
+        Self {
+            writer: Arc::new(tx),
+            inner,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`RequestWriterService`] that prints requests to stdout
@@ -178,21 +208,23 @@ where
     type Output = S::Output;
 
     async fn serve(&self, req: Request<ReqBody>) -> Result<Self::Output, Self::Error> {
-        let req = if req.extensions().get_ref::<DoNotWriteRequest>().is_some() {
-            req.map(Body::new)
+        if req.extensions().get_ref::<DoNotWriteRequest>().is_some() {
+            self.inner.serve(req.map(Body::new)).await.into_box_error()
         } else {
             let (parts, body) = req.into_parts();
-            let body_bytes = body
-                .collect()
-                .await
-                .context("printer prepare: collect request body")?
-                .to_bytes();
-            let req = Request::from_parts(parts.clone(), Body::from(body_bytes.clone()));
-            self.writer.write_request(req).await;
-            Request::from_parts(parts, Body::from(body_bytes))
-        };
-
-        self.inner.serve(req).await.into_box_error()
+            let (capture, captured_body) = capture_body_channel();
+            let captured_parts = parts.clone();
+            let captured_request = Request::from_parts(captured_parts, captured_body);
+            let request = Request::from_parts(
+                parts,
+                Body::new(CaptureBody::new(body.map_err(Into::into), capture)),
+            );
+            let writer = Arc::clone(&self.writer);
+            self.executor.spawn_task(async move {
+                writer.write_request(captured_request).await;
+            });
+            self.inner.serve(request).await.into_box_error()
+        }
     }
 }
 
@@ -225,15 +257,28 @@ where
 #[derive(Clone)]
 /// Middleware to print Http request in std format.
 ///
+/// Request bodies are observed while they stream to the inner service. The
+/// writer receives an owned body stream and processes frames concurrently.
+///
 /// See the [module docs](super) for more details.
 pub struct RequestWriterLayer<W> {
     writer: W,
+    executor: Executor,
 }
 
 impl<W> RequestWriterLayer<W> {
     /// Create a new [`RequestWriterLayer`] with a custom [`RequestWriter`].
+    ///
+    /// Use [`Self::new_with_executor`] when streaming writer tasks must
+    /// participate in graceful shutdown.
     pub const fn new(writer: W) -> Self {
-        Self { writer }
+        Self::new_with_executor(writer, Executor::new())
+    }
+
+    /// Create a new [`RequestWriterLayer`] with a custom [`RequestWriter`] and
+    /// executor for streaming writer tasks.
+    pub const fn new_with_executor(writer: W, executor: Executor) -> Self {
+        Self { writer, executor }
     }
 }
 
@@ -266,7 +311,10 @@ impl RequestWriterLayer<UnboundedSender<Request>> {
             }
             .instrument(span),
         );
-        Self { writer: tx }
+        Self {
+            writer: tx,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`RequestWriterService`] that prints requests to stdout
@@ -310,7 +358,10 @@ impl RequestWriterLayer<Sender<Request>> {
             }
             .instrument(span),
         );
-        Self { writer: tx }
+        Self {
+            writer: tx,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`RequestWriterService`] that prints requests to stdout
@@ -334,14 +385,150 @@ impl<S, W: Clone> Layer<S> for RequestWriterLayer<W> {
     fn layer(&self, inner: S) -> Self::Service {
         RequestWriterService {
             inner,
-            writer: self.writer.clone(),
+            writer: Arc::new(self.writer.clone()),
+            executor: self.executor.clone(),
         }
     }
 
     fn into_layer(self, inner: S) -> Self::Service {
         RequestWriterService {
             inner,
-            writer: self.writer,
+            writer: Arc::new(self.writer),
+            executor: self.executor,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use rama_core::{Layer as _, Service as _, service::service_fn};
+    use tokio::io::AsyncReadExt as _;
+
+    use super::*;
+    use crate::Response;
+
+    #[tokio::test]
+    async fn writer_observes_request_without_collecting_before_inner_service() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let body_polls = Arc::clone(&polls);
+        let body = Body::from_stream(rama_core::futures::stream::once(async move {
+            body_polls.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, Infallible>(Bytes::from_static(b"streamed request"))
+        }));
+        let (writer, mut written) = tokio::sync::mpsc::unbounded_channel();
+        let inner_polls = Arc::clone(&polls);
+        let service =
+            RequestWriterLayer::new(writer).into_layer(service_fn(move |request: Request| {
+                let polls = Arc::clone(&inner_polls);
+                async move {
+                    assert_eq!(polls.load(Ordering::Relaxed), 0);
+                    assert_eq!(
+                        request.into_body().collect().await.unwrap().to_bytes(),
+                        Bytes::from_static(b"streamed request")
+                    );
+                    Ok::<_, Infallible>(Response::new(Body::empty()))
+                }
+            }));
+
+        let serve = service.serve(Request::new(body));
+        let observe = async {
+            let request = written.recv().await.unwrap();
+            request.into_body().collect().await.unwrap().to_bytes()
+        };
+        let (result, captured) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(serve, observe)
+        })
+        .await
+        .expect("request capture should finish promptly");
+        result.unwrap();
+        assert_eq!(polls.load(Ordering::Relaxed), 1);
+        assert_eq!(captured, Bytes::from_static(b"streamed request"));
+    }
+
+    #[tokio::test]
+    async fn retained_request_body_does_not_delay_the_response() {
+        let (held_body, mut held_bodies) = tokio::sync::mpsc::unbounded_channel();
+        let inner = service_fn(move |request: Request| {
+            let held_body = held_body.clone();
+            async move {
+                held_body.send(request.into_body()).unwrap();
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }
+        });
+        let (writer_done, mut writer_completions) = tokio::sync::mpsc::unbounded_channel();
+        let writer = move |request: Request| {
+            let writer_done = writer_done.clone();
+            async move {
+                request.into_body().collect().await.unwrap();
+                writer_done.send(()).unwrap();
+            }
+        };
+        let service = RequestWriterLayer::new(writer).into_layer(inner);
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            service.serve(Request::new(Body::from("retained"))),
+        )
+        .await
+        .expect("the response must not wait for the request writer")
+        .unwrap();
+
+        let body = held_bodies.recv().await.unwrap();
+        assert_eq!(
+            body.collect().await.unwrap().to_bytes(),
+            Bytes::from_static(b"retained")
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), writer_completions.recv())
+            .await
+            .expect("the request writer should finish after the body is consumed")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn built_in_writer_emits_the_streaming_request_entry() {
+        let inner = service_fn(|request: Request| async move {
+            assert_eq!(
+                request.into_body().collect().await.unwrap().to_bytes(),
+                Bytes::from_static(b"payload")
+            );
+            Ok::<_, Infallible>(Response::new(Body::empty()))
+        });
+        let executor = Executor::new();
+        let (writer, mut output) = tokio::io::duplex(256);
+        let service =
+            RequestWriterLayer::writer_unbounded(&executor, writer, Some(WriterMode::All))
+                .into_layer(inner);
+
+        service
+            .serve(
+                Request::builder()
+                    .method("POST")
+                    .uri("/upload")
+                    .header("x-test", "yes")
+                    .body(Body::from("payload"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        drop(service);
+
+        let mut written = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), output.read_to_end(&mut written))
+            .await
+            .expect("the request writer should shut down promptly")
+            .unwrap();
+        let written = String::from_utf8(written).unwrap();
+        assert!(written.starts_with("POST /upload HTTP/1.1\r\n"));
+        assert!(written.contains("x-test: yes\r\n"));
+        assert!(written.ends_with("\r\npayload\r\n"));
     }
 }

--- a/rama-http/src/layer/traffic_writer/request.rs
+++ b/rama-http/src/layer/traffic_writer/request.rs
@@ -1,4 +1,7 @@
-use super::{PerMessageFileWriter, WriterMode, capture_body_channel, write_headers_body_flags};
+use super::{
+    PerMessageFileWriter, WriterMode, capture_body_channel, ensure_traffic_writer_id,
+    write_headers_body_flags,
+};
 use crate::io::write_http_request_streaming;
 use crate::{Body, Request, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
@@ -229,6 +232,7 @@ where
         if req.extensions().get_ref::<DoNotWriteRequest>().is_some() {
             self.inner.serve(req.map(Body::new)).await.into_box_error()
         } else {
+            ensure_traffic_writer_id(req.extensions());
             let (parts, body) = req.into_parts();
             let (capture, captured_body) = capture_body_channel();
             let captured_parts = parts.clone();
@@ -450,6 +454,7 @@ mod tests {
 
     use super::*;
     use crate::Response;
+    use crate::layer::traffic_writer::TrafficWriterId;
 
     #[tokio::test]
     async fn file_constructors_only_enable_request_capture() {
@@ -477,6 +482,36 @@ mod tests {
         .unwrap();
         assert_eq!(service.writer.request_mode(), Some(WriterMode::Body));
         assert_eq!(service.writer.response_mode(), None);
+    }
+
+    #[tokio::test]
+    async fn request_writer_shares_private_id_with_inner_request() {
+        let (writer, mut captured_requests) = tokio::sync::mpsc::unbounded_channel();
+        let (seen_id, mut seen_ids) = tokio::sync::mpsc::unbounded_channel();
+        let inner = service_fn(move |request: Request| {
+            let seen_id = seen_id.clone();
+            async move {
+                seen_id
+                    .send(*request.extensions().get_ref::<TrafficWriterId>().unwrap())
+                    .unwrap();
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }
+        });
+        let service = RequestWriterLayer::new(writer).into_layer(inner);
+
+        service.serve(Request::new(Body::empty())).await.unwrap();
+        let captured = tokio::time::timeout(Duration::from_secs(1), captured_requests.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let request_id = tokio::time::timeout(Duration::from_secs(1), seen_ids.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            captured.extensions().get_ref::<TrafficWriterId>(),
+            Some(&request_id)
+        );
     }
 
     #[tokio::test]

--- a/rama-http/src/layer/traffic_writer/response.rs
+++ b/rama-http/src/layer/traffic_writer/response.rs
@@ -1,4 +1,7 @@
-use super::{PerMessageFileWriter, WriterMode, capture_body_channel, write_headers_body_flags};
+use super::{
+    PerMessageFileWriter, TrafficWriterId, WriterMode, capture_body_channel,
+    ensure_traffic_writer_id, write_headers_body_flags,
+};
 use crate::io::write_http_response_streaming;
 use crate::{Body, Request, Response, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
@@ -351,10 +354,14 @@ where
 
     async fn serve(&self, req: Request<ReqBody>) -> Result<Self::Output, Self::Error> {
         let do_not_print_response: Option<Arc<DoNotWriteResponse>> = req.extensions().get_arc();
+        let traffic_writer_id = do_not_print_response
+            .is_none()
+            .then(|| ensure_traffic_writer_id(req.extensions()));
         let resp = self.inner.serve(req).await.into_box_error()?;
-        let resp = if do_not_print_response.is_some() {
-            resp.map(Body::new)
-        } else {
+        let resp = if let Some(traffic_writer_id) = traffic_writer_id {
+            if resp.extensions().get_ref::<TrafficWriterId>().copied() != Some(traffic_writer_id) {
+                resp.extensions().insert(traffic_writer_id);
+            }
             let (parts, body) = resp.into_parts();
             let (capture, captured_body) = capture_body_channel();
             let captured_parts = parts.clone();
@@ -368,6 +375,8 @@ where
                 parts,
                 Body::new(CaptureBody::new(body.map_err(Into::into), capture)),
             )
+        } else {
+            resp.map(Body::new)
         };
         Ok(resp)
     }
@@ -414,6 +423,7 @@ mod tests {
     use tokio::io::AsyncReadExt as _;
 
     use super::*;
+    use crate::layer::traffic_writer::TrafficWriterId;
 
     #[tokio::test]
     async fn file_constructors_only_enable_response_capture() {
@@ -441,6 +451,40 @@ mod tests {
         .unwrap();
         assert_eq!(service.writer.request_mode(), None);
         assert_eq!(service.writer.response_mode(), Some(WriterMode::Body));
+    }
+
+    #[tokio::test]
+    async fn response_writer_propagates_private_request_id_to_both_responses() {
+        let (writer, mut captured_responses) = tokio::sync::mpsc::unbounded_channel();
+        let (seen_id, mut seen_ids) = tokio::sync::mpsc::unbounded_channel();
+        let inner = service_fn(move |request: Request| {
+            let seen_id = seen_id.clone();
+            async move {
+                seen_id
+                    .send(*request.extensions().get_ref::<TrafficWriterId>().unwrap())
+                    .unwrap();
+                Ok::<_, Infallible>(Response::new(Body::empty()))
+            }
+        });
+        let service = ResponseWriterLayer::new(writer).into_layer(inner);
+
+        let response = service.serve(Request::new(Body::empty())).await.unwrap();
+        let captured = tokio::time::timeout(Duration::from_secs(1), captured_responses.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let request_id = tokio::time::timeout(Duration::from_secs(1), seen_ids.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            response.extensions().get_ref::<TrafficWriterId>(),
+            Some(&request_id)
+        );
+        assert_eq!(
+            captured.extensions().get_ref::<TrafficWriterId>(),
+            Some(&request_id)
+        );
     }
 
     #[tokio::test]

--- a/rama-http/src/layer/traffic_writer/response.rs
+++ b/rama-http/src/layer/traffic_writer/response.rs
@@ -1,4 +1,4 @@
-use super::{WriterMode, capture_body_channel, write_headers_body_flags};
+use super::{PerMessageFileWriter, WriterMode, capture_body_channel, write_headers_body_flags};
 use crate::io::write_http_response_streaming;
 use crate::{Body, Request, Response, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
@@ -9,8 +9,7 @@ use rama_core::telemetry::tracing::{self, Instrument};
 use rama_core::{Layer, Service};
 use rama_http_types::CaptureBody;
 use rama_utils::macros::define_inner_service_accessors;
-use std::fmt::Debug;
-use std::sync::Arc;
+use std::{fmt::Debug, io, path::PathBuf, sync::Arc};
 use tokio::io::{AsyncWrite, stderr, stdout};
 use tokio::sync::mpsc::{Sender, UnboundedSender, channel, unbounded_channel};
 
@@ -52,9 +51,9 @@ impl<W> ResponseWriterLayer<W> {
 pub trait ResponseWriter: Send + Sync + 'static {
     /// Write the HTTP response while its body is streaming.
     ///
-    /// Implementations should consume or deliberately drop the body while this
-    /// future runs. Retaining it for later allows its unbounded observational
-    /// capture queue to grow until the original response body terminates.
+    /// Implementations must consume or deliberately drop the body while this
+    /// future runs. Retaining it for later applies backpressure once its
+    /// single-frame observational capture queue is full.
     fn write_response(&self, res: Response) -> impl Future<Output = ()> + Send + '_;
 }
 
@@ -117,6 +116,23 @@ impl ResponseWriterLayer<UnboundedSender<Response>> {
     #[must_use]
     pub fn stderr_unbounded(executor: &Executor, mode: Option<WriterMode>) -> Self {
         Self::writer_unbounded(executor, stderr(), mode)
+    }
+}
+
+impl ResponseWriterLayer<PerMessageFileWriter> {
+    /// Create a layer that streams every response into a unique file below
+    /// `directory` using the portable filename `prefix`.
+    pub async fn file_per_response(
+        executor: &Executor,
+        directory: impl Into<PathBuf>,
+        prefix: impl AsRef<str>,
+        mode: Option<WriterMode>,
+    ) -> io::Result<Self> {
+        let writer = PerMessageFileWriter::try_new(directory, prefix)
+            .await?
+            .with_request_mode(None)
+            .with_response_mode(mode);
+        Ok(Self::new_with_executor(writer, executor.clone()))
     }
 }
 
@@ -265,6 +281,22 @@ impl<S> ResponseWriterService<S, UnboundedSender<Response>> {
     }
 }
 
+impl<S> ResponseWriterService<S, PerMessageFileWriter> {
+    /// Create a service that streams every response into a unique file below
+    /// `directory` using the portable filename `prefix`.
+    pub async fn file_per_response(
+        executor: &Executor,
+        directory: impl Into<PathBuf>,
+        prefix: impl AsRef<str>,
+        mode: Option<WriterMode>,
+        inner: S,
+    ) -> io::Result<Self> {
+        let layer =
+            ResponseWriterLayer::file_per_response(executor, directory, prefix, mode).await?;
+        Ok(layer.into_layer(inner))
+    }
+}
+
 impl<S> ResponseWriterService<S, Sender<Response>> {
     /// Create a new [`ResponseWriterService`] that prints responses to an [`AsyncWrite`]r
     /// over a bounded channel with a fixed buffer size.
@@ -382,6 +414,35 @@ mod tests {
     use tokio::io::AsyncReadExt as _;
 
     use super::*;
+
+    #[tokio::test]
+    async fn file_constructors_only_enable_response_capture() {
+        let temp = tempfile::tempdir().unwrap();
+        let executor = Executor::new();
+        let layer = ResponseWriterLayer::file_per_response(
+            &executor,
+            temp.path(),
+            "responses",
+            Some(WriterMode::Headers),
+        )
+        .await
+        .unwrap();
+        assert_eq!(layer.writer.request_mode(), None);
+        assert_eq!(layer.writer.response_mode(), Some(WriterMode::Headers));
+
+        let service = ResponseWriterService::file_per_response(
+            &executor,
+            temp.path(),
+            "responses",
+            Some(WriterMode::Body),
+            (),
+        )
+        .await
+        .unwrap();
+        assert_eq!(service.writer.request_mode(), None);
+        assert_eq!(service.writer.response_mode(), Some(WriterMode::Body));
+    }
+
     #[tokio::test]
     async fn writer_observes_response_as_the_caller_streams_it() {
         let polls = Arc::new(AtomicUsize::new(0));
@@ -428,7 +489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slow_first_capture_does_not_stall_later_response_body() {
+    async fn shared_writer_backpressures_later_response_without_interleaving() {
         let (first_sender, first_receiver) = tokio::sync::mpsc::unbounded_channel();
         let first_receiver = Arc::new(tokio::sync::Mutex::new(Some(first_receiver)));
         let inner_receiver = Arc::clone(&first_receiver);
@@ -485,16 +546,28 @@ mod tests {
         assert_eq!(&first_output, b"\r\nfirst");
 
         let second_response = service.serve(Request::new(Body::empty())).await.unwrap();
-        let second = tokio::time::timeout(Duration::from_secs(1), async {
-            second_response.into_body().collect().await
-        })
-        .await
-        .expect("a later response must not wait for the first capture")
-        .unwrap();
-        assert_eq!(second.to_bytes(), Bytes::from_static(b"second"));
+        let mut second = Box::pin(second_response.into_body().collect());
+        tokio::time::timeout(Duration::from_millis(50), &mut second)
+            .await
+            .expect_err("the shared writer must backpressure a later body");
 
         drop(first_body);
         drop(first_sender);
+        let second = tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("the later body should resume when the first capture ends")
+            .unwrap();
+        assert_eq!(second.to_bytes(), Bytes::from_static(b"second"));
+
+        let mut second_output = [0; 8];
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            output.read_exact(&mut second_output),
+        )
+        .await
+        .expect("the second response should be written after the first")
+        .unwrap();
+        assert_eq!(&second_output, b"\r\nsecond");
     }
 
     #[tokio::test]

--- a/rama-http/src/layer/traffic_writer/response.rs
+++ b/rama-http/src/layer/traffic_writer/response.rs
@@ -1,12 +1,13 @@
-use super::{WriterMode, write_headers_body_flags};
-use crate::io::write_http_response;
-use crate::{Body, Request, Response, StreamingBody, body::util::BodyExt};
+use super::{WriterMode, capture_body_channel, write_headers_body_flags};
+use crate::io::write_http_response_streaming;
+use crate::{Body, Request, Response, StreamingBody, body::util::BodyExt as _};
 use rama_core::bytes::Bytes;
-use rama_core::error::{BoxError, ErrorContext};
+use rama_core::error::{BoxError, ErrorContext as _};
 use rama_core::extensions::{Extension, ExtensionsRef};
 use rama_core::rt::Executor;
 use rama_core::telemetry::tracing::{self, Instrument};
 use rama_core::{Layer, Service};
+use rama_http_types::CaptureBody;
 use rama_utils::macros::define_inner_service_accessors;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -14,9 +15,13 @@ use tokio::io::{AsyncWrite, stderr, stdout};
 use tokio::sync::mpsc::{Sender, UnboundedSender, channel, unbounded_channel};
 
 /// Layer that applies [`ResponseWriterService`] which prints the http response in std format.
+///
+/// Response bodies are observed while they stream to the caller. The writer
+/// receives an owned body stream and processes frames concurrently.
 #[derive(Clone)]
 pub struct ResponseWriterLayer<W> {
     writer: W,
+    executor: Executor,
 }
 
 impl<W> Debug for ResponseWriterLayer<W> {
@@ -29,14 +34,27 @@ impl<W> Debug for ResponseWriterLayer<W> {
 
 impl<W> ResponseWriterLayer<W> {
     /// Create a new [`ResponseWriterLayer`] with a custom [`ResponseWriter`].
+    ///
+    /// Use [`Self::new_with_executor`] when streaming writer tasks must participate
+    /// in graceful shutdown.
     pub const fn new(writer: W) -> Self {
-        Self { writer }
+        Self::new_with_executor(writer, Executor::new())
+    }
+
+    /// Create a new [`ResponseWriterLayer`] with a custom [`ResponseWriter`]
+    /// and executor for streaming writer tasks.
+    pub const fn new_with_executor(writer: W, executor: Executor) -> Self {
+        Self { writer, executor }
     }
 }
 
 /// A trait for writing http responses.
 pub trait ResponseWriter: Send + Sync + 'static {
-    /// Write the http response.
+    /// Write the HTTP response while its body is streaming.
+    ///
+    /// Implementations should consume or deliberately drop the body while this
+    /// future runs. Retaining it for later allows its unbounded observational
+    /// capture queue to grow until the original response body terminates.
     fn write_response(&self, res: Response) -> impl Future<Output = ()> + Send + '_;
 }
 
@@ -71,7 +89,8 @@ impl ResponseWriterLayer<UnboundedSender<Response>> {
             async move {
                 while let Some(res) = rx.recv().await {
                     if let Err(err) =
-                        write_http_response(&mut writer, res, write_headers, write_body).await
+                        write_http_response_streaming(&mut writer, res, write_headers, write_body)
+                            .await
                     {
                         tracing::error!("failed to write http response to writer: {err:?}")
                     }
@@ -80,7 +99,10 @@ impl ResponseWriterLayer<UnboundedSender<Response>> {
             .instrument(span),
         );
 
-        Self { writer: tx }
+        Self {
+            writer: tx,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`ResponseWriterLayer`] that prints responses to stdout
@@ -120,7 +142,8 @@ impl ResponseWriterLayer<Sender<Response>> {
             async move {
                 while let Some(res) = rx.recv().await {
                     if let Err(err) =
-                        write_http_response(&mut writer, res, write_headers, write_body).await
+                        write_http_response_streaming(&mut writer, res, write_headers, write_body)
+                            .await
                     {
                         tracing::error!("failed to write http response to writer: {err:?}")
                     }
@@ -128,7 +151,10 @@ impl ResponseWriterLayer<Sender<Response>> {
             }
             .instrument(span),
         );
-        Self { writer: tx }
+        Self {
+            writer: tx,
+            executor: executor.clone(),
+        }
     }
 
     /// Create a new [`ResponseWriterLayer`] that prints responses to stdout
@@ -152,31 +178,50 @@ impl<S, W: Clone> Layer<S> for ResponseWriterLayer<W> {
     fn layer(&self, inner: S) -> Self::Service {
         ResponseWriterService {
             inner,
-            writer: self.writer.clone(),
+            writer: Arc::new(self.writer.clone()),
+            executor: self.executor.clone(),
         }
     }
 
     fn into_layer(self, inner: S) -> Self::Service {
         ResponseWriterService {
             inner,
-            writer: self.writer,
+            writer: Arc::new(self.writer),
+            executor: self.executor,
         }
     }
 }
 
-/// Middleware to print Http request in std format.
+/// Middleware to print Http responses in std format.
+///
+/// Response bodies are observed while they stream to the caller. The writer
+/// receives an owned body stream and processes frames concurrently.
 ///
 /// See the [module docs](super) for more details.
 #[derive(Clone)]
 pub struct ResponseWriterService<S, W> {
     inner: S,
-    writer: W,
+    writer: Arc<W>,
+    executor: Executor,
 }
 
 impl<S, W> ResponseWriterService<S, W> {
     /// Create a new [`ResponseWriterService`] with a custom [`ResponseWriter`].
-    pub const fn new(writer: W, inner: S) -> Self {
-        Self { inner, writer }
+    ///
+    /// Use [`Self::new_with_executor`] when streaming writer tasks must participate
+    /// in graceful shutdown.
+    pub fn new(writer: W, inner: S) -> Self {
+        Self::new_with_executor(writer, inner, Executor::new())
+    }
+
+    /// Create a new [`ResponseWriterService`] with a custom [`ResponseWriter`]
+    /// and executor for streaming writer tasks.
+    pub fn new_with_executor(writer: W, inner: S, executor: Executor) -> Self {
+        Self {
+            inner,
+            writer: Arc::new(writer),
+            executor,
+        }
     }
 
     define_inner_service_accessors!();
@@ -279,15 +324,18 @@ where
             resp.map(Body::new)
         } else {
             let (parts, body) = resp.into_parts();
-            let body_bytes = body
-                .collect()
-                .await
-                .context("printer prepare: collect response body")?
-                .to_bytes();
-            let resp: rama_http_types::Response<Body> =
-                Response::from_parts(parts.clone(), Body::from(body_bytes.clone()));
-            self.writer.write_response(resp).await;
-            Response::from_parts(parts, Body::from(body_bytes))
+            let (capture, captured_body) = capture_body_channel();
+            let captured_parts = parts.clone();
+            let writer = Arc::clone(&self.writer);
+            self.executor.spawn_task(async move {
+                writer
+                    .write_response(Response::from_parts(captured_parts, captured_body))
+                    .await;
+            });
+            Response::from_parts(
+                parts,
+                Body::new(CaptureBody::new(body.map_err(Into::into), capture)),
+            )
         };
         Ok(resp)
     }
@@ -316,5 +364,170 @@ where
 {
     async fn write_response(&self, res: Response) {
         self(res).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
+
+    use rama_core::{Layer as _, Service as _, service::service_fn};
+    use tokio::io::AsyncReadExt as _;
+
+    use super::*;
+    #[tokio::test]
+    async fn writer_observes_response_as_the_caller_streams_it() {
+        let polls = Arc::new(AtomicUsize::new(0));
+        let response_polls = Arc::clone(&polls);
+        let (writer, mut written) = tokio::sync::mpsc::unbounded_channel();
+        let service =
+            ResponseWriterLayer::new(writer).into_layer(service_fn(move |_request: Request| {
+                let polls = Arc::clone(&response_polls);
+                async move {
+                    let body = Body::from_stream(rama_core::futures::stream::once(async move {
+                        polls.fetch_add(1, Ordering::Relaxed);
+                        Ok::<_, Infallible>(Bytes::from_static(b"streamed response"))
+                    }));
+                    Ok::<_, Infallible>(Response::new(body))
+                }
+            }));
+
+        let response = service.serve(Request::new(Body::empty())).await.unwrap();
+        assert_eq!(polls.load(Ordering::Relaxed), 0);
+        written.try_recv().unwrap_err();
+
+        let written_response =
+            tokio::time::timeout(std::time::Duration::from_secs(1), written.recv())
+                .await
+                .expect("response capture should arrive promptly")
+                .unwrap();
+        let (response, captured) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(
+                response.into_body().collect(),
+                written_response.into_body().collect(),
+            )
+        })
+        .await
+        .expect("response streams should finish promptly");
+        assert_eq!(
+            response.unwrap().to_bytes(),
+            Bytes::from_static(b"streamed response")
+        );
+        assert_eq!(polls.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            captured.unwrap().to_bytes(),
+            Bytes::from_static(b"streamed response")
+        );
+    }
+
+    #[tokio::test]
+    async fn slow_first_capture_does_not_stall_later_response_body() {
+        let (first_sender, first_receiver) = tokio::sync::mpsc::unbounded_channel();
+        let first_receiver = Arc::new(tokio::sync::Mutex::new(Some(first_receiver)));
+        let inner_receiver = Arc::clone(&first_receiver);
+        let inner = service_fn(move |request: Request| {
+            let first_receiver = Arc::clone(&inner_receiver);
+            async move {
+                let body = if request.headers().contains_key("x-long-lived") {
+                    let receiver = first_receiver
+                        .lock()
+                        .await
+                        .take()
+                        .expect("the long-lived response is requested once");
+                    Body::from_stream(rama_core::futures::stream::unfold(
+                        receiver,
+                        |mut receiver| async move { receiver.recv().await.map(|item| (item, receiver)) },
+                    ))
+                } else {
+                    Body::from("second")
+                };
+                Ok::<_, Infallible>(Response::new(body))
+            }
+        });
+        let executor = Executor::new();
+        let (writer, mut output) = tokio::io::duplex(64);
+        let service =
+            ResponseWriterLayer::writer_unbounded(&executor, writer, Some(WriterMode::Body))
+                .into_layer(inner);
+
+        let first_request = Request::builder()
+            .header("x-long-lived", "true")
+            .body(Body::empty())
+            .unwrap();
+        let first_response = service.serve(first_request).await.unwrap();
+        let mut first_body = first_response.into_body();
+        first_sender
+            .send(Ok::<_, Infallible>(Bytes::from_static(b"first")))
+            .unwrap();
+        assert_eq!(
+            first_body
+                .frame()
+                .await
+                .unwrap()
+                .unwrap()
+                .into_data()
+                .unwrap(),
+            "first"
+        );
+
+        let mut first_output = [0; 7];
+        tokio::time::timeout(Duration::from_secs(1), output.read_exact(&mut first_output))
+            .await
+            .expect("the writer should start draining the first response")
+            .unwrap();
+        assert_eq!(&first_output, b"\r\nfirst");
+
+        let second_response = service.serve(Request::new(Body::empty())).await.unwrap();
+        let second = tokio::time::timeout(Duration::from_secs(1), async {
+            second_response.into_body().collect().await
+        })
+        .await
+        .expect("a later response must not wait for the first capture")
+        .unwrap();
+        assert_eq!(second.to_bytes(), Bytes::from_static(b"second"));
+
+        drop(first_body);
+        drop(first_sender);
+    }
+
+    #[tokio::test]
+    async fn headers_only_writer_does_not_consume_or_stall_live_body() {
+        let inner = service_fn(|_request: Request| async {
+            Ok::<_, Infallible>(
+                Response::builder()
+                    .header("x-written", "yes")
+                    .body(Body::from("live payload"))
+                    .unwrap(),
+            )
+        });
+        let executor = Executor::new();
+        let (writer, mut output) = tokio::io::duplex(128);
+        let service =
+            ResponseWriterLayer::writer_unbounded(&executor, writer, Some(WriterMode::Headers))
+                .into_layer(inner);
+
+        let response = service.serve(Request::new(Body::empty())).await.unwrap();
+        assert_eq!(
+            response.into_body().collect().await.unwrap().to_bytes(),
+            Bytes::from_static(b"live payload")
+        );
+        drop(service);
+
+        let mut written = Vec::new();
+        tokio::time::timeout(Duration::from_secs(1), output.read_to_end(&mut written))
+            .await
+            .expect("the headers-only writer should shut down promptly")
+            .unwrap();
+        let written = String::from_utf8(written).unwrap();
+        assert!(written.contains("HTTP/1.1 200 OK\r\n"));
+        assert!(written.contains("x-written: yes\r\n"));
+        assert!(!written.contains("live payload"));
     }
 }

--- a/rama-http/src/lib.rs
+++ b/rama-http/src/lib.rs
@@ -20,10 +20,12 @@
 
 #[doc(inline)]
 pub use ::rama_http_types::{
-    Body, BodyDataStream, BodyExtractExt, BodyLimit, BodyLimitLayer, BodyLimitService,
-    Error as HttpError, HeaderMap, HeaderName, HeaderValue, InfiniteReader, Method, Request,
-    Response, Result as HttpResult, StatusCode, StreamingBody, Version, conn, fingerprint, header,
-    method, mime, opentelemetry, proto, request, response, sse, status, version,
+    Body, BodyCaptureEvent, BodyCaptureSink, BodyDataStream, BodyExtractExt, BodyLimit,
+    BodyLimitLayer, BodyLimitService, BufferedBodyCapture, CaptureBody, CaptureCanceled,
+    CaptureHandle, CaptureLimit, CaptureOutcome, CapturedBody, Error as HttpError, HeaderMap,
+    HeaderName, HeaderValue, InfiniteReader, Method, Request, Response, Result as HttpResult,
+    StatusCode, StreamingBody, Version, conn, fingerprint, header, method, mime, opentelemetry,
+    proto, request, response, sse, status, version,
 };
 
 #[doc(inline)]

--- a/rama-net/src/http/version.rs
+++ b/rama-net/src/http/version.rs
@@ -134,5 +134,9 @@ impl fmt::Display for InvalidVersion {
 
 impl Error for InvalidVersion {}
 
+use rama_utils::macros::serde_str::impl_serde_str;
+
+impl_serde_str!(as_str Version);
+
 // `ApplicationProtocol` (ALPN) <-> `Version` conversions live in `rama-tls`
 // (which depends on both this crate and the TLS enum vocabulary).

--- a/rama-tls/Cargo.toml
+++ b/rama-tls/Cargo.toml
@@ -33,7 +33,7 @@ dial9 = ["dep:dial9-trace-format", "rama-core/dial9"]
 [dependencies]
 ahash = { workspace = true }
 base64 = { workspace = true }
-bytes = { workspace = true }
+bytes = { workspace = true, features = ["std"] }
 dial9-trace-format = { workspace = true, optional = true }
 flume = { workspace = true, features = ["async"] }
 hex = { workspace = true }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -5,10 +5,12 @@
 
 #[doc(inline)]
 pub use ::rama_http::{
-    Body, BodyDataStream, BodyExtractExt, BodyLimit, BodyLimitLayer, BodyLimitService, HeaderMap,
-    HeaderName, HeaderValue, HttpError, HttpResult, InfiniteReader, Method, Request, Response,
-    StatusCode, StreamingBody, Version, body, conn, convert, fingerprint, header, headers, io,
-    layer, matcher, mime, opentelemetry, proto, protocols, request, response, service, sse, utils,
+    Body, BodyCaptureEvent, BodyCaptureSink, BodyDataStream, BodyExtractExt, BodyLimit,
+    BodyLimitLayer, BodyLimitService, BufferedBodyCapture, CaptureBody, CaptureCanceled,
+    CaptureHandle, CaptureLimit, CaptureOutcome, CapturedBody, HeaderMap, HeaderName, HeaderValue,
+    HttpError, HttpResult, InfiniteReader, Method, Request, Response, StatusCode, StreamingBody,
+    Version, body, conn, convert, fingerprint, header, headers, io, layer, matcher, mime,
+    opentelemetry, proto, protocols, request, response, service, sse, utils,
 };
 
 #[cfg(feature = "http-backend")]


### PR DESCRIPTION
Add Serde support for HTTP types and asynchronous streaming body capture.
Integrate non-blocking capture with traffic writers and buffered utilities.