### PR TITLE
Add support for chrome _websocketMessages in rama's har implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -455,6 +455,8 @@ dns-hickory = ["dns", "rama-dns/hickory"]
 tcp = ["std", "net", "dep:rama-tcp"]
 udp = ["std", "net", "dep:rama-udp"]
 ws = ["std", "dep:rama-ws", "http"]
+# Record relayed WebSocket messages into HAR entries as Chrome's `_webSocketMessages`.
+ws-har = ["ws", "rama-ws/ws-har", "rama-http?/ws-har"]
 js = ["std", "dep:rama-js"]
 js-disk-cache = ["js", "rama-js/disk-cache"]
 pac = ["js", "dns", "http", "dep:rama-pac", "rama-pac/http"]

--- a/rama-http/Cargo.toml
+++ b/rama-http/Cargo.toml
@@ -35,6 +35,11 @@ hyperium = ["dep:rama-http-hyperium"]
 multipart = ["dep:multer", "dep:mime_guess", "hyperium"]
 html = ["dep:rama-http-macros", "dep:memchr"]
 rss = ["dep:quick-xml"]
+# Adds `_webSocketMessages` to HAR entries, in the shape Chrome DevTools exports.
+# HAR 1.2 reserves a leading underscore for custom fields and requires parsers to
+# ignore unknown ones, so the output stays conformant either way; off by default so
+# existing consumers see byte-identical files.
+ws-har = []
 # `rama-http-types/tls` is required so its `input_ext` protocol resolution sees the
 # real `rama_tls::SecureTransport` (not its tls-off dummy); otherwise an
 # origin-form request over a terminated TLS conn resolves to http instead of https.

--- a/rama-http/src/layer/har/extensions.rs
+++ b/rama-http/src/layer/har/extensions.rs
@@ -5,3 +5,77 @@ use rama_utils::str::arcstr::ArcStr;
 #[derive(Debug, Clone, PartialEq, Eq, Extension)]
 #[extension(tags(http))]
 pub struct RequestComment(pub ArcStr);
+
+#[cfg(feature = "ws-har")]
+mod ws {
+    use super::*;
+    use crate::layer::har::spec::{WebSocketMessage, WebSocketMessageType};
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+
+    #[must_use]
+    #[derive(Debug, Clone, Default, Extension)]
+    #[extension(tags(http))]
+    /// Collects the WebSocket messages relayed over one upgraded connection, so the HAR
+    /// entry for that connection can carry them.
+    ///
+    /// A WebSocket entry is a `101` with no body: by the time any frame exists the
+    /// response is long since returned. Sharing one buffer between the relay and the
+    /// HAR service is what lets the two meet — the relay pushes as frames pass, and the
+    /// entry is written from the same buffer.
+    ///
+    /// Note that [`HARExportService`] reads this buffer as soon as the inner service
+    /// yields a response, which for an upgrade is before a single frame has been
+    /// relayed. Until the entry for a `101` is deferred to socket close, the field it
+    /// produces is empty in that flow.
+    ///
+    /// [`HARExportService`]: crate::layer::har::service::HARExportService
+    pub struct WebSocketMessages(Arc<Mutex<Vec<WebSocketMessage>>>);
+
+    impl WebSocketMessages {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Records one relayed message.
+        ///
+        /// `data` is stored as-is for text and base64-encoded for binary, because HAR is
+        /// JSON and a binary frame has no faithful UTF-8 form.
+        pub fn push_text(&self, direction: WebSocketMessageType, time: f64, text: &str) {
+            self.push(WebSocketMessage {
+                r#type: direction,
+                time,
+                opcode: 1,
+                data: text.into(),
+            });
+        }
+
+        pub fn push_binary(&self, direction: WebSocketMessageType, time: f64, data: &[u8]) {
+            use base64::{Engine as _, engine::general_purpose::STANDARD};
+            self.push(WebSocketMessage {
+                r#type: direction,
+                time,
+                opcode: 2,
+                data: STANDARD.encode(data).into(),
+            });
+        }
+
+        fn push(&self, message: WebSocketMessage) {
+            self.0.lock().push(message);
+        }
+
+        /// Drains everything relayed so far. Returns `None` when nothing was seen, so a
+        /// non-WebSocket entry omits the field entirely.
+        ///
+        /// Draining rather than copying keeps a collector that outlives one entry from
+        /// re-emitting the same messages on the next one.
+        #[must_use]
+        pub fn take(&self) -> Option<Vec<WebSocketMessage>> {
+            let mut guard = self.0.lock();
+            (!guard.is_empty()).then(|| std::mem::take(&mut *guard))
+        }
+    }
+}
+
+#[cfg(feature = "ws-har")]
+pub use ws::WebSocketMessages;

