### PR TITLE
update dial9 to 0.5 and make tokio_unstable optional

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,17 +1,5 @@
 # Workspace-wide build flags.
 #
-# `tokio_unstable` is set so that any rama crate which opts into the
-# `dial9` cargo feature can depend on `dial9-tokio-telemetry` and emit
-# events from its own lifecycle hooks. dial9 hooks into Tokio's unstable
-# runtime APIs and refuses to compile without this flag.
-#
-# It is benign for crates that do not reference unstable Tokio APIs —
-# the flag only widens the API surface; it does not change behaviour
-# of the stable surface. We rely on `cargo clippy -D warnings` and
-# code review to keep accidental unstable-API usage out of crates that
-# don't intentionally opt into it.
-[build]
-rustflags = ["--cfg", "tokio_unstable"]
 
 # Resilient crates.io fetches for fragile environments like CI.
 [net]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-# Workspace-wide build flags.
-#
-
 # Resilient crates.io fetches for fragile environments like CI.
 [net]
 retry = 10

--- a/.github/workflows/CI-unstable.yml
+++ b/.github/workflows/CI-unstable.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: ${{ matrix.os == 'windows-latest' && matrix.profile == 'release' && 210 || 150 }}
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
@@ -123,7 +123,6 @@ jobs:
       RUSTUP_TOOLCHAIN: beta
       # No `-D warnings` here: we want clippy to apply as many
       # auto-fixes as it can, even if some lints remain unfixable.
-      RUSTFLAGS: --cfg tokio_unstable
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -238,11 +237,7 @@ jobs:
       # toolchain can pick up `+crt-static` from a recent image
       # default, so disable it explicitly here. rustc emits exactly
       # this fix in the error message when the combination fires.
-      # Also keep `--cfg tokio_unstable` here because setting
-      # RUSTFLAGS via env overrides the workspace's
-      # `.cargo/config.toml` rustflags entirely (rather than
-      # appending).
-      RUSTFLAGS: "--cfg tokio_unstable -C target-feature=-crt-static"
+      RUSTFLAGS: "-C target-feature=-crt-static"
       # `cargo-fuzz` uses the host triple by default. A recent
       # ubuntu-latest image flipped that to
       # `x86_64-unknown-linux-musl`, which isn't installed by

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -240,6 +240,14 @@ jobs:
         run: just qa-ffi-apple
       - name: Run transparent proxy Apple FFI e2e tests
         run: just test-e2e-ffi-apple
