### PR TITLE
improve apple NE refusal logic

### DIFF
--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNEFFI/include/rama_apple_ne_ffi.h
@@ -278,8 +278,8 @@ typedef struct {
     /// Connect-timeout clamp while the start-latency breaker is open.
     uint32_t tcp_breaker_connect_timeout_ms;
     /// How the provider treats a flow it declines for its own reasons (start
-    /// hard cap / latency breaker, or a missing session): `0` = Block (default,
-    /// fail closed), `1` = Passthrough (fail open). Always logged either way.
+    /// hard cap / latency breaker, or a missing session): `0` = Block (fail
+    /// closed), `1` = Passthrough (default, fail open). Always logged either way.
     uint32_t flow_refusal_action;
 } RamaTransparentProxyConfig;
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/FFI/RamaFFI.swift
@@ -54,7 +54,8 @@ struct RamaTransparentProxyConfigBridge {
     var tcpBreakerConnectTimeoutMs: UInt32
     /// When the provider declines a flow for its own reasons (start cap /
     /// breaker, or a missing session), hand it to the kernel untouched instead
-    /// of blocking it. `false` (Block, fail closed) is the default.
+    /// of blocking it. `true` (Passthrough, fail open) is the default; see
+    /// `FlowRefusalAction` on the Rust side.
     var flowRefusalPassthrough: Bool
 }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -1065,9 +1065,11 @@ public final class RamaTransparentProxyProvider: NETransparentProxyProvider {
         logDebug: (_ publicMessage: String, _ privateMetadata: String) -> Void
     ) -> Bool {
         let callbackReturn = decision.callbackReturnValue
+        // Source app in the clear, like the TCP shed lines and the tick's
+        // `topApps=`; the destination stays private.
         logDebug(
-            "udp_callback=\(callback.rawValue) rama_decision=\(decision.rawValue) callback_return=\(callbackReturn)",
-            "initial_remote=\(remoteEndpoint?.description ?? "<unsupported-or-missing>") source_app=\(sourceAppSigningIdentifier ?? "<missing>")"
+            "udp_callback=\(callback.rawValue) rama_decision=\(decision.rawValue) callback_return=\(callbackReturn) source_app=\(sourceAppSigningIdentifier ?? "<missing>")",
+            "initial_remote=\(remoteEndpoint?.description ?? "<unsupported-or-missing>")"
         )
         return callbackReturn
     }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/RamaTransparentProxyProvider.swift
@@ -462,7 +462,10 @@ nonisolated(unsafe) var defaultPromotedIdleTimeoutMs: UInt32 = 900_000
 //     BOTH TCP and UDP admission (a UDP burst can approach the ceiling too).
 //   * This reaper never refuses or delays a new flow: the new flow is admitted;
 //     the reap (async, off the delivery thread) frees room for SUBSEQUENT flows.
-//     A burst of triggers is coalesced (`pressureReapInFlight`) into one scan.
+//     A burst of triggers is coalesced (`pressureReapScheduled`) into one scan,
+//     and after a scan finds nothing idle past the floor, rescans are skipped
+//     until the closest flow could possibly cross it (bounded to 250ms–5s) —
+//     under a churn burst the registry is not re-sorted per admission.
 //     Separate TCP start admission caps below may still reject pre-ready egress
 //     starts before another expensive `NWConnection.start` is added.
 //   * NEVER touches an active or recently-active flow: only flows idle past
@@ -495,17 +498,23 @@ nonisolated(unsafe) var defaultFlowPressureIdleFloorMs: UInt32 = 120_000
 /// `.ready` yet. This is the admission-side circuit breaker: every pre-ready
 /// egress connection is exactly the expensive NECP handler population that
 /// makes the next `nw_connection_start` slower, so once this cap is full we
-/// fail newly-claimed intercepted flows fast instead of adding another stalled
-/// start. `0` disables hard admission refusal.
+/// refuse newly-claimed intercepted flows — declined to the direct route, or
+/// blocked, per `defaultFlowRefusalPassthrough` — instead of adding another
+/// stalled start. `0` disables hard admission refusal.
 nonisolated(unsafe) var defaultTcpStartInFlightHardCap: UInt32 = 128
 
 /// When the provider declines a flow for its OWN reasons — the start hard cap /
 /// latency breaker tripping, or the engine handing back an intercept decision
 /// without a session — hand the flow to the kernel untouched (fail open) instead
-/// of blocking it (fail closed). `false` (Block) is the default; the rama user
-/// opts in via `TransparentProxyConfig::with_flow_refusal_action(Passthrough)`.
-/// The chosen action is logged at each decision site regardless.
-nonisolated(unsafe) var defaultFlowRefusalPassthrough: Bool = false
+/// of blocking it (fail closed). `true` (Passthrough) is the default, mirroring
+/// the Rust `FlowRefusalAction` default: these are capacity refusals, and the
+/// direct route the flow declines onto is the same one every policy-passthrough
+/// flow already takes. Blocking turns transient overload into hard connect
+/// errors machine-wide, whose retry storms feed the overload. A strict-posture
+/// deployment opts into that via
+/// `TransparentProxyConfig::with_flow_refusal_action(Block)`. The chosen action
+/// is logged at each decision site regardless.
+nonisolated(unsafe) var defaultFlowRefusalPassthrough: Bool = true
 
 /// Softer pre-ready pressure level used by the latency breaker. A slow
 /// start-to-ready window opens the breaker, but admission refusal only begins
@@ -517,7 +526,11 @@ nonisolated(unsafe) var defaultTcpStartInFlightSoftCap: UInt32 = 64
 /// Start-to-ready latency threshold for the breaker, in milliseconds. The core
 /// tracks a rolling window of recent egress starts; if p95 crosses this
 /// threshold while pre-ready pressure is present, it opens the breaker and
-/// begins shedding new intercepted starts at the soft cap.
+/// begins shedding new intercepted starts at the soft cap. Evaluated on
+/// completion, on admission at/over the soft cap (ahead of the hard-cap
+/// check), and on the maintenance tick, so the admission that brings pressure
+/// onto an already-slow window opens it rather than the next completion. The
+/// window is completed starts only; see `TcpOverloadState.percentile`.
 nonisolated(unsafe) var defaultTcpStartLatencyBreakerP95Ms: UInt32 = 1_500
 
 /// Close threshold for the start-latency breaker. Once p95 drops below this

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -122,16 +122,17 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
                     reason = "unavailable"
                     appId = "unknown"
                 }
+                // `app=` in the clear: the source bundle id is already public
+                // in Apple's own per-flow NE log lines on the same machine, and
+                // it is the first thing a post-incident read needs.
                 if defaultFlowRefusalPassthrough {
                     core.logLifecycle(
-                        "tcp admission rejected: \(reason); passing through (fail open)",
-                        privateMetadata: "app=\(appId)")
+                        "tcp admission rejected: \(reason); passing through (fail open) app=\(appId)")
                     session.cancel()
                     return false
                 }
                 core.logLifecycle(
-                    "tcp admission rejected: \(reason); blocking (fail closed)",
-                    privateMetadata: "app=\(appId)")
+                    "tcp admission rejected: \(reason); blocking (fail closed) app=\(appId)")
                 let error = tcpUpstreamUnavailableError()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)
@@ -410,6 +411,11 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
         }
         egressReady = true
         ctx.egressReady = true