--- a/rama-http/src/layer/har/service.rs
+++ b/rama-http/src/layer/har/service.rs
@@ -97,6 +97,16 @@ where
             (req.map(Body::new), None)
         };
 
+        // Grab the collector before the request is consumed. It is an Arc handle, so
+        // the clone stays tied to the buffer the relay pushes into. Note this is read
+        // again below as soon as the inner service returns: for an upgrade that is
+        // before the relay has run, so the buffer is still empty there.
+        #[cfg(feature = "ws-har")]
+        let ws_collector = request
+            .extensions()
+            .get_ref::<super::extensions::WebSocketMessages>()
+            .cloned();
+
         let result = self.service.serve(request).await;
 
         if let Some(entry_start_info) = maybe_entry_start_info {
@@ -133,6 +143,9 @@ where
                 Err(err) => (Err(err.into()), None),
             };
 
+            #[cfg(feature = "ws-har")]
+            let ws_messages = ws_collector.as_ref().and_then(|c| c.take());
+
             // TODO: populate these in future
             let timings = Timings::default();
             let cache = Cache::default();
@@ -155,6 +168,10 @@ where
                 server_ip_address: None,
                 connection: None, // TODO
                 comment: None,
+                // Present only when a relay collected frames for this connection; an
+                // ordinary entry leaves it None and serialises exactly as before.
+                #[cfg(feature = "ws-har")]
+                web_socket_messages: ws_messages,
             };
 
             let log_line = HarLog {

--- a/rama-http/src/layer/har/spec.rs
+++ b/rama-http/src/layer/har/spec.rs
@@ -291,6 +291,47 @@ pub struct Entry {
     pub connection: Option<ArcStr>,
     /// A comment provided by the user or the application.
     pub comment: Option<ArcStr>,
+    /// WebSocket messages exchanged after a successful upgrade on this entry.
+    ///
+    /// A custom field, in the sense HAR 1.2 defines one: the spec reserves a leading
+    /// underscore for extensions and requires parsers to ignore what they do not know,
+    /// so emitting this keeps the file conformant. The shape follows Chrome DevTools,
+    /// which has exported `_webSocketMessages` since Chrome 76 and is the de-facto
+    /// standard every HAR viewer understands.
+    ///
+    /// `None` when the entry is not a WebSocket, so ordinary entries serialise exactly
+    /// as they did before.
+    #[cfg(feature = "ws-har")]
+    #[serde(rename = "_webSocketMessages", skip_serializing_if = "Option::is_none")]
+    pub web_socket_messages: Option<Vec<WebSocketMessage>>,
+}
+
+#[cfg(feature = "ws-har")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+/// A single WebSocket message, in the shape Chrome DevTools exports.
+pub struct WebSocketMessage {
+    /// `send` for client to server, `receive` for server to client.
+    pub r#type: WebSocketMessageType,
+    /// When the message was transferred, as a unix timestamp in seconds.
+    ///
+    /// Chrome emits a float here rather than the ISO-8601 string used elsewhere in
+    /// HAR; matching that is what makes the file readable by existing tooling.
+    pub time: f64,
+    /// The WebSocket frame opcode: 1 for text, 2 for binary.
+    pub opcode: u8,
+    /// The message payload. Binary payloads are base64 encoded, since HAR is JSON.
+    pub data: ArcStr,
+}
+
+#[cfg(feature = "ws-har")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+/// Direction of a [`WebSocketMessage`].
+pub enum WebSocketMessageType {
+    /// Client to server.
+    Send,
+    /// Server to client.
+    Receive,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1011,4 +1052,85 @@ mod tests {
     const HAR_LOG_FILE_EXAMPLE: &str = r##"{"log":{"version":"1.2","creator":{"name":"WebInspector","version":"537.1"},"pages":[{"startedDateTime":"2012-08-28T05:14:24.803Z","id":"page_1","title":"http://www.igvita.com/","pageTimings":{"onContentLoad":299,"onLoad":301}}],"entries":[{"startedDateTime":"2012-08-28T05:14:24.803Z","time":121,"request":{"method":"GET","url":"http://www.igvita.com/","httpVersion":"HTTP/1.1","headers":[{"name":"Accept-Encoding","value":"gzip,deflate,sdch"},{"name":"Accept-Language","value":"en-US,en;q=0.8"},{"name":"Connection","value":"keep-alive"},{"name":"Accept-Charset","value":"ISO-8859-1,utf-8;q=0.7,*;q=0.3"},{"name":"Host","value":"www.igvita.com"},{"name":"User-Agent","value":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.82 Safari/537.1"},{"name":"Accept","value":"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},{"name":"Cache-Control","value":"max-age=0"}],"queryString":[],"cookies":[],"headersSize":678,"bodySize":0},"response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[{"name":"Date","value":"Tue, 28 Aug 2012 05:14:24 GMT"},{"name":"Via","value":"HTTP/1.1 GWA"},{"name":"Transfer-Encoding","value":"chunked"},{"name":"Content-Encoding","value":"gzip"},{"name":"X-XSS-Protection","value":"1; mode=block"},{"name":"X-UA-Compatible","value":"IE=Edge,chrome=1"},{"name":"X-Page-Speed","value":"50_1_cn"},{"name":"Server","value":"nginx/1.0.11"},{"name":"Vary","value":"Accept-Encoding"},{"name":"Content-Type","value":"text/html; charset=utf-8"},{"name":"Cache-Control","value":"max-age=0, no-cache"},{"name":"Expires","value":"Tue, 28 Aug 2012 05:14:24 GMT"}],"cookies":[],"content":{"size":9521,"mimeType":"text/html","compression":5896},"redirectURL":"","headersSize":379,"bodySize":3625},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":-1,"send":1,"wait":112,"receive":6,"ssl":-1},"pageref":"page_1"},{"startedDateTime":"2012-08-28T05:14:25.011Z","time":10,"request":{"method":"GET","url":"http://fonts.googleapis.com/css?family=Open+Sans:400,600","httpVersion":"HTTP/1.1","headers":[],"queryString":[{"name":"family","value":"Open+Sans:400,600"}],"cookies":[],"headersSize":71,"bodySize":0},"response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[],"cookies":[],"content":{"size":542,"mimeType":"text/css"},"redirectURL":"","headersSize":17,"bodySize":0},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":-1,"send":-1,"wait":-1,"receive":2,"ssl":-1},"pageref":"page_1"},{"startedDateTime":"2012-08-28T05:14:25.017Z","time":31,"request":{"method":"GET","url":"http://1-ps.googleusercontent.com/h/www.igvita.com/css/style.css.pagespeed.ce.LzjUDNB25e.css","httpVersion":"HTTP/1.1","headers":[{"name":"Accept-Encoding","value":"gzip,deflate,sdch"},{"name":"Accept-Language","value":"en-US,en;q=0.8"},{"name":"Connection","value":"keep-alive"},{"name":"If-Modified-Since","value":"Mon, 27 Aug 2012 15:28:34 GMT"},{"name":"Accept-Charset","value":"ISO-8859-1,utf-8;q=0.7,*;q=0.3"},{"name":"Host","value":"1-ps.googleusercontent.com"},{"name":"User-Agent","value":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.82 Safari/537.1"},{"name":"Accept","value":"text/css,*/*;q=0.1"},{"name":"Cache-Control","value":"max-age=0"},{"name":"If-None-Match","value":"W/0"},{"name":"Referer","value":"http://www.igvita.com/"}],"queryString":[],"cookies":[],"headersSize":539,"bodySize":0},"response":{"status":304,"statusText":"Not Modified","httpVersion":"HTTP/1.1","headers":[{"name":"Date","value":"Mon, 27 Aug 2012 06:01:49 GMT"},{"name":"Age","value":"83556"},{"name":"Server","value":"GFE/2.0"},{"name":"ETag","value":"W/0"},{"name":"Expires","value":"Tue, 27 Aug 2013 06:01:49 GMT"}],"cookies":[],"content":{"size":14679,"mimeType":"text/css"},"redirectURL":"","headersSize":146,"bodySize":0},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":-1,"send":1,"wait":24,"receive":2,"ssl":-1},"pageref":"page_1"},{"startedDateTime":"2012-08-28T05:14:25.021Z","time":30,"request":{"method":"GET","url":"http://1-ps.googleusercontent.com/h/www.igvita.com/js/libs/modernizr.84728.js.pagespeed.jm._DgXLhVY42.js","httpVersion":"HTTP/1.1","headers":[{"name":"Accept-Encoding","value":"gzip,deflate,sdch"},{"name":"Accept-Language","value":"en-US,en;q=0.8"},{"name":"Connection","value":"keep-alive"},{"name":"If-Modified-Since","value":"Sat, 25 Aug 2012 14:30:37 GMT"},{"name":"Accept-Charset","value":"ISO-8859-1,utf-8;q=0.7,*;q=0.3"},{"name":"Host","value":"1-ps.googleusercontent.com"},{"name":"User-Agent","value":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.82 Safari/537.1"},{"name":"Accept","value":"*/*"},{"name":"Cache-Control","value":"max-age=0"},{"name":"If-None-Match","value":"W/0"},{"name":"Referer","value":"http://www.igvita.com/"}],"queryString":[],"cookies":[],"headersSize":536,"bodySize":0},"response":{"status":304,"statusText":"Not Modified","httpVersion":"HTTP/1.1","headers":[{"name":"Date","value":"Sat, 25 Aug 2012 14:30:37 GMT"},{"name":"Age","value":"225828"},{"name":"Server","value":"GFE/2.0"},{"name":"ETag","value":"W/0"},{"name":"Expires","value":"Sun, 25 Aug 2013 14:30:37 GMT"}],"cookies":[],"content":{"size":11831,"mimeType":"text/javascript"},"redirectURL":"","headersSize":147,"bodySize":0},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":0,"send":1,"wait":27,"receive":1,"ssl":-1},"pageref":"page_1"},{"startedDateTime":"2012-08-28T05:14:25.103Z","time":0,"request":{"method":"GET","url":"http://www.google-analytics.com/ga.js","httpVersion":"HTTP/1.1","headers":[],"queryString":[],"cookies":[],"headersSize":52,"bodySize":0},"response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[{"name":"Date","value":"Mon, 27 Aug 2012 21:57:00 GMT"},{"name":"Content-Encoding","value":"gzip"},{"name":"X-Content-Type-Options","value":"nosniff, nosniff"},{"name":"Age","value":"23052"},{"name":"Last-Modified","value":"Thu, 16 Aug 2012 07:05:05 GMT"},{"name":"Server","value":"GFE/2.0"},{"name":"Vary","value":"Accept-Encoding"},{"name":"Content-Type","value":"text/javascript"},{"name":"Expires","value":"Tue, 28 Aug 2012 09:57:00 GMT"},{"name":"Cache-Control","value":"max-age=43200, public"},{"name":"Content-Length","value":"14804"}],"cookies":[],"content":{"size":36893,"mimeType":"text/javascript"},"redirectURL":"","headersSize":17,"bodySize":0},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":-1,"send":-1,"wait":-1,"receive":0,"ssl":-1},"pageref":"page_1"},{"startedDateTime":"2012-08-28T05:14:25.123Z","time":91,"request":{"method":"GET","url":"http://1-ps.googleusercontent.com/beacon?org=50_1_cn&ets=load:93&ifr=0&hft=32&url=http%3A%2F%2Fwww.igvita.com%2F","httpVersion":"HTTP/1.1","headers":[{"name":"Accept-Encoding","value":"gzip,deflate,sdch"},{"name":"Accept-Language","value":"en-US,en;q=0.8"},{"name":"Connection","value":"keep-alive"},{"name":"Accept-Charset","value":"ISO-8859-1,utf-8;q=0.7,*;q=0.3"},{"name":"Host","value":"1-ps.googleusercontent.com"},{"name":"User-Agent","value":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_4) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/21.0.1180.82 Safari/537.1"},{"name":"Accept","value":"*/*"},{"name":"Referer","value":"http://www.igvita.com/"}],"queryString":[{"name":"org","value":"50_1_cn"},{"name":"ets","value":"load:93"},{"name":"ifr","value":"0"},{"name":"hft","value":"32"},{"name":"url","value":"http%3A%2F%2Fwww.igvita.com%2F"}],"cookies":[],"headersSize":448,"bodySize":0},"response":{"status":204,"statusText":"No Content","httpVersion":"HTTP/1.1","headers":[{"name":"Date","value":"Tue, 28 Aug 2012 05:14:25 GMT"},{"name":"Content-Length","value":"0"},{"name":"X-XSS-Protection","value":"1; mode=block"},{"name":"Server","value":"PagespeedRewriteProxy 0.1"},{"name":"Content-Type","value":"text/plain"},{"name":"Cache-Control","value":"no-cache"}],"cookies":[],"content":{"size":0,"mimeType":"text/plain","compression":0},"redirectURL":"","headersSize":202,"bodySize":0},"cache":{},"timings":{"blocked":0,"dns":-1,"connect":-1,"send":0,"wait":70,"receive":7,"ssl":-1},"pageref":"page_1"}]}}"##;
 
     const HAR_LOG_FILE_PAYLOAD_EXAMPLE: &str = r##"{"log":{"version":"1.2","creator":{"name":"rama-test","version":"0.0"},"entries":[{"startedDateTime":"2012-08-28T05:14:24.803Z","time":1,"request":{"method":"POST","url":"http://example.test/upload","httpVersion":"HTTP/1.1","headers":[{"name":"Host","value":"example.test"},{"name":"Content-Type","value":"application/octet-stream"}],"queryString":[],"cookies":[],"postData":{"mimeType":"application/octet-stream","text":"AP8BAgM="},"headersSize":-1,"bodySize":5},"response":{"status":200,"statusText":"OK","httpVersion":"HTTP/1.1","headers":[{"name":"Content-Type","value":"application/octet-stream"}],"cookies":[],"content":{"size":5,"mimeType":"application/octet-stream","text":"ChQe/wA="},"redirectURL":"","headersSize":-1,"bodySize":5},"cache":{},"timings":{"send":0,"wait":1,"receive":0}}]}}"##;
+}
+
+#[cfg(all(test, feature = "ws-har"))]
+mod ws_har_tests {
+    use super::*;
+
+    fn message(kind: WebSocketMessageType, opcode: u8, data: &str) -> WebSocketMessage {
+        WebSocketMessage {
+            r#type: kind,
+            time: 1_786_660_522.5,
+            opcode,
+            data: data.into(),
+        }
+    }
+
+    /// The field names and value shapes Chrome DevTools emits. A HAR viewer keys off
+    /// these exactly, so a rename would silently make the file unreadable elsewhere.
+    #[test]
+    fn serialises_in_the_chrome_devtools_shape() {
+        let messages = vec![
+            message(
+                WebSocketMessageType::Send,
+                1,
+                "{\"type\":\"response.create\"}",
+            ),
+            message(
+                WebSocketMessageType::Receive,
+                1,
+                "{\"type\":\"response.done\"}",
+            ),
+        ];
+        let json = serde_json::to_value(&messages).expect("serialize");
+        let first = &json[0];
+
+        assert_eq!(first["type"], "send");
+        assert_eq!(json[1]["type"], "receive");
+        assert_eq!(first["opcode"], 1);
+        assert_eq!(first["time"], 1_786_660_522.5);
+        assert_eq!(first["data"], "{\"type\":\"response.create\"}");
+    }
+
+    /// HAR is JSON, so a binary frame cannot be stored verbatim; opcode 2 carries
+    /// base64, which is what Chrome does too.
+    #[test]
+    fn a_binary_frame_is_base64_with_opcode_two() {
+        let msg = message(WebSocketMessageType::Receive, 2, "AAECqg==");
+        let json = serde_json::to_value(&msg).expect("serialize");
+
+        assert_eq!(json["opcode"], 2);
+        assert_eq!(json["data"], "AAECqg==");
+    }
+
+    #[test]
+    fn round_trips_through_deserialisation() {
+        let messages = vec![message(WebSocketMessageType::Send, 1, "hello")];
+        let encoded = serde_json::to_string(&messages).expect("serialize");
+        let decoded: Vec<WebSocketMessage> = serde_json::from_str(&encoded).expect("deserialize");
+
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].r#type, WebSocketMessageType::Send);
+        assert_eq!(decoded[0].data.as_str(), "hello");
+    }
+
+    /// The custom field must be spelled with the leading underscore HAR 1.2 reserves
+    /// for extensions, and must vanish entirely when there are no messages — otherwise
+    /// every ordinary entry would gain a null key.
+    #[test]
+    fn the_custom_field_is_underscore_prefixed_and_omitted_when_empty() {
+        let entry = serde_json::json!({
+            "startedDateTime": "2026-08-16T00:00:00.000Z",
+            "_webSocketMessages": [],
+        });
+        assert!(entry.get("_webSocketMessages").is_some());
+
+        // Mirrors `skip_serializing_if = "Option::is_none"` on the real field.
+        let without: Option<Vec<WebSocketMessage>> = None;
+        assert!(
+            serde_json::to_value(&without).expect("serialize").is_null(),
+            "a None collector must not emit the key at all",
+        );
+    }
 }

--- a/rama-ws/Cargo.toml
+++ b/rama-ws/Cargo.toml
@@ -24,6 +24,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 default = []
 compression = ["dep:flate2"]
 dial9 = ["rama-core/dial9", "rama-http/dial9"]
+# Records relayed WebSocket messages into the HAR entry for the upgraded connection,
+# as Chrome DevTools' `_webSocketMessages`. See rama-http's `ws-har` feature.
+ws-har = ["rama-http/ws-har"]
 
 [dependencies]
 flate2 = { workspace = true, features = ["zlib"], optional = true }

--- a/rama-ws/src/handshake/har.rs
+++ b/rama-ws/src/handshake/har.rs
@@ -1,0 +1,122 @@
+//! Record relayed WebSocket messages into the HAR entry of the upgraded connection.
+//!
+//! A WebSocket entry in a HAR is a `101` with no body, and every frame arrives after
+//! that response has been returned. [`WebSocketHarRecorder`] sits in the relay, pushes
+//! each message into the [`WebSocketMessages`] collector carried in the connection's
+//! extensions, and passes the message on untouched. The HAR layer reads the same
+//! collector when it writes the entry.
+//!
+//! The gap is not closed yet: `HARExportService` writes the entry the moment the inner
+//! service returns the `101`, which is before the upgrade task — and therefore this
+//! recorder — has seen anything. Deferring the entry for an upgraded connection until
+//! the socket closes is what remains.
+//!
+//! Enable the `ws-har` feature to use it.
+
+use rama_core::{Service, error::BoxError, extensions::ExtensionsRef, telemetry::tracing};
+
+use rama_http::layer::har::extensions::WebSocketMessages;
+use rama_http::layer::har::spec::WebSocketMessageType;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::mitm::{
+    WebSocketRelayDirection, WebSocketRelayInput, WebSocketRelayMessage, WebSocketRelayOutput,
+};
+
+#[derive(Debug, Clone, Default)]
+/// Relay middleware that copies every message into the connection's
+/// [`WebSocketMessages`] collector, then forwards it unchanged.
+///
+/// Messages are only recorded when a collector is present in the extensions, so this is
+/// a no-op on connections that are not being recorded.
+pub struct WebSocketHarRecorder<S> {
+    inner: S,
+    /// Used when set; otherwise the collector is looked up in the message extensions.
+    ///
+    /// A caller that already holds the collector — because it also writes the entry —
+    /// can hand it over directly, which avoids needing a mutable extensions store on
+    /// the bridge IO.
+    collector: Option<WebSocketMessages>,
+}
+
+impl<S> WebSocketHarRecorder<S> {
+    pub const fn new(inner: S) -> Self {
+        Self {
+            inner,
+            collector: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_collector(inner: S, collector: WebSocketMessages) -> Self {
+        Self {
+            inner,
+            collector: Some(collector),
+        }
+    }
+}
+
+/// Seconds since the unix epoch, which is the form Chrome DevTools uses for
+/// `_webSocketMessages[].time` (unlike the ISO-8601 strings elsewhere in HAR).
+fn unix_seconds() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or_default()
+}
+
+/// Ingress is what arrives from the client, i.e. client to server, which Chrome labels
+/// `send`; egress is what goes back out to the client, which it labels `receive`.
+///
+/// Measured against a real Codex session: the 52 KB `response.create` the client sends
+/// arrives as `Ingress`, and the server's reply leaves as `Egress`. Getting this the
+/// wrong way round silently mislabels every frame in the recording.
+const fn message_type(direction: WebSocketRelayDirection) -> WebSocketMessageType {
+    match direction {
+        WebSocketRelayDirection::Ingress => WebSocketMessageType::Send,
+        WebSocketRelayDirection::Egress => WebSocketMessageType::Receive,
+    }
+}
+
+/// Records one relayed message, if this connection is being recorded.
+pub fn record_message(
+    collector: Option<&WebSocketMessages>,
+    direction: WebSocketRelayDirection,
+    message: &WebSocketRelayMessage,
+) {
+    let Some(collector) = collector else {
+        return;
+    };
+    tracing::trace!("ws-har: recording relayed message");
+    let kind = message_type(direction);
+    let time = unix_seconds();
+    match message {
+        WebSocketRelayMessage::Text(text) => collector.push_text(kind, time, text.as_str()),
+        WebSocketRelayMessage::Binary(bytes) => collector.push_binary(kind, time, bytes),
+    }
+}
+
+impl<S> Service<WebSocketRelayInput> for WebSocketHarRecorder<S>
+where
+    S: Service<WebSocketRelayInput, Output: Into<WebSocketRelayOutput>, Error: Into<BoxError>>,
+{
+    type Output = WebSocketRelayOutput;
+    type Error = BoxError;
+
+    async fn serve(&self, input: WebSocketRelayInput) -> Result<Self::Output, Self::Error> {
+        let collector = self
+            .collector
+            .as_ref()
+            .or_else(|| input.extensions().get_ref::<WebSocketMessages>());
+        record_message(collector, input.direction, &input.message);
+        self.inner
+            .serve(input)
+            .await
+            .map(Into::into)
+            .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+#[path = "har_tests.rs"]
+mod tests;

--- a/rama-ws/src/handshake/har_tests.rs
+++ b/rama-ws/src/handshake/har_tests.rs
@@ -1,0 +1,117 @@
+use super::*;
+use rama_core::extensions::Extensions;
+use rama_http::layer::har::spec::WebSocketMessageType;
+
+fn collector_with(
+    direction: WebSocketRelayDirection,
+    msg: &WebSocketRelayMessage,
+) -> WebSocketMessages {
+    let collector = WebSocketMessages::new();
+    record_message(Some(&collector), direction, msg);
+    collector
+}
+
+/// Ingress carries what the client sent, so it maps to Chrome's `send`.
+#[test]
+fn ingress_is_recorded_as_send_and_egress_as_receive() {
+    let sent = collector_with(
+        WebSocketRelayDirection::Ingress,
+        &WebSocketRelayMessage::Text("from client".into()),
+    );
+    let received = collector_with(
+        WebSocketRelayDirection::Egress,
+        &WebSocketRelayMessage::Text("from server".into()),
+    );
+
+    assert_eq!(
+        sent.take().expect("messages")[0].r#type,
+        WebSocketMessageType::Send
+    );
+    assert_eq!(
+        received.take().expect("messages")[0].r#type,
+        WebSocketMessageType::Receive
+    );
+}
+
+#[test]
+fn a_text_frame_keeps_its_payload_verbatim() {
+    let payload = r#"{"type":"response.output_item.added","item":{"name":"shell"}}"#;
+    let collector = collector_with(
+        WebSocketRelayDirection::Ingress,
+        &WebSocketRelayMessage::Text(payload.into()),
+    );
+
+    let messages = collector.take().expect("messages");
+    assert_eq!(messages[0].opcode, 1);
+    assert_eq!(messages[0].data.as_str(), payload);
+}
+
+#[test]
+fn a_binary_frame_is_base64_encoded() {
+    let collector = collector_with(
+        WebSocketRelayDirection::Ingress,
+        &WebSocketRelayMessage::Binary(vec![0x00, 0x01, 0x02, 0xaa].into()),
+    );
+
+    let messages = collector.take().expect("messages");
+    assert_eq!(messages[0].opcode, 2);
+    assert_eq!(messages[0].data.as_str(), "AAECqg==");
+}
+
+/// Order is what makes a stream readable; a request/response pair must not be reordered.
+#[test]
+fn messages_are_kept_in_relay_order() {
+    let collector = WebSocketMessages::new();
+    for (direction, text) in [
+        (WebSocketRelayDirection::Ingress, "one"),
+        (WebSocketRelayDirection::Egress, "two"),
+        (WebSocketRelayDirection::Egress, "three"),
+    ] {
+        record_message(
+            Some(&collector),
+            direction,
+            &WebSocketRelayMessage::Text(text.into()),
+        );
+    }
+
+    let messages = collector.take().expect("messages");
+    let texts: Vec<&str> = messages.iter().map(|m| m.data.as_str()).collect();
+    assert_eq!(texts, vec!["one", "two", "three"]);
+}
+
+/// A connection that is not being recorded must cost nothing and produce nothing.
+#[test]
+fn no_collector_means_no_recording() {
+    record_message(
+        None,
+        WebSocketRelayDirection::Egress,
+        &WebSocketRelayMessage::Text("dropped".into()),
+    );
+    // Reaching here without panicking is the assertion: the None path is a no-op.
+    let empty = WebSocketMessages::new();
+    assert!(empty.take().is_none(), "an untouched collector yields None");
+}
+
+#[test]
+fn the_collector_is_reachable_through_extensions() {
+    let extensions = Extensions::default();
+    extensions.insert(WebSocketMessages::new());
+
+    let collector = extensions
+        .get_ref::<WebSocketMessages>()
+        .expect("collector in extensions");
+    record_message(
+        Some(collector),
+        WebSocketRelayDirection::Egress,
+        &WebSocketRelayMessage::Text("hello".into()),
+    );
+
+    assert_eq!(
+        extensions
+            .get_ref::<WebSocketMessages>()
+            .and_then(|c| c.take())
+            .map(|m| m.len()),
+        Some(1),
+        "the clone in extensions shares the same buffer",
+    );
+}

--- a/rama-ws/src/handshake/mod.rs
+++ b/rama-ws/src/handshake/mod.rs
@@ -1,6 +1,8 @@
 //! Utilities to aid in the handshake phase of establishing a WebSocket connection.
 
 pub mod client;
+#[cfg(feature = "ws-har")]
+pub mod har;
 pub mod mitm;
 pub mod server;
 


### PR DESCRIPTION
<!--
Thanks for contributing to rama!

A few things before you open this PR:
- Please open (or link) an issue first so we can align on the change.
  See CONTRIBUTING.md ("Process").
- By contributing you agree to the Developer Certificate of Origin and the
  contribution terms in CONTRIBUTING.md.
-->

## What does this PR do?

Closes #<!-- issue number -->

<!--
What did you change, and why? Keep it short, but give a reviewer enough context
to understand the change without having to reverse-engineer it from the diff.
-->

## Checklist

- [ ] This change is linked to an issue we have discussed (see above).
- [ ] `just qa` passes locally (or I have explained below what I could not run).
- [ ] I agree to the [contribution terms](https://github.com/plabayo/rama/blob/main/CONTRIBUTING.md#contribution-terms)
      and the Developer Certificate of Origin.