+      - name: Dump crash reports
+        if: failure()
+        run: |
+          sleep 10
+          for f in ~/Library/Logs/DiagnosticReports/*; do
+            echo "=== $f ==="
+            cat "$f" || true
+          done
 
   test-rama-apple-ne-swift-ffi:
     runs-on: macos-latest
@@ -261,6 +269,14 @@ jobs:
         run: brew install just
       - name: Run RamaAppleNetworkExtension Swift FFI tests
         run: just test-e2e-ffi-swift
+      - name: Dump crash reports
+        if: failure()
+        run: |
+          sleep 10
+          for f in ~/Library/Logs/DiagnosticReports/*; do
+            echo "=== $f ==="
+            cat "$f" || true
+          done
 
   test-rama-apple-xpc:
     runs-on: macos-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
   precheck-rust:
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -72,7 +72,7 @@ jobs:
       - precheck-docs
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.toolchain }}
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
@@ -104,7 +104,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
       RUSTDOCFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -141,7 +141,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
@@ -196,7 +196,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -220,7 +220,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -247,7 +247,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -268,7 +268,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -336,7 +336,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -410,7 +410,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -536,7 +536,7 @@ jobs:
       - precheck-docs
     runs-on: ${{ matrix.os }}
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -590,29 +590,29 @@ jobs:
         run: |
           cargo build --target ${{ matrix.target }} --tests --all-features
 
-  test-baseline-no-tokio-unstable:
+  # The rest of CI builds rama on stable tokio. This job covers dial9's full-fidelity path
+  test-dial9-tokio-unstable:
     runs-on: ubuntu-latest
     needs:
       - precheck-rust
       - precheck-docs
-    env:
-      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{env.RUST_TOOLCHAIN}}
+          components: clippy
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2.86.7
         with:
-          tool: nextest
+          tool: just
       - uses: ./.github/actions/rust-cache
         with:
           env-vars: "RUST_TOOLCHAIN=${{env.RUST_TOOLCHAIN}}"
-          key: ubuntu-latest-${{env.RUST_TOOLCHAIN}}-baseline-no-tokio-unstable
-      - name: Baseline tests without tokio_unstable
-        run: |
-          cargo nextest run --workspace
-          cargo test --doc --workspace
+          key: ubuntu-latest-${{env.RUST_TOOLCHAIN}}-dial9-tokio-unstable
+      # The recipe sets `--cfg tokio_unstable`, setting RUSTFLAGS here would
+      # not survive the justfile's own `export RUSTFLAGS`.
+      - name: Run dial9 QA checks under tokio_unstable
+        run: just qa-dial9-tokio-unstable
 
   test-loom:
     runs-on: ubuntu-latest
@@ -663,13 +663,14 @@ jobs:
       - name: cargo hack check without dial9
         run: cargo hack check --each-feature --exclude-features dial9 --exclude-all-features --no-dev-deps --workspace
 
+  # Every feature combination, dial9 included
   cargo-hack-dial9:
     runs-on: ubuntu-latest
     needs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -724,7 +725,7 @@ jobs:
       - precheck-rust
       - precheck-docs
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ilammy/setup-nasm@72793074d3c8cdda771dba85f6deafe00623038b # v1.5.2
@@ -753,7 +754,7 @@ jobs:
     # The server suite usually takes ~12-22m.
     timeout-minutes: 90
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -780,7 +781,7 @@ jobs:
     # have occasionally made it exceed 25m.
     timeout-minutes: 90
     env:
-      RUSTFLAGS: -D warnings --cfg tokio_unstable
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -838,7 +839,7 @@ jobs:
       - test-fastcgi-php
       - test-rust-linux-musl
       - test-rama-apple-xpc
-      - test-baseline-no-tokio-unstable
+      - test-dial9-tokio-unstable
       - test-loom
       - cargo-hack-base
       - cargo-hack-dial9

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -818,6 +818,12 @@ jobs:
     needs:
       - precheck-rust
       - precheck-docs
+    env:
+      # The released 0.4 baseline still depends on dial9 0.3, which only
+      # compiles with Tokio's unstable APIs (the workspace config used to
+      # carry this flag). Drop once a dial9-0.5-based rama is the
+      # published baseline.
+      RUSTFLAGS: --cfg tokio_unstable
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check semver

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -240,14 +240,18 @@ jobs:
         run: just qa-ffi-apple
       - name: Run transparent proxy Apple FFI e2e tests
         run: just test-e2e-ffi-apple
-      - name: Dump crash reports
+      - name: Rerun Swift FFI battery under lldb on failure
         if: failure()
         run: |
-          sleep 10
-          for f in ~/Library/Logs/DiagnosticReports/*; do
-            echo "=== $f ==="
-            cat "$f" || true
-          done
+          sysctl hw.ncpu hw.memsize
+          ulimit -n
+          xcrun lldb --batch \
+            -o "run" \
+            -k "thread backtrace all" \
+            -k "quit 1" \
+            -o "quit" \
+            -- "$(xcrun --find xctest)" \
+            .build/arm64-apple-macosx/debug/RamaAppleNetworkExtensionPackageTests.xctest
 
   test-rama-apple-ne-swift-ffi:
     runs-on: macos-latest
@@ -269,14 +273,18 @@ jobs:
         run: brew install just
       - name: Run RamaAppleNetworkExtension Swift FFI tests
         run: just test-e2e-ffi-swift
-      - name: Dump crash reports
+      - name: Rerun Swift FFI battery under lldb on failure
         if: failure()
         run: |
-          sleep 10
-          for f in ~/Library/Logs/DiagnosticReports/*; do
-            echo "=== $f ==="
-            cat "$f" || true
-          done
+          sysctl hw.ncpu hw.memsize
+          ulimit -n
+          xcrun lldb --batch \
+            -o "run" \
+            -k "thread backtrace all" \
+            -k "quit 1" \
+            -o "quit" \
+            -- "$(xcrun --find xctest)" \
+            .build/arm64-apple-macosx/debug/RamaAppleNetworkExtensionPackageTests.xctest
 
   test-rama-apple-xpc:
     runs-on: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "blazesym"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847a0a95b041ad5aae1bdc44f2bd54743f76eb0065c4f86b139f81343c287eaf"
+dependencies = [
+ "cpp_demangle",
+ "crc32fast",
+ "flate2",
+ "gimli",
+ "libc",
+ "memmap2",
+ "rustc-demangle",
+ "tempfile",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +527,12 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "c-enum"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd17eb909a8c6a894926bfcc3400a4bb0e732f5a57d37b1f14e8b29e329bace8"
 
 [[package]]
 name = "castaway"
@@ -1284,10 +1306,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-macro"
-version = "0.3.7"
+name = "dial9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7e31f073f2e14e5a9d338c543a0601aeaf7c43fc428cd59ce417230d0db37d"
+checksum = "49b11bce55173f77d9003cce8f129b4af889a4639005c53c3498cef933bc895c"
+dependencies = [
+ "bon",
+ "dial9-core",
+ "dial9-macro",
+ "dial9-metrique",
+ "dial9-perf-self-profile",
+ "dial9-tokio-telemetry",
+ "dial9-trace-format",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8cbbc8955394be626249a3b52ddd6bf664373661eaeae70d87eb12bf6f20b6"
+dependencies = [
+ "arc-swap",
+ "bon",
+ "bytes",
+ "crossbeam-queue",
+ "dial9-trace-format",
+ "flate2",
+ "futures-util",
+ "libc",
+ "metrique",
+ "metrique-timesource",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
+name = "dial9-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4177b8f8bf95d8e3769c1aad596f5d6fb231953a45c4c3d2a5946fe8e4ec327b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1295,24 +1356,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-tokio-telemetry"
-version = "0.3.15"
+name = "dial9-metrique"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b511dfd54f5191f7eb86856fe19d8e3c8f71673bd256e1bfa1c8128fbbc0cdb"
+checksum = "d42fe0e3e14e8780c4ecf9ee14c183dbcb9b1ae3612cc9a689e7dc83b13adef1"
 dependencies = [
- "arc-swap",
+ "dial9-core",
+ "dial9-trace-format",
+ "metrique",
+ "metrique-writer",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-perf-self-profile"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f65948455c504bf08576c7b5cfe93bfcaa486d661dc4ee85c2a6309ab89629"
+dependencies = [
+ "blazesym",
+ "bytes",
+ "crossbeam-utils",
+ "dial9-core",
+ "dial9-trace-format",
+ "libc",
+ "perf-event-data",
+ "perf-event-open-sys2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-tokio-telemetry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1244091367c805b5d98a6a590f8ab992efda06e6d2560a6967ef898ffd30a2"
+dependencies = [
  "bon",
  "bytes",
- "crossbeam-queue",
- "dial9-macro",
+ "dial9-core",
  "dial9-trace-format",
  "flate2",
  "futures-util",
  "hostname",
  "libc",
- "metrique",
  "metrique-timesource",
- "metrique-writer",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -1324,20 +1413,22 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3636d6ec60d94840cc414dcd6a95c77b3ba0a7b86d43fd035b89662eeb5cfa7"
+checksum = "86083b7240114b2d0da4a7e9d041571d80ca3b1f92ae0ec794f1be21709daa6a"
 dependencies = [
  "dial9-trace-format-derive",
  "serde",
+ "typeid",
 ]
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff7c2855b73d0de34bc31d6dc7afbf0f6ce230a668403ac2b57b21d1ffe3928"
+checksum = "9309248f12e414d88bcc9505f78b0c9ed47f79c5b62db611493e19a612cdc9d6"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1643,6 +1734,7 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2754,7 +2846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b55bfa39e6f5e44a37a59a794915ce36d04371471cf62ae365cd9703f58a5e0"
 dependencies = [
  "itoa",
- "jiff",
  "metrique-core",
  "metrique-macro",
  "metrique-service-metrics",
@@ -2763,7 +2854,6 @@ dependencies = [
  "metrique-writer-core",
  "metrique-writer-macro",
  "ryu",
- "serde_json",
  "tokio",
 ]
 
@@ -3292,6 +3382,27 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "perf-event-data"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575828d9d7d205188048eb1508560607a03d21eafdbba47b8cade1736c1c28e1"
+dependencies = [
+ "bitflags 2.13.1",
+ "c-enum",
+ "perf-event-open-sys2",
+]
+
+[[package]]
+name = "perf-event-open-sys2"
+version = "5.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c25955321465255e437600b54296983fab1feac2cd0c38958adeb26dbae49e"
+dependencies = [
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "pest"
@@ -3937,7 +4048,7 @@ dependencies = [
  "ahash",
  "asynk-strim",
  "bytes",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "futures",
  "opentelemetry",
@@ -3995,7 +4106,7 @@ dependencies = [
  "arc-swap",
  "base64 0.23.1",
  "bindgen",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "hickory-resolver",
  "libc",
@@ -4400,7 +4511,7 @@ dependencies = [
  "const_format",
  "core-foundation 0.10.1",
  "csv",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "idna",
  "ipnet",
@@ -4441,7 +4552,7 @@ dependencies = [
  "atomic-waker",
  "bindgen",
  "cc",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "libc",
  "parking_lot",
@@ -4512,7 +4623,7 @@ name = "rama-socks5"
 version = "0.5.0"
 dependencies = [
  "byteorder",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "parking_lot",
  "rama-core",
@@ -4587,7 +4698,7 @@ dependencies = [
  "ahash",
  "brotli",
  "der",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "flate2",
  "itertools 0.15.0",
@@ -4612,7 +4723,7 @@ dependencies = [
 name = "rama-tls-rustls"
 version = "0.5.0"
 dependencies = [
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "moka",
  "pin-project-lite",
@@ -6289,6 +6400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6299,6 +6416,16 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.5",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"
@@ -7376,6 +7503,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,8 +122,8 @@ const_format = "0.2"
 core-foundation = "0.10"
 csv = "1.4"
 derive_more = "2.1"
-dial9-tokio-telemetry = "0.3.15"
-dial9-trace-format = "0.4"
+dial9 = { version = "0.5.0", default-features = false, features = ["tokio"] }
+dial9-trace-format = "0.5.0"
 divan = "0.1"
 escargot = "0.5"
 flate2 = "1.1"
@@ -526,15 +526,17 @@ opentelemetry = [
 ]
 # Optional [dial9] runtime-telemetry support across the rama crate
 # family. Sub-crates either ship predefined `TraceEvent` types or forward
-# support to shared runtime boundaries. Event emission is a no-op when the
-# consumer's runtime is not a `dial9-tokio-telemetry::TracedRuntime`.
+# support to shared runtime boundaries. Event emission is a no-op when no
+# `dial9` recorder is attached to the consumer's runtime.
 #
-# Enabling this feature requires building with `--cfg tokio_unstable`
-# (workspace-wide via `.cargo/config.toml`, or per-build via
-# `RUSTFLAGS`). Users who DO NOT enable `dial9` do not need
-# `tokio_unstable`.
+# `--cfg tokio_unstable` is optional. Without it dial9 takes poll
+# events from its own spawn helpers, so coverage is the tasks rama
+# routes through `rama_core::rt::Executor`. Set it (per-build via
+# `RUSTFLAGS`, or in your `.cargo/config.toml`) to also get every
+# other task on the runtime, task spawn/terminate events and
+# per-worker queue depth.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+# [dial9]: https://github.com/dial9-rs/dial9
 dial9 = [
     "std",
     "rama-core/dial9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -531,10 +531,10 @@ opentelemetry = [
 #
 # `--cfg tokio_unstable` is optional. Without it dial9 takes poll
 # events from its own spawn helpers, so coverage is the tasks rama
-# routes through `rama_core::rt::Executor`. Set it (per-build via
-# `RUSTFLAGS`, or in your `.cargo/config.toml`) to also get every
-# other task on the runtime, task spawn/terminate events and
-# per-worker queue depth.
+# routes through `rama_core::rt::Executor` and `rama_core::rt::spawn`.
+# Set it (per-build via `RUSTFLAGS`, or in your `.cargo/config.toml`)
+# to also get every other task on the runtime, task spawn/terminate
+# events and per-worker queue depth.
 #
 # [dial9]: https://github.com/dial9-rs/dial9
 dial9 = [

--- a/docs/book/src/dial9.md
+++ b/docs/book/src/dial9.md
@@ -9,7 +9,7 @@ application-defined events into a binary trace you can analyse offline.
 Rama crates that emit events or expose runtime boundaries have an opt-in
 `dial9` cargo feature. Event-producing crates emit their predefined events at
 the matching lifecycle hooks; recording becomes a no-op when no [`dial9`]
-recorder is wirted into the application. 
+recorder is wired into the application.
 The `rama` mono-crate has a bundled `dial9` feature that activates the same on every enabled sub-crate.
 
 Library code that wants its own events alongside rama's predefined
@@ -26,8 +26,8 @@ boundaries remain associated with that runtime's trace.
 
 ### tokio_unstable
 
-`--cfg tokio_unstable` can be used to widen dial9's task coverage. 
-Without it, poll events come from dial9's own spawn helpers, so the task timeline covers what rama routes through `rama_core::rt::Executor`, task spawn/terminate events and per-worker queue depth are unavailable. 
+`--cfg tokio_unstable` can be used to widen dial9's task coverage.
+Without it, poll events come from dial9's own spawn helpers, so the task timeline covers what rama routes through `rama_core::rt::Executor` and `rama_core::rt::spawn`; task spawn/terminate events and per-worker queue depth are unavailable.
 Set it to get the full timeline:
 
 ```toml
@@ -38,6 +38,13 @@ rustflags = ["--cfg", "tokio_unstable"]
 
 ## Caveats
 
+- dial9 allows a single recorder per process: a second enabled recorder
+  (a second blocking runtime with `DIAL9_ENABLED`, or one built next to
+  your own) silently records nothing, with an error log. Only the first
+  runtime gets traced.
+- A misconfigured `DIAL9_*` environment (e.g. an unwritable trace
+  directory) no longer fails runtime construction: dial9 logs an error
+  and the runtime comes up untraced.
 - macOS only captures runtime-level + application events; Linux gets
   kernel scheduling delays and CPU profiling samples too.
 - ~1 MiB trace buffer per OS thread.

--- a/docs/book/src/dial9.md
+++ b/docs/book/src/dial9.md
@@ -8,10 +8,9 @@ application-defined events into a binary trace you can analyse offline.
 
 Rama crates that emit events or expose runtime boundaries have an opt-in
 `dial9` cargo feature. Event-producing crates emit their predefined events at
-the matching lifecycle hooks; recording becomes a no-op when no
-[`dial9-tokio-telemetry`] `TracedRuntime` is wired into the
-application. The `rama` mono-crate has a bundled `dial9` feature that
-activates the same on every enabled sub-crate.
+the matching lifecycle hooks; recording becomes a no-op when no [`dial9`]
+recorder is wirted into the application. 
+The `rama` mono-crate has a bundled `dial9` feature that activates the same on every enabled sub-crate.
 
 Library code that wants its own events alongside rama's predefined
 sets can depend on `dial9-trace-format` directly and derive
@@ -20,17 +19,22 @@ sets can depend on `dial9-trace-format` directly and derive
 The `rama` crate's `dial9` feature also exposes it through
 `rama::telemetry::dial9`.
 Runtime-owning integrations can use `rama::rt::OwnedRuntime`. Blocking
-runtimes resolve `Dial9Config::from_env()` when built if the feature is enabled;
-call `with_dial9_config(...)` to replace it or `without_dial9_config()` to opt
-out explicitly. Tasks crossing those boundaries remain associated with that
-runtime's trace.
+runtimes resolve the `DIAL9_*` environment when built if the feature is enabled;
+call `with_dial9_recorder(...)` to supply your own `dial9::Recorder` or
+`without_dial9_recorder()` to opt out explicitly. Tasks crossing those
+boundaries remain associated with that runtime's trace.
 
 ### tokio_unstable
 
-Enabling `dial9` on any rama crate requires `--cfg tokio_unstable`
-(the standard requirement for [`dial9-tokio-telemetry`]). The rama
-workspace sets this in `.cargo/config.toml`. Users who do not enable
-`dial9` do not need it.
+`--cfg tokio_unstable` can be used to widen dial9's task coverage. 
+Without it, poll events come from dial9's own spawn helpers, so the task timeline covers what rama routes through `rama_core::rt::Executor`, task spawn/terminate events and per-worker queue depth are unavailable. 
+Set it to get the full timeline:
+
+```toml
+# .cargo/config.toml
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+```
 
 ## Caveats
 
@@ -47,8 +51,8 @@ For the design and motivation, see [ Netstack.FM episode 37], the
 the rama tree:
 [`ffi/apple/examples/transparent_proxy/`](https://github.com/plabayo/rama/tree/main/ffi/apple/examples/transparent_proxy).
 
-[dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-[`dial9-tokio-telemetry`]: https://github.com/dial9-rs/dial9-tokio-telemetry
+[dial9]: https://github.com/dial9-rs/dial9
+[`dial9`]: https://github.com/dial9-rs/dial9
 [Netstack.FM episode 37]: https://netstack.fm/#episode-37
 [Tokio blog post]: https://tokio.rs/blog/2026-03-18-dial9
-[dial9 README]: https://github.com/dial9-rs/dial9-tokio-telemetry
+[dial9 README]: https://github.com/dial9-rs/dial9

--- a/ffi/apple/examples/transparent_proxy/README.md
+++ b/ffi/apple/examples/transparent_proxy/README.md
@@ -650,7 +650,7 @@ runtime events.
 
 ## Observability with dial9
 
-This example always builds with [dial9](https://github.com/dial9-rs/dial9-tokio-telemetry)
+This example always builds with [dial9](https://github.com/dial9-rs/dial9)
 runtime telemetry on. Wiring + tuning knobs live in
 [`tproxy_rs/src/dial9.rs`](./tproxy_rs/src/dial9.rs); a misconfigured
 build falls back to a plain runtime rather than failing the engine
@@ -661,7 +661,7 @@ The test harness wires no storage directory through, so it stays plain.
 ### Reading traces
 
 The trace is a self-describing binary stream from
-[`dial9-tokio-telemetry`](https://github.com/dial9-rs/dial9-tokio-telemetry).
+[`dial9`](https://github.com/dial9-rs/dial9).
 Triage with `dial9-viewer` (GUI timeline), `dial9` /  `dial9-cli` (grep
 + JSON; pipe into an LLM for triage), or deserialise programmatically
 with [`dial9-trace-format`](https://docs.rs/dial9-trace-format). Follow

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/.cargo/config.toml
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/.cargo/config.toml
@@ -1,7 +1,8 @@
 [build]
-# dial9-tokio-telemetry needs Tokio's unstable runtime hooks. We always
-# enable dial9 in this example; this is the canonical place to opt into
-# the cfg flag for everything built from this crate.
+# This example always enables dial9 and wants its full task timeline, which
+# comes from Tokio's unstable runtime hooks. The flag is optional (dial9
+# builds without it, with narrower task coverage), this is the canonical
+# place to opt in for everything built from this crate.
 rustflags = ["--cfg", "tokio_unstable"]
 
 [env]

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -193,6 +193,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "blazesym"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "847a0a95b041ad5aae1bdc44f2bd54743f76eb0065c4f86b139f81343c287eaf"
+dependencies = [
+ "cpp_demangle",
+ "crc32fast",
+ "flate2",
+ "gimli",
+ "libc",
+ "memmap2",
+ "rustc-demangle",
+ "tempfile",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +300,12 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "c-enum"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd17eb909a8c6a894926bfcc3400a4bb0e732f5a57d37b1f14e8b29e329bace8"
 
 [[package]]
 name = "cc"
@@ -421,6 +443,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -643,10 +674,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-macro"
-version = "0.3.7"
+name = "dial9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7e31f073f2e14e5a9d338c543a0601aeaf7c43fc428cd59ce417230d0db37d"
+checksum = "49b11bce55173f77d9003cce8f129b4af889a4639005c53c3498cef933bc895c"
+dependencies = [
+ "bon",
+ "dial9-core",
+ "dial9-macro",
+ "dial9-metrique",
+ "dial9-perf-self-profile",
+ "dial9-tokio-telemetry",
+ "dial9-trace-format",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8cbbc8955394be626249a3b52ddd6bf664373661eaeae70d87eb12bf6f20b6"
+dependencies = [
+ "arc-swap",
+ "bon",
+ "bytes",
+ "crossbeam-queue",
+ "dial9-trace-format",
+ "flate2",
+ "futures-util",
+ "libc",
+ "metrique",
+ "metrique-timesource",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+]
+
+[[package]]
+name = "dial9-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4177b8f8bf95d8e3769c1aad596f5d6fb231953a45c4c3d2a5946fe8e4ec327b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -654,24 +724,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "dial9-tokio-telemetry"
-version = "0.3.15"
+name = "dial9-metrique"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b511dfd54f5191f7eb86856fe19d8e3c8f71673bd256e1bfa1c8128fbbc0cdb"
+checksum = "d42fe0e3e14e8780c4ecf9ee14c183dbcb9b1ae3612cc9a689e7dc83b13adef1"
 dependencies = [
- "arc-swap",
+ "dial9-core",
+ "dial9-trace-format",
+ "metrique",
+ "metrique-writer",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-perf-self-profile"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f65948455c504bf08576c7b5cfe93bfcaa486d661dc4ee85c2a6309ab89629"
+dependencies = [
+ "blazesym",
+ "bytes",
+ "crossbeam-utils",
+ "dial9-core",
+ "dial9-trace-format",
+ "libc",
+ "perf-event-data",
+ "perf-event-open-sys2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "dial9-tokio-telemetry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1244091367c805b5d98a6a590f8ab992efda06e6d2560a6967ef898ffd30a2"
+dependencies = [
  "bon",
  "bytes",
- "crossbeam-queue",
- "dial9-macro",
+ "dial9-core",
  "dial9-trace-format",
  "flate2",
  "futures-util",
  "hostname",
  "libc",
- "metrique",
  "metrique-timesource",
- "metrique-writer",
  "pin-project-lite",
  "serde",
  "serde_json",
@@ -683,20 +781,22 @@ dependencies = [
 
 [[package]]
 name = "dial9-trace-format"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3636d6ec60d94840cc414dcd6a95c77b3ba0a7b86d43fd035b89662eeb5cfa7"
+checksum = "86083b7240114b2d0da4a7e9d041571d80ca3b1f92ae0ec794f1be21709daa6a"
 dependencies = [
  "dial9-trace-format-derive",
  "serde",
+ "typeid",
 ]
 
 [[package]]
 name = "dial9-trace-format-derive"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff7c2855b73d0de34bc31d6dc7afbf0f6ce230a668403ac2b57b21d1ffe3928"
+checksum = "9309248f12e414d88bcc9505f78b0c9ed47f79c5b62db611493e19a612cdc9d6"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -764,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -817,6 +917,7 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1039,6 +1140,18 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1549,6 +1662,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "metrics"
 version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,7 +1717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b55bfa39e6f5e44a37a59a794915ce36d04371471cf62ae365cd9703f58a5e0"
 dependencies = [
  "itoa",
- "jiff",
  "metrique-core",
  "metrique-macro",
  "metrique-service-metrics",
@@ -1595,7 +1725,6 @@ dependencies = [
  "metrique-writer-core",
  "metrique-writer-macro",
  "ryu",
- "serde_json",
  "tokio",
 ]
 
@@ -1938,6 +2067,27 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "perf-event-data"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "575828d9d7d205188048eb1508560607a03d21eafdbba47b8cade1736c1c28e1"
+dependencies = [
+ "bitflags 2.13.1",
+ "c-enum",
+ "perf-event-open-sys2",
+]
+
+[[package]]
+name = "perf-event-open-sys2"
+version = "5.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c25955321465255e437600b54296983fab1feac2cd0c38958adeb26dbae49e"
+dependencies = [
+ "libc",
+ "memoffset",
+]
 
 [[package]]
 name = "petgraph"
@@ -2323,7 +2473,7 @@ dependencies = [
  "ahash",
  "asynk-strim",
  "bytes",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "futures",
  "parking_lot",
@@ -2372,7 +2522,7 @@ dependencies = [
  "arc-swap",
  "base64",
  "bindgen",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "libc",
  "moka",
@@ -2658,7 +2808,7 @@ dependencies = [
  "const_format",
  "core-foundation",
  "csv",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "idna",
  "ipnet",
@@ -2693,7 +2843,7 @@ dependencies = [
  "atomic-waker",
  "bindgen",
  "cc",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "libc",
  "parking_lot",
@@ -2726,7 +2876,7 @@ name = "rama-socks5"
 version = "0.5.0"
 dependencies = [
  "byteorder",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "rama-core",
  "rama-dns",
@@ -2781,7 +2931,7 @@ version = "0.5.0"
 dependencies = [
  "ahash",
  "brotli",
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "flate2",
  "itertools 0.15.0",
@@ -2804,7 +2954,7 @@ dependencies = [
 name = "rama-tls-rustls"
 version = "0.5.0"
 dependencies = [
- "dial9-tokio-telemetry",
+ "dial9",
  "dial9-trace-format",
  "moka",
  "pin-project-lite",
@@ -2911,7 +3061,7 @@ dependencies = [
  "ahash",
  "arc-swap",
  "base64",
- "dial9-tokio-telemetry",
+ "dial9",
  "moka",
  "rama",
  "serde",
@@ -3052,6 +3202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3085,7 +3241,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3462,7 +3618,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3779,10 +3935,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.5",
+ "web-time",
+]
 
 [[package]]
 name = "unicase"
@@ -3933,6 +4105,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3981,7 +4163,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4236,6 +4418,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.toml
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["staticlib"]
 ahash = "0.8"
 arc-swap = "1"
 base64 = "0.23"
-dial9-tokio-telemetry = "0.3"
+dial9 = { version = "0.5.0", default-features = false, features = ["tokio"] }
 jemallocator = { package = "tikv-jemallocator", version = "0.6" }
 moka = { version = "0.12", features = ["sync"] }
 rama = { path = "../../../../../", features = ["dial9", "net-apple-networkextension", "net-apple-xpc", "tcp", "udp", "dns", "socks5", "ws", "http-full", "boring"] }

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/src/dial9.rs
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/src/dial9.rs
@@ -9,15 +9,15 @@
 //! a test process is more noise than signal.
 //!
 //! Misconfiguration of an enabled config falls back to a plain
-//! runtime via dial9's [`build_or_disabled`] semantics rather than
+//! runtime via dial9's [`recorder_or_disabled`] semantics rather than
 //! failing the engine build.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-//! [`build_or_disabled`]: dial9_tokio_telemetry::Dial9ConfigBuilder::build_or_disabled
+//! [dial9]: https://github.com/dial9-rs/dial9
+//! [`recorder_or_disabled`]: dial9::recorder_or_disabled
 
 use std::time::Duration;
 
-use ::dial9_tokio_telemetry::Dial9Config;
+use ::dial9::{DiskBuffer, TokioAttachOptions};
 use rama::{
     net::apple::networkextension::tproxy::DefaultTransparentProxyAsyncRuntimeFactory,
     telemetry::tracing, utils::octets::mib_u64,
@@ -50,14 +50,14 @@ pub(super) fn make_runtime_factory() -> DefaultTransparentProxyAsyncRuntimeFacto
         tracing::debug!(
             "rama-tproxy dial9: explicitly disabled via RAMA_TPROXY_DIAL9_DISABLED env var",
         );
-        return factory.without_dial9_config();
+        return factory.without_dial9_recorder();
     }
 
     let Some(storage) = super::utils::storage_dir() else {
         tracing::debug!(
             "rama-tproxy dial9: no storage dir provided; running with plain tokio runtime",
         );
-        return factory.without_dial9_config();
+        return factory.without_dial9_recorder();
     };
 
     let trace_dir = storage.join("dial9-traces");
@@ -67,24 +67,29 @@ pub(super) fn make_runtime_factory() -> DefaultTransparentProxyAsyncRuntimeFacto
             %err,
             "rama-tproxy dial9: failed to create trace dir; running with plain runtime",
         );
-        return factory.without_dial9_config();
+        return factory.without_dial9_recorder();
     }
-
-    let cfg = Dial9Config::builder()
-        .enabled(true)
-        .base_path(trace_dir.join("trace.bin"))
-        .max_file_size(MAX_FILE_BYTES)
-        .max_total_size(MAX_TOTAL_BYTES)
-        .rotation_period(ROTATION_PERIOD)
-        // Name the runtime so a multi-extension dial9 trace can be
-        // disambiguated; cost is a small string in the trace header.
-        .with_runtime(|b| b.with_runtime_name("rama-tproxy-example"))
-        .build_or_disabled();
 
     tracing::info!(
         path = %trace_dir.display(),
         "rama-tproxy dial9: telemetry enabled",
     );
 
-    factory.with_dial9_config(cfg)
+    // Segments land in `<trace_dir>/trace.{n}.bin`.
+    let writer = DiskBuffer::builder()
+        .base_path(trace_dir)
+        .max_file_size(MAX_FILE_BYTES)
+        .max_total_size(MAX_TOTAL_BYTES)
+        .rotation_period(ROTATION_PERIOD)
+        .build();
+
+    factory
+        .with_dial9_recorder(::dial9::recorder_or_disabled(writer).build())
+        // Name the runtime so a multi-extension dial9 trace can be
+        // disambiguated; cost is a small string in the trace header.
+        .with_dial9_attach_options(
+            TokioAttachOptions::builder()
+                .runtime_name("rama-tproxy-example")
+                .build(),
+        )
 }

--- a/justfile
+++ b/justfile
@@ -1,19 +1,23 @@
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
-# `--cfg tokio_unstable` enables Tokio's unstable runtime APIs that
-# `dial9-tokio-telemetry` requires. It is benign for crates that do
-# not opt into the `dial9` feature; the workspace `.cargo/config.toml`
-# carries the same flag for raw `cargo` invocations. We set it via env
-# here because justfile's `export RUSTFLAGS` overrides cargo's config.
-#
 # Set `ALLOW_WARNINGS=true` for local iteration to drop `-D warnings`
 # so in-progress code with unused imports / dead code still builds.
+#
+# Set `TOKIO_UNSTABLE=true` to add `--cfg tokio_unstable`, which widens
+# dial9's task coverage.
+
+# This is an `export` rather than a `.cargo/config.toml` entry because
+# justfile's `export RUSTFLAGS` overrides cargo's config either way.
 export RUSTFLAGS := \
-    if env_var_or_default("ALLOW_WARNINGS", "false") == "true" { \
-        "--cfg tokio_unstable" \
+    (if env_var_or_default("ALLOW_WARNINGS", "false") == "true" { \
+        "" \
     } else { \
-        "-D warnings --cfg tokio_unstable" \
-    }
+        "-D warnings" \
+    }) + (if env_var_or_default("TOKIO_UNSTABLE", "false") == "true" { \
+        " --cfg tokio_unstable" \
+    } else { \
+        "" \
+    })
 # Mirror CI's doc job: rustdoc warnings (e.g. private intra-doc links) fail
 # locally too, unless ALLOW_WARNINGS=true. rustdoc reads RUSTDOCFLAGS, not
 # RUSTFLAGS, so it needs its own export.
@@ -199,9 +203,8 @@ qq: sort-check fmt-check check check-nostd clippy doc extra-checks
 qa: qq docsrs-metadata-check test test-no-default-features test-doc deny
 
 # QA pass for the optional `dial9` runtime-telemetry feature. Builds, lints
-# and tests the rama crates that opt into dial9. `tokio_unstable` is
-# required by `dial9-tokio-telemetry` and is set workspace-wide in
-# `.cargo/config.toml` so this recipe does not need to set it explicitly.
+# and tests the rama crates that opt into dial9, on stable Tokio. Use
+# `qa-dial9-tokio-unstable` for the same pass with `--cfg tokio_unstable`.
 #
 # Kept separate from the main `qa` recipe so the standard QA path stays
 # focused — but is part of `qa-full` so anyone running the full suite
@@ -211,6 +214,10 @@ qa-dial9:
     cargo check -p rama-core -p rama-http -p rama-ws -p rama-net -p rama-net-apple-networkextension -p rama-dns -p rama-tls-rustls -p rama-tls-boring -p rama-socks5 -p rama --features dial9 --all-targets
     cargo clippy -p rama-core -p rama-http -p rama-ws -p rama-net -p rama-net-apple-networkextension -p rama-dns -p rama-tls-rustls -p rama-tls-boring -p rama-socks5 -p rama --features dial9 --all-targets
     cargo nextest run -p rama-core -p rama-http -p rama-ws -p rama-net -p rama-net-apple-networkextension -p rama-dns -p rama-socks5 --features dial9
+
+# `qa-dial9` under `--cfg tokio_unstable`, where dial9 gets its full task coverage.
+qa-dial9-tokio-unstable:
+    TOKIO_UNSTABLE=true just qa-dial9
 
 # Interactive: boot the fastcgi-php gateway demo (HTTPS → FastCGI/TCP → php-fpm)
 # and leave it running until Ctrl-C so you can curl / browse it.
@@ -281,7 +288,7 @@ test-e2e-ffi-swift:
 
 test-ffi-apple-full: qa-ffi-apple test-e2e-ffi-apple test-e2e-ffi-swift qa-xpc-apple
 
-qa-full: qa qa-dial9 hack test-ignored test-ignored-release test-loom fuzz-60s check-links
+qa-full: qa qa-dial9 qa-dial9-tokio-unstable hack test-ignored test-ignored-release test-loom fuzz-60s check-links
 
 bench-e2e-http-client-server *ARGS:
     ./scripts/bench/e2e_http_client_server.py {{ARGS}}

--- a/rama-cli/src/cmd/serve/discard/mod.rs
+++ b/rama-cli/src/cmd/serve/discard/mod.rs
@@ -193,7 +193,7 @@ pub async fn run(graceful: ShutdownGuard, cfg: CliCommandDiscard) -> Result<(), 
             );
 
             // no graceful shutdown for udp :)
-            tokio::spawn(async move {
+            rama::rt::spawn(async move {
                 tracing::info!(
                     network.local.address = %bind_address.ip(),
                     network.local.port = %bind_address.port(),

--- a/rama-cli/src/cmd/serve/proxy/capture.rs
+++ b/rama-cli/src/cmd/serve/proxy/capture.rs
@@ -648,7 +648,7 @@ impl CaptureStore {
         let mut key = [0_u8; 32];
         rand_bytes(&mut key).context("generate in-memory MITM capture key")?;
         let (temp_cleanup, temp_cleanup_worker) = TempPathCleanup::new();
-        tokio::spawn(temp_cleanup_worker.run());
+        rama::rt::spawn(temp_cleanup_worker.run());
         let (changes, _) = watch::channel(0);
         Ok(Self(Arc::new(CaptureStoreInner {
             inspection,

--- a/rama-cli/src/cmd/serve/proxy/capture/service.rs
+++ b/rama-cli/src/cmd/serve/proxy/capture/service.rs
@@ -19,7 +19,7 @@ impl BodyCaptureSink for EncryptedBodySink {
 
     fn aborted(&self) {
         let this = self.clone();
-        tokio::spawn(async move {
+        rama::rt::spawn(async move {
             this.store
                 .body_event(
                     this.exchange_id,

--- a/rama-cli/src/main.rs
+++ b/rama-cli/src/main.rs
@@ -97,7 +97,7 @@ async fn main() -> Result<(), BoxError> {
     };
 
     // Keep command futures off Windows' smaller process-main stack.
-    let result = tokio::spawn(run(cmds))
+    let result = rama::rt::spawn(run(cmds))
         .await
         .context("join CLI command task")?;
 

--- a/rama-core/Cargo.toml
+++ b/rama-core/Cargo.toml
@@ -51,16 +51,16 @@ opentelemetry = [
     "dep:opentelemetry_sdk",
     "dep:tracing-opentelemetry",
 ]
-# Route task spawns through `dial9-tokio-telemetry::spawn` so they pick
-# up wake-event tracking when a `TracedRuntime` is active. Inert when
-# no traced runtime is present. Requires `--cfg tokio_unstable`.
-dial9 = ["std", "dep:dial9-tokio-telemetry", "dep:dial9-trace-format"]
+# Route task spawns through `dial9::spawn` so they pick
+# up wake-event tracking when a recorder is attached. Inert when
+# no traced runtime is present. `--cfg tokio_unstable` widens dial9's task coverage.
+dial9 = ["std", "dep:dial9", "dep:dial9-trace-format"]
 
 [dependencies]
 ahash = { workspace = true, optional = true }
 asynk-strim = { workspace = true }
 bytes = { workspace = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 futures = { version = "0.3", default-features = false, features = ["alloc", "async-await"] }
 opentelemetry = { workspace = true, optional = true }

--- a/rama-core/src/rt/blocking.rs
+++ b/rama-core/src/rt/blocking.rs
@@ -192,7 +192,11 @@ impl RuntimeBuilder {
         /// Set how this runtime is traced: task tracking, dumps, hooks, and its
         /// name in the trace.
         ///
-        /// Only used alongside [`with_dial9_recorder`](Self::with_dial9_recorder).
+        /// Applies alongside [`with_dial9_recorder`](Self::with_dial9_recorder).
+        /// The implicit environment path configures itself from `DIAL9_*`, so
+        /// combining options with it is rejected by
+        /// [`try_build`](Self::try_build); with telemetry explicitly disabled
+        /// the options are moot.
         /// When unset, the runtime takes this builder's thread name. Set options
         /// and you name it yourself.
         #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
@@ -214,6 +218,16 @@ impl RuntimeBuilder {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
                 "blocking runtime worker thread count must be greater than zero",
+            ));
+        }
+
+        #[cfg(feature = "dial9")]
+        if self.dial9_attach_options.is_some()
+            && matches!(self.dial9_recorder, RuntimeDial9Recorder::FromEnv)
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "dial9 attach options require an explicit dial9 recorder; the environment path configures itself from `DIAL9_*`",
             ));
         }
 
@@ -1183,6 +1197,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(runtime.flavor(), RuntimeFlavor::CurrentThread);
+    }
+
+    #[cfg(feature = "dial9")]
+    #[test]
+    fn dial9_attach_options_require_an_explicit_recorder() {
+        let err = Runtime::builder()
+            .with_dial9_attach_options(::dial9::TokioAttachOptions::default())
+            .try_build()
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 
     #[cfg(feature = "dial9")]

--- a/rama-core/src/rt/blocking.rs
+++ b/rama-core/src/rt/blocking.rs
@@ -15,6 +15,8 @@ use crate::{
     extensions::{Extensions, ExtensionsRef},
     rt::{OwnedRuntime, OwnedRuntimeHandle},
 };
+#[cfg(feature = "dial9")]
+use ::dial9::Dial9HandleTokioExt as _;
 use core::{
     fmt,
     future::Future,
@@ -60,17 +62,19 @@ pub struct RuntimeBuilder {
     flavor: RuntimeFlavor,
     flavor_explicit: bool,
     #[cfg(feature = "dial9")]
-    dial9_config: RuntimeDial9Config,
+    dial9_recorder: RuntimeDial9Recorder,
     #[cfg(feature = "dial9")]
-    dial9_config_may_be_enabled: bool,
+    dial9_attach_options: Option<::dial9::TokioAttachOptions>,
+    #[cfg(feature = "dial9")]
+    dial9_may_be_enabled: bool,
 }
 
 #[cfg(feature = "dial9")]
 #[derive(Debug)]
-enum RuntimeDial9Config {
+enum RuntimeDial9Recorder {
     FromEnv,
     Disabled,
-    Custom(Box<::dial9_tokio_telemetry::Dial9Config>),
+    Custom(Box<::dial9::Recorder>),
 }
 
 impl Default for RuntimeBuilder {
@@ -81,15 +85,17 @@ impl Default for RuntimeBuilder {
             flavor: RuntimeFlavor::CurrentThread,
             flavor_explicit: false,
             #[cfg(feature = "dial9")]
-            dial9_config: RuntimeDial9Config::FromEnv,
+            dial9_recorder: RuntimeDial9Recorder::FromEnv,
             #[cfg(feature = "dial9")]
-            dial9_config_may_be_enabled: implicit_dial9_config_may_be_enabled(),
+            dial9_attach_options: None,
+            #[cfg(feature = "dial9")]
+            dial9_may_be_enabled: implicit_dial9_may_be_enabled(),
         }
     }
 }
 
 #[cfg(feature = "dial9")]
-fn implicit_dial9_config_may_be_enabled() -> bool {
+fn implicit_dial9_may_be_enabled() -> bool {
     match std::env::var("DIAL9_ENABLED") {
         Err(std::env::VarError::NotPresent) => false,
         Ok(value) => !matches!(
@@ -130,9 +136,8 @@ impl RuntimeBuilder {
         /// Use a current-thread Tokio scheduler.
         ///
         /// With the `dial9` feature, this overrides the implicit environment
-        /// config when telemetry is disabled. An enabled environment config or
-        /// an explicitly supplied dial9 config owns its scheduler and conflicts
-        /// with this setting.
+        /// config when telemetry is disabled. Enabled telemetry needs the
+        /// multi-thread scheduler and conflicts with this setting.
         pub fn current_thread(mut self) -> Self {
             self.flavor = RuntimeFlavor::CurrentThread;
             self.flavor_explicit = true;
@@ -144,9 +149,8 @@ impl RuntimeBuilder {
         /// Use a multi-thread Tokio scheduler.
         ///
         /// With the `dial9` feature, this overrides the implicit environment
-        /// config when telemetry is disabled. An enabled environment config or
-        /// an explicitly supplied dial9 config owns its scheduler and conflicts
-        /// with this setting.
+        /// config when telemetry is disabled, and its worker count applies to
+        /// the instrumented runtime otherwise.
         pub fn worker_threads(mut self, worker_threads: usize) -> Self {
             self.flavor = RuntimeFlavor::MultiThread { worker_threads };
             self.flavor_explicit = true;
@@ -156,32 +160,47 @@ impl RuntimeBuilder {
 
     #[cfg(feature = "dial9")]
     rama_utils::macros::generate_set_and_with! {
-        /// Set the dial9 runtime configuration.
+        /// Set the [`Recorder`] this runtime records into.
         ///
-        /// With the `dial9` feature, this defaults to resolving
-        /// [`Dial9Config::from_env`] when the runtime is built. An enabled
-        /// dial9 config owns its Tokio scheduler configuration. Combining an
-        /// explicitly supplied config with
-        /// [`with_current_thread`](Self::with_current_thread) or
-        /// [`with_worker_threads`](Self::with_worker_threads) is rejected by
-        /// [`try_build`](Self::try_build). An implicit environment config yields
-        /// to an explicit Rama scheduler when telemetry is disabled. Use
-        /// [`without_dial9_config`](Self::without_dial9_config) to explicitly
-        /// select a Rama-configured scheduler without dial9.
+        /// With the `dial9` feature, this defaults to resolving the `DIAL9_*`
+        /// environment when the runtime is built. Combining an enabled recorder
+        /// with [`with_current_thread`](Self::with_current_thread) is rejected
+        /// by [`try_build`](Self::try_build). An implicit environment config
+        /// yields to an explicit Rama scheduler when telemetry is disabled. Use
+        /// [`without_dial9_recorder`](Self::without_dial9_recorder) to
+        /// explicitly select a Rama-configured scheduler without dial9.
         ///
-        /// An enabled config must produce a multi-thread runtime because dial9
+        /// An enabled recorder must produce a multi-thread runtime because dial9
         /// installs ambient telemetry handles on Tokio-owned worker threads.
         ///
-        /// [`Dial9Config::from_env`]: dial9_tokio_telemetry::Dial9Config::from_env
+        /// [`Recorder`]: dial9::Recorder
         #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
-        pub fn dial9_config(
+        pub fn dial9_recorder(
             mut self,
-            dial9_config: Option<::dial9_tokio_telemetry::Dial9Config>,
+            dial9_recorder: Option<::dial9::Recorder>,
         ) -> Self {
-            self.dial9_config = match dial9_config {
-                Some(config) => RuntimeDial9Config::Custom(Box::new(config)),
-                None => RuntimeDial9Config::Disabled,
+            self.dial9_recorder = match dial9_recorder {
+                Some(recorder) => RuntimeDial9Recorder::Custom(Box::new(recorder)),
+                None => RuntimeDial9Recorder::Disabled,
             };
+            self
+        }
+    }
+
+    #[cfg(feature = "dial9")]
+    rama_utils::macros::generate_set_and_with! {
+        /// Set how this runtime is traced: task tracking, dumps, hooks, and its
+        /// name in the trace.
+        ///
+        /// Only used alongside [`with_dial9_recorder`](Self::with_dial9_recorder).
+        /// When unset, the runtime takes this builder's thread name. Set options
+        /// and you name it yourself.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
+        pub fn dial9_attach_options(
+            mut self,
+            dial9_attach_options: ::dial9::TokioAttachOptions,
+        ) -> Self {
+            self.dial9_attach_options = Some(dial9_attach_options);
             self
         }
     }
@@ -198,23 +217,17 @@ impl RuntimeBuilder {
             ));
         }
 
-        #[cfg(feature = "dial9")]
-        if matches!(&self.dial9_config, RuntimeDial9Config::Custom(_)) && self.flavor_explicit {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "blocking runtime scheduler must be configured either through Rama or dial9, not both",
-            ));
-        }
-
         let Self {
             thread_name,
             shutdown_timeout,
             flavor,
             flavor_explicit,
             #[cfg(feature = "dial9")]
-            dial9_config,
+            dial9_recorder,
             #[cfg(feature = "dial9")]
-            dial9_config_may_be_enabled,
+            dial9_attach_options,
+            #[cfg(feature = "dial9")]
+            dial9_may_be_enabled,
         } = self;
 
         #[cfg(not(feature = "dial9"))]
@@ -231,51 +244,47 @@ impl RuntimeBuilder {
         let thread = thread::Builder::new().name(thread_name).spawn(move || {
             #[cfg(feature = "dial9")]
             let runtime = match (|| -> io::Result<OwnedRuntime> {
-                if matches!(&dial9_config, RuntimeDial9Config::FromEnv)
-                    && !dial9_config_may_be_enabled
-                {
-                    return build_tokio_runtime(flavor, &runtime_thread_name)
-                        .map(OwnedRuntime::from_tokio);
-                }
-
-                let (config, dial9_config_explicit) = match dial9_config {
-                    RuntimeDial9Config::FromEnv => (
-                        Some(::dial9_tokio_telemetry::Dial9Config::from_env()),
-                        false,
-                    ),
-                    RuntimeDial9Config::Disabled => (None, true),
-                    RuntimeDial9Config::Custom(config) => (Some(*config), true),
+                let plain = || {
+                    build_tokio_runtime(flavor, &runtime_thread_name).map(OwnedRuntime::from_tokio)
                 };
-                let Some(config) = config else {
-                    return build_tokio_runtime(flavor, &runtime_thread_name)
-                        .map(OwnedRuntime::from_tokio);
-                };
-                let runtime = ::dial9_tokio_telemetry::TracedRuntime::try_new(config)
-                    .map_err(io::Error::other)?;
 
-                if !runtime.guard().is_enabled() && !dial9_config_explicit {
-                    drop(runtime);
-                    return build_tokio_runtime(flavor, &runtime_thread_name)
-                        .map(OwnedRuntime::from_tokio);
+                match dial9_recorder {
+                    RuntimeDial9Recorder::Disabled => plain(),
+                    // An unset `DIAL9_ENABLED` means the implicit environment is
+                    // off, so skip dial9 and leave Rama's scheduler in charge.
+                    RuntimeDial9Recorder::FromEnv if !dial9_may_be_enabled => plain(),
+                    RuntimeDial9Recorder::FromEnv => {
+                        let (recorder, runtime) = ::dial9::recorder_from_env_with(|builder| {
+                            configure_dial9_builder(builder, flavor, &runtime_thread_name);
+                        })?;
+                        // The environment resolved to telemetry-off after all;
+                        // hand the scheduler choice back to Rama.
+                        if !recorder.handle().is_enabled() {
+                            drop((runtime, recorder));
+                            return plain();
+                        }
+                        require_multi_thread(flavor, flavor_explicit)?;
+                        Ok(OwnedRuntime::from_dial9((recorder, runtime)))
+                    }
+                    RuntimeDial9Recorder::Custom(recorder) => {
+                        // A disabled recorder records nothing, so it does not
+                        // constrain the scheduler.
+                        if !recorder.handle().is_enabled() {
+                            return plain();
+                        }
+                        require_multi_thread(flavor, flavor_explicit)?;
+                        let mut builder = tokio::runtime::Builder::new_multi_thread();
+                        builder.enable_all();
+                        configure_dial9_builder(&mut builder, flavor, &runtime_thread_name);
+                        let options = dial9_attach_options.unwrap_or_else(|| {
+                            ::dial9::TokioAttachOptions::builder()
+                                .runtime_name(runtime_thread_name.as_str())
+                                .build()
+                        });
+                        let runtime = recorder.handle().attach_tokio_runtime(builder, options)?;
+                        Ok(OwnedRuntime::from_dial9((*recorder, runtime)))
+                    }
                 }
-                if flavor_explicit {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "blocking runtime scheduler must be configured either through Rama or enabled dial9 telemetry, not both",
-                    ));
-                }
-                if runtime.guard().is_enabled()
-                    && matches!(
-                        runtime.runtime().handle().runtime_flavor(),
-                        tokio::runtime::RuntimeFlavor::CurrentThread
-                    )
-                {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "dial9 telemetry at a blocking boundary requires a multi-thread Tokio runtime",
-                    ));
-                }
-                Ok(OwnedRuntime::from_dial9(runtime))
             })() {
                 Ok(runtime) => runtime,
                 Err(err) => {
@@ -351,6 +360,35 @@ fn build_tokio_runtime(
     builder.enable_all();
     builder.thread_name(format!("{thread_name}-worker"));
     builder.build()
+}
+
+/// Reject an explicit current-thread scheduler paired with enabled telemetry.
+///
+/// dial9 installs its ambient handles on Tokio-owned worker threads, so an
+/// unset scheduler takes multi-thread implicitly rather than erroring.
+#[cfg(feature = "dial9")]
+fn require_multi_thread(flavor: RuntimeFlavor, flavor_explicit: bool) -> io::Result<()> {
+    if flavor_explicit && matches!(flavor, RuntimeFlavor::CurrentThread) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "dial9 telemetry at a blocking boundary requires a multi-thread Tokio runtime",
+        ));
+    }
+    Ok(())
+}
+
+/// Apply this builder's scheduler settings to a dial9-instrumented runtime.
+/// An unset worker count leaves Tokio's default in place.
+#[cfg(feature = "dial9")]
+fn configure_dial9_builder(
+    builder: &mut tokio::runtime::Builder,
+    flavor: RuntimeFlavor,
+    thread_name: &str,
+) {
+    if let RuntimeFlavor::MultiThread { worker_threads } = flavor {
+        builder.worker_threads(worker_threads);
+    }
+    builder.thread_name(format!("{thread_name}-worker"));
 }
 
 fn describe_runtime_flavor(runtime: &OwnedRuntime) -> io::Result<RuntimeFlavor> {
@@ -1006,7 +1044,7 @@ mod tests {
     fn final_runtime_lease_can_drop_on_worker() {
         let builder = Runtime::builder();
         #[cfg(feature = "dial9")]
-        let builder = builder.without_dial9_config();
+        let builder = builder.without_dial9_recorder();
         let runtime = builder
             .with_worker_threads(1)
             .with_shutdown_timeout(Duration::from_secs(1))
@@ -1032,7 +1070,7 @@ mod tests {
     fn multi_thread_runtime_is_supported() {
         let builder = Runtime::builder();
         #[cfg(feature = "dial9")]
-        let builder = builder.without_dial9_config();
+        let builder = builder.without_dial9_recorder();
         let runtime = builder.with_worker_threads(2).try_build().unwrap();
         assert_eq!(
             runtime.flavor(),
@@ -1048,7 +1086,7 @@ mod tests {
     fn zero_worker_threads_is_rejected() {
         let builder = Runtime::builder();
         #[cfg(feature = "dial9")]
-        let builder = builder.without_dial9_config();
+        let builder = builder.without_dial9_recorder();
         let err = builder.with_worker_threads(0).try_build().unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
@@ -1057,17 +1095,23 @@ mod tests {
     #[test]
     fn default_builder_defers_dial9_environment_resolution() {
         let builder = Runtime::builder();
-        assert!(matches!(builder.dial9_config, RuntimeDial9Config::FromEnv));
+        assert!(matches!(
+            builder.dial9_recorder,
+            RuntimeDial9Recorder::FromEnv
+        ));
 
-        let builder = builder.without_dial9_config();
-        assert!(matches!(builder.dial9_config, RuntimeDial9Config::Disabled));
+        let builder = builder.without_dial9_recorder();
+        assert!(matches!(
+            builder.dial9_recorder,
+            RuntimeDial9Recorder::Disabled
+        ));
     }
 
     #[cfg(feature = "dial9")]
     #[test]
     fn implicit_disabled_dial9_uses_current_thread_scheduler() {
         let mut builder = Runtime::builder();
-        builder.dial9_config_may_be_enabled = false;
+        builder.dial9_may_be_enabled = false;
 
         let runtime = builder.try_build().unwrap();
         assert_eq!(runtime.flavor(), RuntimeFlavor::CurrentThread);
@@ -1077,7 +1121,7 @@ mod tests {
     #[test]
     fn explicit_scheduler_overrides_disabled_implicit_dial9() {
         let mut builder = Runtime::builder();
-        builder.dial9_config_may_be_enabled = false;
+        builder.dial9_may_be_enabled = false;
 
         let runtime = builder.with_worker_threads(1).try_build().unwrap();
         assert_eq!(
@@ -1088,39 +1132,70 @@ mod tests {
 
     #[cfg(feature = "dial9")]
     #[test]
-    fn explicit_scheduler_conflicts_with_explicit_dial9_config() {
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(false)
-            .build()
-            .unwrap();
-        let err = Runtime::builder()
-            .with_dial9_config(config)
-            .with_worker_threads(1)
+    fn explicit_worker_threads_apply_to_the_dial9_runtime() {
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
+        let temp_dir = rama_utils::fs::tempdir().unwrap();
+        let runtime = Runtime::builder()
+            .with_dial9_recorder(crate::rt::dial9_test_util::recorder(temp_dir.path()))
+            .with_worker_threads(2)
             .try_build()
-            .unwrap_err();
+            .unwrap();
 
-        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(
+            runtime.flavor(),
+            RuntimeFlavor::MultiThread { worker_threads: 2 }
+        );
+        drop(runtime);
+    }
+
+    #[cfg(feature = "dial9")]
+    #[test]
+    fn dial9_attach_options_are_applied() {
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
+        let temp_dir = rama_utils::fs::tempdir().unwrap();
+        let runtime = Runtime::builder()
+            .with_dial9_recorder(crate::rt::dial9_test_util::recorder(temp_dir.path()))
+            .with_dial9_attach_options(
+                ::dial9::TokioAttachOptions::builder()
+                    .tokio_instrumentation_enabled(false)
+                    .build(),
+            )
+            .try_build()
+            .unwrap();
+
+        // The recorder is live, but this runtime opted out of instrumentation,
+        // so its workers never join the session.
+        let service = runtime.service(service_fn(|()| async {
+            Ok::<_, core::convert::Infallible>(::dial9::Dial9Handle::current().is_enabled())
+        }));
+        assert!(!*service.serve(()).unwrap());
+        drop(service);
+        drop(runtime);
+    }
+
+    #[cfg(feature = "dial9")]
+    #[test]
+    fn disabled_dial9_recorder_keeps_the_rama_scheduler() {
+        let runtime = Runtime::builder()
+            .with_dial9_recorder(::dial9::recorder_disabled())
+            .with_current_thread()
+            .try_build()
+            .unwrap();
+
+        assert_eq!(runtime.flavor(), RuntimeFlavor::CurrentThread);
     }
 
     #[cfg(feature = "dial9")]
     #[test]
     fn dial9_tracks_blocking_service_root() {
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("blocking-runtime.bin"))
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
-            .build()
-            .unwrap();
         let runtime = Runtime::builder()
-            .with_dial9_config(config)
+            .with_dial9_recorder(crate::rt::dial9_test_util::recorder(temp_dir.path()))
             .try_build()
             .unwrap();
         let service = runtime.service(service_fn(|()| async {
-            Ok::<_, core::convert::Infallible>(
-                ::dial9_tokio_telemetry::telemetry::TelemetryHandle::current().is_enabled(),
-            )
+            Ok::<_, core::convert::Infallible>(::dial9::Dial9Handle::current().is_enabled())
         }));
 
         assert!(matches!(
@@ -1135,16 +1210,10 @@ mod tests {
     #[cfg(feature = "dial9")]
     #[test]
     fn dial9_tracks_tasks_spawned_through_handle() {
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("blocking-runtime-handle.bin"))
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
-            .build()
-            .unwrap();
         let runtime = Runtime::builder()
-            .with_dial9_config(config)
+            .with_dial9_recorder(crate::rt::dial9_test_util::recorder(temp_dir.path()))
             .try_build()
             .unwrap();
         let handle = runtime.handle();
@@ -1152,10 +1221,8 @@ mod tests {
 
         thread::spawn(move || {
             _ = handle.spawn(async move {
-                tx.send(
-                    ::dial9_tokio_telemetry::telemetry::TelemetryHandle::current().is_enabled(),
-                )
-                .unwrap();
+                tx.send(::dial9::Dial9Handle::current().is_enabled())
+                    .unwrap();
             });
         })
         .join()
@@ -1168,21 +1235,11 @@ mod tests {
     #[cfg(feature = "dial9")]
     #[test]
     fn dial9_rejects_current_thread_scheduler() {
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("blocking-current-thread.bin"))
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
-            .with_tokio(|builder| {
-                *builder = tokio::runtime::Builder::new_current_thread();
-                builder.enable_all();
-            })
-            .build()
-            .unwrap();
-
         let err = Runtime::builder()
-            .with_dial9_config(config)
+            .with_dial9_recorder(crate::rt::dial9_test_util::recorder(temp_dir.path()))
+            .with_current_thread()
             .try_build()
             .unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);

--- a/rama-core/src/rt/dial9_test_util.rs
+++ b/rama-core/src/rt/dial9_test_util.rs
@@ -13,7 +13,7 @@ pub(crate) fn recorder_slot() -> parking_lot::MutexGuard<'static, ()> {
 pub(crate) fn recorder(trace_dir: &std::path::Path) -> ::dial9::Recorder {
     let writer = ::dial9::DiskBuffer::builder()
         .base_path(trace_dir)
-        .max_file_size(1024 * 1024)
+        .max_file_size(mib(1))
         .max_total_size(4 * 1024 * 1024)
         .build();
     let recorder = ::dial9::recorder_or_disabled(writer).build();

--- a/rama-core/src/rt/dial9_test_util.rs
+++ b/rama-core/src/rt/dial9_test_util.rs
@@ -14,7 +14,7 @@ pub(crate) fn recorder(trace_dir: &std::path::Path) -> ::dial9::Recorder {
     let writer = ::dial9::DiskBuffer::builder()
         .base_path(trace_dir)
         .max_file_size(mib(1))
-        .max_total_size(4 * 1024 * 1024)
+        .max_total_size(mib(4))
         .build();
     let recorder = ::dial9::recorder_or_disabled(writer).build();
     assert!(

--- a/rama-core/src/rt/dial9_test_util.rs
+++ b/rama-core/src/rt/dial9_test_util.rs
@@ -1,5 +1,7 @@
 //! Shared setup for the tests that exercise the dial9 integration.
 
+use rama_utils::octets::mib_u64;
+
 /// Serializes tests that build an enabled dial9 recorder (a second `build()`
 /// while one is alive returns a disabled recorder).
 pub(crate) fn recorder_slot() -> parking_lot::MutexGuard<'static, ()> {
@@ -13,8 +15,8 @@ pub(crate) fn recorder_slot() -> parking_lot::MutexGuard<'static, ()> {
 pub(crate) fn recorder(trace_dir: &std::path::Path) -> ::dial9::Recorder {
     let writer = ::dial9::DiskBuffer::builder()
         .base_path(trace_dir)
-        .max_file_size(mib(1))
-        .max_total_size(mib(4))
+        .max_file_size(mib_u64(1))
+        .max_total_size(mib_u64(4))
         .build();
     let recorder = ::dial9::recorder_or_disabled(writer).build();
     assert!(

--- a/rama-core/src/rt/dial9_test_util.rs
+++ b/rama-core/src/rt/dial9_test_util.rs
@@ -1,0 +1,25 @@
+//! Shared setup for the tests that exercise the dial9 integration.
+
+/// Serializes tests that build an enabled dial9 recorder (a second `build()`
+/// while one is alive returns a disabled recorder).
+pub(crate) fn recorder_slot() -> parking_lot::MutexGuard<'static, ()> {
+    static SLOT: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+    SLOT.lock()
+}
+
+/// Build an enabled recorder writing into `trace_dir`.
+///
+/// Callers must hold [`recorder_slot`].
+pub(crate) fn recorder(trace_dir: &std::path::Path) -> ::dial9::Recorder {
+    let writer = ::dial9::DiskBuffer::builder()
+        .base_path(trace_dir)
+        .max_file_size(1024 * 1024)
+        .max_total_size(4 * 1024 * 1024)
+        .build();
+    let recorder = ::dial9::recorder_or_disabled(writer).build();
+    assert!(
+        recorder.handle().is_enabled(),
+        "expected an enabled recorder, is another recorder still alive?"
+    );
+    recorder
+}

--- a/rama-core/src/rt/executor.rs
+++ b/rama-core/src/rt/executor.rs
@@ -118,7 +118,7 @@ impl Executor {
 /// Spawn a future on the current tokio runtime.
 ///
 /// When the `dial9` feature is enabled this routes through
-/// `dial9_tokio_telemetry::spawn`, which wraps the future with
+/// `dial9::spawn`, which wraps the future with
 /// wake-event tracking on a traced runtime and falls through to
 /// plain `tokio::spawn` otherwise. With the feature disabled this
 /// is a direct call to `tokio::spawn`.
@@ -129,7 +129,7 @@ where
 {
     #[cfg(feature = "dial9")]
     {
-        ::dial9_tokio_telemetry::spawn(future)
+        ::dial9::spawn(future)
     }
     #[cfg(not(feature = "dial9"))]
     {

--- a/rama-core/src/rt/executor.rs
+++ b/rama-core/src/rt/executor.rs
@@ -117,13 +117,24 @@ impl Executor {
 
 /// Spawn a future on the current tokio runtime.
 ///
+/// Drop-in replacement for `tokio::spawn` for tasks that intentionally
+/// live outside graceful shutdown (background workers, detached drivers).
+/// Prefer [`Executor::spawn_task`] for work that should be awaited on
+/// shutdown.
+///
 /// When the `dial9` feature is enabled this routes through
 /// `dial9::spawn`, which wraps the future with
 /// wake-event tracking on a traced runtime and falls through to
 /// plain `tokio::spawn` otherwise. With the feature disabled this
 /// is a direct call to `tokio::spawn`.
+///
+/// # Panics
+///
+/// Panics if called from outside a tokio runtime context,
+/// same as `tokio::spawn`.
 #[inline]
-fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+#[track_caller]
+pub fn spawn<F>(future: F) -> tokio::task::JoinHandle<F::Output>
 where
     F: Future<Output: Send + 'static> + Send + 'static,
 {

--- a/rama-core/src/rt/mod.rs
+++ b/rama-core/src/rt/mod.rs
@@ -10,7 +10,7 @@
 
 mod executor;
 #[doc(inline)]
-pub use executor::Executor;
+pub use executor::{Executor, spawn};
 
 mod owned;
 #[doc(inline)]

--- a/rama-core/src/rt/mod.rs
+++ b/rama-core/src/rt/mod.rs
@@ -19,3 +19,7 @@ pub use owned::{OwnedRuntime, OwnedRuntimeHandle};
 pub mod blocking;
 
 pub mod future;
+
+#[cfg(test)]
+#[cfg(feature = "dial9")]
+mod dial9_test_util;

--- a/rama-core/src/rt/owned.rs
+++ b/rama-core/src/rt/owned.rs
@@ -196,15 +196,16 @@ impl OwnedRuntime {
 
     /// Dispose of the runtime without blocking the caller indefinitely.
     ///
-    /// Workers get `grace` to stop. With `dial9` the trace pipeline then gets
-    /// another `grace` to drain, so budget for twice that.
+    /// `grace` is the total budget: workers get it to stop, and with `dial9`
+    /// the trace pipeline drains within whatever of it remains.
     pub fn shutdown_bounded(self, grace: Duration) {
         match self.inner {
             RuntimeInner::Tokio(runtime) => runtime.shutdown_timeout(grace),
             #[cfg(feature = "dial9")]
             RuntimeInner::Dial9 { runtime, recorder } => {
+                let started = std::time::Instant::now();
                 runtime.shutdown_timeout(grace);
-                recorder.graceful_shutdown(grace);
+                recorder.graceful_shutdown(grace.saturating_sub(started.elapsed()));
             }
         }
     }

--- a/rama-core/src/rt/owned.rs
+++ b/rama-core/src/rt/owned.rs
@@ -4,13 +4,9 @@ use core::future::Future;
 use std::time::Duration;
 use tokio::runtime::{EnterGuard, Handle, Runtime};
 
-#[cfg(feature = "dial9")]
-use crate::telemetry::tracing;
-
 /// A cloneable handle targeting one specific [`OwnedRuntime`].
 ///
-/// Unlike an ambient spawn helper, this handle targets one Tokio runtime and,
-/// when enabled, retains the dial9 telemetry session to which work belongs. It
+/// Unlike an ambient spawn helper, this handle targets one Tokio runtime. It
 /// can therefore spawn correctly instrumented tasks from arbitrary threads.
 ///
 /// The handle does not keep the runtime itself alive. Retain the owning
@@ -19,12 +15,10 @@ use crate::telemetry::tracing;
 #[derive(Clone, Debug)]
 pub struct OwnedRuntimeHandle {
     tokio: Handle,
-    #[cfg(feature = "dial9")]
-    dial9: ::dial9_tokio_telemetry::telemetry::TelemetryHandle,
 }
 
 impl OwnedRuntimeHandle {
-    /// Capture the current Tokio runtime and dial9 telemetry session.
+    /// Capture the current Tokio runtime.
     ///
     /// # Panics
     ///
@@ -33,8 +27,6 @@ impl OwnedRuntimeHandle {
     pub fn current() -> Self {
         Self {
             tokio: Handle::current(),
-            #[cfg(feature = "dial9")]
-            dial9: ::dial9_tokio_telemetry::telemetry::TelemetryHandle::current(),
         }
     }
 
@@ -50,7 +42,7 @@ impl OwnedRuntimeHandle {
     /// Spawn an owned task on the targeted runtime.
     ///
     /// With `dial9` enabled, the task is associated with the exact telemetry
-    /// session captured by this handle, even when called from another thread.
+    /// session of the targeted runtime, even when called from another thread.
     pub fn spawn<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
@@ -58,8 +50,7 @@ impl OwnedRuntimeHandle {
     {
         #[cfg(feature = "dial9")]
         {
-            let _enter = self.tokio.enter();
-            self.dial9.spawn(future)
+            ::dial9::spawn_in(&self.tokio, future)
         }
         #[cfg(not(feature = "dial9"))]
         {
@@ -91,11 +82,7 @@ impl OwnedRuntimeHandle {
 
 impl From<Handle> for OwnedRuntimeHandle {
     fn from(tokio: Handle) -> Self {
-        Self {
-            tokio,
-            #[cfg(feature = "dial9")]
-            dial9: ::dial9_tokio_telemetry::telemetry::TelemetryHandle::disabled(),
-        }
+        Self { tokio }
     }
 }
 
@@ -115,7 +102,10 @@ pub struct OwnedRuntime {
 enum RuntimeInner {
     Tokio(Runtime),
     #[cfg(feature = "dial9")]
-    Dial9(::dial9_tokio_telemetry::TracedRuntime),
+    Dial9 {
+        runtime: Runtime,
+        recorder: ::dial9::Recorder,
+    },
 }
 
 impl OwnedRuntime {
@@ -127,13 +117,14 @@ impl OwnedRuntime {
         }
     }
 
-    /// Wrap a dial9 traced runtime and retain its telemetry guard.
+    /// Wrap a dial9 traced runtime and retain its recorder.
     #[cfg(feature = "dial9")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
     #[must_use]
-    pub fn from_dial9(runtime: ::dial9_tokio_telemetry::TracedRuntime) -> Self {
+    pub fn from_dial9(attached: ::dial9::AttachedRuntime) -> Self {
+        let (recorder, runtime) = attached;
         Self {
-            inner: RuntimeInner::Dial9(runtime),
+            inner: RuntimeInner::Dial9 { runtime, recorder },
         }
     }
 
@@ -145,10 +136,7 @@ impl OwnedRuntime {
         match &self.inner {
             RuntimeInner::Tokio(runtime) => runtime.handle().clone().into(),
             #[cfg(feature = "dial9")]
-            RuntimeInner::Dial9(runtime) => OwnedRuntimeHandle {
-                tokio: runtime.runtime().handle().clone(),
-                dial9: runtime.guard().handle(),
-            },
+            RuntimeInner::Dial9 { runtime, .. } => runtime.handle().clone().into(),
         }
     }
 
@@ -156,7 +144,7 @@ impl OwnedRuntime {
         match &self.inner {
             RuntimeInner::Tokio(runtime) => runtime,
             #[cfg(feature = "dial9")]
-            RuntimeInner::Dial9(runtime) => runtime.runtime(),
+            RuntimeInner::Dial9 { runtime, .. } => runtime,
         }
     }
 
@@ -189,7 +177,7 @@ impl OwnedRuntime {
         match &self.inner {
             RuntimeInner::Tokio(runtime) => runtime.block_on(future),
             #[cfg(feature = "dial9")]
-            RuntimeInner::Dial9(runtime) => runtime.block_on(future),
+            RuntimeInner::Dial9 { runtime, .. } => ::dial9::block_on(runtime, future),
         }
     }
 
@@ -208,45 +196,15 @@ impl OwnedRuntime {
 
     /// Dispose of the runtime without blocking the caller indefinitely.
     ///
-    /// Tokio supports a bounded consuming shutdown directly. dial9's traced
-    /// runtime does not currently expose one, so its drop is isolated on a
-    /// reaper thread and awaited for at most `grace`.
+    /// Workers get `grace` to stop. With `dial9` the trace pipeline then gets
+    /// another `grace` to drain, so budget for twice that.
     pub fn shutdown_bounded(self, grace: Duration) {
         match self.inner {
             RuntimeInner::Tokio(runtime) => runtime.shutdown_timeout(grace),
             #[cfg(feature = "dial9")]
-            RuntimeInner::Dial9(runtime) => {
-                let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
-                let mut runtime = std::mem::ManuallyDrop::new(runtime);
-                let spawned = std::thread::Builder::new()
-                    .name("rama-runtime-dispose".to_owned())
-                    .spawn(move || {
-                        // SAFETY: the closure is the sole owner and takes the
-                        // value exactly once.
-                        drop(unsafe { std::mem::ManuallyDrop::take(&mut runtime) });
-                        _ = done_tx.send(());
-                    });
-                match spawned {
-                    Ok(thread) => match done_rx.recv_timeout(grace) {
-                        Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                            if thread.join().is_err() {
-                                tracing::error!("dial9 runtime dispose thread panicked");
-                            }
-                        }
-                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                            tracing::warn!(
-                                ?grace,
-                                "dial9 runtime shutdown timed out; detaching dispose thread"
-                            );
-                        }
-                    },
-                    Err(err) => {
-                        tracing::error!(
-                            %err,
-                            "failed to spawn dial9 runtime dispose thread; leaking runtime"
-                        );
-                    }
-                }
+            RuntimeInner::Dial9 { runtime, recorder } => {
+                runtime.shutdown_timeout(grace);
+                recorder.graceful_shutdown(grace);
             }
         }
     }
@@ -282,28 +240,26 @@ mod tests {
     #[cfg(feature = "dial9")]
     #[test]
     fn external_spawn_keeps_its_dial9_session() {
+        use ::dial9::Dial9HandleTokioExt as _;
         use std::sync::mpsc;
 
+        let _slot = crate::rt::dial9_test_util::recorder_slot();
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("owned-runtime.bin"))
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
-            .build()
+        let recorder = crate::rt::dial9_test_util::recorder(temp_dir.path());
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.enable_all();
+        let tokio_runtime = recorder
+            .handle()
+            .attach_tokio_runtime(builder, ::dial9::TokioAttachOptions::default())
             .unwrap();
-        let runtime = OwnedRuntime::from_dial9(
-            ::dial9_tokio_telemetry::TracedRuntime::try_new(config).unwrap(),
-        );
+        let runtime = OwnedRuntime::from_dial9((recorder, tokio_runtime));
         let handle = runtime.handle();
         let (tx, rx) = mpsc::sync_channel(1);
 
         std::thread::spawn(move || {
             _ = handle.spawn(async move {
-                tx.send(
-                    ::dial9_tokio_telemetry::telemetry::TelemetryHandle::current().is_enabled(),
-                )
-                .unwrap();
+                tx.send(::dial9::Dial9Handle::current().is_enabled())
+                    .unwrap();
             });
         })
         .join()
@@ -316,15 +272,19 @@ mod tests {
     #[cfg(feature = "dial9")]
     #[test]
     fn dial9_shutdown_honors_the_grace_period() {
+        use ::dial9::Dial9HandleTokioExt as _;
         use std::sync::mpsc;
 
-        let config = ::dial9_tokio_telemetry::Dial9Config::builder()
-            .enabled(false)
-            .build()
+        // A disabled recorder claims no process-wide slot, so this one needs no
+        // serializing against the other dial9 tests.
+        let recorder = ::dial9::recorder_disabled();
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+        builder.enable_all();
+        let tokio_runtime = recorder
+            .handle()
+            .attach_tokio_runtime(builder, ::dial9::TokioAttachOptions::default())
             .unwrap();
-        let runtime = OwnedRuntime::from_dial9(
-            ::dial9_tokio_telemetry::TracedRuntime::try_new(config).unwrap(),
-        );
+        let runtime = OwnedRuntime::from_dial9((recorder, tokio_runtime));
         let (started_tx, started_rx) = mpsc::sync_channel(1);
         let (release_tx, release_rx) = mpsc::sync_channel(1);
         _ = runtime.spawn(async move {

--- a/rama-core/src/stream/forward.rs
+++ b/rama-core/src/stream/forward.rs
@@ -93,8 +93,6 @@ impl core::fmt::Display for BridgeCloseReason {
 #[cfg(feature = "dial9")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
 impl dial9_trace_format::TraceField for BridgeCloseReason {
-    type Ref<'a> = Self;
-
     fn field_type() -> dial9_trace_format::types::FieldType {
         dial9_trace_format::types::FieldType::U8
     }
@@ -118,25 +116,6 @@ impl dial9_trace_format::TraceField for BridgeCloseReason {
             Self::FirstByteTimeout => 12,
         };
         enc.write_u8(code)
-    }
-
-    fn decode_ref<'a>(val: &dial9_trace_format::types::FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        use dial9_trace_format::types::FieldValueRef;
-        match val {
-            FieldValueRef::Varint(1) => Some(Self::Shutdown),
-            FieldValueRef::Varint(2) => Some(Self::IdleTimeout),
-            FieldValueRef::Varint(3) => Some(Self::PeerEofLeft),
-            FieldValueRef::Varint(4) => Some(Self::PeerEofRight),
-            FieldValueRef::Varint(5) => Some(Self::ReadErrorLeft),
-            FieldValueRef::Varint(6) => Some(Self::ReadErrorRight),
-            FieldValueRef::Varint(7) => Some(Self::WriteErrorLeft),
-            FieldValueRef::Varint(8) => Some(Self::WriteErrorRight),
-            FieldValueRef::Varint(9) => Some(Self::PeekTimeout),
-            FieldValueRef::Varint(10) => Some(Self::HandlerDeadline),
-            FieldValueRef::Varint(11) => Some(Self::PausedTimeout),
-            FieldValueRef::Varint(12) => Some(Self::FirstByteTimeout),
-            _ => None,
-        }
     }
 }
 

--- a/rama-core/src/telemetry/mod.rs
+++ b/rama-core/src/telemetry/mod.rs
@@ -6,7 +6,7 @@ pub mod dial9 {
     //! dial9 runtime telemetry re-exports.
 
     #[doc(inline)]
-    pub use ::dial9_tokio_telemetry::*;
+    pub use ::dial9::*;
     #[doc(inline)]
     pub use ::dial9_trace_format as trace_format;
 }

--- a/rama-dns/Cargo.toml
+++ b/rama-dns/Cargo.toml
@@ -33,13 +33,13 @@ default = []
 hickory = ["dep:hickory-resolver"]
 # Optional [dial9] runtime telemetry support.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = ["dep:dial9-tokio-telemetry", "dep:dial9-trace-format", "rama-net/dial9"]
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["dep:dial9", "dep:dial9-trace-format", "rama-net/dial9"]
 
 [dependencies]
 ahash = { workspace = true }
 arc-swap = { workspace = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 hickory-resolver = { workspace = true, optional = true }
 moka = { workspace = true, features = ["future", "sync"] }

--- a/rama-dns/src/client/lb/cache.rs
+++ b/rama-dns/src/client/lb/cache.rs
@@ -171,7 +171,7 @@ where
             return;
         };
 
-        tokio::spawn(async move {
+        rama_core::rt::spawn(async move {
             match self.resolve(&host).await {
                 Ok(ips) => {
                     tracing::trace!(%host, ?ips, "dns lb: refreshed addresses");

--- a/rama-dns/src/client/systemd_resolved.rs
+++ b/rama-dns/src/client/systemd_resolved.rs
@@ -248,7 +248,7 @@ impl SystemdResolved {
             return ResolvedLookup::Unavailable;
         }
         let this = self.clone();
-        join(tokio::spawn(async move {
+        join(rama_core::rt::spawn(async move {
             this.record_query(claim, name, rooted, timeout).await
         }))
         .await
@@ -266,7 +266,7 @@ impl SystemdResolved {
         };
         let this = self.clone();
         let name = wire_name(domain);
-        join(tokio::spawn(async move {
+        join(rama_core::rt::spawn(async move {
             this.hostname_query(claim, name, family, timeout, decode)
                 .await
         }))

--- a/rama-dns/src/dial9.rs
+++ b/rama-dns/src/dial9.rs
@@ -1,8 +1,9 @@
 //! Pre-defined [dial9] events for DNS lookups.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
 use dial9_trace_format::TraceEvent;
 use rama_net::address::Domain;
 
@@ -31,16 +32,13 @@ pub struct DnsLookupResolved {
 
 #[inline]
 pub(crate) fn record_lookup_started(domain: Domain, query_family: u8) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            DnsLookupStarted {
-                timestamp_ns: clock_monotonic_ns(),
-                domain,
-                query_family: query_family as u32,
-            },
-            &handle,
-        );
+        handle.record_event(DnsLookupStarted {
+            timestamp_ns: clock_monotonic_ns(),
+            domain,
+            query_family: query_family as u32,
+        });
     }
 }
 
@@ -51,17 +49,14 @@ pub(crate) fn record_lookup_resolved(
     elapsed_ms: u64,
     success: bool,
 ) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            DnsLookupResolved {
-                timestamp_ns: clock_monotonic_ns(),
-                domain,
-                query_family: query_family as u32,
-                elapsed_ms,
-                success,
-            },
-            &handle,
-        );
+        handle.record_event(DnsLookupResolved {
+            timestamp_ns: clock_monotonic_ns(),
+            domain,
+            query_family: query_family as u32,
+            elapsed_ms,
+            success,
+        });
     }
 }

--- a/rama-fastcgi/src/server/mod.rs
+++ b/rama-fastcgi/src/server/mod.rs
@@ -256,7 +256,7 @@ impl<S> FastCgiServer<S> {
             oneshot::channel::<io::Result<(ReadHalf<IO>, bool)>>();
 
         let options_for_task = self.options.clone();
-        let handle = tokio::spawn(async move {
+        let handle = rama_core::rt::spawn(async move {
             let result =
                 conn::read_body_records(rh, request_id, stdin_tx, data_tx, options_for_task).await;
             if reader_return_tx.send(result).is_err() {

--- a/rama-http-backend/src/client/proxy/layer/proxy_connector/connector.rs
+++ b/rama-http-backend/src/client/proxy/layer/proxy_connector/connector.rs
@@ -106,7 +106,7 @@ impl InnerHttpProxyConnector {
             .await
             .map_err(|err| HttpProxyError::Transport(err.into()))?;
 
-        tokio::spawn(async move {
+        rama_core::rt::spawn(async move {
             if let Err(err) = conn.with_upgrades().await {
                 tracing::debug!("http upgrade proxy client conn failed: {err:?}");
             }
@@ -126,7 +126,7 @@ impl InnerHttpProxyConnector {
             .await
             .map_err(|err| HttpProxyError::Transport(err.into()))?;
 
-        tokio::spawn(async move {
+        rama_core::rt::spawn(async move {
             if let Err(err) = conn.await {
                 tracing::debug!("http2 proxy client conn failed: {err:?}");
             }

--- a/rama-http/src/layer/har/recorder/fs.rs
+++ b/rama-http/src/layer/har/recorder/fs.rs
@@ -256,7 +256,7 @@ impl FileRecorderTask {
         let mut completed = BTreeMap::new();
         let (cancel_tx, _) = watch::channel(false);
         let (temp_cleanup, temp_cleanup_worker) = TempPathCleanup::new();
-        let temp_cleanup_task = tokio::spawn(temp_cleanup_worker.run());
+        let temp_cleanup_task = rama_core::rt::spawn(temp_cleanup_worker.run());
 
         loop {
             tokio::select! {
@@ -624,7 +624,7 @@ async fn create_web_socket_capture(
     });
     let closer = capture.close_handle();
     let (done, completion) = oneshot::channel();
-    tokio::spawn(async move {
+    rama_core::rt::spawn(async move {
         _ = done.send(write_web_socket_capture(file, path, receiver, closed_at_rx).await);
     });
     Ok((capture, completion, closer))
@@ -1393,7 +1393,7 @@ impl FileRecorder {
         self.task.once.call_once(|| {
             let task = self.task.task.lock().take();
             if let Some(task) = task {
-                tokio::spawn(task.run());
+                rama_core::rt::spawn(task.run());
             }
         });
     }

--- a/rama-http/src/layer/har/toggle.rs
+++ b/rama-http/src/layer/har/toggle.rs
@@ -73,7 +73,7 @@ where
 {
     let toggle: Arc<AtomicBool> = Default::default();
     let flag = toggle.clone();
-    tokio::spawn(async move {
+    rama_core::rt::spawn(async move {
         let mut cancel = std::pin::pin!(cancel);
         loop {
             tokio::select! {
@@ -115,7 +115,7 @@ where
 {
     let toggle: Arc<AtomicBool> = Default::default();
     let flag = toggle.clone();
-    tokio::spawn(async move {
+    rama_core::rt::spawn(async move {
         let mut cancel = std::pin::pin!(cancel);
         loop {
             tokio::select! {
@@ -161,7 +161,7 @@ where
     let toggle: Arc<AtomicBool> = Default::default();
     let flag = toggle.clone();
 
-    tokio::spawn(async move {
+    rama_core::rt::spawn(async move {
         let mut cancel = std::pin::pin!(cancel);
         loop {
             tokio::select! {

--- a/rama-http/src/service/client/blocking.rs
+++ b/rama-http/src/service/client/blocking.rs
@@ -566,8 +566,8 @@ mod tests {
         let temp_dir = rama_utils::fs::tempdir().unwrap();
         let writer = rama_core::telemetry::dial9::DiskBuffer::builder()
             .base_path(temp_dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
+            .max_file_size(rama_utils::octets::mib_u64(1))
+            .max_total_size(rama_utils::octets::mib_u64(4))
             .build();
         let recorder = rama_core::telemetry::dial9::recorder_or_disabled(writer).build();
         let runtime = Runtime::builder()

--- a/rama-http/src/service/client/blocking.rs
+++ b/rama-http/src/service/client/blocking.rs
@@ -564,22 +564,19 @@ mod tests {
     #[test]
     fn client_request_runs_inside_dial9_session() {
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = rama_core::telemetry::dial9::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("blocking-http.bin"))
+        let writer = rama_core::telemetry::dial9::DiskBuffer::builder()
+            .base_path(temp_dir.path())
             .max_file_size(1024 * 1024)
             .max_total_size(4 * 1024 * 1024)
-            .build()
-            .unwrap();
+            .build();
+        let recorder = rama_core::telemetry::dial9::recorder_or_disabled(writer).build();
         let runtime = Runtime::builder()
-            .with_dial9_config(config)
+            .with_dial9_recorder(recorder)
             .try_build()
             .unwrap();
         let client = Client::with_runtime(
             service_fn(|_: Request| async {
-                assert!(
-                    rama_core::telemetry::dial9::telemetry::TelemetryHandle::current().is_enabled()
-                );
+                assert!(rama_core::telemetry::dial9::Dial9Handle::current().is_enabled());
                 Ok::<_, BoxError>(HttpResponse::new(HttpBody::from("tracked")))
             }),
             &runtime,

--- a/rama-net-apple-networkextension/Cargo.toml
+++ b/rama-net-apple-networkextension/Cargo.toml
@@ -27,14 +27,13 @@ ignored = ["bindgen", "cc"]
 default = []
 # Optional [dial9] runtime telemetry support.
 #
-# Building with this feature requires `--cfg tokio_unstable`.
-#
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = ["dep:dial9-tokio-telemetry", "dep:dial9-trace-format", "rama-core/dial9"]
+# `--cfg tokio_unstable` widens dial9's task coverage.
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["dep:dial9", "dep:dial9-trace-format", "rama-core/dial9"]
 
 [dependencies]
 atomic-waker = { workspace = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 libc = { workspace = true }
 parking_lot = { workspace = true }

--- a/rama-net-apple-networkextension/src/tproxy/dial9.rs
+++ b/rama-net-apple-networkextension/src/tproxy/dial9.rs
@@ -1,17 +1,18 @@
 //! Pre-defined [dial9] events for the transparent proxy engine, plus
 //! tiny recording helpers that emit them when a
-//! `dial9-tokio-telemetry::TracedRuntime` is active.
+//! a `dial9` recorder is attached to the runtime.
 //!
 //! Mirrors the structured `tracing` events emitted by the engine
 //! (`open` / `close` / `handler-deadline`), encoded for fast offline
 //! analysis with `dial9-viewer` and friends.
 //!
 //! Enabled with the `dial9` cargo feature on this crate. Emission is a
-//! no-op when no `TracedRuntime` is in effect.
+//! no-op when no recorder is attached.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
 use dial9_trace_format::TraceEvent;
 
 /// Emitted right after the engine has assigned a `flow_id` to a new
@@ -55,48 +56,39 @@ pub struct TproxyHandlerDeadline {
 
 #[inline]
 pub(crate) fn record_flow_opened(flow_id: u64, protocol: u32, pid: Option<i32>) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TproxyFlowOpened {
-                timestamp_ns: clock_monotonic_ns(),
-                flow_id,
-                protocol,
-                pid: pid.map(i64::from).unwrap_or(0),
-            },
-            &handle,
-        );
+        handle.record_event(TproxyFlowOpened {
+            timestamp_ns: clock_monotonic_ns(),
+            flow_id,
+            protocol,
+            pid: pid.map(i64::from).unwrap_or(0),
+        });
     }
 }
 
 #[inline]
 pub(crate) fn record_flow_closed(flow_id: u64, age_ms: u64, bytes_in: u64, bytes_out: u64) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TproxyFlowClosed {
-                timestamp_ns: clock_monotonic_ns(),
-                flow_id,
-                age_ms,
-                bytes_in,
-                bytes_out,
-            },
-            &handle,
-        );
+        handle.record_event(TproxyFlowClosed {
+            timestamp_ns: clock_monotonic_ns(),
+            flow_id,
+            age_ms,
+            bytes_in,
+            bytes_out,
+        });
     }
 }
 
 #[inline]
 pub(crate) fn record_handler_deadline(flow_id: u64, deadline_ms: u64) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TproxyHandlerDeadline {
-                timestamp_ns: clock_monotonic_ns(),
-                flow_id,
-                deadline_ms,
-            },
-            &handle,
-        );
+        handle.record_event(TproxyHandlerDeadline {
+            timestamp_ns: clock_monotonic_ns(),
+            flow_id,
+            deadline_ms,
+        });
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/dial9.rs
+++ b/rama-net-apple-networkextension/src/tproxy/dial9.rs
@@ -1,6 +1,6 @@
 //! Pre-defined [dial9] events for the transparent proxy engine, plus
 //! tiny recording helpers that emit them when a
-//! a `dial9` recorder is attached to the runtime.
+//! `dial9` recorder is attached to the runtime.
 //!
 //! Mirrors the structured `tracing` events emitted by the engine
 //! (`open` / `close` / `handler-deadline`), encoded for fast offline

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -1208,7 +1208,10 @@ where
         }
     }
 
-    let service_task = Executor::graceful(flow_guard.clone()).spawn_task(async move {
+    // Boxed: the future embeds the whole per-flow service stack, and this
+    // spawn runs on Swift dispatch threads with 512 KiB stacks — moving it
+    // by value through the spawn chain overflows them in debug builds.
+    let service_task = Executor::graceful(flow_guard.clone()).spawn_task(Box::pin(async move {
         let _task_guard = TcpFlowTaskGuard::new();
         let Ok(bridge) = bridge_rx.await else {
             // Cancelled before `activate`. Emit a synthetic close so
@@ -1300,7 +1303,7 @@ where
                 ingress_sent,
             );
         }
-    });
+    }));
 
     let pending = TcpSessionPendingData {
         bridge_tx,
@@ -1688,7 +1691,8 @@ where
     let meta_for_close = meta_arc.clone();
     let flow_guard_for_task = flow_guard.clone();
     let idle_notify_for_task = idle_notify.clone();
-    let service_task = Executor::graceful(flow_guard).spawn_task(async move {
+    // Boxed for the same small-FFI-stack reason as the TCP service task.
+    let service_task = Executor::graceful(flow_guard).spawn_task(Box::pin(async move {
         let Ok(flow) = flow_rx.await else {
             // Cancelled before activate — emit a synthetic close so post-mortem
             // logs still account for the flow.
@@ -1780,7 +1784,7 @@ where
             crate::tproxy::dial9::record_flow_closed(meta_for_close.flow_id, age_ms, 0, 0);
         }
         closed_sink();
-    });
+    }));
 
     let pending = UdpSessionPendingData {
         flow_tx,

--- a/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/mod.rs
@@ -1165,7 +1165,7 @@ where
     // Spawn through the rama `Executor` (graceful-aware) instead of
     // `flow_guard.spawn_task` directly, so that with the `dial9`
     // feature on the inner `tokio::spawn` is replaced by
-    // `dial9_tokio_telemetry::spawn` — giving per-future wake-event
+    // `dial9::spawn` — giving per-future wake-event
     // tracking on this long-lived per-flow service task.
     let meta_for_close = meta.clone();
     let counters_for_close = byte_counters.clone();

--- a/rama-net-apple-networkextension/src/tproxy/engine/runtime.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/runtime.rs
@@ -6,8 +6,8 @@ use rama_core::rt::{OwnedRuntime, OwnedRuntimeHandle};
 /// Async runtime owned by a [`TransparentProxyEngine`].
 ///
 /// This is the shared [`rama_core::rt::OwnedRuntime`] used across Rama. It
-/// wraps either a plain Tokio runtime or, when `dial9` is enabled, a traced
-/// runtime while retaining the exact telemetry handle used for spawned work.
+/// wraps either a plain Tokio runtime or, when `dial9` is enabled, a
+/// dial9-instrumented runtime against a recorder it keeps alive.
 ///
 /// [`TransparentProxyEngine`]: super::TransparentProxyEngine
 #[derive(Debug)]
@@ -24,13 +24,13 @@ impl TransparentProxyAsyncRuntime {
         }
     }
 
-    /// Wrap a dial9 traced runtime.
+    /// Wrap a dial9-instrumented runtime and its recorder.
     #[cfg(feature = "dial9")]
     #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
     #[must_use]
-    pub fn from_dial9(runtime: ::dial9_tokio_telemetry::TracedRuntime) -> Self {
+    pub fn from_dial9(attached: ::dial9::AttachedRuntime) -> Self {
         Self {
-            inner: OwnedRuntime::from_dial9(runtime),
+            inner: OwnedRuntime::from_dial9(attached),
         }
     }
 
@@ -107,31 +107,32 @@ where
 
 /// Default factory for a multi-thread Tokio runtime.
 ///
-/// With the `dial9` feature it resolves [`Dial9Config::from_env`] when creating
-/// the runtime and builds a `dial9-tokio-telemetry::TracedRuntime`. The
+/// With the `dial9` feature it resolves the `DIAL9_*` environment when creating
+/// the runtime and instruments it against the resulting recorder. The
 /// environment default is telemetry-disabled unless `DIAL9_ENABLED` requests it.
-///
-/// [`Dial9Config`]: dial9_tokio_telemetry::Dial9Config
-/// [`Dial9Config::from_env`]: dial9_tokio_telemetry::Dial9Config::from_env
 #[derive(Debug)]
 pub struct DefaultTransparentProxyAsyncRuntimeFactory {
     #[cfg(feature = "dial9")]
-    dial9_config: FactoryDial9Config,
+    dial9_recorder: FactoryDial9Recorder,
+    #[cfg(feature = "dial9")]
+    dial9_attach_options: ::dial9::TokioAttachOptions,
 }
 
 #[cfg(feature = "dial9")]
 #[derive(Debug)]
-enum FactoryDial9Config {
+enum FactoryDial9Recorder {
     FromEnv,
     Disabled,
-    Custom(Box<::dial9_tokio_telemetry::Dial9Config>),
+    Custom(Box<::dial9::Recorder>),
 }
 
 impl Default for DefaultTransparentProxyAsyncRuntimeFactory {
     fn default() -> Self {
         Self {
             #[cfg(feature = "dial9")]
-            dial9_config: FactoryDial9Config::FromEnv,
+            dial9_recorder: FactoryDial9Recorder::FromEnv,
+            #[cfg(feature = "dial9")]
+            dial9_attach_options: ::dial9::TokioAttachOptions::default(),
         }
     }
 }
@@ -145,27 +146,44 @@ impl DefaultTransparentProxyAsyncRuntimeFactory {
 
     #[cfg(feature = "dial9")]
     rama_utils::macros::generate_set_and_with! {
-        /// Set the [`Dial9Config`] used to build the runtime.
+        /// Set the [`Recorder`] the runtime is recorded into.
         ///
-        /// This defaults to resolving [`Dial9Config::from_env`] when creating
+        /// This defaults to resolving the `DIAL9_*` environment when creating
         /// the runtime. Use
-        /// [`without_dial9_config`](Self::without_dial9_config) for a plain
-        /// Tokio runtime. Use [`Dial9ConfigBuilder::build_or_disabled`] when a
-        /// custom config should fall back to a plain runtime on configuration
+        /// [`without_dial9_recorder`](Self::without_dial9_recorder) for a plain
+        /// Tokio runtime. Use [`dial9::recorder_or_disabled`] when a
+        /// custom recorder should fall back to a plain runtime on configuration
         /// failure.
         ///
-        /// [`Dial9Config`]: dial9_tokio_telemetry::Dial9Config
-        /// [`Dial9Config::from_env`]: dial9_tokio_telemetry::Dial9Config::from_env
-        /// [`Dial9ConfigBuilder::build_or_disabled`]: dial9_tokio_telemetry::Dial9ConfigBuilder::build_or_disabled
+        /// [`Recorder`]: dial9::Recorder
+        /// [`dial9::recorder_or_disabled`]: dial9::recorder_or_disabled
         #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
-        pub fn dial9_config(
+        pub fn dial9_recorder(
             mut self,
-            dial9_config: Option<::dial9_tokio_telemetry::Dial9Config>,
+            dial9_recorder: Option<::dial9::Recorder>,
         ) -> Self {
-            self.dial9_config = match dial9_config {
-                Some(config) => FactoryDial9Config::Custom(Box::new(config)),
-                None => FactoryDial9Config::Disabled,
+            self.dial9_recorder = match dial9_recorder {
+                Some(recorder) => FactoryDial9Recorder::Custom(Box::new(recorder)),
+                None => FactoryDial9Recorder::Disabled,
             };
+            self
+        }
+    }
+
+    #[cfg(feature = "dial9")]
+    rama_utils::macros::generate_set_and_with! {
+        /// Set the dial9 tracing options for the engine's runtime, such as the
+        /// runtime name a multi-extension trace is disambiguated by.
+        ///
+        /// Only applies alongside
+        /// [`with_dial9_recorder`](Self::with_dial9_recorder): the environment
+        /// path takes its options from the `DIAL9_*` variables.
+        #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
+        pub fn dial9_attach_options(
+            mut self,
+            dial9_attach_options: ::dial9::TokioAttachOptions,
+        ) -> Self {
+            self.dial9_attach_options = dial9_attach_options;
             self
         }
     }
@@ -179,17 +197,26 @@ impl TransparentProxyAsyncRuntimeFactory for DefaultTransparentProxyAsyncRuntime
         _: Option<&[u8]>,
     ) -> Result<TransparentProxyAsyncRuntime, Self::Error> {
         #[cfg(feature = "dial9")]
-        let dial9_config = match self.dial9_config {
-            FactoryDial9Config::FromEnv => Some(::dial9_tokio_telemetry::Dial9Config::from_env()),
-            FactoryDial9Config::Disabled => None,
-            FactoryDial9Config::Custom(config) => Some(*config),
-        };
+        match self.dial9_recorder {
+            FactoryDial9Recorder::Disabled => {}
+            FactoryDial9Recorder::FromEnv => {
+                let attached = ::dial9::recorder_from_env()
+                    .context("build dial9 instrumented runtime from environment")?;
+                return Ok(TransparentProxyAsyncRuntime::from_dial9(attached));
+            }
+            FactoryDial9Recorder::Custom(recorder) => {
+                use ::dial9::Dial9HandleTokioExt as _;
 
-        #[cfg(feature = "dial9")]
-        if let Some(cfg) = dial9_config {
-            let rt = ::dial9_tokio_telemetry::TracedRuntime::try_new(cfg)
-                .context("build dial9 traced runtime")?;
-            return Ok(TransparentProxyAsyncRuntime::from_dial9(rt));
+                let mut builder = tokio::runtime::Builder::new_multi_thread();
+                builder.enable_all();
+                let runtime = recorder
+                    .handle()
+                    .attach_tokio_runtime(builder, self.dial9_attach_options)
+                    .context("attach dial9 recorder to engine runtime")?;
+                return Ok(TransparentProxyAsyncRuntime::from_dial9((
+                    *recorder, runtime,
+                )));
+            }
         }
 
         let rt = tokio::runtime::Builder::new_multi_thread()
@@ -207,9 +234,15 @@ mod tests {
     #[test]
     fn default_factory_defers_dial9_environment_resolution() {
         let factory = DefaultTransparentProxyAsyncRuntimeFactory::default();
-        assert!(matches!(factory.dial9_config, FactoryDial9Config::FromEnv));
+        assert!(matches!(
+            factory.dial9_recorder,
+            FactoryDial9Recorder::FromEnv
+        ));
 
-        let factory = factory.without_dial9_config();
-        assert!(matches!(factory.dial9_config, FactoryDial9Config::Disabled));
+        let factory = factory.without_dial9_recorder();
+        assert!(matches!(
+            factory.dial9_recorder,
+            FactoryDial9Recorder::Disabled
+        ));
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/runtime.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/runtime.rs
@@ -115,7 +115,7 @@ pub struct DefaultTransparentProxyAsyncRuntimeFactory {
     #[cfg(feature = "dial9")]
     dial9_recorder: FactoryDial9Recorder,
     #[cfg(feature = "dial9")]
-    dial9_attach_options: ::dial9::TokioAttachOptions,
+    dial9_attach_options: Option<::dial9::TokioAttachOptions>,
 }
 
 #[cfg(feature = "dial9")]
@@ -132,7 +132,7 @@ impl Default for DefaultTransparentProxyAsyncRuntimeFactory {
             #[cfg(feature = "dial9")]
             dial9_recorder: FactoryDial9Recorder::FromEnv,
             #[cfg(feature = "dial9")]
-            dial9_attach_options: ::dial9::TokioAttachOptions::default(),
+            dial9_attach_options: None,
         }
     }
 }
@@ -175,15 +175,17 @@ impl DefaultTransparentProxyAsyncRuntimeFactory {
         /// Set the dial9 tracing options for the engine's runtime, such as the
         /// runtime name a multi-extension trace is disambiguated by.
         ///
-        /// Only applies alongside
-        /// [`with_dial9_recorder`](Self::with_dial9_recorder): the environment
-        /// path takes its options from the `DIAL9_*` variables.
+        /// Applies alongside
+        /// [`with_dial9_recorder`](Self::with_dial9_recorder). The environment
+        /// path takes its options from the `DIAL9_*` variables, so combining
+        /// options with it is rejected when the runtime is created; with
+        /// telemetry explicitly disabled the options are moot.
         #[cfg_attr(docsrs, doc(cfg(feature = "dial9")))]
         pub fn dial9_attach_options(
             mut self,
             dial9_attach_options: ::dial9::TokioAttachOptions,
         ) -> Self {
-            self.dial9_attach_options = dial9_attach_options;
+            self.dial9_attach_options = Some(dial9_attach_options);
             self
         }
     }
@@ -197,25 +199,39 @@ impl TransparentProxyAsyncRuntimeFactory for DefaultTransparentProxyAsyncRuntime
         _: Option<&[u8]>,
     ) -> Result<TransparentProxyAsyncRuntime, Self::Error> {
         #[cfg(feature = "dial9")]
-        match self.dial9_recorder {
-            FactoryDial9Recorder::Disabled => {}
-            FactoryDial9Recorder::FromEnv => {
-                let attached = ::dial9::recorder_from_env()
-                    .context("build dial9 instrumented runtime from environment")?;
-                return Ok(TransparentProxyAsyncRuntime::from_dial9(attached));
+        {
+            if self.dial9_attach_options.is_some()
+                && matches!(self.dial9_recorder, FactoryDial9Recorder::FromEnv)
+            {
+                return Err(rama_core::error::extra::OpaqueError::from_static_str(
+                    "dial9 attach options require an explicit dial9 recorder; the environment path configures itself from `DIAL9_*`",
+                )
+                .into());
             }
-            FactoryDial9Recorder::Custom(recorder) => {
-                use ::dial9::Dial9HandleTokioExt as _;
 
-                let mut builder = tokio::runtime::Builder::new_multi_thread();
-                builder.enable_all();
-                let runtime = recorder
-                    .handle()
-                    .attach_tokio_runtime(builder, self.dial9_attach_options)
-                    .context("attach dial9 recorder to engine runtime")?;
-                return Ok(TransparentProxyAsyncRuntime::from_dial9((
-                    *recorder, runtime,
-                )));
+            match self.dial9_recorder {
+                FactoryDial9Recorder::Disabled => {}
+                FactoryDial9Recorder::FromEnv => {
+                    let attached = ::dial9::recorder_from_env()
+                        .context("build dial9 instrumented runtime from environment")?;
+                    return Ok(TransparentProxyAsyncRuntime::from_dial9(attached));
+                }
+                FactoryDial9Recorder::Custom(recorder) => {
+                    use ::dial9::Dial9HandleTokioExt as _;
+
+                    let mut builder = tokio::runtime::Builder::new_multi_thread();
+                    builder.enable_all();
+                    let runtime = recorder
+                        .handle()
+                        .attach_tokio_runtime(
+                            builder,
+                            self.dial9_attach_options.unwrap_or_default(),
+                        )
+                        .context("attach dial9 recorder to engine runtime")?;
+                    return Ok(TransparentProxyAsyncRuntime::from_dial9((
+                        *recorder, runtime,
+                    )));
+                }
             }
         }
 
@@ -244,5 +260,12 @@ mod tests {
             factory.dial9_recorder,
             FactoryDial9Recorder::Disabled
         ));
+    }
+
+    #[test]
+    fn dial9_attach_options_require_an_explicit_recorder() {
+        let factory = DefaultTransparentProxyAsyncRuntimeFactory::new()
+            .with_dial9_attach_options(::dial9::TokioAttachOptions::default());
+        factory.create_async_runtime(None).unwrap_err();
     }
 }

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/dial9.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/dial9.rs
@@ -3,7 +3,7 @@
 use super::common::*;
 use crate::tproxy::engine::*;
 use crate::tproxy::{TransparentProxyFlowMeta, TransparentProxyFlowProtocol};
-use dial9_tokio_telemetry::{Dial9Config, telemetry::TelemetryHandle};
+use dial9::Dial9Handle;
 use parking_lot::Mutex;
 use rama_core::{
     extensions::ExtensionsRef,
@@ -12,21 +12,32 @@ use rama_core::{
 };
 use std::{convert::Infallible, sync::Arc, time::Duration};
 
+/// Serializes tests that build an enabled dial9 recorder, since
+/// dial9 allows a single recorder per process (a second `build()` while one is
+/// alive returns a disabled recorder).
+fn recorder_slot() -> parking_lot::MutexGuard<'static, ()> {
+    static SLOT: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+    SLOT.lock()
+}
+
 fn build_dial9_engine(
     handler: TestHandler,
-    trace_path: std::path::PathBuf,
+    trace_dir: &std::path::Path,
 ) -> TransparentProxyEngine<TestHandler> {
-    let config = Dial9Config::builder()
-        .enabled(true)
-        .base_path(trace_path)
+    let writer = dial9::DiskBuffer::builder()
+        .base_path(trace_dir)
         .max_file_size(1024 * 1024)
         .max_total_size(4 * 1024 * 1024)
-        .build()
-        .expect("build dial9 config");
+        .build();
+    let recorder = dial9::recorder_or_disabled(writer).build();
+    assert!(
+        recorder.handle().is_enabled(),
+        "expected an enabled recorder; is another one still alive?"
+    );
 
     TransparentProxyEngineBuilder::new(TestHandlerFactory(handler))
         .with_runtime_factory(
-            DefaultTransparentProxyAsyncRuntimeFactory::new().with_dial9_config(config),
+            DefaultTransparentProxyAsyncRuntimeFactory::new().with_dial9_recorder(recorder),
         )
         .build()
         .expect("build dial9 engine")
@@ -34,10 +45,11 @@ fn build_dial9_engine(
 
 #[test]
 fn synchronous_app_message_works_with_dial9_runtime() {
+    let _slot = recorder_slot();
     let temp_dir = rama_utils::fs::tempdir().expect("create trace directory");
     let mut handler = TestHandler::passthrough();
     handler.app_message_handler = Arc::new(|_| Some(vec![42]));
-    let engine = build_dial9_engine(handler, temp_dir.path().join("app-message.bin"));
+    let engine = build_dial9_engine(handler, temp_dir.path());
 
     let reply = engine
         .handle_app_message(rama_core::bytes::Bytes::new())
@@ -49,6 +61,7 @@ fn synchronous_app_message_works_with_dial9_runtime() {
 
 #[test]
 fn external_promote_keeps_engine_dial9_session() {
+    let _slot = recorder_slot();
     let temp_dir = rama_utils::fs::tempdir().expect("create trace directory");
     let engine_runtime_id = Arc::new(Mutex::new(None));
     let callback_runtime_id = Arc::clone(&engine_runtime_id);
@@ -84,7 +97,7 @@ fn external_promote_keeps_engine_dial9_session() {
         on_sleep: None,
         on_wake: None,
     };
-    let engine = build_dial9_engine(handler, temp_dir.path().join("promote.bin"));
+    let engine = build_dial9_engine(handler, temp_dir.path());
     let runtime_id = {
         let _enter = engine.rt.as_ref().unwrap().enter();
         tokio::runtime::Handle::current().id()
@@ -104,7 +117,7 @@ fn external_promote_keeps_engine_dial9_session() {
             (*callback_runtime_id.lock()).expect("engine runtime id initialized");
         callback_tx
             .send(
-                TelemetryHandle::current().is_enabled()
+                Dial9Handle::current().is_enabled()
                     && tokio::runtime::Handle::current().id() == expected_runtime_id,
             )
             .expect("send callback telemetry state");

--- a/rama-net-apple-networkextension/src/tproxy/engine/tests/dial9.rs
+++ b/rama-net-apple-networkextension/src/tproxy/engine/tests/dial9.rs
@@ -26,8 +26,8 @@ fn build_dial9_engine(
 ) -> TransparentProxyEngine<TestHandler> {
     let writer = dial9::DiskBuffer::builder()
         .base_path(trace_dir)
-        .max_file_size(1024 * 1024)
-        .max_total_size(4 * 1024 * 1024)
+        .max_file_size(rama_utils::octets::mib_u64(1))
+        .max_total_size(rama_utils::octets::mib_u64(4))
         .build();
     let recorder = dial9::recorder_or_disabled(writer).build();
     assert!(

--- a/rama-net/Cargo.toml
+++ b/rama-net/Cargo.toml
@@ -67,15 +67,10 @@ mmap = ["std", "dep:memmap2"]
 opentelemetry = ["std", "rama-core/opentelemetry"]
 # Optional [dial9] runtime telemetry support.
 #
-# Building with this feature requires `--cfg tokio_unstable`.
+# `--cfg tokio_unstable` widens dial9's task coverage.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = [
-    "std",
-    "dep:dial9-tokio-telemetry",
-    "dep:dial9-trace-format",
-    "rama-core/dial9",
-]
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["std", "dep:dial9", "dep:dial9-trace-format", "rama-core/dial9"]
 
 [dependencies]
 ahash = { workspace = true, optional = true }
@@ -85,7 +80,7 @@ base64 = { version = "0.23", default-features = false, features = ["alloc"], opt
 bitflags = { workspace = true }
 const_format = { workspace = true }
 csv = { workspace = true, optional = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 idna = { workspace = true, optional = true }
 ipnet = { workspace = true, features = ["serde"] }

--- a/rama-net/src/dial9/trace_field.rs
+++ b/rama-net/src/dial9/trace_field.rs
@@ -2,13 +2,8 @@ use std::io::{self, Write};
 
 use crate::address::{Domain, Host};
 
-use dial9_trace_format::{
-    EventEncoder, TraceField,
-    types::{FieldType, FieldValueRef},
-};
+use dial9_trace_format::{EventEncoder, TraceField, types::FieldType};
 impl TraceField for Domain {
-    type Ref<'a> = &'a str;
-
     fn field_type() -> FieldType {
         FieldType::String
     }
@@ -16,18 +11,9 @@ impl TraceField for Domain {
     fn encode<W: Write>(&self, enc: &mut EventEncoder<'_, W>) -> io::Result<()> {
         enc.write_string(self.as_str())
     }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::String(s) => Some(s),
-            _ => None,
-        }
-    }
 }
 
 impl TraceField for Host {
-    type Ref<'a> = &'a str;
-
     fn field_type() -> FieldType {
         FieldType::String
     }
@@ -40,13 +26,6 @@ impl TraceField for Host {
             // `Display`, which handles the bracketed IPvFuture case
             // (re-adds `[...]`) and emits reg-name bytes verbatim.
             Self::Uninterpreted(host) => enc.write_string(&host.to_string()),
-        }
-    }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::String(s) => Some(s),
-            _ => None,
         }
     }
 }

--- a/rama-net/src/proxy/dial9.rs
+++ b/rama-net/src/proxy/dial9.rs
@@ -1,10 +1,11 @@
 //! Pre-defined [dial9] events for proxy bridge lifecycle.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
 use crate::dial9::{io_error_kind_code, io_error_raw_os_code};
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
 use dial9_trace_format::TraceEvent;
 
 /// Bridge lifecycle: the copy loop is about to start.
@@ -41,16 +42,13 @@ pub struct IoForwardBridgeClosed {
 
 #[inline]
 pub(super) fn record_bridge_opened(idle_timeout_ms: u64, graceful: bool) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            IoForwardBridgeOpened {
-                timestamp_ns: clock_monotonic_ns(),
-                idle_timeout_ms,
-                graceful,
-            },
-            &handle,
-        );
+        handle.record_event(IoForwardBridgeOpened {
+            timestamp_ns: clock_monotonic_ns(),
+            idle_timeout_ms,
+            graceful,
+        });
     }
 }
 
@@ -62,19 +60,16 @@ pub(super) fn record_bridge_closed(
     bytes_r_to_l: u64,
     error: Option<&std::io::Error>,
 ) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            IoForwardBridgeClosed {
-                timestamp_ns: clock_monotonic_ns(),
-                reason,
-                age_ms,
-                bytes_l_to_r,
-                bytes_r_to_l,
-                error_kind: error.map(|e| io_error_kind_code(e.kind())),
-                error_raw_os: error.and_then(io_error_raw_os_code),
-            },
-            &handle,
-        );
+        handle.record_event(IoForwardBridgeClosed {
+            timestamp_ns: clock_monotonic_ns(),
+            reason,
+            age_ms,
+            bytes_l_to_r,
+            bytes_r_to_l,
+            error_kind: error.map(|e| io_error_kind_code(e.kind())),
+            error_raw_os: error.and_then(io_error_raw_os_code),
+        });
     }
 }

--- a/rama-socks5/Cargo.toml
+++ b/rama-socks5/Cargo.toml
@@ -30,14 +30,13 @@ default = []
 dns = ["dep:rama-dns"]
 # Optional [dial9] runtime telemetry support.
 #
-# Building with this feature requires `--cfg tokio_unstable`.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = ["dep:dial9-tokio-telemetry", "dep:dial9-trace-format", "rama-net/dial9"]
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["dep:dial9", "dep:dial9-trace-format", "rama-net/dial9"]
 
 [dependencies]
 byteorder = { workspace = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 rama-core = { workspace = true, features = ["std"] }
 rama-dns = { workspace = true, optional = true }

--- a/rama-socks5/src/dial9.rs
+++ b/rama-socks5/src/dial9.rs
@@ -1,8 +1,9 @@
 //! Pre-defined [dial9] events for the SOCKS5 client handshake.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
 use dial9_trace_format::TraceEvent;
 use rama_net::address::Host;
 
@@ -36,31 +37,25 @@ pub struct Socks5HandshakeConnect {
 
 #[inline]
 pub(crate) fn record_handshake_auth(auth_method: u8, success: bool) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            Socks5HandshakeAuth {
-                timestamp_ns: clock_monotonic_ns(),
-                auth_method: auth_method as u32,
-                success,
-            },
-            &handle,
-        );
+        handle.record_event(Socks5HandshakeAuth {
+            timestamp_ns: clock_monotonic_ns(),
+            auth_method: auth_method as u32,
+            success,
+        });
     }
 }
 
 #[inline]
 pub(crate) fn record_handshake_connect(host: Host, port: u16, reply_kind: u8) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            Socks5HandshakeConnect {
-                timestamp_ns: clock_monotonic_ns(),
-                destination_host: host,
-                destination_port: port as u32,
-                reply_kind: reply_kind as u32,
-            },
-            &handle,
-        );
+        handle.record_event(Socks5HandshakeConnect {
+            timestamp_ns: clock_monotonic_ns(),
+            destination_host: host,
+            destination_port: port as u32,
+            reply_kind: reply_kind as u32,
+        });
     }
 }

--- a/rama-socks5/src/dns.rs
+++ b/rama-socks5/src/dns.rs
@@ -32,7 +32,7 @@ pub(crate) async fn race_resolve_dual(
         DnsResolveIpMode::SingleIpV4 | DnsResolveIpMode::SingleIpV6 => (false, false),
     };
 
-    tokio::spawn(
+    rama_core::rt::spawn(
         {
             let tx = tx.clone();
             let domain = domain.clone();
@@ -64,7 +64,7 @@ pub(crate) async fn race_resolve_dual(
         .instrument(trace_span!("dns::ipv4_lookup")),
     );
 
-    tokio::spawn(
+    rama_core::rt::spawn(
         {
             let dns_resolver = dns_resolver.clone();
             async move {

--- a/rama-tls-boring/Cargo.toml
+++ b/rama-tls-boring/Cargo.toml
@@ -27,18 +27,13 @@ compression = ["dep:flate2", "dep:brotli", "dep:zstd"]
 ua = ["dep:rama-ua"]
 # Optional [dial9] runtime telemetry support.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = [
-    "dep:dial9-tokio-telemetry",
-    "dep:dial9-trace-format",
-    "rama-net/dial9",
-    "rama-tls/dial9",
-]
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["dep:dial9", "dep:dial9-trace-format", "rama-net/dial9", "rama-tls/dial9"]
 
 [dependencies]
 ahash = { workspace = true }
 brotli = { workspace = true, optional = true }
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 itertools = { workspace = true }

--- a/rama-tls-boring/src/dial9.rs
+++ b/rama-tls-boring/src/dial9.rs
@@ -1,12 +1,10 @@
 //! Pre-defined [dial9] events for the BoringSSL client handshake.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
-use dial9_trace_format::{
-    EventEncoder, TraceEvent, TraceField,
-    types::{FieldType, FieldValueRef},
-};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
+use dial9_trace_format::{EventEncoder, TraceEvent, TraceField, types::FieldType};
 use rama_net::address::Host;
 use rama_tls::{ApplicationProtocol, ProtocolVersion};
 use std::io::{self, Write};
@@ -15,8 +13,6 @@ use std::io::{self, Write};
 pub struct MaybeServerName(Option<Host>);
 
 impl TraceField for MaybeServerName {
-    type Ref<'a> = &'a str;
-
     fn field_type() -> FieldType {
         FieldType::String
     }
@@ -30,21 +26,12 @@ impl TraceField for MaybeServerName {
             None => enc.write_string(""),
         }
     }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::String(s) => Some(s),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MaybeAlpnSelected(Option<ApplicationProtocol>);
 
 impl TraceField for MaybeAlpnSelected {
-    type Ref<'a> = &'a [u8];
-
     fn field_type() -> FieldType {
         FieldType::Bytes
     }
@@ -53,13 +40,6 @@ impl TraceField for MaybeAlpnSelected {
         match self.0.as_ref() {
             Some(protocol) => enc.write_bytes(protocol.as_bytes()),
             None => enc.write_bytes(&[]),
-        }
-    }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::Bytes(bytes) => Some(bytes),
-            _ => None,
         }
     }
 }
@@ -119,15 +99,12 @@ pub struct TlsHandshakeFailed {
 
 #[inline]
 pub(crate) fn record_handshake_started(server_name: Option<Host>) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeStarted {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name: MaybeServerName(server_name),
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeStarted {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name: MaybeServerName(server_name),
+        });
     }
 }
 
@@ -138,18 +115,15 @@ pub(crate) fn record_handshake_completed(
     alpn_selected: Option<ApplicationProtocol>,
     peer_cert_chain_depth: usize,
 ) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeCompleted {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name: MaybeServerName(server_name),
-                protocol_version,
-                alpn_selected: MaybeAlpnSelected(alpn_selected),
-                peer_cert_chain_depth: u32::try_from(peer_cert_chain_depth).unwrap_or(u32::MAX),
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeCompleted {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name: MaybeServerName(server_name),
+            protocol_version,
+            alpn_selected: MaybeAlpnSelected(alpn_selected),
+            peer_cert_chain_depth: u32::try_from(peer_cert_chain_depth).unwrap_or(u32::MAX),
+        });
     }
 }
 
@@ -159,16 +133,13 @@ pub(crate) fn record_handshake_failed(
     error_kind: u32,
     io_error_kind: Option<u32>,
 ) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeFailed {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name: MaybeServerName(server_name),
-                error_kind,
-                io_error_kind,
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeFailed {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name: MaybeServerName(server_name),
+            error_kind,
+            io_error_kind,
+        });
     }
 }

--- a/rama-tls-rustls/Cargo.toml
+++ b/rama-tls-rustls/Cargo.toml
@@ -33,18 +33,12 @@ aws-lc = [
 ring = ["rustls/ring", "tokio-rustls/ring", "rcgen/ring", "rama-crypto/ring"]
 # Optional [dial9] runtime telemetry support.
 #
-# Building with this feature requires `--cfg tokio_unstable`.
 #
-# [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
-dial9 = [
-    "dep:dial9-tokio-telemetry",
-    "dep:dial9-trace-format",
-    "rama-net/dial9",
-    "rama-tls/dial9",
-]
+# [dial9]: https://github.com/dial9-rs/dial9
+dial9 = ["dep:dial9", "dep:dial9-trace-format", "rama-net/dial9", "rama-tls/dial9"]
 
 [dependencies]
-dial9-tokio-telemetry = { workspace = true, optional = true }
+dial9 = { workspace = true, optional = true }
 dial9-trace-format = { workspace = true, optional = true }
 moka = { workspace = true, features = ["sync"] }
 pin-project-lite = { workspace = true }

--- a/rama-tls-rustls/src/dial9.rs
+++ b/rama-tls-rustls/src/dial9.rs
@@ -1,12 +1,10 @@
 //! Pre-defined [dial9] events for the rustls client handshake.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
-use dial9_tokio_telemetry::telemetry::{TelemetryHandle, clock_monotonic_ns, record_event};
-use dial9_trace_format::{
-    EventEncoder, TraceEvent, TraceField,
-    types::{FieldType, FieldValueRef},
-};
+use dial9::Dial9Handle;
+use dial9::core::clock_monotonic_ns;
+use dial9_trace_format::{EventEncoder, TraceEvent, TraceField, types::FieldType};
 use rama_net::{
     address::Host,
     dial9::{io_error_kind_code, io_error_raw_os_code},
@@ -18,8 +16,6 @@ use std::io::{self, Write};
 pub struct MaybeAlpnSelected(Option<ApplicationProtocol>);
 
 impl TraceField for MaybeAlpnSelected {
-    type Ref<'a> = &'a [u8];
-
     fn field_type() -> FieldType {
         FieldType::Bytes
     }
@@ -28,13 +24,6 @@ impl TraceField for MaybeAlpnSelected {
         match self.0.as_ref() {
             Some(protocol) => enc.write_bytes(protocol.as_bytes()),
             None => enc.write_bytes(&[]),
-        }
-    }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::Bytes(bytes) => Some(bytes),
-            _ => None,
         }
     }
 }
@@ -76,15 +65,12 @@ pub struct TlsHandshakeFailed {
 
 #[inline]
 pub(crate) fn record_handshake_started(server_name: Host) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeStarted {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name,
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeStarted {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name,
+        });
     }
 }
 
@@ -95,33 +81,27 @@ pub(crate) fn record_handshake_completed(
     alpn_selected: Option<ApplicationProtocol>,
     peer_cert_chain_depth: usize,
 ) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeCompleted {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name,
-                protocol_version,
-                alpn_selected: MaybeAlpnSelected(alpn_selected),
-                peer_cert_chain_depth: u32::try_from(peer_cert_chain_depth).unwrap_or(u32::MAX),
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeCompleted {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name,
+            protocol_version,
+            alpn_selected: MaybeAlpnSelected(alpn_selected),
+            peer_cert_chain_depth: u32::try_from(peer_cert_chain_depth).unwrap_or(u32::MAX),
+        });
     }
 }
 
 #[inline]
 pub(crate) fn record_handshake_failed(server_name: Host, error: &std::io::Error) {
-    let handle = TelemetryHandle::current();
+    let handle = Dial9Handle::current();
     if handle.is_enabled() {
-        record_event(
-            TlsHandshakeFailed {
-                timestamp_ns: clock_monotonic_ns(),
-                server_name,
-                error_kind: io_error_kind_code(error.kind()),
-                error_raw_os: io_error_raw_os_code(error),
-            },
-            &handle,
-        );
+        handle.record_event(TlsHandshakeFailed {
+            timestamp_ns: clock_monotonic_ns(),
+            server_name,
+            error_kind: io_error_kind_code(error.kind()),
+            error_raw_os: io_error_raw_os_code(error),
+        });
     }
 }

--- a/rama-tls/src/dial9.rs
+++ b/rama-tls/src/dial9.rs
@@ -1,17 +1,12 @@
 //! [dial9] telemetry `TraceField` impls for the TLS enum vocabulary.
 //!
-//! [dial9]: https://github.com/dial9-rs/dial9-tokio-telemetry
+//! [dial9]: https://github.com/dial9-rs/dial9
 
 use crate::{ApplicationProtocol, ProtocolVersion};
-use dial9_trace_format::{
-    EventEncoder, TraceField,
-    types::{FieldType, FieldValueRef},
-};
+use dial9_trace_format::{EventEncoder, TraceField, types::FieldType};
 use std::io::{self, Write};
 
 impl TraceField for ProtocolVersion {
-    type Ref<'a> = Self;
-
     fn field_type() -> FieldType {
         FieldType::U16
     }
@@ -19,30 +14,14 @@ impl TraceField for ProtocolVersion {
     fn encode<W: Write>(&self, enc: &mut EventEncoder<'_, W>) -> io::Result<()> {
         enc.write_u16(u16::from(*self))
     }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::Varint(v) => u16::try_from(*v).ok().map(Self::from),
-            _ => None,
-        }
-    }
 }
 
 impl TraceField for ApplicationProtocol {
-    type Ref<'a> = &'a [u8];
-
     fn field_type() -> FieldType {
         FieldType::Bytes
     }
 
     fn encode<W: Write>(&self, enc: &mut EventEncoder<'_, W>) -> io::Result<()> {
         enc.write_bytes(self.as_bytes())
-    }
-
-    fn decode_ref<'a>(val: &FieldValueRef<'a>) -> Option<Self::Ref<'a>> {
-        match val {
-            FieldValueRef::Bytes(bytes) => Some(bytes),
-            _ => None,
-        }
     }
 }

--- a/rama-ws/src/handshake/client.rs
+++ b/rama-ws/src/handshake/client.rs
@@ -1735,21 +1735,18 @@ mod tests {
     #[test]
     fn blocking_handshake_runs_inside_dial9_session() {
         let temp_dir = rama_utils::fs::tempdir().unwrap();
-        let config = rama_core::telemetry::dial9::Dial9Config::builder()
-            .enabled(true)
-            .base_path(temp_dir.path().join("blocking-websocket.bin"))
+        let writer = rama_core::telemetry::dial9::DiskBuffer::builder()
+            .base_path(temp_dir.path())
             .max_file_size(1024 * 1024)
             .max_total_size(4 * 1024 * 1024)
-            .build()
-            .unwrap();
+            .build();
+        let recorder = rama_core::telemetry::dial9::recorder_or_disabled(writer).build();
         let runtime = rama_core::rt::blocking::Runtime::builder()
-            .with_dial9_config(config)
+            .with_dial9_recorder(recorder)
             .try_build()
             .unwrap();
         let service = service_fn(|request: Request| async move {
-            assert!(
-                rama_core::telemetry::dial9::telemetry::TelemetryHandle::current().is_enabled()
-            );
+            assert!(rama_core::telemetry::dial9::Dial9Handle::current().is_enabled());
             let key = request
                 .headers()
                 .typed_get::<SecWebSocketKey>()

--- a/rama-ws/src/handshake/client.rs
+++ b/rama-ws/src/handshake/client.rs
@@ -1737,8 +1737,8 @@ mod tests {
         let temp_dir = rama_utils::fs::tempdir().unwrap();
         let writer = rama_core::telemetry::dial9::DiskBuffer::builder()
             .base_path(temp_dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(4 * 1024 * 1024)
+            .max_file_size(rama_utils::octets::mib_u64(1))
+            .max_total_size(rama_utils::octets::mib_u64(4))
             .build();
         let recorder = rama_core::telemetry::dial9::recorder_or_disabled(writer).build();
         let runtime = rama_core::rt::blocking::Runtime::builder()

--- a/scripts/docsrs-metadata-check.sh
+++ b/scripts/docsrs-metadata-check.sh
@@ -6,8 +6,8 @@ exit_code=0
 
 # docs.rs builds use the package metadata from the published crate, not this
 # workspace's local `.cargo/config.toml`. Any crate whose docs.rs all-features
-# build enables `dial9` must pass `--cfg tokio_unstable` via rustc-args, because
-# `dial9-tokio-telemetry` depends on Tokio's unstable runtime APIs.
+# build enables `dial9` must pass `--cfg tokio_unstable` via rustc-args, so the rendered docs cover dial9's
+# full API.
 echo "Checking docs.rs metadata for dial9 crates..."
 docs_rs_metadata_missing=0
 for manifest in $(cd $SCRIPT_DIR/.. && find . -name Cargo.toml -not -path './target/*' | sort); do


### PR DESCRIPTION
Upgrades dial9 0.3 -> 0.5

Moves rama to the `dial9` 0.5 crate (dial9-tokio-telemetry is no longer the main crate to depend on), and drops `--cfg tokio_unstable` as a build requirement.

## API

0.5 removed `Dial9Config` and `TracedRuntime`, users now build a `Recorder` (used to say what and where to record), and attach a Tokio runtime to it (see [release page](https://github.com/dial9-rs/dial9/releases/tag/dial9-v0.5.0)). 
Before you also had to pass your Tokio settings into dial9 and it built the runtime, now you build the runtime and pass it in. 

In summary, the main changes are:

- `with_dial9_config(Dial9Config)` becomes `with_dial9_recorder(dial9::Recorder)`, on both `rt::blocking::RuntimeBuilder` and `DefaultTransparentProxyAsyncRuntimeFactory`.
- A new `with_dial9_attach_options(TokioAttachOptions)` on both, for the per-runtime knobs (task tracking, task dumps, Tokio hooks, runtime name) that used to go inside `Dial9Config`.
- `OwnedRuntime::from_dial9` takes a `dial9::AttachedRuntime` (a recorder + its runtime) and keeps the recorder up.

Some minor cleanup that 0.5 made possible:

- `shutdown_bounded` doesn't need a dispose thread: in 0.3 `TracedRuntime` bundled the runtime and the guard, handing out only references, so neither `shutdown_timeout` nor `graceful_shutdown` (both consuming) were reachable. Holding the two separately now makes both reachable, so the `ManuallyDrop` + dispose-thread + channel trick is gone (including unsafe)
- `OwnedRuntimeHandle` doesn't need the dial9 handle field, `spawn_in` resolves the session on the target worker at first poll, so nothing needs capturing up front.
- dial9 used to build the runtime, so rama's `with_worker_threads` could never reach it and pairing the two was rejected. Now rama builds it, so the worker count applies. Enabled telemetry still needs multi-thread, so `with_current_thread()` is still rejected.
- Decoding is serde-based now and driven by the on-wire schema, so `TraceField` no longer has a decode side. rama's impls drop `type Ref<'a>` and `decode_ref`.

## tokio_unstable

dial9 now builds without tokio unstable, so we remove it from `.cargo/config.toml` and CI jobs (left just one `test-dial9-tokio-unstable`).

Tradeoff for default builds without unstable (users can still opt in): poll events come from dial9's own spawn helpers rather than from tokio, so the task timeline only covers what goes through `rama_core::rt::Executor`. 
That is most of it, since the accept loop and rama-http-core's h2 internals already spawn that way. 
I see that there are some places using bare `tokio::spawn` (socks5 DNS racing, the HTTP proxy connection driver, HAR workers, DNS cache refresh, fastcgi accept) and will go untraced. Task spawn/terminate events and per-worker queue depth need the flag regardless.

Up for discussion / follow-up:
Perhaps `rt::executor::spawn` could be made public and have the places mentioned above start using it? (I'm guessing it wouldn't be `Executor::spawn_task` since that also opts into graceful shutdown)

## Checklist

- [x] This change is linked to an issue we have discussed (see above). (discussed on discord)
- [x] `just qa` passes locally (or I have explained below what I could not run).
- [x] I agree to the [contribution terms](https://github.com/plabayo/rama/blob/main/CONTRIBUTING.md#contribution-terms)
      and the Developer Certificate of Origin.
