### PR TITLE
revert 1.97.1 back to stable

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.97.1
+  RUST_TOOLCHAIN: stable
   RUST_TOOLCHAIN_MSRV: 1.96.0
   CARGO_INCREMENTAL: 0
   CARGO_PROFILE_TEST_DEBUG: 0
@@ -61,7 +61,7 @@ jobs:
       matrix:
         toolchain:
           - 1.96.0 # MSRV
-          - 1.97.1
+          - stable
         os:
           - ubuntu-latest
           - macos-latest
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.97.1
+          - stable
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
@@ -423,10 +423,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            toolchain: 1.97.1
+            toolchain: stable
             target: x86_64-unknown-linux-musl
           - os: ubuntu-24.04-arm
-            toolchain: 1.97.1
+            toolchain: stable
             target: aarch64-unknown-linux-musl
     name: test-rust-linux-musl-${{ matrix.toolchain }}-${{ matrix.os }}-${{ matrix.target }}
     runs-on: ${{ matrix.os }}
@@ -521,17 +521,17 @@ jobs:
       matrix:
         include:
           - os: macos-latest
-            rust-toolchain: 1.97.1
+            rust-toolchain: stable
             rust-target: x86_64-unknown-linux-gnu
             zig-target: x86_64-unknown-linux-gnu.2.17
             just-recipe: test-zigbuild-linux-gnu
           - os: macos-latest
-            rust-toolchain: 1.97.1
+            rust-toolchain: stable
             rust-target: aarch64-unknown-linux-gnu
             zig-target: aarch64-unknown-linux-gnu.2.17
             just-recipe: test-zigbuild-linux-gnu-native-dns
           - os: windows-latest
-            rust-toolchain: 1.97.1-x86_64-pc-windows-gnu
+            rust-toolchain: stable-x86_64-pc-windows-gnu
             rust-target: x86_64-unknown-linux-gnu
             zig-target: x86_64-unknown-linux-gnu.2.17
             just-recipe: test-zigbuild-linux-gnu-cli
@@ -606,30 +606,30 @@ jobs:
           - custom_env: {}
           - thing: arm-android
             target: armv7-linux-androideabi
-            rust: 1.97.1
+            rust: stable
             os: ubuntu-latest
           - thing: arm64-android
             target: aarch64-linux-android
-            rust: 1.97.1
+            rust: stable
             os: ubuntu-latest
           - thing: i686-android
             target: i686-linux-android
-            rust: 1.97.1
+            rust: stable
             os: ubuntu-latest
           - thing: x86_64-android
             target: x86_64-linux-android
-            rust: 1.97.1
+            rust: stable
             os: ubuntu-latest
           - thing: aarch64-ios
             target: aarch64-apple-ios
-            rust: 1.97.1
+            rust: stable
             os: macos-latest
             custom_env:
               IPHONEOS_DEPLOYMENT_TARGET: 17.5
           - thing: x86_64-ios
             target: x86_64-apple-ios
             os: macos-15-intel
-            rust: 1.97.1
+            rust: stable
             custom_env:
               IPHONEOS_DEPLOYMENT_TARGET: 17.5
     needs:
@@ -816,7 +816,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.97.1
+          - stable
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/RamaCLIRelease.yaml
+++ b/.github/workflows/RamaCLIRelease.yaml
@@ -32,7 +32,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.97.1
+  RUST_TOOLCHAIN: stable
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
 permissions:

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -11,7 +11,7 @@ name: Deploy mdBook site to Pages
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_TOOLCHAIN: 1.97.1
+  RUST_TOOLCHAIN: stable
   # Rustdoc uses `--cfg docsrs`, which enables nightly-only `doc_cfg`
   # annotations. Track latest nightly, same as docs.rs does.
   RUSTDOC_TOOLCHAIN: nightly

--- a/docs/book/src/crate.md
+++ b/docs/book/src/crate.md
@@ -122,8 +122,8 @@ GNU/Linux binaries can also be cross-compiled from macOS and Windows using
 in CI for `x86_64-unknown-linux-gnu` with Rama's native system DNS resolver and
 native TLS backends enabled. Cross-built binaries must be run on a compatible
 Linux system, not on the macOS or Windows build host.
-On Windows, install the `x86_64-pc-windows-gnu` variant of the Rust toolchain
-selected by `rust-toolchain.toml`; the `just` recipes select it automatically.
+On Windows, install the `x86_64-pc-windows-gnu` variant of the stable Rust
+toolchain; the `just` recipes select it automatically.
 
 ### Tier 2 Platforms
 

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ _zigbuild-linux-gnu-with-native-env-unix RECIPE TARGET:
     AR="zig ar" AWS_LC_SYS_CMAKE_BUILDER=0 just {{RECIPE}} {{TARGET}}
 
 _zigbuild-linux-gnu-with-native-env-windows RECIPE TARGET:
-    $rustVersion = (Select-String -Path rust-toolchain.toml -Pattern '^channel = "([^"]+)"$').Matches[0].Groups[1].Value; $gitShell = (Get-Command sh.exe).Source; $shortShell = (New-Object -ComObject Scripting.FileSystemObject).GetFile($gitShell).ShortPath.Replace('\', '/'); $env:RUSTUP_TOOLCHAIN = "${rustVersion}-x86_64-pc-windows-gnu"; $env:MAKEFLAGS = "SHELL=$shortShell"; $env:AR = "zig ar"; $env:AWS_LC_SYS_CMAKE_BUILDER = "0"; just {{RECIPE}} {{TARGET}}
+    $gitShell = (Get-Command sh.exe).Source; $shortShell = (New-Object -ComObject Scripting.FileSystemObject).GetFile($gitShell).ShortPath.Replace('\', '/'); $env:RUSTUP_TOOLCHAIN = "stable-x86_64-pc-windows-gnu"; $env:MAKEFLAGS = "SHELL=$shortShell"; $env:AR = "zig ar"; $env:AWS_LC_SYS_CMAKE_BUILDER = "0"; just {{RECIPE}} {{TARGET}}
 
 # check no_std crates against a target without std: any dep that links
 # std fails loudly here instead of poisoning downstream no_std consumers

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "1.97.1"
-profile = "minimal"
-components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Rust 1.98.1 has been released
See: https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/

Which closes the issue
https://github.com/rust-lang/rust/issues/161441
reported by us 2 weeks ago and the reason why we were forced to pin latest stable for now to 1.97.1 given we were consistently getting failures because of the issue present in 1.98.0, and now fixed in 1.98.1

mostly a revert of https://github.com/plabayo/rama/commit/c6be57b8aac23a02fbbb20fd2c8135fd08b067da, except for some details that matter to current context