+        // Reaching ready is progress: start the idle clock here, not at
+        // creation, so a flow that connected slowly does not enter the
+        // pressure reaper's eligible set already aged — the rescan bound
+        // in `collectPressureVictimsLocked` counts on that.
+        ctx.lastActivityAt = .now()
         if let token = ctx.admissionToken {
             core?.finishTcpStart(token, outcome: .ready)
             ctx.admissionToken = nil

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/Session/TcpFlowSession.swift
@@ -115,24 +115,32 @@ final class TcpFlowSession<F: TcpFlowLike>: TcpFlowSessionAnchor, @unchecked Sen
             guard case .admit(let token) = admission else {
                 let reason: String
                 let appId: String
-                if case .reject(let r, let id) = admission {
+                let persist: Bool
+                if case .reject(let r, let id, let p) = admission {
                     reason = r
                     appId = id
+                    persist = p
                 } else {
                     reason = "unavailable"
                     appId = "unknown"
+                    persist = true
                 }
                 // `app=` in the clear: the source bundle id is already public
                 // in Apple's own per-flow NE log lines on the same machine, and
-                // it is the first thing a post-incident read needs.
+                // it is the first thing a post-incident read needs. Past the
+                // per-tick budget the line goes to debug only — see
+                // `TcpAdmissionDecision.reject(persist:)`; the tick carries
+                // the counts and the top refusing apps.
+                let line =
+                    "tcp admission rejected: \(reason); "
+                    + (defaultFlowRefusalPassthrough
+                        ? "passing through (fail open)" : "blocking (fail closed)")
+                    + " app=\(appId)"
+                if persist { core.logLifecycle(line) } else { core.logDebug(line) }
                 if defaultFlowRefusalPassthrough {
-                    core.logLifecycle(
-                        "tcp admission rejected: \(reason); passing through (fail open) app=\(appId)")
                     session.cancel()
                     return false
                 }
-                core.logLifecycle(
-                    "tcp admission rejected: \(reason); blocking (fail closed) app=\(appId)")
                 let error = tcpUpstreamUnavailableError()
                 flow.closeReadWithError(error)
                 flow.closeWriteWithError(error)

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
@@ -8,7 +8,15 @@ struct TcpAdmissionToken: Sendable {
 
 enum TcpAdmissionDecision {
     case admit(TcpAdmissionToken)
-    case reject(reason: String, appId: String)
+    /// `persist`: whether the per-flow refusal line may go to the
+    /// persisted lifecycle log. Only the first few refusals of each
+    /// tick window do; the rest log at debug and are carried by the
+    /// tick's counters. A refusal storm otherwise trips logd's
+    /// per-process rate limit on persisted messages, which then
+    /// drops the ticks and episode summaries too — observed on
+    /// device: ~6,600 lines in 90s silenced the lifecycle category
+    /// for well over ten minutes while the burst that mattered ran.
+    case reject(reason: String, appId: String, persist: Bool)
 }
 
 enum TcpStartOutcome {
@@ -43,8 +51,13 @@ struct TcpOverloadState {
     var shedsSinceTick = 0
     var shedHardCapSinceTick = 0
     var shedBreakerSinceTick = 0
+    var shedsByAppSinceTick: [String: Int] = [:]
     var startsInFlightPeakSinceTick = 0
     var breakerOpen = false
+
+    /// Per-flow refusal lines allowed into the persisted log per tick
+    /// window; see `TcpAdmissionDecision.reject(persist:)`.
+    static let persistedShedLinesPerTick = 8
 
     mutating func appId(for meta: RamaTransparentProxyFlowMetaBridge) -> String {
         meta.sourceAppBundleIdentifier
@@ -72,6 +85,19 @@ struct TcpOverloadState {
         let sorted = startLatencyMsWindow.sorted()
         let rawIndex = Int((Double(sorted.count - 1) * percentile).rounded(.up))
         return sorted[min(max(rawIndex, 0), sorted.count - 1)]
+    }
+
+    /// Top refusing apps this tick window — attribution for the sheds
+    /// whose per-flow lines were not persisted.
+    func topShedAppSummary(limit: Int = 3) -> String {
+        shedsByAppSinceTick
+            .sorted { lhs, rhs in
+                if lhs.value == rhs.value { return lhs.key < rhs.key }
+                return lhs.value > rhs.value
+            }
+            .prefix(limit)
+            .map { "\($0.key)=\($0.value)" }
+            .joined(separator: ",")
     }
 
     func topAppSummary(limit: Int = 3) -> String {
@@ -106,6 +132,7 @@ struct TcpOverloadState {
         shedsSinceTick = 0
         shedHardCapSinceTick = 0
         shedBreakerSinceTick = 0
+        shedsByAppSinceTick.removeAll(keepingCapacity: true)
         startsInFlightPeakSinceTick = startsInFlight.count
         return snapshot
     }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TcpAdmissionControl.swift
@@ -22,6 +22,11 @@ struct TcpOverloadSnapshot {
     var timeoutRate: Double
     var shedRate: Double
     var startsInFlight: Int
+    /// High-water mark of `startsInFlight` within the tick window — the
+    /// near-miss signal a bundle needs when nothing was actually shed.
+    var startsInFlightPeak: Int
+    var shedHardCap: Int
+    var shedBreaker: Int
     var p50StartMs: UInt64
     var p95StartMs: UInt64
     var p99StartMs: UInt64
@@ -36,6 +41,9 @@ struct TcpOverloadState {
     var admissionsSinceTick = 0
     var timeoutsSinceTick = 0
     var shedsSinceTick = 0
+    var shedHardCapSinceTick = 0
+    var shedBreakerSinceTick = 0
+    var startsInFlightPeakSinceTick = 0
     var breakerOpen = false
 
     mutating func appId(for meta: RamaTransparentProxyFlowMetaBridge) -> String {
@@ -52,6 +60,13 @@ struct TcpOverloadState {
         }
     }
 
+    /// Over COMPLETED starts only. Pending starts are deliberately NOT
+    /// folded in as censored samples: a slow start is pending longer, so
+    /// the in-flight set over-represents the slow tail, and a healthy
+    /// load with a ~1% dead-destination tail then trips a p95 rule on
+    /// most at-soft-cap admissions. A genuine stall still reaches this
+    /// window through its connect timeouts (≤ one pressure clamp), and
+    /// under fail-open the hard cap already sheds in the meantime.
     func percentile(_ percentile: Double) -> UInt64 {
         guard !startLatencyMsWindow.isEmpty else { return 0 }
         let sorted = startLatencyMsWindow.sorted()
@@ -78,6 +93,9 @@ struct TcpOverloadState {
             timeoutRate: Double(timeoutsSinceTick) / seconds,
             shedRate: Double(shedsSinceTick) / seconds,
             startsInFlight: startsInFlight.count,
+            startsInFlightPeak: max(startsInFlightPeakSinceTick, startsInFlight.count),
+            shedHardCap: shedHardCapSinceTick,
+            shedBreaker: shedBreakerSinceTick,
             p50StartMs: percentile(0.50),
             p95StartMs: percentile(0.95),
             p99StartMs: percentile(0.99),
@@ -86,6 +104,9 @@ struct TcpOverloadState {
         admissionsSinceTick = 0
         timeoutsSinceTick = 0
         shedsSinceTick = 0
+        shedHardCapSinceTick = 0
+        shedBreakerSinceTick = 0
+        startsInFlightPeakSinceTick = startsInFlight.count
         return snapshot
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -391,7 +391,9 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// takes occupancy back under the cap. Summarised in a single lifecycle
     /// line at its end — the shape of a burst (how long, how high, what the
     /// reaper managed) is what a post-incident bundle needs and what the
-    /// 60s tick is too coarse to show. Only mutated on `stateQueue`.
+    /// 60s tick is too coarse to show. An episode cut short by a provider
+    /// restart is dropped unsummarised (the tick deltas still cover it).
+    /// Only mutated on `stateQueue`.
     private struct PressureEpisode {
         var startNs: UInt64
         var peakOccupancy: UInt64
@@ -611,10 +613,11 @@ final class TransparentProxyCore: @unchecked Sendable {
             // Skip rescans until then (bounded) instead of re-sorting the
             // registry on every admission of a burst that, by construction,
             // has nothing to give. Pre-ready flows are excluded — they
-            // become eligible via a state change, not via age; one that
-            // turns ready inside the window enters at an idle age of its
-            // connect time, far under any sane floor, and the cap bounds
-            // the rest. `+ 1`: eligibility is strictly past the floor.
+            // become eligible via a state change, not via age, and one
+            // that turns ready inside the window enters at idle age 0
+            // (`handleEgressReady` resets the clock), so it cannot beat
+            // this bound; the cap covers the rest. `+ 1`: eligibility is
+            // strictly past the floor.
             let maxIdleMs =
                 candidates.lazy
                 .filter { $0.state.egressReady }
@@ -1127,6 +1130,10 @@ final class TransparentProxyCore: @unchecked Sendable {
             guard self.overload.startsInFlight.removeValue(forKey: token.flowId) != nil else {
                 return
             }
+            // Latency comes from the token the CALLER hands back, not the
+            // stored one — on purpose: tests shape the latency window by
+            // backdating `startedAt`. Production always passes the token it
+            // was issued, so the two are identical there.
             let latencyMs =
                 (DispatchTime.now().uptimeNanoseconds &- token.startedAt.uptimeNanoseconds)
                 / 1_000_000
@@ -1188,13 +1195,19 @@ final class TransparentProxyCore: @unchecked Sendable {
 
     /// MUST be called on `stateQueue` after a registry removal. The reaper
     /// only ever runs at/over the cap, so a removal is the only production
-    /// event that can observe the drop below it: end the pressure episode
+    /// event that can observe the drop back down: end the pressure episode
     /// here — re-arm the once-per-episode log and drop rescan suppression —
     /// so the next episode opens with a fresh scan instead of a view that
-    /// could be up to the suppression cap stale.
+    /// could be up to the suppression cap stale. The boundary is the
+    /// reaper's own low-water mark, not the cap itself: occupancy hovering
+    /// one removal below the cap would otherwise close and reopen an
+    /// episode on every crossing, each with a summary line and a fresh
+    /// full scan. A dip that stops short of low-water is one episode.
     private func endPressureEpisodeIfUnderCapLocked() {
         let softCap = Int(defaultFlowPressureSoftCap)
-        guard softCap > 0, self.tcpSessions.count + self.udpSessions.count < softCap else { return }
+        guard softCap > 0 else { return }
+        let episodeEnd = min(Int(defaultFlowPressureLowWater), softCap - 1)
+        guard self.tcpSessions.count + self.udpSessions.count <= episodeEnd else { return }
         pressureNoHeadroomLogged = false
         pressureRescanSuppressedUntilNs = 0
         if let episode = pressureEpisode {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -740,6 +740,7 @@ final class TransparentProxyCore: @unchecked Sendable {
         self.updateTcpAdmissionBreakerLocked(trigger: "tick")
         // Combined total is what matters for the kernel nexus ceiling (global
         // across the flowswitch). `cap`/`peak` make pressure visible in soak.
+        let topShedApps = self.overload.topShedAppSummary()
         let overloadSnapshot = self.overload.snapshotAndResetRates(
             intervalSeconds: Self.periodicMaintenanceIntervalSeconds)
         let topApps = self.overload.topAppSummary()
@@ -748,6 +749,7 @@ final class TransparentProxyCore: @unchecked Sendable {
         let shedRate = String(format: "%.2f", overloadSnapshot.shedRate)
         let breaker = overloadSnapshot.breakerOpen ? "open" : "closed"
         let appSummary = topApps.isEmpty ? "-" : topApps
+        let shedAppSummary = topShedApps.isEmpty ? "-" : topShedApps
         let latencySummary =
             "p50=\(overloadSnapshot.p50StartMs),p95=\(overloadSnapshot.p95StartMs),"
             + "p99=\(overloadSnapshot.p99StartMs)"
@@ -760,7 +762,7 @@ final class TransparentProxyCore: @unchecked Sendable {
             + "hardCap=\(defaultTcpStartInFlightHardCap) "
             + "admissionRate=\(admissionRate)/s timeoutRate=\(timeoutRate)/s "
             + "shedRate=\(shedRate)/s shedHardCap=\(overloadSnapshot.shedHardCap) "
-            + "shedBreaker=\(overloadSnapshot.shedBreaker) "
+            + "shedBreaker=\(overloadSnapshot.shedBreaker) shedApps=\(shedAppSummary) "
             + "startLatencyMs[\(latencySummary)] breaker=\(breaker)"
         let triggers = self.pressureTriggersTotal.withLock { $0 }
         let scans = self.pressureScansTotal.withLock { $0 }
@@ -1103,16 +1105,14 @@ final class TransparentProxyCore: @unchecked Sendable {
                 self.updateTcpAdmissionBreakerLocked(trigger: "admission")
             }
             if hardCap > 0, inFlight >= hardCap {
-                self.overload.shedsSinceTick += 1
                 self.overload.shedHardCapSinceTick += 1
-                return .reject(
+                return self.recordShedLocked(
                     reason: "hard start cap reached inFlight=\(inFlight) hardCap=\(hardCap)",
                     appId: appId)
             }
             if self.overload.breakerOpen, softCap > 0, inFlight >= softCap {
-                self.overload.shedsSinceTick += 1
                 self.overload.shedBreakerSinceTick += 1
-                return .reject(
+                return self.recordShedLocked(
                     reason: "latency breaker open inFlight=\(inFlight) softCap=\(softCap)",
                     appId: appId)
             }
@@ -1123,6 +1123,16 @@ final class TransparentProxyCore: @unchecked Sendable {
                 self.overload.startsInFlightPeakSinceTick, self.overload.startsInFlight.count)
             return .admit(token)
         }
+    }
+
+    /// Count a refusal and decide whether its per-flow line may be
+    /// persisted (first `persistedShedLinesPerTick` per window). MUST be
+    /// called on `stateQueue`.
+    private func recordShedLocked(reason: String, appId: String) -> TcpAdmissionDecision {
+        self.overload.shedsSinceTick += 1
+        self.overload.shedsByAppSinceTick[appId, default: 0] += 1
+        let persist = self.overload.shedsSinceTick <= TcpOverloadState.persistedShedLinesPerTick
+        return .reject(reason: reason, appId: appId, persist: persist)
     }
 
     func finishTcpStart(_ token: TcpAdmissionToken, outcome: TcpStartOutcome) {

--- a/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Sources/RamaAppleNetworkExtension/Provider/TransparentProxyCore.swift
@@ -347,13 +347,66 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// mutated from `stateQueue`.
     private var flowCountHighWater = 0
 
-    /// Coalesces a burst of `reapIdleUnderPressure` triggers (one fires per
-    /// admission while combined occupancy is over the soft cap) into a single
-    /// outstanding selection scan. Only mutated on `stateQueue`. Without it,
-    /// every over-cap admission enqueues a fresh O(n log n) selection on the
-    /// serial `stateQueue`, behind which the next admission's
-    /// `registerTcpFlow.sync` (on the NE delivery thread) head-of-line-blocks.
-    private var pressureReapInFlight = false
+    /// Coalesces a burst of `reapIdleUnderPressure` triggers (one per
+    /// admission while over the soft cap) into one outstanding scan. Set
+    /// on the triggering thread at enqueue and cleared by the scan block,
+    /// so it must be locked rather than `stateQueue`-confined: a flag that
+    /// lives only inside the serial block is never visible to the block
+    /// queued behind it, and every admission would enqueue its own
+    /// O(n log n) scan — behind which the next admission's
+    /// `registerTcpFlow.sync` on the NE delivery thread would block.
+    private let pressureReapScheduled = Locked(false)
+
+    /// Monotonic deadline (uptime ns) before which a pressure scan is
+    /// skipped outright. Armed by a no-headroom scan: nothing was idle
+    /// past the floor, and idle age only grows, so no flow can qualify
+    /// before the closest one crosses it. Under a churn burst — every
+    /// flow seconds old against a 120s floor — this turns dozens of
+    /// futile full scans per second into none. Cleared by a successful
+    /// reap and whenever a removal drops occupancy under the cap. Only
+    /// mutated on `stateQueue`.
+    private var pressureRescanSuppressedUntilNs: UInt64 = 0
+
+    /// Bounds on that suppression. The upper one caps how long a stale
+    /// view can outlive a change the idle-age argument doesn't cover
+    /// (flows leaving the registry, a knob being lowered); the lower one
+    /// keeps the corner where something is idle past the floor yet
+    /// ineligible for a non-idle reason (a terminal flow whose drain
+    /// isn't pending) from degrading back into a scan per admission.
+    private static let pressureRescanMaxSuppressMs: UInt64 = 5_000
+    private static let pressureRescanMinSuppressMs: UInt64 = 250
+
+    /// Reaper counters, monotonic; the tick reports the deltas so a bundle
+    /// shows coalescing (triggers ≫ scans) and suppression (skipped) at work.
+    /// `triggers` and `scans` are locked, not `stateQueue`-confined: the
+    /// first is bumped on the triggering thread, the second is read by
+    /// tests while they hold the queue.
+    private let pressureTriggersTotal = Locked(0)
+    private let pressureScansTotal = Locked(0)
+    private var pressureSkipsTotal = 0
+    private var pressureVictimsTotal = 0
+    private var pressureStatsAtLastTick = (triggers: 0, scans: 0, skips: 0, victims: 0)
+
+    /// One over-cap stretch, from the first over-cap scan to the removal that
+    /// takes occupancy back under the cap. Summarised in a single lifecycle
+    /// line at its end — the shape of a burst (how long, how high, what the
+    /// reaper managed) is what a post-incident bundle needs and what the
+    /// 60s tick is too coarse to show. Only mutated on `stateQueue`.
+    private struct PressureEpisode {
+        var startNs: UInt64
+        var peakOccupancy: UInt64
+        var scans = 0
+        var skips = 0
+        var victims = 0
+    }
+    private var pressureEpisode: PressureEpisode?
+
+    #if DEBUG
+        /// Test-only: the suppression most recently armed, in ms. Lets a
+        /// test assert the derived bound itself instead of racing the
+        /// clock for what remains of it. Only mutated on `stateQueue`.
+        private var pressureRescanLastArmedMs: UInt64 = 0
+    #endif
 
     /// Rate-limits the "over cap but nothing idle to reap" lifecycle log to once
     /// per pressure episode (re-armed when occupancy drops back under the cap or
@@ -428,7 +481,7 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// `defaultFlowPressureSoftCap`. Reaps idle TCP flows past
     /// `defaultFlowPressureIdleFloorMs`, oldest-idle first (LRU), down to
     /// `defaultFlowPressureLowWater`, to free nexus slots for SUBSEQUENT flows.
-    /// Coalesced via `pressureReapInFlight` so a burst is a single scan.
+    /// Coalesced via `pressureReapScheduled` so a burst is a single scan.
     ///
     /// Guarantees (see the tunable doc for the policy rationale):
     ///   * The just-admitted flow is NEVER the victim and is never delayed —
@@ -444,25 +497,46 @@ final class TransparentProxyCore: @unchecked Sendable {
     ///     idempotent via `isDone`.
     func reapIdleUnderPressure() {
         guard defaultFlowPressureSoftCap > 0 else { return }
-        // Selection on `stateQueue` ASYNC — never a second `stateQueue.sync` on
-        // the delivery thread that admitted the flow (admission already
-        // happened; a sync here could stall all flow delivery). `fire` only
-        // DISPATCHES teardowns to each victim's `flowQueue`, so nothing heavy
-        // runs while on `stateQueue`.
+        // Claim the single outstanding scan slot BEFORE dispatching; a
+        // trigger that finds it taken rides the scan already queued, which
+        // re-reads occupancy when it runs. Never `stateQueue.sync` here —
+        // this is the delivery thread that just admitted the flow.
+        pressureTriggersTotal.withLock { $0 += 1 }
+        let claimed = pressureReapScheduled.withLock { scheduled -> Bool in
+            if scheduled { return false }
+            scheduled = true
+            return true
+        }
+        guard claimed else { return }
         stateQueue.async {
-            // Coalesce a burst: if a selection scan is already outstanding this
-            // trigger rides it rather than enqueuing another O(n log n) scan on
-            // the serial queue behind the delivery thread's register `.sync`.
-            // The flag guards selection + dispatch (the stateQueue-bound work);
-            // the dispatched teardowns run independently on their flowQueues, and
-            // a trigger arriving after dispatch correctly runs a fresh scan that
-            // re-reads occupancy.
-            guard !self.pressureReapInFlight else { return }
-            self.pressureReapInFlight = true
-            defer { self.pressureReapInFlight = false }
-            let victims = self.collectPressureVictimsLocked()
+            // Release the slot first so a trigger landing mid-scan gets a
+            // fresh scan afterwards instead of being dropped.
+            self.pressureReapScheduled.withLock { $0 = false }
+            let victims = self.collectPressureVictimsIfDueLocked()
+            // `fire` only DISPATCHES teardowns to each victim's `flowQueue`,
+            // so nothing heavy runs while on `stateQueue`.
             self.firePressureEvictions(victims)
         }
+    }
+
+    /// Suppression gate in front of `collectPressureVictimsLocked`. MUST be
+    /// called on `stateQueue`. Only an over-cap scan is expensive, so only
+    /// that is what the deadline skips; under the cap the scan is O(1) and
+    /// is what clears the gate and re-arms the episode log.
+    private func collectPressureVictimsIfDueLocked() -> [TcpFlowContext] {
+        let nowNs = DispatchTime.now().uptimeNanoseconds
+        let occupancy = self.tcpSessions.count + self.udpSessions.count
+        let overCap = occupancy >= Int(defaultFlowPressureSoftCap)
+        guard !overCap || nowNs >= pressureRescanSuppressedUntilNs else {
+            pressureSkipsTotal += 1
+            if var episode = pressureEpisode {
+                episode.skips += 1
+                episode.peakOccupancy = max(episode.peakOccupancy, UInt64(occupancy))
+                pressureEpisode = episode
+            }
+            return []
+        }
+        return collectPressureVictimsLocked(nowNs: nowNs)
     }
 
     /// Victim selection. MUST be called on `stateQueue`. Re-reads live occupancy
@@ -476,19 +550,29 @@ final class TransparentProxyCore: @unchecked Sendable {
     /// this (via `registerUdpFlow` occupancy), reaping idle TCP slots to relieve
     /// the global ceiling. Empty result = nothing to do (under cap, or no idle
     /// headroom).
-    private func collectPressureVictimsLocked() -> [TcpFlowContext] {
+    private func collectPressureVictimsLocked(
+        nowNs: UInt64 = DispatchTime.now().uptimeNanoseconds
+    ) -> [TcpFlowContext] {
         let softCap = defaultFlowPressureSoftCap
         guard softCap > 0 else { return [] }
         let lowWater = max(UInt64(defaultFlowPressureLowWater), 1)
         let floorMs = UInt64(defaultFlowPressureIdleFloorMs)
         let occupancy = UInt64(self.tcpSessions.count + self.udpSessions.count)
         guard occupancy >= UInt64(softCap) else {
-            // Back under the cap: re-arm the no-headroom log for the next episode.
+            // Back under the cap: re-arm the no-headroom log for the next
+            // episode, and drop any rescan suppression so the next one is
+            // never skipped on the strength of a stale view.
             pressureNoHeadroomLogged = false
+            pressureRescanSuppressedUntilNs = 0
             return []
         }
         let want = occupancy > lowWater ? Int(occupancy - lowWater) : 0
         guard want > 0 else { return [] }
+        pressureScansTotal.withLock { $0 += 1 }
+        var episode = pressureEpisode ?? PressureEpisode(startNs: nowNs, peakOccupancy: occupancy)
+        episode.scans += 1
+        episode.peakOccupancy = max(episode.peakOccupancy, occupancy)
+        pressureEpisode = episode
         // Snapshot the LRU sort key (`lastActivityAt`) and a single `now` into
         // immutable locals BEFORE filtering/sorting. `lastActivityAt` is mutated
         // on each flow's own `flowQueue` (onActivity), so sorting the live
@@ -496,7 +580,6 @@ final class TransparentProxyCore: @unchecked Sendable {
         // data race and an unstable comparator. Snapshotting makes the ordering
         // self-consistent; the fire-loop re-check on `flowQueue` remains the
         // authority on whether a chosen victim is actually still idle.
-        let nowNs = DispatchTime.now().uptimeNanoseconds
         typealias Candidate = (
             ctx: TcpFlowContext, state: TcpFlowMaintenanceState, lastNs: UInt64
         )
@@ -523,6 +606,28 @@ final class TransparentProxyCore: @unchecked Sendable {
         }
         let eligible: [TcpFlowContext] = sortedCandidates.map { $0.ctx }
         if eligible.isEmpty {
+            // Nothing idle past the floor, and idle age only grows: no flow
+            // can qualify before the closest established one crosses it.
+            // Skip rescans until then (bounded) instead of re-sorting the
+            // registry on every admission of a burst that, by construction,
+            // has nothing to give. Pre-ready flows are excluded — they
+            // become eligible via a state change, not via age; one that
+            // turns ready inside the window enters at an idle age of its
+            // connect time, far under any sane floor, and the cap bounds
+            // the rest. `+ 1`: eligibility is strictly past the floor.
+            let maxIdleMs =
+                candidates.lazy
+                .filter { $0.state.egressReady }
+                .map { (nowNs &- $0.lastNs) / 1_000_000 }
+                .max() ?? 0
+            let untilEligibleMs = floorMs > maxIdleMs ? floorMs - maxIdleMs + 1 : 0
+            let suppressMs = min(
+                max(untilEligibleMs, Self.pressureRescanMinSuppressMs),
+                Self.pressureRescanMaxSuppressMs)
+            pressureRescanSuppressedUntilNs = nowNs &+ suppressMs &* 1_000_000
+            #if DEBUG
+                pressureRescanLastArmedMs = suppressMs
+            #endif
             // Over the cap but nothing idle enough to sacrifice — admit and ride
             // rather than reset a live flow. Logged ONCE per episode (not per
             // admission): a sustained over-cap population — notably UDP-dominated
@@ -538,7 +643,10 @@ final class TransparentProxyCore: @unchecked Sendable {
             return []
         }
         pressureNoHeadroomLogged = false
+        pressureRescanSuppressedUntilNs = 0
         let victims = Array(eligible.prefix(want))
+        pressureVictimsTotal += victims.count
+        pressureEpisode?.victims += victims.count
         self.logLifecycle(
             "flow pressure: occupancy \(occupancy) over soft cap \(softCap); reaping "
                 + "\(victims.count) idle flow(s) toward low-water \(lowWater)"
@@ -600,6 +708,9 @@ final class TransparentProxyCore: @unchecked Sendable {
             self.stuckPreReadyFlowIds.removeAll(keepingCapacity: false)
             self.stuckClosingFlowIds.removeAll(keepingCapacity: false)
             self.overload = TcpOverloadState()
+            self.pressureRescanSuppressedUntilNs = 0
+            self.pressureNoHeadroomLogged = false
+            self.pressureEpisode = nil
         }
     }
 
@@ -618,6 +729,12 @@ final class TransparentProxyCore: @unchecked Sendable {
         let udp = self.udpSessions.count
         let total = tcp + udp
         if total > self.flowCountHighWater { self.flowCountHighWater = total }
+        // Tick-driven breaker pass: catches the state where pressure arrived
+        // through admissions under the soft cap after a slow completion, so
+        // neither event evaluated with both conditions true. Cannot close on
+        // its own — in-flight only drops on completion, which evaluates
+        // itself. Also keeps the `breaker=` field below fresh.
+        self.updateTcpAdmissionBreakerLocked(trigger: "tick")
         // Combined total is what matters for the kernel nexus ceiling (global
         // across the flowswitch). `cap`/`peak` make pressure visible in soak.
         let overloadSnapshot = self.overload.snapshotAndResetRates(
@@ -636,12 +753,26 @@ final class TransparentProxyCore: @unchecked Sendable {
             + "peak=\(self.flowCountHighWater) softCap=\(defaultFlowPressureSoftCap)"
         let overloadSummary =
             "tcpStartsInFlight=\(overloadSnapshot.startsInFlight) "
+            + "tcpStartsInFlightPeak=\(overloadSnapshot.startsInFlightPeak) "
+            + "hardCap=\(defaultTcpStartInFlightHardCap) "
             + "admissionRate=\(admissionRate)/s timeoutRate=\(timeoutRate)/s "
-            + "shedRate=\(shedRate)/s startLatencyMs[\(latencySummary)] "
-            + "breaker=\(breaker)"
+            + "shedRate=\(shedRate)/s shedHardCap=\(overloadSnapshot.shedHardCap) "
+            + "shedBreaker=\(overloadSnapshot.shedBreaker) "
+            + "startLatencyMs[\(latencySummary)] breaker=\(breaker)"
+        let triggers = self.pressureTriggersTotal.withLock { $0 }
+        let scans = self.pressureScansTotal.withLock { $0 }
+        let pressureSummary =
+            "pressure[triggers=\(triggers - pressureStatsAtLastTick.triggers) "
+            + "scans=\(scans - pressureStatsAtLastTick.scans) "
+            + "skipped=\(pressureSkipsTotal - pressureStatsAtLastTick.skips) "
+            + "evicted=\(pressureVictimsTotal - pressureStatsAtLastTick.victims)]"
+        pressureStatsAtLastTick = (triggers, scans, pressureSkipsTotal, pressureVictimsTotal)
+        // Bundle ids are in the clear: Apple's own `com.apple.networkextension`
+        // subsystem logs the source app of every flow publicly on the same
+        // machine, so redacting them here only hides them from our own
+        // post-incident reads.
         self.logLifecycle(
-            "\(countSummary) \(overloadSummary)",
-            privateMetadata: "topApps=\(appSummary)")
+            "\(countSummary) \(overloadSummary) \(pressureSummary) topApps=\(appSummary)")
 
         // Track two cross-tick "stuck" sets. An ID present in both the
         // previous AND the current set has been stuck for ≥ one tick
@@ -801,6 +932,44 @@ final class TransparentProxyCore: @unchecked Sendable {
             firePressureEvictions(victims)
         }
 
+        /// Test hook: the production trigger's on-queue half, rescan
+        /// suppression included, run synchronously.
+        /// `testReapIdleUnderPressure` bypasses the gate on purpose (it pins
+        /// victim selection alone).
+        func testReapIdleUnderPressureIfDue() {
+            let victims = stateQueue.sync { self.collectPressureVictimsIfDueLocked() }
+            firePressureEvictions(victims)
+        }
+
+        /// Test hook: full selection scans performed so far.
+        var testPressureScanCount: Int { pressureScansTotal.withLock { $0 } }
+
+        /// Test hook: a scan is queued and has not started yet.
+        var testPressureReapScheduled: Bool { pressureReapScheduled.withLock { $0 } }
+
+        /// Test hook: the suppression most recently armed, in ms.
+        var testPressureRescanLastArmedMs: UInt64 {
+            stateQueue.sync { self.pressureRescanLastArmedMs }
+        }
+
+        /// Test hook: remaining rescan suppression in ms (`0` = none).
+        var testPressureRescanSuppressedForMs: UInt64 {
+            stateQueue.sync {
+                let now = DispatchTime.now().uptimeNanoseconds
+                guard now < self.pressureRescanSuppressedUntilNs else { return 0 }
+                return (self.pressureRescanSuppressedUntilNs - now) / 1_000_000
+            }
+        }
+
+        /// Test hook: park `stateQueue` until the returned semaphore is
+        /// signalled, so a test can pile triggers up behind it. Do not call
+        /// any `stateQueue.sync` hook while it is held.
+        func testHoldStateQueue() -> DispatchSemaphore {
+            let gate = DispatchSemaphore(value: 0)
+            stateQueue.async { gate.wait() }
+            return gate
+        }
+
         /// Test hook: run the post-wake established-flow path re-check
         /// synchronously, skipping the `defaultPostWakePathRecheckMs`
         /// settle timer. Mirrors `testRunPeriodicMaintenance`.
@@ -899,6 +1068,7 @@ final class TransparentProxyCore: @unchecked Sendable {
                     self.overload.perAppFlowCounts[appId] = count - 1
                 }
             }
+            self.endPressureEpisodeIfUnderCapLocked()
             // Belt-and-suspenders against `ObjectIdentifier` reuse:
             // if a torn-down flow's pointer is recycled for a new ctx
             // within one maintenance tick, the new ctx would inherit
@@ -920,14 +1090,25 @@ final class TransparentProxyCore: @unchecked Sendable {
             let hardCap = Int(defaultTcpStartInFlightHardCap)
             let softCap = Int(defaultTcpStartInFlightSoftCap)
             let inFlight = self.overload.startsInFlight.count
+            // Evaluate on admission too, not only on completion, and BEFORE
+            // the hard-cap branch: the latency window may already be bad
+            // from completions that happened under the soft cap, and the
+            // admission that brings pressure is the one that should open
+            // the breaker — not the next completion, and not never, when
+            // pinned at the hard cap.
+            if !self.overload.breakerOpen, softCap > 0, inFlight >= softCap {
+                self.updateTcpAdmissionBreakerLocked(trigger: "admission")
+            }
             if hardCap > 0, inFlight >= hardCap {
                 self.overload.shedsSinceTick += 1
+                self.overload.shedHardCapSinceTick += 1
                 return .reject(
                     reason: "hard start cap reached inFlight=\(inFlight) hardCap=\(hardCap)",
                     appId: appId)
             }
             if self.overload.breakerOpen, softCap > 0, inFlight >= softCap {
                 self.overload.shedsSinceTick += 1
+                self.overload.shedBreakerSinceTick += 1
                 return .reject(
                     reason: "latency breaker open inFlight=\(inFlight) softCap=\(softCap)",
                     appId: appId)
@@ -935,6 +1116,8 @@ final class TransparentProxyCore: @unchecked Sendable {
             let token = TcpAdmissionToken(flowId: flowId, startedAt: .now(), appId: appId)
             self.overload.startsInFlight[flowId] = token
             self.overload.admissionsSinceTick += 1
+            self.overload.startsInFlightPeakSinceTick = max(
+                self.overload.startsInFlightPeakSinceTick, self.overload.startsInFlight.count)
             return .admit(token)
         }
     }
@@ -951,7 +1134,7 @@ final class TransparentProxyCore: @unchecked Sendable {
             if outcome == .timeout {
                 self.overload.timeoutsSinceTick += 1
             }
-            self.updateTcpAdmissionBreakerLocked()
+            self.updateTcpAdmissionBreakerLocked(trigger: "completion")
         }
     }
 
@@ -969,28 +1152,60 @@ final class TransparentProxyCore: @unchecked Sendable {
         }
     }
 
-    private func updateTcpAdmissionBreakerLocked() {
-        let p95 = self.overload.percentile(0.95)
+    /// Runs on start completion, on admission at/over the soft cap, and on
+    /// the maintenance tick. Both inputs — the completed-latency window and
+    /// the in-flight count — change only on admission or completion, so the
+    /// tick is a backstop for the case where the last evaluation saw one
+    /// condition but not the other and nothing has arrived since.
+    private func updateTcpAdmissionBreakerLocked(trigger: String) {
         let inFlight = self.overload.startsInFlight.count
         let softCap = Int(defaultTcpStartInFlightSoftCap)
         let openThreshold = UInt64(defaultTcpStartLatencyBreakerP95Ms)
         let closeThreshold = UInt64(defaultTcpStartLatencyBreakerCloseP95Ms)
         guard softCap > 0, openThreshold > 0 else { return }
+        let p95 = self.overload.percentile(0.95)
         if !self.overload.breakerOpen, inFlight >= softCap, p95 >= openThreshold {
             self.overload.breakerOpen = true
             self.logLifecycle(
-                "tcp overload breaker open: p95StartMs=\(p95) inFlight=\(inFlight) softCap=\(softCap)")
+                "tcp overload breaker open (on \(trigger)): p95StartMs=\(p95) "
+                    + "inFlight=\(inFlight) softCap=\(softCap) openP95Ms=\(openThreshold)")
         } else if self.overload.breakerOpen, inFlight < softCap, p95 <= closeThreshold {
             self.overload.breakerOpen = false
             self.logLifecycle(
-                "tcp overload breaker closed: p95StartMs=\(p95) inFlight=\(inFlight) softCap=\(softCap)")
+                "tcp overload breaker closed (on \(trigger)): p95StartMs=\(p95) "
+                    + "inFlight=\(inFlight) softCap=\(softCap) closeP95Ms=\(closeThreshold)")
         }
     }
 
     func removeUdpFlow(_ flowId: ObjectIdentifier) {
         // `.async` for the same reason as `removeTcpFlow` — never block a
         // per-flow teardown on the shared serial queue.
-        stateQueue.async { self.udpSessions.removeValue(forKey: flowId) }
+        stateQueue.async {
+            self.udpSessions.removeValue(forKey: flowId)
+            self.endPressureEpisodeIfUnderCapLocked()
+        }
+    }
+
+    /// MUST be called on `stateQueue` after a registry removal. The reaper
+    /// only ever runs at/over the cap, so a removal is the only production
+    /// event that can observe the drop below it: end the pressure episode
+    /// here — re-arm the once-per-episode log and drop rescan suppression —
+    /// so the next episode opens with a fresh scan instead of a view that
+    /// could be up to the suppression cap stale.
+    private func endPressureEpisodeIfUnderCapLocked() {
+        let softCap = Int(defaultFlowPressureSoftCap)
+        guard softCap > 0, self.tcpSessions.count + self.udpSessions.count < softCap else { return }
+        pressureNoHeadroomLogged = false
+        pressureRescanSuppressedUntilNs = 0
+        if let episode = pressureEpisode {
+            pressureEpisode = nil
+            let durationMs =
+                (DispatchTime.now().uptimeNanoseconds &- episode.startNs) / 1_000_000
+            logLifecycle(
+                "flow pressure episode ended: durationMs=\(durationMs) "
+                    + "peakOccupancy=\(episode.peakOccupancy) softCap=\(softCap) "
+                    + "scans=\(episode.scans) skipped=\(episode.skips) evicted=\(episode.victims)")
+        }
     }
 
     /// Count of currently-registered TCP flows. Test-only signal for

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
@@ -439,7 +439,7 @@ final class FlowPressureReaperTests: XCTestCase {
         XCTAssertEqual(core.testPressureScanCount, 1)
         XCTAssertFalse(f4.wasTornDown, "nothing idle past the floor yet")
         let armedMs = core.testPressureRescanLastArmedMs
-        XCTAssertGreaterThanOrEqual(armedMs, 990, "bound derives from the closest flow (5s − 4s)")
+        XCTAssertGreaterThanOrEqual(armedMs, 900, "bound derives from the closest flow (5s − 4s)")
         XCTAssertLessThanOrEqual(armedMs, 1_001, "+1ms: eligibility is strictly past the floor")
 
         core.testReapIdleUnderPressureIfDue()

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowPressureReaperTests.swift
@@ -36,6 +36,7 @@ final class FlowPressureReaperTests: XCTestCase {
     }
 
     override func tearDown() {
+        LifecycleLog.noticeOverride = nil
         defaultFlowPressureSoftCap = savedSoftCap
         defaultFlowPressureLowWater = savedLowWater
         defaultFlowPressureIdleFloorMs = savedFloorMs
@@ -415,5 +416,169 @@ final class FlowPressureReaperTests: XCTestCase {
         XCTAssertEqual(
             fxs.filter { $0.wasTornDown }.count, 3,
             "the async production path evicts down to low-water (5 − 2 = 3)")
+    }
+
+    // MARK: - TG-8: rescan suppression after a no-headroom scan
+
+    /// A churn burst is every flow seconds old against a floor of minutes:
+    /// each admission's scan finds nothing, and the next admission scans
+    /// again. After a no-headroom result the reaper must skip rescans until
+    /// the closest established flow could possibly cross the floor — then
+    /// resume and actually evict it.
+    func testNoHeadroomScanSuppressesRescansUntilClosestFlowCanCrossFloor() {
+        defaultFlowPressureSoftCap = 2
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 5_000
+        let core = makeCore()
+        let f1 = Fx(core: core, idleSeconds: 1)
+        let f2 = Fx(core: core, idleSeconds: 2)
+        let f4 = Fx(core: core, idleSeconds: 4)  // crosses the 5s floor in ~1s
+        insert(core, [f1, f2, f4])
+
+        core.testReapIdleUnderPressureIfDue()
+        XCTAssertEqual(core.testPressureScanCount, 1)
+        XCTAssertFalse(f4.wasTornDown, "nothing idle past the floor yet")
+        let armedMs = core.testPressureRescanLastArmedMs
+        XCTAssertGreaterThanOrEqual(armedMs, 990, "bound derives from the closest flow (5s − 4s)")
+        XCTAssertLessThanOrEqual(armedMs, 1_001, "+1ms: eligibility is strictly past the floor")
+
+        core.testReapIdleUnderPressureIfDue()
+        XCTAssertEqual(core.testPressureScanCount, 1, "rescan skipped while nothing can qualify")
+
+        // Past the (≤1s) window f4 is ~5.2s idle: over the floor, and the gate
+        // is open again. Wall-clock on the same monotonic clock the gate uses,
+        // so one reap here is deterministic — not a deadline-fire we could miss.
+        Thread.sleep(forTimeInterval: 1.2)
+        core.testReapIdleUnderPressureIfDue()
+
+        XCTAssertEqual(core.testPressureScanCount, 2, "rescan resumed once something could qualify")
+        XCTAssertTrue(f4.wasTornDown, "and evicted the flow that crossed the floor")
+        XCTAssertFalse(f1.wasTornDown)
+        XCTAssertFalse(f2.wasTornDown)
+        XCTAssertEqual(
+            core.testPressureRescanSuppressedForMs, 0, "a successful reap clears suppression")
+    }
+
+    func testRescanSuppressionIsBoundedWhenFloorIsFarAway() {
+        defaultFlowPressureSoftCap = 2
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 600_000
+        let core = makeCore()
+        insert(core, [Fx(core: core, idleSeconds: 1), Fx(core: core, idleSeconds: 1)])
+
+        core.testReapIdleUnderPressureIfDue()
+
+        XCTAssertEqual(
+            core.testPressureRescanLastArmedMs, 5_000, "≈599s until anything qualifies, capped")
+    }
+
+    /// A flow idle past the floor but ineligible for a non-idle reason
+    /// (terminal signalled, drain not pending) would compute a zero bound and
+    /// put the reaper back on a scan per admission. The lower bound holds it.
+    func testRescanSuppressionHasAFloorWhenIneligibilityIsNotIdleDriven() {
+        defaultFlowPressureSoftCap = 2
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 5_000
+        let core = makeCore()
+        let stuck = Fx(core: core, idleSeconds: 30)
+        stuck.ctx.terminalSignalled = true  // drainClosePending stays false → not wedged
+        let fresh = Fx(core: core, idleSeconds: 1)
+        insert(core, [stuck, fresh])
+
+        core.testReapIdleUnderPressureIfDue()
+
+        XCTAssertFalse(stuck.wasTornDown, "terminal-but-not-wedged is ineligible")
+        XCTAssertEqual(
+            core.testPressureRescanLastArmedMs, 250, "the lower bound, not the zero the idle math gives")
+    }
+
+    func testTriggerUnderCapDoesNotScan() {
+        defaultFlowPressureSoftCap = 5
+        defaultFlowPressureLowWater = 4
+        let core = makeCore()
+        insert(core, [Fx(core: core, idleSeconds: 30), Fx(core: core, idleSeconds: 30)])
+
+        core.testReapIdleUnderPressureIfDue()
+
+        XCTAssertEqual(core.testPressureScanCount, 0, "the occupancy guard is O(1); no selection")
+    }
+
+    // MARK: - TG-9: trigger coalescing on the production async path
+
+    /// One trigger fires per admission while over the cap. With the queue
+    /// busy — as it is under exactly that load — ten triggers must collapse
+    /// into ONE queued scan. The previous flag lived inside the serial block
+    /// and could never be observed set by the block queued behind it.
+    func testRapidTriggersCoalesceIntoOneScanWhileStateQueueIsBusy() {
+        defaultFlowPressureSoftCap = 1
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 60_000
+        let core = makeCore()
+        insert(core, [Fx(core: core, idleSeconds: 1), Fx(core: core, idleSeconds: 1)])
+
+        let gate = core.testHoldStateQueue()
+        for _ in 0..<10 { core.reapIdleUnderPressure() }
+        XCTAssertTrue(core.testPressureReapScheduled, "exactly one scan is queued")
+        XCTAssertEqual(core.testPressureScanCount, 0, "and it hasn't run: the queue is held")
+
+        gate.signal()
+        pollUntil("queued scan runs") { core.testPressureScanCount == 1 }
+        pollUntil("slot released") { !core.testPressureReapScheduled }
+        XCTAssertEqual(core.testPressureScanCount, 1, "ten triggers, one scan")
+
+        // Nothing was idle past the 60s floor, so that scan armed suppression:
+        // a fresh trigger claims the (free) slot but its scan is skipped.
+        core.reapIdleUnderPressure()
+        pollUntil("second trigger drains") { !core.testPressureReapScheduled }
+        _ = core.testPressureRescanSuppressedForMs  // stateQueue.sync barrier behind the block
+        XCTAssertEqual(core.testPressureScanCount, 1, "suppressed rescan on the async path")
+    }
+
+    // MARK: - TG-10: episode boundary via the production removal path
+
+    /// The reaper only runs at/over the cap, so the under-cap branch of the
+    /// scan is unreachable in production; a removal is the only event that
+    /// sees occupancy drop. It must end the episode — clear suppression and
+    /// re-arm the once-per-episode log — or the next burst inherits a view up
+    /// to 5s stale and its first no-headroom line is swallowed.
+    func testRemovalUnderCapEndsTheEpisodeSoTheNextOneScansFresh() {
+        defaultFlowPressureSoftCap = 2
+        defaultFlowPressureLowWater = 1
+        defaultFlowPressureIdleFloorMs = 60_000
+        let core = makeCore()
+        let notices = Locked([String]())
+        LifecycleLog.noticeOverride = { message in notices.withLock { $0.append(message) } }
+        func noHeadroomLines() -> Int {
+            notices.withLock { $0.filter { $0.contains("admitting without reap") }.count }
+        }
+        let a = Fx(core: core, idleSeconds: 1)
+        let b = Fx(core: core, idleSeconds: 1)
+        let c = Fx(core: core, idleSeconds: 1)
+        insert(core, [a, b, c])
+
+        core.testReapIdleUnderPressureIfDue()
+        XCTAssertEqual(core.testPressureScanCount, 1)
+        XCTAssertEqual(core.testPressureRescanLastArmedMs, 5_000, "episode 1 armed the cap")
+        XCTAssertEqual(noHeadroomLines(), 1)
+        core.testReapIdleUnderPressureIfDue()  // suppressed: counted as a skip, not a scan
+        XCTAssertEqual(core.testPressureScanCount, 1)
+
+        // Two removals through the production path take occupancy to 1 (< cap).
+        core.removeTcpFlow(b.flowId)
+        core.removeTcpFlow(c.flowId)
+        XCTAssertEqual(
+            core.testPressureRescanSuppressedForMs, 0,
+            "dropping under the cap ends the episode (the sync read doubles as the barrier)")
+        let episodeLines = notices.withLock { $0.filter { $0.contains("flow pressure episode ended") } }
+        XCTAssertEqual(episodeLines.count, 1, "one summary line per episode")
+        XCTAssertTrue(
+            episodeLines.first?.contains("peakOccupancy=3 softCap=2 scans=1 skipped=1 evicted=0")
+                ?? false, episodeLines.first ?? "")
+
+        // Episode 2, well inside the old 5s deadline: must scan and must log.
+        insert(core, [Fx(core: core, idleSeconds: 1), Fx(core: core, idleSeconds: 1)])
+        core.testReapIdleUnderPressureIfDue()
+        XCTAssertEqual(core.testPressureScanCount, 2, "fresh scan, not a suppressed skip")
+        XCTAssertEqual(noHeadroomLines(), 2, "once-per-episode log re-armed")
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowRefusalActionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/FlowRefusalActionTests.swift
@@ -3,10 +3,10 @@ import XCTest
 @testable import RamaAppleNetworkExtension
 
 /// The provider-side fail-open/closed decision for flows it declines for its own
-/// reasons (unknown action / missing session over FFI). The full admission-cap
-/// integration runs through `TcpFlowSession.start()`, which needs a real engine
-/// session and so is only reachable in the FFI e2e suite; this pins the decision
-/// logic + the `defaultFlowRefusalPassthrough` wiring.
+/// reasons (start cap / breaker, or a missing session over FFI). The full
+/// admission-cap integration runs through `TcpFlowSession.start()`, which needs
+/// a real engine session and so is only reachable in the FFI e2e suite; this
+/// pins the decision logic + the `defaultFlowRefusalPassthrough` wiring.
 final class FlowRefusalActionTests: XCTestCase {
     private var saved = false
 
@@ -20,13 +20,21 @@ final class FlowRefusalActionTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultsToFailClosed() {
-        defaultFlowRefusalPassthrough = false
-        XCTAssertFalse(failOpenOnFlowRefusal("unit reason"), "default is Block (fail closed)")
+    /// Rust's `TransparentProxyConfig` is authoritative at runtime; the Swift
+    /// global is the fallback for tests and startup-failure paths, and must
+    /// agree with the Rust default so the two can never disagree on a path
+    /// that skipped `applyRuntimeConfig`.
+    func testSwiftFallbackDefaultIsFailOpenLikeRust() {
+        XCTAssertTrue(saved, "Swift fallback must mirror FlowRefusalAction's Passthrough default")
     }
 
-    func testFailsOpenWhenConfigured() {
+    func testFailsOpenWhenPassthrough() {
         defaultFlowRefusalPassthrough = true
-        XCTAssertTrue(failOpenOnFlowRefusal("unit reason"), "Passthrough opts into fail open")
+        XCTAssertTrue(failOpenOnFlowRefusal("unit reason"), "Passthrough fails open")
+    }
+
+    func testBlocksWhenConfiguredClosed() {
+        defaultFlowRefusalPassthrough = false
+        XCTAssertFalse(failOpenOnFlowRefusal("unit reason"), "Block opts into fail closed")
     }
 }

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ModernUdpFlowHandlingTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ModernUdpFlowHandlingTests.swift
@@ -94,10 +94,12 @@ final class ModernUdpFlowHandlingTests: XCTestCase {
             XCTAssertTrue(publicMessages[0].contains("udp_callback=\(callback.rawValue)"))
             XCTAssertTrue(publicMessages[0].contains("rama_decision=passthrough"))
             XCTAssertTrue(publicMessages[0].contains("callback_return=false"))
+            // Destination stays private; the source app is public, like the
+            // TCP shed lines and the tick's `topApps=`.
             XCTAssertFalse(publicMessages[0].contains("203.0.113.9"))
-            XCTAssertFalse(publicMessages[0].contains("com.example.client"))
+            XCTAssertTrue(publicMessages[0].contains("source_app=com.example.client"))
             XCTAssertTrue(privateMetadata[0].contains("initial_remote=203.0.113.9:443"))
-            XCTAssertTrue(privateMetadata[0].contains("source_app=com.example.client"))
+            XCTAssertFalse(privateMetadata[0].contains("com.example.client"))
         }
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/ProviderStaticHelperTests.swift
@@ -323,6 +323,7 @@ final class ProviderStaticHelperTests: XCTestCase {
         let savedCloseP95 = defaultTcpStartLatencyBreakerCloseP95Ms
         let savedPressureTimeout = defaultTcpPressureConnectTimeoutMs
         let savedBreakerTimeout = defaultTcpBreakerConnectTimeoutMs
+        let savedRefusalPassthrough = defaultFlowRefusalPassthrough
         defer {
             writePumpMaxPendingBytes = savedWriteCap
             writePumpHwmLogThresholdBytes = savedWriteHwm
@@ -335,6 +336,7 @@ final class ProviderStaticHelperTests: XCTestCase {
             defaultTcpStartLatencyBreakerCloseP95Ms = savedCloseP95
             defaultTcpPressureConnectTimeoutMs = savedPressureTimeout
             defaultTcpBreakerConnectTimeoutMs = savedBreakerTimeout
+            defaultFlowRefusalPassthrough = savedRefusalPassthrough
         }
 
         let startup = RamaTransparentProxyConfigBridge(
@@ -350,7 +352,8 @@ final class ProviderStaticHelperTests: XCTestCase {
             tcpStartLatencyBreakerCloseP95Ms: 17,
             tcpPressureConnectTimeoutMs: 18,
             tcpBreakerConnectTimeoutMs: 19,
-            flowRefusalPassthrough: true)
+            // Opposite of the Swift default, so this proves the override lands.
+            flowRefusalPassthrough: false)
 
         var logs: [String] = []
         RamaTransparentProxyProvider.applyRuntimeConfig(from: startup) { logs.append($0) }
@@ -366,7 +369,7 @@ final class ProviderStaticHelperTests: XCTestCase {
         XCTAssertEqual(defaultTcpStartLatencyBreakerCloseP95Ms, 17)
         XCTAssertEqual(defaultTcpPressureConnectTimeoutMs, 18)
         XCTAssertEqual(defaultTcpBreakerConnectTimeoutMs, 19)
-        XCTAssertTrue(defaultFlowRefusalPassthrough)
+        XCTAssertFalse(defaultFlowRefusalPassthrough)
         XCTAssertEqual(logs.count, 4)
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
@@ -44,7 +44,7 @@ final class TcpOverloadAdmissionTests: XCTestCase {
             return
         }
 
-        guard case .reject(let reason, _) = core.testAdmitTcpStart(
+        guard case .reject(let reason, _, _) = core.testAdmitTcpStart(
             flowId: ObjectIdentifier(second), meta: meta())
         else {
             XCTFail("second start should be rejected at hard cap")
@@ -87,7 +87,7 @@ final class TcpOverloadAdmissionTests: XCTestCase {
 
         waitFor("breaker opens") { core.testTcpOverloadBreakerOpen }
 
-        guard case .reject(let reason, _) = core.testAdmitTcpStart(
+        guard case .reject(let reason, _, _) = core.testAdmitTcpStart(
             flowId: ObjectIdentifier(third), meta: meta(bundleId: "com.example.third"))
         else {
             XCTFail("breaker should reject while in-flight starts are still at the soft cap")
@@ -123,7 +123,7 @@ final class TcpOverloadAdmissionTests: XCTestCase {
 
         _ = admittedToken(core, second)  // inFlight 0 → 1, under the soft cap
         _ = admittedToken(core, third)  // inFlight 1 → 2
-        guard case .reject(let reason, _) = core.testAdmitTcpStart(
+        guard case .reject(let reason, _, _) = core.testAdmitTcpStart(
             flowId: ObjectIdentifier(fourth), meta: meta())
         else {
             XCTFail("the admission that reaches the soft cap on a slow window must open and shed")
@@ -250,6 +250,52 @@ final class TcpOverloadAdmissionTests: XCTestCase {
         XCTAssertFalse(core.testTcpOverloadBreakerOpen)
     }
 
+    /// A refusal storm must not take the persisted log down with it: only the
+    /// first few per-flow lines of a tick window are marked for persistence,
+    /// and the tick carries the counts plus the top refusing apps.
+    func testShedLinesArePersistedOnlyWithinThePerTickBudget() {
+        defaultTcpStartInFlightHardCap = 1
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+        let holder = NSObject()
+        _ = admittedToken(core, holder)  // pins inFlight at the cap of 1
+
+        var persisted = 0
+        var demoted = 0
+        let objects = (0..<20).map { _ in NSObject() }
+        for (i, object) in objects.enumerated() {
+            let app = i % 2 == 0 ? "com.example.noisy" : "com.example.quiet"
+            guard case .reject(_, let appId, let persist) = core.testAdmitTcpStart(
+                flowId: ObjectIdentifier(object), meta: meta(bundleId: app))
+            else {
+                XCTFail("at the hard cap every start is refused")
+                return
+            }
+            XCTAssertEqual(appId, app)
+            if persist { persisted += 1 } else { demoted += 1 }
+        }
+        XCTAssertEqual(persisted, TcpOverloadState.persistedShedLinesPerTick)
+        XCTAssertEqual(demoted, 20 - TcpOverloadState.persistedShedLinesPerTick)
+
+        core.testRunPeriodicMaintenance()
+        let tick = captured.values.joined(separator: "\n")
+        XCTAssertTrue(tick.contains("shedHardCap=20"), tick)
+        XCTAssertTrue(
+            tick.contains("shedApps=com.example.noisy=10,com.example.quiet=10"),
+            "attribution for the demoted lines rides the tick: \(tick)")
+
+        // A new window re-opens the budget.
+        let later = NSObject()
+        guard case .reject(_, _, let persistAgain) = core.testAdmitTcpStart(
+            flowId: ObjectIdentifier(later), meta: meta())
+        else {
+            XCTFail("still at the cap")
+            return
+        }
+        XCTAssertTrue(persistAgain, "the persist budget resets with the tick window")
+    }
+
     func testMaintenanceTelemetryIsPersistedAndIncludesOverloadFields() {
         defaultTcpStartInFlightHardCap = 10
         let core = TransparentProxyCore()
@@ -270,7 +316,7 @@ final class TcpOverloadAdmissionTests: XCTestCase {
         XCTAssertTrue(joined.contains("breaker="))
         XCTAssertTrue(joined.contains("hardCap=10"), "the cap the peak is measured against")
         XCTAssertTrue(joined.contains("shedHardCap=0"))
-        XCTAssertTrue(joined.contains("shedBreaker=0"))
+        XCTAssertTrue(joined.contains("shedBreaker=0 shedApps=-"))
         XCTAssertTrue(joined.contains("pressure[triggers=0 scans=0 skipped=0 evicted=0]"))
     }
 

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
@@ -96,6 +96,141 @@ final class TcpOverloadAdmissionTests: XCTestCase {
         XCTAssertTrue(reason.contains("latency breaker open"))
     }
 
+    // MARK: - Breaker evaluation off the completion path
+
+    /// The window already says "slow" from a completion that happened under
+    /// the soft cap (so that completion's own evaluation saw no pressure).
+    /// The admission that brings in-flight up to the soft cap must open the
+    /// breaker itself and be shed — a completion-only breaker would admit it
+    /// and open on some later completion.
+    func testBreakerOpensOnTheAdmissionThatBringsPressureOntoASlowWindow() {
+        defaultTcpStartInFlightHardCap = 10
+        defaultTcpStartInFlightSoftCap = 2
+        defaultTcpStartLatencyBreakerP95Ms = 1
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+        let slow = NSObject()
+        let second = NSObject()
+        let third = NSObject()
+        let fourth = NSObject()
+
+        let slowToken = admittedToken(core, slow)
+        Thread.sleep(forTimeInterval: 0.005)
+        core.testFinishTcpStart(slowToken, outcome: .ready)  // ~5ms > 1ms, but inFlight 0
+        waitFor("completion lands") { core.testTcpStartsInFlight == 0 }
+        XCTAssertFalse(core.testTcpOverloadBreakerOpen, "slow window without pressure stays closed")
+
+        _ = admittedToken(core, second)  // inFlight 0 → 1, under the soft cap
+        _ = admittedToken(core, third)  // inFlight 1 → 2
+        guard case .reject(let reason, _) = core.testAdmitTcpStart(
+            flowId: ObjectIdentifier(fourth), meta: meta())
+        else {
+            XCTFail("the admission that reaches the soft cap on a slow window must open and shed")
+            return
+        }
+        XCTAssertTrue(reason.contains("latency breaker open"), reason)
+        XCTAssertTrue(core.testTcpOverloadBreakerOpen)
+        XCTAssertEqual(core.testTcpStartsInFlight, 2, "the shed start never enters the gauge")
+        XCTAssertTrue(
+            captured.values.joined(separator: "\n").contains("breaker open (on admission)"),
+            "the lifecycle line must say which evaluation opened it")
+    }
+
+    /// Pressure alone is not overload: with no slow completions on record the
+    /// admission-path evaluation must leave the breaker closed and admit.
+    func testPressureWithoutSlowCompletionsDoesNotOpenBreakerOnAdmission() {
+        defaultTcpStartInFlightHardCap = 10
+        defaultTcpStartInFlightSoftCap = 2
+        defaultTcpStartLatencyBreakerP95Ms = 1
+        let core = TransparentProxyCore()
+        let first = NSObject()
+        let second = NSObject()
+        let third = NSObject()
+
+        _ = admittedToken(core, first)
+        _ = admittedToken(core, second)
+        Thread.sleep(forTimeInterval: 0.005)  // pending starts age; that must not count
+        guard case .admit = core.testAdmitTcpStart(flowId: ObjectIdentifier(third), meta: meta())
+        else {
+            XCTFail("pressure without slow completions is not overload; must be admitted")
+            return
+        }
+        XCTAssertFalse(core.testTcpOverloadBreakerOpen)
+        XCTAssertEqual(core.testTcpStartsInFlight, 3)
+    }
+
+    /// Both conditions true, but no single event saw them together: the slow
+    /// completion evaluated under the soft cap, and the admissions that then
+    /// raised in-flight to the soft cap were each still under it when they
+    /// evaluated. Nothing else arrives. The tick must open it.
+    func testMaintenanceTickOpensBreakerWhenNoEventSawBothConditions() {
+        defaultTcpStartInFlightHardCap = 10
+        defaultTcpStartInFlightSoftCap = 2
+        defaultTcpStartLatencyBreakerP95Ms = 1
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+        let slow = NSObject()
+        let second = NSObject()
+        let third = NSObject()
+
+        let slowToken = admittedToken(core, slow)
+        Thread.sleep(forTimeInterval: 0.005)
+        core.testFinishTcpStart(slowToken, outcome: .ready)
+        waitFor("completion lands") { core.testTcpStartsInFlight == 0 }
+        _ = admittedToken(core, second)  // evaluates at inFlight 0: no pressure
+        _ = admittedToken(core, third)  // evaluates at inFlight 1: no pressure
+        XCTAssertFalse(core.testTcpOverloadBreakerOpen, "precondition: no event saw both")
+        XCTAssertEqual(core.testTcpStartsInFlight, 2)
+
+        core.testRunPeriodicMaintenance()
+
+        XCTAssertTrue(core.testTcpOverloadBreakerOpen, "tick must evaluate the open direction")
+        XCTAssertTrue(
+            captured.values.joined(separator: "\n").contains("breaker=open"),
+            "tick telemetry reflects the evaluation it just ran")
+    }
+
+    /// A healthy load with a small timeout-bound tail: 6 of 128 completions at
+    /// 5s, the rest at 100ms, true p95 100ms. Folding the ages of PENDING
+    /// starts into the percentile would open the breaker here on most
+    /// at-soft-cap admissions (a slow start is pending longer, so the pending
+    /// set over-represents the tail); the completed-only window must not.
+    func testHealthyHeavyTailCompletionsDoNotOpenBreakerUnderPressure() {
+        defaultTcpStartInFlightHardCap = 300
+        defaultTcpStartInFlightSoftCap = 64
+        defaultTcpStartLatencyBreakerP95Ms = 1_500
+        let core = TransparentProxyCore()
+        let nowNs = DispatchTime.now().uptimeNanoseconds
+        // Fill the 128-sample window deterministically: `finishTcpStart` takes
+        // the latency from the token it is handed, so a backdated copy sets it.
+        for i in 0..<128 {
+            let slow = i % 25 == 0
+            let token = admittedToken(core, NSObject())
+            let backdated = TcpAdmissionToken(
+                flowId: token.flowId,
+                startedAt: DispatchTime(
+                    uptimeNanoseconds: nowNs - (slow ? 5_000_000_000 : 100_000_000)),
+                appId: token.appId)
+            core.testFinishTcpStart(backdated, outcome: slow ? .timeout : .ready)
+        }
+        waitFor("window filled") { core.testTcpStartsInFlight == 0 }
+        XCTAssertFalse(core.testTcpOverloadBreakerOpen)
+
+        // Genuine pressure on top: 64 starts pending and ageing, none completing.
+        let pending = (0..<64).map { _ in NSObject() }
+        for object in pending { _ = admittedToken(core, object) }
+        Thread.sleep(forTimeInterval: 0.005)
+        let probe = NSObject()
+        guard case .admit = core.testAdmitTcpStart(flowId: ObjectIdentifier(probe), meta: meta())
+        else {
+            XCTFail("a healthy tail is not overload; the at-soft-cap admission must pass")
+            return
+        }
+        XCTAssertFalse(core.testTcpOverloadBreakerOpen)
+    }
+
     func testMaintenanceTelemetryIsPersistedAndIncludesOverloadFields() {
         defaultTcpStartInFlightHardCap = 10
         let core = TransparentProxyCore()
@@ -114,6 +249,46 @@ final class TcpOverloadAdmissionTests: XCTestCase {
         XCTAssertTrue(joined.contains("timeoutRate="))
         XCTAssertTrue(joined.contains("startLatencyMs["))
         XCTAssertTrue(joined.contains("breaker="))
+        XCTAssertTrue(joined.contains("hardCap=10"), "the cap the peak is measured against")
+        XCTAssertTrue(joined.contains("shedHardCap=0"))
+        XCTAssertTrue(joined.contains("shedBreaker=0"))
+        XCTAssertTrue(joined.contains("pressure[triggers=0 scans=0 skipped=0 evicted=0]"))
+    }
+
+    /// A burst that came within a few starts of the hard cap but shed nothing
+    /// leaves no per-flow line behind. The tick's peak is the only trace, and
+    /// it must survive the gauge having drained by the time the tick fires.
+    func testTickReportsInFlightPeakAsTheNearMissSignal() {
+        defaultTcpStartInFlightHardCap = 10
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+        let objects = (0..<8).map { _ in NSObject() }
+        let tokens = objects.map { admittedToken(core, $0) }
+        for token in tokens.dropLast() { core.testFinishTcpStart(token, outcome: .ready) }
+        waitFor("gauge drains to one") { core.testTcpStartsInFlight == 1 }
+
+        core.testRunPeriodicMaintenance()
+
+        let joined = captured.values.joined(separator: "\n")
+        XCTAssertTrue(joined.contains("tcpStartsInFlight=1 tcpStartsInFlightPeak=8"), joined)
+    }
+
+    /// Bundle ids are what a post-incident read needs first, and Apple logs
+    /// them in the clear for every flow anyway: the tick's top-app summary
+    /// must be in the message body, not in redacted metadata.
+    func testTickTopAppsIsPublic() {
+        defaultTcpStartInFlightHardCap = 10
+        let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
+        let anchor = _TestTcpFlowSessionAnchor(ctx: TcpFlowContext())
+        core.registerTcpFlow(ObjectIdentifier(anchor), anchor: anchor, appId: "com.example.chatty")
+
+        core.testRunPeriodicMaintenance()
+
+        XCTAssertTrue(
+            captured.values.joined(separator: "\n").contains("topApps=com.example.chatty=1"))
     }
 
     func testConnectTimeoutClampsUnderPressureAndBreaker() {

--- a/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
+++ b/ffi/apple/RamaAppleNetworkExtension/Tests/RamaAppleNetworkExtensionTests/TcpOverloadAdmissionTests.swift
@@ -193,15 +193,17 @@ final class TcpOverloadAdmissionTests: XCTestCase {
     }
 
     /// A healthy load with a small timeout-bound tail: 6 of 128 completions at
-    /// 5s, the rest at 100ms, true p95 100ms. Folding the ages of PENDING
-    /// starts into the percentile would open the breaker here on most
-    /// at-soft-cap admissions (a slow start is pending longer, so the pending
-    /// set over-represents the tail); the completed-only window must not.
+    /// 5s, the rest at 100ms, true p95 100ms. Pressure on top of it is not
+    /// overload. (The pin against folding PENDING ages into the percentile is
+    /// `testPressureWithoutSlowCompletionsDoesNotOpenBreakerOnAdmission`; this
+    /// one pins the window shape itself via the tick's latency summary.)
     func testHealthyHeavyTailCompletionsDoNotOpenBreakerUnderPressure() {
         defaultTcpStartInFlightHardCap = 300
         defaultTcpStartInFlightSoftCap = 64
         defaultTcpStartLatencyBreakerP95Ms = 1_500
         let core = TransparentProxyCore()
+        let captured = CapturedNotices()
+        LifecycleLog.noticeOverride = { captured.append($0) }
         let nowNs = DispatchTime.now().uptimeNanoseconds
         // Fill the 128-sample window deterministically: `finishTcpStart` takes
         // the latency from the token it is handed, so a backdated copy sets it.
@@ -217,6 +219,23 @@ final class TcpOverloadAdmissionTests: XCTestCase {
         }
         waitFor("window filled") { core.testTcpStartsInFlight == 0 }
         XCTAssertFalse(core.testTcpOverloadBreakerOpen)
+        // Pins that the backdated tokens really shaped the window (and so that
+        // `finishTcpStart` keeps taking latency from the handed token). The
+        // completions land a few ms after the backdated start, so match ranges.
+        core.testRunPeriodicMaintenance()
+        let tick = captured.values.joined(separator: "\n")
+        let pattern = try! NSRegularExpression(pattern: #"startLatencyMs\[p50=(\d+),p95=(\d+),p99=(\d+)\]"#)
+        guard let match = pattern.firstMatch(in: tick, range: NSRange(tick.startIndex..., in: tick))
+        else {
+            XCTFail("no latency summary in tick: \(tick)")
+            return
+        }
+        func percentile(_ group: Int) -> Int {
+            Int(tick[Range(match.range(at: group), in: tick)!]) ?? -1
+        }
+        XCTAssertTrue((100..<200).contains(percentile(1)), "p50 ≈ 100ms, got \(percentile(1))")
+        XCTAssertTrue((100..<200).contains(percentile(2)), "p95 ≈ 100ms (tail is <5%), got \(percentile(2))")
+        XCTAssertGreaterThanOrEqual(percentile(3), 5_000, "p99 sees the 5s tail")
 
         // Genuine pressure on top: 64 starts pending and ageing, none completing.
         let pending = (0..<64).map { _ in NSObject() }

--- a/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_ffi_e2e/Cargo.lock
@@ -2016,6 +2016,7 @@ dependencies = [
  "arc-swap",
  "base64",
  "bindgen",
+ "cc",
  "libc",
  "moka",
  "parking_lot",
@@ -2472,11 +2473,13 @@ dependencies = [
 name = "rama-udp"
 version = "0.5.0"
 dependencies = [
+ "libc",
  "rama-core",
  "rama-net",
  "rama-utils",
  "tokio",
  "tokio-util",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
+++ b/ffi/apple/examples/transparent_proxy/tproxy_rs/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "arc-swap",
  "base64",
  "bindgen",
+ "cc",
  "dial9",
  "dial9-trace-format",
  "libc",
@@ -3005,11 +3006,13 @@ dependencies = [
 name = "rama-udp"
 version = "0.5.0"
 dependencies = [
+ "libc",
  "rama-core",
  "rama-net",
  "rama-utils",
  "tokio",
  "tokio-util",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rama-net-apple-networkextension/src/ffi/tproxy.rs
+++ b/rama-net-apple-networkextension/src/ffi/tproxy.rs
@@ -245,7 +245,7 @@ pub struct TransparentProxyConfig {
     /// See [`tproxy::TransparentProxyConfig::tcp_breaker_connect_timeout_ms`].
     pub tcp_breaker_connect_timeout_ms: u32,
     /// Action when the provider declines a flow for its own reasons (start cap /
-    /// breaker, or missing session): `0` = Block (default), `1` = Passthrough.
+    /// breaker, or missing session): `0` = Block, `1` = Passthrough (default).
     /// See [`tproxy::FlowRefusalAction`].
     pub flow_refusal_action: u32,
 }
@@ -929,25 +929,28 @@ mod tests {
     }
 
     #[test]
-    fn flow_refusal_action_defaults_block_and_maps_to_ffi() {
+    fn flow_refusal_action_defaults_passthrough_and_maps_to_ffi() {
         use crate::tproxy::FlowRefusalAction;
-        // Default is fail-closed.
+        // Default is fail-open: capacity refusals decline to the direct route.
         assert_eq!(
             tproxy::TransparentProxyConfig::new().flow_refusal_action(),
-            FlowRefusalAction::Block
+            FlowRefusalAction::Passthrough
         );
-        let block = TransparentProxyConfig::from_rust_type(&tproxy::TransparentProxyConfig::new());
-        assert_eq!(block.flow_refusal_action, 0);
-        // SAFETY: freshly built, not yet freed.
-        unsafe { block.free() };
-
-        let cfg = tproxy::TransparentProxyConfig::new()
-            .with_flow_refusal_action(FlowRefusalAction::Passthrough);
-        assert_eq!(cfg.flow_refusal_action(), FlowRefusalAction::Passthrough);
-        let pass = TransparentProxyConfig::from_rust_type(&cfg);
+        assert_eq!(FlowRefusalAction::default(), FlowRefusalAction::Passthrough);
+        let pass = TransparentProxyConfig::from_rust_type(&tproxy::TransparentProxyConfig::new());
         assert_eq!(pass.flow_refusal_action, 1);
         // SAFETY: freshly built, not yet freed.
         unsafe { pass.free() };
+
+        // The wire encoding is fixed (0 = Block, 1 = Passthrough) independent
+        // of which one is the default, so the Swift side never has to know.
+        let cfg = tproxy::TransparentProxyConfig::new()
+            .with_flow_refusal_action(FlowRefusalAction::Block);
+        assert_eq!(cfg.flow_refusal_action(), FlowRefusalAction::Block);
+        let block = TransparentProxyConfig::from_rust_type(&cfg);
+        assert_eq!(block.flow_refusal_action, 0);
+        // SAFETY: freshly built, not yet freed.
+        unsafe { block.free() };
     }
 
     #[test]

--- a/rama-net-apple-networkextension/src/tproxy/types.rs
+++ b/rama-net-apple-networkextension/src/tproxy/types.rs
@@ -646,15 +646,27 @@ impl TransparentProxyNetworkRule {
 /// How the provider treats a flow it declines to intercept for its OWN reasons
 /// — the pre-ready TCP start hard cap / latency breaker tripping, or a missing /
 /// invalid session — as distinct from a [`crate::tproxy::FlowAction::Blocked`]
-/// your handler returns. Default [`Block`](Self::Block) (fail closed); set
-/// [`Passthrough`](Self::Passthrough) to fail open. The chosen action is always
-/// logged at the decision site.
+/// your handler returns. The chosen action is always logged at the decision
+/// site.
+///
+/// Default [`Passthrough`](Self::Passthrough) (fail open). These refusals are
+/// capacity decisions, not policy: the flow is one the handler WOULD have
+/// intercepted, and the direct route still exists. Declining hands it to that
+/// route per the transparent-provider contract (see the crate-level `tproxy`
+/// docs) — the same path every policy-passthrough flow already takes, so it
+/// adds no new exposure class. Blocking instead turns a transient overload into
+/// hard connect errors for every app on the machine, and a client retry storm
+/// (the usual reaction to those errors) then feeds the very overload that
+/// caused them.
+///
+/// Set [`Block`](Self::Block) only where an uninspected flow is worse than no
+/// flow AND you accept a machine-wide outage under load as the cost.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum FlowRefusalAction {
     /// Refuse the flow (fail closed).
-    #[default]
     Block,
     /// Hand the flow to the kernel untouched (fail open).
+    #[default]
     Passthrough,
 }
 
@@ -713,7 +725,7 @@ pub struct TransparentProxyConfig {
     tcp_breaker_connect_timeout_ms: u32,
     /// How to treat a flow the provider declines to intercept for its own
     /// reasons (start hard cap / latency breaker, or a missing session).
-    /// Default [`FlowRefusalAction::Block`].
+    /// Default [`FlowRefusalAction::Passthrough`].
     flow_refusal_action: FlowRefusalAction,
 }
 
@@ -738,7 +750,7 @@ impl TransparentProxyConfig {
             tcp_start_latency_breaker_close_p95_ms: DEFAULT_TCP_START_LATENCY_BREAKER_CLOSE_P95_MS,
             tcp_pressure_connect_timeout_ms: DEFAULT_TCP_PRESSURE_CONNECT_TIMEOUT_MS,
             tcp_breaker_connect_timeout_ms: DEFAULT_TCP_BREAKER_CONNECT_TIMEOUT_MS,
-            flow_refusal_action: FlowRefusalAction::Block,
+            flow_refusal_action: FlowRefusalAction::Passthrough,
         }
     }
 
@@ -834,7 +846,8 @@ impl TransparentProxyConfig {
     generate_set_and_with! {
         /// Set how the provider treats a flow it declines to intercept for its
         /// own reasons — start hard cap / latency breaker, or a missing session.
-        /// Default [`FlowRefusalAction::Block`] (fail closed).
+        /// Default [`FlowRefusalAction::Passthrough`] (fail open); see the type
+        /// docs before choosing [`FlowRefusalAction::Block`].
         pub fn flow_refusal_action(mut self, action: FlowRefusalAction) -> Self {
             self.flow_refusal_action = action;
             self


### PR DESCRIPTION
Apple NE tproxy: fail open on the provider's own refusals; fix the admission path.

- `FlowRefusalAction` defaults to `Passthrough`: capacity refusals (start cap, breaker, missing session) decline to the direct route instead of erroring. Handler `Blocked` still fails closed; `Block` stays available.
- Latency breaker also evaluates on admission (before the hard cap) and on the tick.
- Reaper: trigger coalescing was a no-op, fixed; no-headroom rescans skip until a flow can cross the idle floor (250ms–5s); episodes end at low-water.
- Logs: per-tick in-flight peak, shed split + top shed apps, breaker trigger site, per-episode summary, app ids in the clear. Refusal lines are budgeted so a storm can't trip logd and silence the ticks.
