### PR TITLE
HTTP/1 relay streaming, framing, and half-close behavior

### DIFF
--- a/rama-http-backend/Cargo.toml
+++ b/rama-http-backend/Cargo.toml
@@ -59,6 +59,7 @@ rama-unix = { workspace = true }
 rama-net = { workspace = true, features = ["test-utils"] }
 rama-ws = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/rama-http-backend/src/proxy/mitm.rs
+++ b/rama-http-backend/src/proxy/mitm.rs
@@ -29,7 +29,10 @@ use rama_http_core::server::conn::{
     auto::Builder as AutoConnBuilder, http1::Builder as Http1ConnBuilder,
     http2::Builder as H2ConnBuilder,
 };
-use rama_http_types::proto::{h1::ext::ConnectionClose, h2::frame::Settings};
+use rama_http_types::proto::{
+    h1::ext::{CloseDelimitedResponse, ConnectionClose, OriginalResponseBodyFraming},
+    h2::frame::Settings,
+};
 use rama_net::client::EstablishedClientConnection;
 use rama_net::uri::Uri;
 
@@ -133,6 +136,13 @@ pub type DefaultMiddleware = (
 /// Useful if you have a fairly standard MITM http flow and already
 /// have pre-established ingress and egress connections (e.g. because
 /// you already MITM'd the <L7 layers, such as SOCKS5 MITM'ng, TLS, ...).
+///
+/// HTTP/1 responses originally delimited by EOF (without Content-Length or
+/// Transfer-Encoding) retain that framing downstream, including HTTP/1.1.
+/// They stream without chunking and close the downstream connection at body EOF.
+/// Middleware can select different framing by adding Content-Length or
+/// Transfer-Encoding; a Trailer header also prevents automatic EOF framing.
+/// HTTP/2 framing is unaffected.
 ///
 /// The relay does not consume proxy-authentication fields: a transparent
 /// intermediary may be forwarding them to the proxy that owns the exchange.
@@ -325,7 +335,25 @@ where
                     let close_ingress = token.clone();
                     let guard = request_guard.clone();
                     async move {
-                        Ok(handle_relay_request(&relay_state, req, guard, close_ingress).await)
+                        let version = req.version();
+                        let resp =
+                            handle_relay_request(&relay_state, req, guard, close_ingress).await;
+                        // Hop sanitation has already consumed received framing headers.
+                        // Use decoder metadata, while respecting framing originated by middleware.
+                        if matches!(version, Version::HTTP_10 | Version::HTTP_11)
+                            && resp.extensions().get_ref::<OriginalResponseBodyFraming>()
+                                == Some(&OriginalResponseBodyFraming::CloseDelimited)
+                            && ![
+                                header::CONTENT_LENGTH,
+                                header::TRANSFER_ENCODING,
+                                header::TRAILER,
+                            ]
+                            .iter()
+                            .any(|name| resp.headers().contains_key(name))
+                        {
+                            resp.extensions().insert(CloseDelimitedResponse);
+                        }
+                        Ok(resp)
                     }
                 }),
             )

--- a/rama-http-backend/src/proxy/mitm.rs
+++ b/rama-http-backend/src/proxy/mitm.rs
@@ -140,6 +140,7 @@ pub type DefaultMiddleware = (
 /// HTTP/1 responses originally delimited by EOF (without Content-Length or
 /// Transfer-Encoding) retain that framing downstream, including HTTP/1.1.
 /// They stream without chunking and close the downstream connection at body EOF.
+/// Preserving EOF framing sacrifices downstream connection reuse and explicit truncation detection.
 /// Middleware can select different framing by adding Content-Length or
 /// Transfer-Encoding; a Trailer header also prevents automatic EOF framing.
 /// HTTP/2 framing is unaffected.

--- a/rama-http-backend/tests/http1_mitm_relay_streaming.rs
+++ b/rama-http-backend/tests/http1_mitm_relay_streaming.rs
@@ -913,3 +913,38 @@ async fn middleware_can_upgrade_response_version_without_rechunking() {
     assert_eof(&mut relay.client).await;
     relay.finish(false).await;
 }
+
+#[tokio::test(start_paused = true)]
+async fn repeated_content_lengths_are_normalized_and_keep_the_relay_reusable() {
+    for headers in [
+        "Content-Length: 4\r\nX-Between: kept\r\nContent-Length: 4\r\n",
+        "Content-Length: 04\r\nContent-Length: 4\r\nContent-Length: 004\r\n",
+        "Content-Length: 4, 4\r\n",
+        "Content-Length: 4, 04\r\nContent-Length: 004\r\n",
+    ] {
+        let mut relay = Relay::with_default_middleware();
+        relay.request("1.1", "GET", b"").await;
+        let head = relay.response_head("1.1", headers).await;
+        assert_framing(&head, "1.1", false, Some(4));
+        assert_eq!(
+            head.to_ascii_lowercase().matches("content-length:").count(),
+            1
+        );
+        write(relay.upstream.get_mut(), b"PO").await;
+        assert_payload(&mut relay.client, b"PO", false).await;
+        assert_no_output(&mut relay.client).await;
+        write(relay.upstream.get_mut(), b"NG").await;
+        assert_payload(&mut relay.client, b"NG", false).await;
+        // The normalized length completes the response without either peer closing.
+        relay.request("1.1", "GET", b"").await;
+        let head = relay
+            .response_head("1.1", "Content-Length: 0\r\nContent-Length: 0\r\n")
+            .await;
+        assert_framing(&head, "1.1", false, Some(0));
+        assert_eq!(
+            head.to_ascii_lowercase().matches("content-length:").count(),
+            1
+        );
+        relay.finish(false).await;
+    }
+}

--- a/rama-http-backend/tests/http1_mitm_relay_streaming.rs
+++ b/rama-http-backend/tests/http1_mitm_relay_streaming.rs
@@ -18,9 +18,13 @@ use std::{
 };
 
 use rama_core::{
-    Service, ServiceInput, error::BoxError, io::BridgeIo, layer::ArcLayer, rt::Executor,
+    Service, ServiceInput,
+    error::BoxError,
+    io::BridgeIo,
+    layer::{ArcLayer, MapOutputLayer},
+    rt::Executor,
 };
-use rama_http::layer::map_response_body::MapResponseBodyLayer;
+use rama_http::{HeaderValue, Response, header, layer::map_response_body::MapResponseBodyLayer};
 use rama_http_backend::proxy::mitm::HttpMitmRelay;
 use rama_net::test_utils::client::MockSocket;
 use tokio::{
@@ -50,7 +54,10 @@ impl AsyncRead for ReadFailureIo {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        if !self.failed && matches!(Pin::new(&mut self.fail).poll(cx), Poll::Ready(Ok(()))) {
+        if !self.failed
+            && let Poll::Ready(result) = Pin::new(&mut self.fail).poll(cx)
+        {
+            result.expect("failure sender dropped before the relay finished");
             self.failed = true;
         }
         if self.failed {
@@ -88,26 +95,44 @@ struct Relay {
 
 impl Relay {
     fn new() -> Self {
+        Self::with_response_transform(|resp| resp)
+    }
+
+    fn with_response_transform(transform: fn(Response) -> Response) -> Self {
+        Self::with_configuration(false, transform)
+    }
+
+    fn with_default_middleware() -> Self {
+        Self::with_configuration(true, |resp| resp)
+    }
+
+    fn with_configuration(default_middleware: bool, transform: fn(Response) -> Response) -> Self {
         let (client, ingress) = tokio::io::duplex(4096);
         let (egress, upstream) = tokio::io::duplex(4096);
         let (fail_upstream, fail) = oneshot::channel();
         let done = tokio::spawn(async move {
-            HttpMitmRelay::new(Executor::new())
-                // Preserve the streaming body wrapper used by callers without
-                // swallowing errors into synthetic responses.
-                .with_http_middleware((
-                    MapResponseBodyLayer::new_boxed_streaming_body(),
-                    ArcLayer::new(),
-                ))
-                .serve(BridgeIo(
-                    MockSocket::new(ingress),
-                    ServiceInput::new(ReadFailureIo {
-                        inner: egress,
-                        fail,
-                        failed: false,
-                    }),
-                ))
-                .await
+            let io = BridgeIo(
+                MockSocket::new(ingress),
+                ServiceInput::new(ReadFailureIo {
+                    inner: egress,
+                    fail,
+                    failed: false,
+                }),
+            );
+            let relay = HttpMitmRelay::new(Executor::new());
+            if default_middleware {
+                relay.serve(io).await
+            } else {
+                // Preserve streaming without replacing egress errors with responses.
+                relay
+                    .with_http_middleware((
+                        MapOutputLayer::new(transform),
+                        MapResponseBodyLayer::new_boxed_streaming_body(),
+                        ArcLayer::new(),
+                    ))
+                    .serve(io)
+                    .await
+            }
         });
         Self {
             client: BufReader::new(client),
@@ -141,7 +166,16 @@ impl Relay {
         read_head(&mut self.client).await
     }
 
-    async fn finish(self, expect_error: bool) {
+    async fn finish(mut self, expect_error: bool) {
+        if expect_error {
+            // The fault must terminate the relay without fixture teardown causing it.
+            timeout(WATCHDOG, &mut self.done)
+                .await
+                .expect("upstream fault did not terminate the relay")
+                .expect("relay task panicked")
+                .expect_err("upstream fault was swallowed");
+            return;
+        }
         drop(self.client);
         drop(self.upstream);
         // Keep the failure sender alive while the connection tasks finish.
@@ -273,7 +307,7 @@ async fn close_delimited_response_version_matrix_streams_until_eof() {
         } else {
             origin_version
         };
-        let chunked = downstream_version == "1.1";
+        let chunked = false;
         assert_framing(&head, downstream_version, chunked, None);
         if connection.contains("close") {
             assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
@@ -289,22 +323,7 @@ async fn close_delimited_response_version_matrix_streams_until_eof() {
         advance(Duration::from_secs(31)).await;
         assert_no_output(&mut relay.client).await;
         relay.upstream.get_mut().shutdown().await.unwrap();
-        if chunked {
-            assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
-            if connection.contains("close") {
-                assert_eof(&mut relay.client).await;
-            } else {
-                // Either keeping this hop open or closing it is valid after
-                // a complete chunked response; neither may append more bytes.
-                let mut byte = [0];
-                assert!(matches!(
-                    timeout(PENDING_WINDOW, relay.client.read(&mut byte)).await,
-                    Err(_) | Ok(Ok(0))
-                ));
-            }
-        } else {
-            assert_eof(&mut relay.client).await;
-        }
+        assert_eof(&mut relay.client).await;
         relay.finish(false).await;
     }
 }
@@ -323,12 +342,12 @@ async fn length_response_then_close_delimited_response_on_same_connection() {
     // This request must reach upstream without closing either socket.
     relay.request("1.1", "POST", b"second request").await;
     let head = relay.response_head("1.1", "").await;
-    assert_framing(&head, "1.1", true, None);
+    assert_framing(&head, "1.1", false, None);
     write(relay.upstream.get_mut(), b"second response").await;
-    assert_payload(&mut relay.client, b"second response", true).await;
+    assert_payload(&mut relay.client, b"second response", false).await;
     assert_no_output(&mut relay.client).await;
     relay.upstream.get_mut().shutdown().await.unwrap();
-    assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+    assert_eof(&mut relay.client).await;
     relay.finish(false).await;
 }
 
@@ -386,9 +405,18 @@ async fn client_write_eof_preserves_pending_response() {
                 assert_no_output(&mut relay.client).await;
             }
             let head = relay.response_head("1.1", headers).await;
-            let chunked = !headers.starts_with("Content-Length");
+            let chunked = headers.starts_with("Transfer-Encoding");
             let origin_chunked = headers.starts_with("Transfer-Encoding");
-            assert_framing(&head, "1.1", chunked, if chunked { None } else { Some(9) });
+            assert_framing(
+                &head,
+                "1.1",
+                chunked,
+                if headers.starts_with("Content-Length") {
+                    Some(9)
+                } else {
+                    None
+                },
+            );
             write(
                 relay.upstream.get_mut(),
                 if origin_chunked {
@@ -433,7 +461,7 @@ async fn client_write_eof_preserves_pending_response() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn upstream_body_errors_do_not_fabricate_response_completion() {
+async fn upstream_body_errors_terminate_relay_without_extra_bytes() {
     for (headers, prefix, chunked, read_error) in [
         ("Content-Length: 8\r\n", b"PONG".as_slice(), false, false),
         (
@@ -442,12 +470,21 @@ async fn upstream_body_errors_do_not_fabricate_response_completion() {
             true,
             false,
         ),
-        ("", b"PONG".as_slice(), true, true),
+        ("", b"PONG".as_slice(), false, true),
     ] {
         let mut relay = Relay::new();
         relay.request("1.1", "POST", b"PING").await;
         let head = relay.response_head("1.1", headers).await;
-        assert_framing(&head, "1.1", chunked, if chunked { None } else { Some(8) });
+        assert_framing(
+            &head,
+            "1.1",
+            chunked,
+            if headers.starts_with("Content-Length") {
+                Some(8)
+            } else {
+                None
+            },
+        );
         write(relay.upstream.get_mut(), prefix).await;
         assert_payload(&mut relay.client, b"PONG", chunked).await;
         assert_no_output(&mut relay.client).await;
@@ -456,8 +493,9 @@ async fn upstream_body_errors_do_not_fabricate_response_completion() {
         } else {
             relay.upstream.get_mut().shutdown().await.unwrap();
         }
-        // An already-started response must end incompletely: no terminal
-        // chunk, synthetic second response, or padding to Content-Length.
+        // No terminal chunk, synthetic second response, or padding to Content-Length.
+        // With EOF framing the downstream cannot distinguish truncation from
+        // completion, but the relay must still report the upstream read error.
         assert_eof(&mut relay.client).await;
         relay.finish(true).await;
     }
@@ -465,16 +503,25 @@ async fn upstream_body_errors_do_not_fabricate_response_completion() {
 
 #[tokio::test(start_paused = true)]
 async fn bodyless_responses_do_not_wait_for_upstream_eof() {
-    for (method, status) in [
-        ("HEAD", "200 OK"),
-        ("GET", "204 No Content"),
-        ("GET", "304 Not Modified"),
+    for (method, status, headers, length) in [
+        ("HEAD", "200 OK", "", None),
+        ("HEAD", "200 OK", "Content-Length: 42\r\n", Some(42)),
+        ("HEAD", "200 OK", "Transfer-Encoding: chunked\r\n", None),
+        ("GET", "204 No Content", "", None),
+        ("GET", "204 No Content", "Content-Length: 0\r\n", None),
+        ("GET", "304 Not Modified", "", None),
+        (
+            "GET",
+            "304 Not Modified",
+            "Content-Length: 42\r\n",
+            Some(42),
+        ),
     ] {
         let mut relay = Relay::new();
         relay.request("1.1", method, b"").await;
         write(
             relay.upstream.get_mut(),
-            format!("HTTP/1.1 {status}\r\n\r\n").as_bytes(),
+            format!("HTTP/1.1 {status}\r\n{headers}\r\n").as_bytes(),
         )
         .await;
         let head = read_head(&mut relay.client).await;
@@ -482,11 +529,387 @@ async fn bodyless_responses_do_not_wait_for_upstream_eof() {
             head.starts_with(&format!("HTTP/1.1 {status}\r\n")),
             "{head:?}"
         );
-        assert!(!head.to_ascii_lowercase().contains("transfer-encoding:"));
+        let lower = head.to_ascii_lowercase();
+        assert!(!lower.contains("transfer-encoding:"));
+        if let Some(length) = length {
+            // HEAD representation metadata is forwarded. For 304, the codec
+            // currently omits this optional field; if emitted, it must describe
+            // the selected representation rather than this empty message body.
+            if method == "HEAD" || lower.contains("content-length:") {
+                assert!(
+                    lower.contains(&format!("content-length: {length}\r\n")),
+                    "{head:?}"
+                );
+            }
+        } else if status.starts_with("204") {
+            assert!(!lower.contains("content-length:"));
+        }
+        assert_no_output(&mut relay.client).await;
         // No body framing is needed to accept the next request on this pair.
         relay.request("1.1", "POST", b"next").await;
         let head = relay.response_head("1.1", "Content-Length: 0\r\n").await;
         assert_framing(&head, "1.1", false, Some(0));
         relay.finish(false).await;
     }
+}
+
+#[tokio::test(start_paused = true)]
+async fn preserved_close_delimited_responses_stream_until_eof_with_half_close() {
+    for (client_version, origin_version) in [
+        ("1.0", "1.0"),
+        ("1.0", "1.1"),
+        ("1.1", "1.0"),
+        ("1.1", "1.1"),
+    ] {
+        for fin in [0, 1, 2] {
+            let mut relay = Relay::new();
+            relay.request(client_version, "POST", b"PING").await;
+            if fin == 1 {
+                relay.client.get_mut().shutdown().await.unwrap();
+            }
+            let head = relay.response_head(origin_version, "").await;
+            let downstream_version = if client_version == "1.0" {
+                "1.0"
+            } else {
+                origin_version
+            };
+            assert_framing(&head, downstream_version, false, None);
+            assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+            assert_no_output(&mut relay.client).await;
+            write(relay.upstream.get_mut(), b"first").await;
+            assert_payload(&mut relay.client, b"first", false).await;
+            if fin == 2 {
+                relay.client.get_mut().shutdown().await.unwrap();
+            }
+            advance(Duration::from_secs(31)).await;
+            assert_no_output(&mut relay.client).await;
+            write(relay.upstream.get_mut(), b"last").await;
+            assert_payload(&mut relay.client, b"last", false).await;
+            assert_no_output(&mut relay.client).await;
+            relay.upstream.get_mut().shutdown().await.unwrap();
+            assert_eof(&mut relay.client).await;
+            relay.finish(false).await;
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn preserved_close_delimited_response_can_be_empty() {
+    let mut relay = Relay::new();
+    relay.request("1.1", "GET", b"").await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", false, None);
+    assert_no_output(&mut relay.client).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    assert_eof(&mut relay.client).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn preservation_leaves_explicit_framing_reusable_until_close_delimited_response() {
+    let mut relay = Relay::new();
+    for (headers, wire_body, chunked, length) in [
+        ("Content-Length: 4\r\n", b"PONG".as_slice(), false, Some(4)),
+        (
+            "Transfer-Encoding: chunked\r\n",
+            b"4\r\nPONG\r\n".as_slice(),
+            true,
+            None,
+        ),
+    ] {
+        relay.request("1.1", "POST", b"PING").await;
+        let head = relay.response_head("1.1", headers).await;
+        assert_framing(&head, "1.1", chunked, length);
+        assert!(!head.to_ascii_lowercase().contains("connection: close"));
+        write(relay.upstream.get_mut(), wire_body).await;
+        assert_payload(&mut relay.client, b"PONG", chunked).await;
+        if chunked {
+            write(relay.upstream.get_mut(), b"0\r\n\r\n").await;
+            assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+        }
+    }
+    relay.request("1.1", "POST", b"last").await;
+    let head = relay
+        .response_head("1.1", "Connection: keep-alive\r\n")
+        .await;
+    assert_framing(&head, "1.1", false, None);
+    assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+    // A pipelined request must not be forwarded after this response.
+    write(
+        relay.client.get_mut(),
+        b"GET /next HTTP/1.1\r\nHost: example.test\r\n\r\n",
+    )
+    .await;
+    write(relay.upstream.get_mut(), b"last response").await;
+    assert_payload(&mut relay.client, b"last response", false).await;
+    assert_no_output(&mut relay.upstream).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    assert_eof(&mut relay.client).await;
+    assert_eof(&mut relay.upstream).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn preserved_close_delimited_response_propagates_read_failure() {
+    let mut relay = Relay::new();
+    relay.request("1.1", "GET", b"").await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", false, None);
+    write(relay.upstream.get_mut(), b"partial").await;
+    assert_payload(&mut relay.client, b"partial", false).await;
+    relay.fail_upstream.take().unwrap().send(()).unwrap();
+    assert_eof(&mut relay.client).await;
+    relay.finish(true).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn middleware_can_explicitly_rechunk_close_delimited_response() {
+    let mut relay = Relay::with_response_transform(|mut resp| {
+        resp.headers_mut().insert(
+            header::TRANSFER_ENCODING,
+            HeaderValue::from_static("chunked"),
+        );
+        resp
+    });
+    relay.request("1.1", "GET", b"").await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", true, None);
+    write(relay.upstream.get_mut(), b"first").await;
+    assert_payload(&mut relay.client, b"first", true).await;
+    advance(Duration::from_secs(31)).await;
+    assert_no_output(&mut relay.client).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn explicit_close_delimited_encoding_closes_for_known_and_empty_bodies() {
+    use rama_core::{extensions::ExtensionsRef, service::service_fn};
+    use rama_http::{Body, Request, proto::h1::ext::CloseDelimitedResponse};
+    use rama_http_backend::server::HttpServer;
+    use std::convert::Infallible;
+
+    for payload in ["", "known length"] {
+        let body_bytes = rama_core::bytes::Bytes::copy_from_slice(payload.as_bytes());
+        let (client, server) = tokio::io::duplex(4096);
+        let done = tokio::spawn(async move {
+            HttpServer::auto(Executor::new())
+                .serve(
+                    MockSocket::new(server),
+                    service_fn(move |_: Request| {
+                        let resp = Response::new(Body::from(body_bytes.clone()));
+                        resp.extensions().insert(CloseDelimitedResponse);
+                        std::future::ready(Ok::<_, Infallible>(resp))
+                    }),
+                )
+                .await
+        });
+        let mut client = BufReader::new(client);
+        write(
+            client.get_mut(),
+            b"GET / HTTP/1.1\r\nHost: example.test\r\n\r\n",
+        )
+        .await;
+        let head = read_head(&mut client).await;
+        assert_framing(&head, "1.1", false, None);
+        assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+        assert_eq!(
+            read_bytes(&mut client, payload.len()).await,
+            payload.as_bytes()
+        );
+        assert_eof(&mut client).await;
+        timeout(WATCHDOG, done).await.unwrap().unwrap().unwrap();
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn middleware_can_replace_eof_framing_with_content_length() {
+    let mut relay = Relay::with_response_transform(|mut resp| {
+        resp.headers_mut()
+            .insert(header::CONTENT_LENGTH, HeaderValue::from_static("4"));
+        resp
+    });
+    relay.request("1.1", "GET", b"").await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", false, Some(4));
+    write(relay.upstream.get_mut(), b"PONG").await;
+    assert_payload(&mut relay.client, b"PONG", false).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn middleware_added_trailers_select_chunked_framing() {
+    use rama_http::HeaderMap;
+    let mut relay = Relay::with_response_transform(|mut resp| {
+        resp.headers_mut()
+            .insert(header::TRAILER, HeaderValue::from_static("x-checksum"));
+        let mut trailers = HeaderMap::new();
+        trailers.insert("x-checksum", HeaderValue::from_static("test-value"));
+        resp.map(|body| body.with_trailer_headers(trailers))
+    });
+    // Trailer negotiation is hop-local, so originate it explicitly on this hop.
+    write(
+        relay.client.get_mut(),
+        b"GET / HTTP/1.1\r\nHost: example.test\r\nTE: trailers\r\nConnection: TE\r\n\r\n",
+    )
+    .await;
+    read_head(&mut relay.upstream).await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", true, None);
+    write(relay.upstream.get_mut(), b"PONG").await;
+    assert_payload(&mut relay.client, b"PONG", true).await;
+    assert_no_output(&mut relay.client).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    let terminal = read_head(&mut relay.client).await;
+    assert_eq!(
+        terminal.to_ascii_lowercase(),
+        "0\r\nx-checksum: test-value\r\n\r\n"
+    );
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_middleware_streams_close_delimited_response_and_reports_body_error() {
+    for fail in [false, true] {
+        let mut relay = Relay::with_default_middleware();
+        relay.request("1.1", "GET", b"").await;
+        let head = relay.response_head("1.1", "").await;
+        assert_framing(&head, "1.1", false, None);
+        write(relay.upstream.get_mut(), b"first").await;
+        assert_payload(&mut relay.client, b"first", false).await;
+        advance(Duration::from_secs(31)).await;
+        assert_no_output(&mut relay.client).await;
+        if fail {
+            relay.fail_upstream.take().unwrap().send(()).unwrap();
+        } else {
+            relay.upstream.get_mut().shutdown().await.unwrap();
+        }
+        assert_eof(&mut relay.client).await;
+        relay.finish(fail).await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn chunked_request_streams_before_client_finishes() {
+    let mut relay = Relay::with_default_middleware();
+    write(
+        relay.client.get_mut(),
+        b"POST / HTTP/1.1\r\nHost: example.test\r\nTransfer-Encoding: chunked\r\n\r\n",
+    )
+    .await;
+    let head = read_head(&mut relay.upstream).await;
+    assert!(
+        head.to_ascii_lowercase()
+            .contains("transfer-encoding: chunked\r\n")
+    );
+    for fragment in [b"first".as_slice(), b"last".as_slice()] {
+        write(
+            relay.client.get_mut(),
+            format!("{:x}\r\n", fragment.len()).as_bytes(),
+        )
+        .await;
+        write(relay.client.get_mut(), fragment).await;
+        write(relay.client.get_mut(), b"\r\n").await;
+        assert_payload(&mut relay.upstream, fragment, true).await;
+        assert_no_output(&mut relay.upstream).await;
+    }
+    write(relay.client.get_mut(), b"0\r\n\r\n").await;
+    assert_eq!(read_bytes(&mut relay.upstream, 5).await, b"0\r\n\r\n");
+    relay.response_head("1.1", "Content-Length: 0\r\n").await;
+    relay.request("1.1", "GET", b"").await;
+    relay.response_head("1.1", "Content-Length: 0\r\n").await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn client_connection_close_finishes_response_without_upstream_eof() {
+    let mut relay = Relay::with_default_middleware();
+    write(
+        relay.client.get_mut(),
+        b"GET / HTTP/1.1\r\nHost: example.test\r\nConnection: close\r\n\r\n",
+    )
+    .await;
+    read_head(&mut relay.upstream).await;
+    let head = relay.response_head("1.1", "Content-Length: 4\r\n").await;
+    assert_framing(&head, "1.1", false, Some(4));
+    assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+    write(relay.upstream.get_mut(), b"PO").await;
+    assert_payload(&mut relay.client, b"PO", false).await;
+    assert_no_output(&mut relay.client).await;
+    write(relay.upstream.get_mut(), b"NG").await;
+    assert_payload(&mut relay.client, b"NG", false).await;
+    assert_eof(&mut relay.client).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn default_middleware_replaces_invalid_upstream_length_with_complete_502() {
+    let mut relay = Relay::with_default_middleware();
+    relay.request("1.1", "GET", b"").await;
+    write(
+        relay.upstream.get_mut(),
+        b"HTTP/1.1 200 OK\r\nContent-Length: invalid\r\n\r\n",
+    )
+    .await;
+    let head = read_head(&mut relay.client).await;
+    let lower = head.to_ascii_lowercase();
+    assert!(
+        lower.starts_with("http/1.1 502 bad gateway\r\n"),
+        "{head:?}"
+    );
+    assert!(lower.contains("content-length: 0\r\n"), "{head:?}");
+    assert!(!lower.contains("transfer-encoding:"));
+    // The synthetic response is complete without origin EOF. Do not require
+    // downstream closure: default error middleware does not currently request it.
+    assert_eof(&mut relay.upstream).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn expect_continue_allows_incremental_request_body() {
+    let mut relay = Relay::with_default_middleware();
+    write(relay.client.get_mut(), b"POST / HTTP/1.1\r\nHost: example.test\r\nExpect: 100-continue\r\nContent-Length: 9\r\n\r\n").await;
+    let head = read_head(&mut relay.upstream).await;
+    assert!(
+        head.to_ascii_lowercase()
+            .contains("expect: 100-continue\r\n")
+    );
+    write(relay.upstream.get_mut(), b"HTTP/1.1 100 Continue\r\n\r\n").await;
+    let interim = read_head(&mut relay.client).await;
+    assert!(
+        interim.starts_with("HTTP/1.1 100 Continue\r\n"),
+        "{interim:?}"
+    );
+    for fragment in [b"first".as_slice(), b"last".as_slice()] {
+        write(relay.client.get_mut(), fragment).await;
+        assert_payload(&mut relay.upstream, fragment, false).await;
+        assert_no_output(&mut relay.upstream).await;
+    }
+    let head = relay.response_head("1.1", "Content-Length: 0\r\n").await;
+    assert_framing(&head, "1.1", false, Some(0));
+    relay.request("1.1", "GET", b"").await;
+    relay.response_head("1.1", "Content-Length: 0\r\n").await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn middleware_can_upgrade_response_version_without_rechunking() {
+    let mut relay = Relay::with_response_transform(|mut resp| {
+        *resp.version_mut() = rama_http::Version::HTTP_11;
+        resp
+    });
+    relay.request("1.1", "GET", b"").await;
+    let head = relay
+        .response_head("1.0", "Connection: keep-alive\r\n")
+        .await;
+    assert_framing(&head, "1.1", false, None);
+    assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+    write(relay.upstream.get_mut(), b"first").await;
+    assert_payload(&mut relay.client, b"first", false).await;
+    assert_no_output(&mut relay.client).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    assert_eof(&mut relay.client).await;
+    relay.finish(false).await;
 }

--- a/rama-http-backend/tests/http1_mitm_relay_streaming.rs
+++ b/rama-http-backend/tests/http1_mitm_relay_streaming.rs
@@ -1,0 +1,492 @@
+//! HTTP/1 relay framing contracts, exercised with raw peers over in-memory IO.
+//! The origin deliberately keeps responses open so collecting a body or waiting
+//! for TCP EOF cannot accidentally hide a streaming regression. All clocks are
+//! paused: timeouts are watchdogs, and pending-read checks take no wall time.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test helpers must fail immediately on invalid wire data, IO errors, or stalled tasks"
+)]
+
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use rama_core::{
+    Service, ServiceInput, error::BoxError, io::BridgeIo, layer::ArcLayer, rt::Executor,
+};
+use rama_http::layer::map_response_body::MapResponseBodyLayer;
+use rama_http_backend::proxy::mitm::HttpMitmRelay;
+use rama_net::test_utils::client::MockSocket;
+use tokio::{
+    io::{
+        AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader,
+        DuplexStream, ReadBuf,
+    },
+    sync::oneshot,
+    task::JoinHandle,
+    time::{advance, timeout},
+};
+
+const WATCHDOG: Duration = Duration::from_secs(2);
+const PENDING_WINDOW: Duration = Duration::from_millis(1);
+
+// A read failure differs from a clean FIN for a close-delimited response. The
+// signal lets the fixture inject it only after the client has received data.
+struct ReadFailureIo {
+    inner: DuplexStream,
+    fail: oneshot::Receiver<()>,
+    failed: bool,
+}
+
+impl AsyncRead for ReadFailureIo {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if !self.failed && matches!(Pin::new(&mut self.fail).poll(cx), Poll::Ready(Ok(()))) {
+            self.failed = true;
+        }
+        if self.failed {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "injected upstream read failure",
+            )));
+        }
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for ReadFailureIo {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+struct Relay {
+    client: BufReader<DuplexStream>,
+    upstream: BufReader<DuplexStream>,
+    fail_upstream: Option<oneshot::Sender<()>>,
+    done: JoinHandle<Result<(), BoxError>>,
+}
+
+impl Relay {
+    fn new() -> Self {
+        let (client, ingress) = tokio::io::duplex(4096);
+        let (egress, upstream) = tokio::io::duplex(4096);
+        let (fail_upstream, fail) = oneshot::channel();
+        let done = tokio::spawn(async move {
+            HttpMitmRelay::new(Executor::new())
+                // Preserve the streaming body wrapper used by callers without
+                // swallowing errors into synthetic responses.
+                .with_http_middleware((
+                    MapResponseBodyLayer::new_boxed_streaming_body(),
+                    ArcLayer::new(),
+                ))
+                .serve(BridgeIo(
+                    MockSocket::new(ingress),
+                    ServiceInput::new(ReadFailureIo {
+                        inner: egress,
+                        fail,
+                        failed: false,
+                    }),
+                ))
+                .await
+        });
+        Self {
+            client: BufReader::new(client),
+            upstream: BufReader::new(upstream),
+            fail_upstream: Some(fail_upstream),
+            done,
+        }
+    }
+
+    async fn request(&mut self, version: &str, method: &str, body: &[u8]) {
+        let head = format!(
+            "{method} / HTTP/{version}\r\nHost: example.test\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        write(self.client.get_mut(), head.as_bytes()).await;
+        write(self.client.get_mut(), body).await;
+        let forwarded = read_head(&mut self.upstream).await;
+        assert!(
+            forwarded.starts_with(&format!("{method} / HTTP/{version}\r\n")),
+            "{forwarded}"
+        );
+        assert_eq!(read_bytes(&mut self.upstream, body.len()).await, body);
+    }
+
+    async fn response_head(&mut self, version: &str, headers: &str) -> String {
+        write(
+            self.upstream.get_mut(),
+            format!("HTTP/{version} 200 OK\r\n{headers}\r\n").as_bytes(),
+        )
+        .await;
+        read_head(&mut self.client).await
+    }
+
+    async fn finish(self, expect_error: bool) {
+        drop(self.client);
+        drop(self.upstream);
+        // Keep the failure sender alive while the connection tasks finish.
+        let result = timeout(WATCHDOG, self.done)
+            .await
+            .expect("relay task hung")
+            .expect("relay task panicked");
+        assert_eq!(result.is_err(), expect_error, "relay result: {result:?}");
+    }
+}
+
+async fn write(io: &mut DuplexStream, bytes: &[u8]) {
+    timeout(WATCHDOG, io.write_all(bytes))
+        .await
+        .expect("write stalled")
+        .unwrap();
+}
+
+async fn read_head(io: &mut BufReader<DuplexStream>) -> String {
+    timeout(WATCHDOG, async {
+        let mut head = String::new();
+        while !head.ends_with("\r\n\r\n") {
+            assert_ne!(
+                io.read_line(&mut head).await.unwrap(),
+                0,
+                "EOF before complete head: {head:?}"
+            );
+            assert!(head.len() < 4096, "unexpectedly large head");
+        }
+        head
+    })
+    .await
+    .expect("head stalled")
+}
+
+async fn read_bytes(io: &mut BufReader<DuplexStream>, len: usize) -> Vec<u8> {
+    let mut bytes = vec![0; len];
+    timeout(WATCHDOG, io.read_exact(&mut bytes))
+        .await
+        .expect("body stalled")
+        .unwrap();
+    bytes
+}
+
+async fn assert_no_output(io: &mut BufReader<DuplexStream>) {
+    let mut byte = [0];
+    assert!(
+        timeout(PENDING_WINDOW, io.read(&mut byte)).await.is_err(),
+        "unexpected bytes, EOF, or read error before response completion"
+    );
+}
+
+fn assert_framing(head: &str, version: &str, chunked: bool, length: Option<usize>) {
+    assert!(
+        head.starts_with(&format!("HTTP/{version} 200 OK\r\n")),
+        "{head:?}"
+    );
+    let head = head.to_ascii_lowercase();
+    assert_eq!(
+        head.contains("transfer-encoding: chunked\r\n"),
+        chunked,
+        "{head:?}"
+    );
+    match length {
+        Some(n) => assert!(
+            head.contains(&format!("content-length: {n}\r\n")),
+            "{head:?}"
+        ),
+        None => assert!(!head.contains("content-length:"), "{head:?}"),
+    }
+}
+
+// Decode the wire ourselves: using Rama as both endpoint parsers could hide a
+// shared bug. Chunk boundaries are deliberately not asserted.
+async fn assert_payload(io: &mut BufReader<DuplexStream>, expected: &[u8], chunked: bool) {
+    if !chunked {
+        assert_eq!(read_bytes(io, expected.len()).await, expected);
+        return;
+    }
+    let mut body = Vec::new();
+    while body.len() < expected.len() {
+        let mut line = String::new();
+        timeout(WATCHDOG, io.read_line(&mut line))
+            .await
+            .expect("chunk size stalled")
+            .unwrap();
+        assert!(line.ends_with("\r\n"), "invalid chunk-size line: {line:?}");
+        let len = usize::from_str_radix(line.trim_end().split(';').next().unwrap(), 16).unwrap();
+        assert!(len > 0, "response terminated before the expected payload");
+        assert!(
+            len <= expected.len() - body.len(),
+            "unexpected payload length"
+        );
+        body.extend(read_bytes(io, len).await);
+        assert_eq!(read_bytes(io, 2).await, b"\r\n");
+    }
+    assert_eq!(body, expected);
+}
+
+async fn assert_eof(io: &mut BufReader<DuplexStream>) {
+    let mut byte = [0];
+    assert_eq!(
+        timeout(WATCHDOG, io.read(&mut byte))
+            .await
+            .expect("EOF stalled")
+            .unwrap(),
+        0,
+        "unexpected trailing bytes"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn close_delimited_response_version_matrix_streams_until_eof() {
+    for (client_version, origin_version, connection) in [
+        ("1.0", "1.0", ""),
+        ("1.0", "1.1", ""),
+        ("1.1", "1.0", ""),
+        ("1.1", "1.1", ""),
+        ("1.1", "1.0", "Connection: keep-alive\r\n"),
+        ("1.1", "1.1", "Connection: close\r\n"),
+    ] {
+        let mut relay = Relay::new();
+        relay.request(client_version, "POST", b"PING").await;
+        // Headers arrive separately from the payload. Even a response with no
+        // body bytes yet must be forwarded without waiting for origin EOF.
+        let head = relay.response_head(origin_version, connection).await;
+        let downstream_version = if client_version == "1.0" {
+            "1.0"
+        } else {
+            origin_version
+        };
+        let chunked = downstream_version == "1.1";
+        assert_framing(&head, downstream_version, chunked, None);
+        if connection.contains("close") {
+            assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+        }
+        assert_no_output(&mut relay.client).await;
+        for fragment in [b"first".as_slice(), b"second".as_slice()] {
+            write(relay.upstream.get_mut(), fragment).await;
+            assert_payload(&mut relay.client, fragment, chunked).await;
+            assert_no_output(&mut relay.client).await;
+        }
+        // Inactivity cannot manufacture an HTTP message boundary. This is
+        // virtual time, not a real 31-second test.
+        advance(Duration::from_secs(31)).await;
+        assert_no_output(&mut relay.client).await;
+        relay.upstream.get_mut().shutdown().await.unwrap();
+        if chunked {
+            assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+            if connection.contains("close") {
+                assert_eof(&mut relay.client).await;
+            } else {
+                // Either keeping this hop open or closing it is valid after
+                // a complete chunked response; neither may append more bytes.
+                let mut byte = [0];
+                assert!(matches!(
+                    timeout(PENDING_WINDOW, relay.client.read(&mut byte)).await,
+                    Err(_) | Ok(Ok(0))
+                ));
+            }
+        } else {
+            assert_eof(&mut relay.client).await;
+        }
+        relay.finish(false).await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn length_response_then_close_delimited_response_on_same_connection() {
+    let mut relay = Relay::new();
+    relay.request("1.1", "POST", b"PING").await;
+    let head = relay.response_head("1.1", "Content-Length: 4\r\n").await;
+    assert_framing(&head, "1.1", false, Some(4));
+    write(relay.upstream.get_mut(), b"PO").await;
+    assert_payload(&mut relay.client, b"PO", false).await;
+    assert_no_output(&mut relay.client).await;
+    write(relay.upstream.get_mut(), b"NG").await;
+    assert_payload(&mut relay.client, b"NG", false).await;
+    // This request must reach upstream without closing either socket.
+    relay.request("1.1", "POST", b"second request").await;
+    let head = relay.response_head("1.1", "").await;
+    assert_framing(&head, "1.1", true, None);
+    write(relay.upstream.get_mut(), b"second response").await;
+    assert_payload(&mut relay.client, b"second response", true).await;
+    assert_no_output(&mut relay.client).await;
+    relay.upstream.get_mut().shutdown().await.unwrap();
+    assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn chunked_response_completes_without_upstream_eof() {
+    let mut relay = Relay::new();
+    relay.request("1.1", "POST", b"PING").await;
+    let head = relay
+        .response_head("1.1", "Transfer-Encoding: chunked\r\n")
+        .await;
+    assert_framing(&head, "1.1", true, None);
+    // Split upstream chunk framing across writes as well as body fragments.
+    write(relay.upstream.get_mut(), b"4\r").await;
+    assert_no_output(&mut relay.client).await;
+    write(relay.upstream.get_mut(), b"\nPONG\r\n").await;
+    assert_payload(&mut relay.client, b"PONG", true).await;
+    assert_no_output(&mut relay.client).await;
+    write(relay.upstream.get_mut(), b"0\r\n\r\n").await;
+    assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+    // The terminator, not TCP EOF, permits the next exchange.
+    relay.request("1.1", "POST", b"next").await;
+    let head = relay.response_head("1.1", "Content-Length: 0\r\n").await;
+    assert_framing(&head, "1.1", false, Some(0));
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn http10_client_receives_decoded_chunked_origin_body() {
+    let mut relay = Relay::new();
+    relay.request("1.0", "POST", b"PING").await;
+    let head = relay
+        .response_head("1.1", "Transfer-Encoding: chunked\r\n")
+        .await;
+    assert_framing(&head, "1.0", false, None);
+    write(relay.upstream.get_mut(), b"4\r\nPONG\r\n").await;
+    assert_payload(&mut relay.client, b"PONG", false).await;
+    assert_no_output(&mut relay.client).await;
+    write(relay.upstream.get_mut(), b"0\r\n\r\n").await;
+    assert_eof(&mut relay.client).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn client_write_eof_preserves_pending_response() {
+    for before_headers in [true, false] {
+        for headers in [
+            "",
+            "Content-Length: 9\r\n",
+            "Transfer-Encoding: chunked\r\n",
+        ] {
+            let mut relay = Relay::new();
+            relay.request("1.1", "POST", b"PING").await;
+            if before_headers {
+                relay.client.get_mut().shutdown().await.unwrap();
+                assert_no_output(&mut relay.client).await;
+            }
+            let head = relay.response_head("1.1", headers).await;
+            let chunked = !headers.starts_with("Content-Length");
+            let origin_chunked = headers.starts_with("Transfer-Encoding");
+            assert_framing(&head, "1.1", chunked, if chunked { None } else { Some(9) });
+            write(
+                relay.upstream.get_mut(),
+                if origin_chunked {
+                    b"5\r\nfirst\r\n"
+                } else {
+                    b"first"
+                },
+            )
+            .await;
+            assert_payload(&mut relay.client, b"first", chunked).await;
+            if !before_headers {
+                relay.client.get_mut().shutdown().await.unwrap();
+            }
+            assert_no_output(&mut relay.client).await;
+            assert!(
+                !relay.done.is_finished(),
+                "client FIN discarded the pending response"
+            );
+            write(
+                relay.upstream.get_mut(),
+                if origin_chunked {
+                    b"4\r\nlast\r\n"
+                } else {
+                    b"last"
+                },
+            )
+            .await;
+            assert_payload(&mut relay.client, b"last", chunked).await;
+            if headers.is_empty() {
+                relay.upstream.get_mut().shutdown().await.unwrap();
+            } else if origin_chunked {
+                write(relay.upstream.get_mut(), b"0\r\n\r\n").await;
+            }
+            if chunked {
+                assert_eq!(read_bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+            }
+            // Length/chunk framing completes even while upstream stays open.
+            assert_eof(&mut relay.client).await;
+            relay.finish(false).await;
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn upstream_body_errors_do_not_fabricate_response_completion() {
+    for (headers, prefix, chunked, read_error) in [
+        ("Content-Length: 8\r\n", b"PONG".as_slice(), false, false),
+        (
+            "Transfer-Encoding: chunked\r\n",
+            b"4\r\nPONG\r\n".as_slice(),
+            true,
+            false,
+        ),
+        ("", b"PONG".as_slice(), true, true),
+    ] {
+        let mut relay = Relay::new();
+        relay.request("1.1", "POST", b"PING").await;
+        let head = relay.response_head("1.1", headers).await;
+        assert_framing(&head, "1.1", chunked, if chunked { None } else { Some(8) });
+        write(relay.upstream.get_mut(), prefix).await;
+        assert_payload(&mut relay.client, b"PONG", chunked).await;
+        assert_no_output(&mut relay.client).await;
+        if read_error {
+            relay.fail_upstream.take().unwrap().send(()).unwrap();
+        } else {
+            relay.upstream.get_mut().shutdown().await.unwrap();
+        }
+        // An already-started response must end incompletely: no terminal
+        // chunk, synthetic second response, or padding to Content-Length.
+        assert_eof(&mut relay.client).await;
+        relay.finish(true).await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn bodyless_responses_do_not_wait_for_upstream_eof() {
+    for (method, status) in [
+        ("HEAD", "200 OK"),
+        ("GET", "204 No Content"),
+        ("GET", "304 Not Modified"),
+    ] {
+        let mut relay = Relay::new();
+        relay.request("1.1", method, b"").await;
+        write(
+            relay.upstream.get_mut(),
+            format!("HTTP/1.1 {status}\r\n\r\n").as_bytes(),
+        )
+        .await;
+        let head = read_head(&mut relay.client).await;
+        assert!(
+            head.starts_with(&format!("HTTP/1.1 {status}\r\n")),
+            "{head:?}"
+        );
+        assert!(!head.to_ascii_lowercase().contains("transfer-encoding:"));
+        // No body framing is needed to accept the next request on this pair.
+        relay.request("1.1", "POST", b"next").await;
+        let head = relay.response_head("1.1", "Content-Length: 0\r\n").await;
+        assert_framing(&head, "1.1", false, Some(0));
+        relay.finish(false).await;
+    }
+}

--- a/rama-http-core/src/proto/h1/conn.rs
+++ b/rama-http-core/src/proto/h1/conn.rs
@@ -1199,6 +1199,31 @@ mod tests {
         }
     }
 
+    #[test]
+    fn server_enforces_peer_version_without_upgrading_response() {
+        for peer_version in [Version::HTTP_10, Version::HTTP_11] {
+            for response_version in [Version::HTTP_10, Version::HTTP_11] {
+                let io = TestIo::new(tokio_test::io::Builder::new().build());
+                let mut conn = Conn::<_, Bytes, ServerTransaction>::new(io);
+                conn.state.version = peer_version;
+                let mut head = MessageHead {
+                    version: response_version,
+                    ..MessageHead::default()
+                };
+                conn.enforce_version(&mut head);
+                assert_eq!(
+                    head.version,
+                    if peer_version == Version::HTTP_10 {
+                        Version::HTTP_10
+                    } else {
+                        response_version
+                    },
+                    "peer={peer_version:?}, response={response_version:?}",
+                );
+            }
+        }
+    }
+
     // A client request carrying `Connection: close` must evict the connection
     // (disable keep-alive) at request-encode time, so it is never returned to the
     // pool for reuse — independent of whether the backend response echoes

--- a/rama-http-core/src/proto/h1/conn.rs
+++ b/rama-http-core/src/proto/h1/conn.rs
@@ -1200,26 +1200,58 @@ mod tests {
     }
 
     #[test]
-    fn server_enforces_peer_version_without_upgrading_response() {
+    fn server_enforces_peer_version_and_keep_alive_state() {
         for peer_version in [Version::HTTP_10, Version::HTTP_11] {
             for response_version in [Version::HTTP_10, Version::HTTP_11] {
-                let io = TestIo::new(tokio_test::io::Builder::new().build());
-                let mut conn = Conn::<_, Bytes, ServerTransaction>::new(io);
-                conn.state.version = peer_version;
-                let mut head = MessageHead {
-                    version: response_version,
-                    ..MessageHead::default()
-                };
-                conn.enforce_version(&mut head);
-                assert_eq!(
-                    head.version,
-                    if peer_version == Version::HTTP_10 {
-                        Version::HTTP_10
-                    } else {
-                        response_version
-                    },
-                    "peer={peer_version:?}, response={response_version:?}",
-                );
+                for enabled in [false, true] {
+                    for explicit_keep_alive in [false, true] {
+                        let io = TestIo::new(tokio_test::io::Builder::new().build());
+                        let mut conn = Conn::<_, Bytes, ServerTransaction>::new(io);
+                        conn.state.version = peer_version;
+                        if !enabled {
+                            conn.state.disable_keep_alive();
+                        }
+                        let mut head = MessageHead {
+                            version: response_version,
+                            ..MessageHead::default()
+                        };
+                        if explicit_keep_alive {
+                            head.headers
+                                .insert(CONNECTION, HeaderValue::from_static("keep-alive"));
+                        }
+                        conn.enforce_version(&mut head);
+                        assert_eq!(
+                            head.version,
+                            if peer_version == Version::HTTP_10 {
+                                Version::HTTP_10
+                            } else {
+                                response_version
+                            }
+                        );
+                        let expected_enabled = enabled
+                            && !(peer_version == Version::HTTP_10
+                                && response_version == Version::HTTP_10
+                                && !explicit_keep_alive);
+                        assert_eq!(conn.state.wants_keep_alive(), expected_enabled);
+                        let expected_header = if peer_version == Version::HTTP_11 && !enabled {
+                            Some("close")
+                        } else if explicit_keep_alive
+                            || (peer_version == Version::HTTP_10
+                                && response_version == Version::HTTP_11
+                                && enabled)
+                        {
+                            Some("keep-alive")
+                        } else {
+                            None
+                        };
+                        assert_eq!(
+                            head.headers
+                                .get(CONNECTION)
+                                .map(|value| value.to_str().unwrap()),
+                            expected_header
+                        );
+                    }
+                }
             }
         }
     }

--- a/rama-http-core/src/proto/h1/role.rs
+++ b/rama-http-core/src/proto/h1/role.rs
@@ -2852,6 +2852,72 @@ mod tests {
         );
     }
 
+    // Unknown response lengths must retain the framing appropriate to the
+    // response version. Connection: close controls reuse, not chunking.
+    #[test]
+    fn server_response_framing_for_version_and_length() {
+        use crate::proto::BodyLength;
+
+        for version in [Version::HTTP_10, Version::HTTP_11] {
+            for known_length in [false, true] {
+                for close in [false, true] {
+                    let mut head = MessageHead {
+                        version,
+                        ..MessageHead::default()
+                    };
+                    if close {
+                        head.headers
+                            .insert(header::CONNECTION, HeaderValue::from_static("close"));
+                    }
+                    let mut bytes = Vec::new();
+                    let encoder = Server::encode(
+                        Encode {
+                            head: EncodeHead {
+                                version: head.version,
+                                subject: head.subject,
+                                headers: head.headers,
+                                extensions: &mut head.extensions,
+                            },
+                            body: Some(if known_length {
+                                BodyLength::Known(4)
+                            } else {
+                                BodyLength::Unknown
+                            }),
+                            keep_alive: !close,
+                            req_method: &mut Some(Method::POST),
+                            title_case_headers: false,
+                            date_header: false,
+                        },
+                        &mut bytes,
+                    )
+                    .unwrap();
+                    let wire = String::from_utf8(bytes).unwrap().to_ascii_lowercase();
+                    let expected = if known_length {
+                        Encoder::length(4)
+                    } else if version == Version::HTTP_10 {
+                        Encoder::close_delimited()
+                    } else {
+                        Encoder::chunked()
+                    }
+                    .set_last(close);
+                    assert_eq!(
+                        encoder, expected,
+                        "{version:?}, known={known_length}, close={close}"
+                    );
+                    assert!(
+                        wire.starts_with(&format!("{version:?} 200 OK\r\n").to_ascii_lowercase())
+                    );
+                    assert_eq!(
+                        wire.contains("transfer-encoding: chunked\r\n"),
+                        encoder.is_chunked()
+                    );
+                    assert_eq!(wire.contains("content-length: 4\r\n"), known_length);
+                    assert_eq!(wire.contains("connection: close\r\n"), close);
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_server_encode_connect_method() {
         let mut head = MessageHead::default();

--- a/rama-http-core/src/proto/h1/role.rs
+++ b/rama-http-core/src/proto/h1/role.rs
@@ -373,12 +373,13 @@ impl Http1Transaction for Server {
             msg.head.subject, msg.body, msg.req_method
         );
 
-        if Self::use_close_delimited_response(
+        let close_delimited = Self::use_close_delimited_response(
             msg.head.extensions,
             &msg.head.headers,
             msg.req_method.as_ref(),
             msg.head.subject,
-        ) {
+        );
+        if close_delimited {
             msg.head
                 .headers
                 .insert(header::CONNECTION, HeaderValue::from_static("close"));
@@ -453,8 +454,9 @@ impl Http1Transaction for Server {
             extend(dst, b"\r\n");
         }
 
-        let extensions = std::mem::take(msg.head.extensions);
-        let encoder = Self::encode_h1_headers(msg, &extensions, dst, is_last, orig_len, wrote_len)?;
+        let _extensions = std::mem::take(msg.head.extensions);
+        let encoder =
+            Self::encode_h1_headers(msg, close_delimited, dst, is_last, orig_len, wrote_len)?;
         ret.map(|()| encoder)
     }
 
@@ -535,7 +537,7 @@ impl Server {
 
     fn encode_h1_headers(
         msg: Encode<'_, StatusCode>,
-        ext: &Extensions,
+        close_delimited: bool,
         dst: &mut Vec<u8>,
         is_last: bool,
         orig_len: usize,
@@ -582,7 +584,7 @@ impl Server {
 
         Self::encode_headers(
             msg,
-            ext,
+            close_delimited,
             dst,
             is_last,
             orig_len,
@@ -593,8 +595,8 @@ impl Server {
 
     #[inline]
     fn encode_headers<W>(
-        msg: Encode<'_, StatusCode>,
-        ext: &Extensions,
+        mut msg: Encode<'_, StatusCode>,
+        close_delimited: bool,
         dst: &mut Vec<u8>,
         mut is_last: bool,
         orig_len: usize,
@@ -611,18 +613,29 @@ impl Server {
             dst.truncate(orig_len);
         };
 
-        let close_delimited = Self::use_close_delimited_response(
-            ext,
-            &msg.head.headers,
-            msg.req_method.as_ref(),
-            msg.head.subject,
-        );
+        // Normalize repeated or comma-separated lengths before writing any headers.
+        // Every value must parse and agree; never select just the first value.
+        let normalize_content_length = {
+            let mut values = msg.head.headers.get_all(header::CONTENT_LENGTH).into_iter();
+            values
+                .next()
+                .is_some_and(|first| first.as_bytes().contains(&b',') || values.next().is_some())
+        };
+        if normalize_content_length {
+            let Some(len) = headers::content_length_parse_all(&msg.head.headers) else {
+                warn!("invalid or conflicting Content-Length values");
+                rewind(dst);
+                return Err(crate::Error::new_user_header());
+            };
+            msg.head
+                .headers
+                .insert(header::CONTENT_LENGTH, HeaderValue::from(len));
+        }
         let mut encoder = Encoder::length(0);
         let mut allowed_trailer_fields = headers::trailer_header_names(&msg.head.headers);
         let mut wrote_date = false;
         let mut is_name_written = false;
         let mut must_write_chunked = false;
-        let mut prev_con_len = None;
         let connection_header_names = headers::connection_header_names(&msg.head.headers);
 
         macro_rules! handle_is_name_written {
@@ -692,27 +705,12 @@ impl Server {
                             // Encoder...
 
                             if let Some(len) = headers::content_length_parse(&value) {
-                                if let Some(prev) = prev_con_len {
-                                    if prev != len {
-                                        warn!(
-                                            "multiple Content-Length values found: [{}, {}]",
-                                            prev, len
-                                        );
-                                        rewind(dst);
-                                        return Err(crate::Error::new_user_header());
-                                    }
-                                    debug_assert!(is_name_written);
-                                    continue 'headers;
-                                } else {
-                                    // we haven't written content-length yet!
-                                    encoder = Encoder::length(len);
-                                    header_name_writer.write_header_name_with_colon(dst, &name);
-                                    extend(dst, value.as_bytes());
-                                    wrote_len = true;
-                                    is_name_written = true;
-                                    prev_con_len = Some(len);
-                                    continue 'headers;
-                                }
+                                encoder = Encoder::length(len);
+                                header_name_writer.write_header_name_with_colon(dst, &name);
+                                extend(dst, value.as_bytes());
+                                wrote_len = true;
+                                is_name_written = true;
+                                continue 'headers;
                             } else {
                                 warn!("illegal Content-Length value: {:?}", value);
                                 rewind(dst);
@@ -2993,6 +2991,139 @@ mod tests {
     }
 
     #[test]
+    fn server_normalizes_identical_content_lengths() {
+        for version in [Version::HTTP_10, Version::HTTP_11] {
+            for preference in [false, true] {
+                for values in [
+                    &["4", "4"][..],
+                    &["04", "4", "004"][..],
+                    &["4, 4"][..],
+                    &["4, 04", "004"][..],
+                ] {
+                    for (method, body, expected_length) in [
+                        (Method::GET, Some(BodyLength::Unknown), 4),
+                        (Method::GET, Some(BodyLength::Known(4)), 4),
+                        (Method::HEAD, None, 0),
+                        (Method::HEAD, Some(BodyLength::Known(0)), 0),
+                    ] {
+                        let mut head = MessageHead {
+                            version,
+                            ..MessageHead::default()
+                        };
+                        if preference {
+                            head.extensions.insert(CloseDelimitedResponse);
+                        }
+                        for value in values {
+                            head.headers
+                                .append("Content-Length", HeaderValue::from_static(value));
+                            head.headers
+                                .insert("x-between", HeaderValue::from_static("kept"));
+                        }
+                        let (encoder, wire) =
+                            encode_close_delimited_test_response(head, body, method).unwrap();
+                        assert_eq!(encoder, Encoder::length(expected_length));
+                        let wire = String::from_utf8(wire).unwrap().to_ascii_lowercase();
+                        assert_eq!(wire.matches("content-length:").count(), 1, "{wire}");
+                        assert!(wire.contains("content-length: 4\r\n"), "{wire}");
+                        assert!(wire.contains("x-between: kept\r\n"), "{wire}");
+                        assert!(!wire.contains("transfer-encoding:"));
+                        assert!(!wire.contains("connection: close"));
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn server_rejects_invalid_or_conflicting_content_lengths_without_output() {
+        for values in [
+            &["4", "5"][..],
+            &["4", ""][..],
+            &["4", "+4"][..],
+            &["4", "four"][..],
+            &["4", "18446744073709551616"][..],
+            &["4, 5"][..],
+            &["4, "][..],
+            &[",4"][..],
+            &["4, 4", "5"][..],
+        ] {
+            for reverse in [false, true] {
+                for preference in [false, true] {
+                    for body in [Some(BodyLength::Unknown), Some(BodyLength::Known(4))] {
+                        let mut head = MessageHead::default();
+                        if preference {
+                            head.extensions.insert(CloseDelimitedResponse);
+                        }
+                        let mut values = values.to_vec();
+                        if reverse {
+                            values.reverse();
+                        }
+                        for value in values {
+                            head.headers
+                                .append(header::CONTENT_LENGTH, HeaderValue::from_static(value));
+                        }
+                        let mut wire = b"previous response".to_vec();
+                        let error = Server::encode(
+                            Encode {
+                                head: EncodeHead {
+                                    version: head.version,
+                                    subject: head.subject,
+                                    headers: head.headers,
+                                    extensions: &mut head.extensions,
+                                },
+                                body,
+                                keep_alive: true,
+                                req_method: &mut Some(Method::GET),
+                                title_case_headers: false,
+                                date_header: false,
+                            },
+                            &mut wire,
+                        )
+                        .unwrap_err();
+                        assert!(matches!(
+                            error.kind(),
+                            crate::error::Kind::User(crate::error::User::UnexpectedHeader)
+                        ));
+                        assert_eq!(wire, b"previous response");
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn normalized_content_length_still_conflicts_with_transfer_encoding() {
+        for transfer_encoding_first in [false, true] {
+            for body in [Some(BodyLength::Unknown), Some(BodyLength::Known(4))] {
+                let mut head = MessageHead::default();
+                head.extensions.insert(CloseDelimitedResponse);
+                if transfer_encoding_first {
+                    head.headers.insert(
+                        header::TRANSFER_ENCODING,
+                        HeaderValue::from_static("chunked"),
+                    );
+                }
+                for _ in 0..2 {
+                    head.headers
+                        .append(header::CONTENT_LENGTH, HeaderValue::from_static("4"));
+                }
+                if !transfer_encoding_first {
+                    head.headers.insert(
+                        header::TRANSFER_ENCODING,
+                        HeaderValue::from_static("chunked"),
+                    );
+                }
+                let error =
+                    encode_close_delimited_test_response(head, body, Method::GET).unwrap_err();
+                assert!(matches!(
+                    error.kind(),
+                    crate::error::Kind::User(crate::error::User::UnexpectedHeader)
+                ));
+            }
+        }
+    }
+
+    #[test]
     fn explicit_close_delimited_response_overrides_size_hint_and_keep_alive() {
         for version in [Version::HTTP_10, Version::HTTP_11] {
             for body in [
@@ -3211,6 +3342,7 @@ mod tests {
                 msg.head.extensions.self_get_ref::<Framing>(),
                 Some(&expected)
             );
+            assert_eq!(msg.head.extensions.get_ref::<Framing>(), Some(&expected));
         }
     }
 

--- a/rama-http-core/src/proto/h1/role.rs
+++ b/rama-http-core/src/proto/h1/role.rs
@@ -373,22 +373,12 @@ impl Http1Transaction for Server {
             msg.head.subject, msg.body, msg.req_method
         );
 
-        let close_delimited = msg
-            .head
-            .extensions
-            .self_contains::<CloseDelimitedResponse>()
-            && Self::can_have_body(msg.req_method.as_ref(), msg.head.subject);
-        if close_delimited {
-            if [
-                header::CONTENT_LENGTH,
-                header::TRANSFER_ENCODING,
-                header::TRAILER,
-            ]
-            .iter()
-            .any(|name| msg.head.headers.contains_key(name))
-            {
-                return Err(crate::Error::new_user_header());
-            }
+        if Self::use_close_delimited_response(
+            msg.head.extensions,
+            &msg.head.headers,
+            msg.req_method.as_ref(),
+            msg.head.subject,
+        ) {
             msg.head
                 .headers
                 .insert(header::CONNECTION, HeaderValue::from_static("close"));
@@ -497,6 +487,25 @@ impl Http1Transaction for Server {
 }
 
 impl Server {
+    // Explicit headers override a framing preference carried in extensions.
+    // Keep normal header validation and bodyless-response handling authoritative.
+    fn use_close_delimited_response(
+        extensions: &Extensions,
+        headers: &HeaderMap,
+        method: Option<&Method>,
+        status: StatusCode,
+    ) -> bool {
+        extensions.contains::<CloseDelimitedResponse>()
+            && Self::can_have_body(method, status)
+            && ![
+                header::CONTENT_LENGTH,
+                header::TRANSFER_ENCODING,
+                header::TRAILER,
+            ]
+            .iter()
+            .any(|name| headers.contains_key(name))
+    }
+
     fn can_have_body(method: Option<&Method>, status: StatusCode) -> bool {
         Self::can_chunked(method, status)
     }
@@ -602,6 +611,12 @@ impl Server {
             dst.truncate(orig_len);
         };
 
+        let close_delimited = Self::use_close_delimited_response(
+            ext,
+            &msg.head.headers,
+            msg.req_method.as_ref(),
+            msg.head.subject,
+        );
         let mut encoder = Encoder::length(0);
         let mut allowed_trailer_fields = headers::trailer_header_names(&msg.head.headers);
         let mut wrote_date = false;
@@ -807,10 +822,7 @@ impl Server {
 
         handle_is_name_written!();
 
-        if !wrote_len
-            && ext.self_contains::<CloseDelimitedResponse>()
-            && Self::can_have_body(msg.req_method.as_ref(), msg.head.subject)
-        {
+        if !wrote_len && close_delimited {
             encoder = Encoder::close_delimited();
         } else if !wrote_len {
             encoder = match msg.body {
@@ -3008,19 +3020,48 @@ mod tests {
     }
 
     #[test]
-    fn explicit_close_delimited_response_rejects_conflicting_headers() {
-        for (name, value) in [
-            (header::CONTENT_LENGTH, "4"),
-            (header::TRANSFER_ENCODING, "chunked"),
-            (header::TRANSFER_ENCODING, "gzip"),
-            (header::TRAILER, "checksum"),
+    fn explicit_headers_override_close_delimited_preference() {
+        for (name, value, expected) in [
+            (header::CONTENT_LENGTH, "4", Encoder::length(4)),
+            (header::TRANSFER_ENCODING, "chunked", Encoder::chunked()),
+            (header::TRANSFER_ENCODING, "gzip", Encoder::chunked()),
         ] {
             let mut head = MessageHead::default();
             head.extensions.insert(CloseDelimitedResponse);
-            head.headers.insert(name, HeaderValue::from_static(value));
-            encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
-                .unwrap_err();
+            head.headers
+                .insert(name.clone(), HeaderValue::from_static(value));
+            let (encoder, wire) =
+                encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+                    .unwrap();
+            assert_eq!(encoder, expected);
+            let wire = String::from_utf8(wire).unwrap();
+            assert!(wire.contains(&format!("{name}: {value}")));
+            assert!(!wire.contains("connection: close"));
         }
+        let mut head = MessageHead::default();
+        head.extensions.insert(CloseDelimitedResponse);
+        head.headers
+            .insert(header::TRAILER, HeaderValue::from_static("checksum"));
+        let (encoder, wire) =
+            encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+                .unwrap();
+        assert!(encoder.is_chunked());
+        assert!(!encoder.is_last());
+        assert!(
+            String::from_utf8(wire)
+                .unwrap()
+                .contains("trailer: checksum\r\n")
+        );
+    }
+
+    #[test]
+    fn close_delimited_preference_does_not_hide_invalid_content_length() {
+        let mut head = MessageHead::default();
+        head.extensions.insert(CloseDelimitedResponse);
+        head.headers
+            .insert(header::CONTENT_LENGTH, HeaderValue::from_static("invalid"));
+        encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+            .unwrap_err();
     }
 
     #[test]
@@ -3049,17 +3090,41 @@ mod tests {
     }
 
     #[test]
-    fn close_delimited_directive_is_not_inherited_from_request() {
-        let request_extensions = Extensions::new();
-        request_extensions.insert(CloseDelimitedResponse);
-        let head = MessageHead {
-            extensions: request_extensions.fork(),
-            ..MessageHead::default()
-        };
-        let (encoder, _) =
-            encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+    fn close_delimited_preference_is_inherited_but_explicit_headers_win() {
+        let context = Extensions::new();
+        context.insert(CloseDelimitedResponse);
+        for extensions in [context.fork(), context.fork().fork()] {
+            for explicit_length in [false, true] {
+                let mut head = MessageHead {
+                    extensions: extensions.clone(),
+                    ..MessageHead::default()
+                };
+                if explicit_length {
+                    head.headers
+                        .insert(header::CONTENT_LENGTH, HeaderValue::from_static("4"));
+                }
+                let (encoder, wire) = encode_close_delimited_test_response(
+                    head,
+                    Some(BodyLength::Unknown),
+                    Method::GET,
+                )
                 .unwrap();
-        assert_eq!(encoder, Encoder::chunked());
+                assert_eq!(
+                    encoder,
+                    if explicit_length {
+                        Encoder::length(4)
+                    } else {
+                        Encoder::close_delimited().set_last(true)
+                    }
+                );
+                assert_eq!(
+                    String::from_utf8(wire)
+                        .unwrap()
+                        .contains("connection: close\r\n"),
+                    !explicit_length
+                );
+            }
+        }
     }
 
     #[test]

--- a/rama-http-core/src/proto/h1/role.rs
+++ b/rama-http-core/src/proto/h1/role.rs
@@ -5,7 +5,9 @@ use rama_core::bytes::BytesMut;
 use rama_core::extensions::Extensions;
 use rama_core::telemetry::tracing::{debug, error, trace, trace_span, warn};
 use rama_http::HeaderName;
-use rama_http::proto::h1::ext::{ReasonPhrase, RequestTargetForm};
+use rama_http::proto::h1::ext::{
+    CloseDelimitedResponse, OriginalResponseBodyFraming, ReasonPhrase, RequestTargetForm,
+};
 use rama_http::proto::{HeaderByteLength, RequestHeaders};
 
 use rama_http_types::header::Entry;
@@ -371,6 +373,28 @@ impl Http1Transaction for Server {
             msg.head.subject, msg.body, msg.req_method
         );
 
+        let close_delimited = msg
+            .head
+            .extensions
+            .self_contains::<CloseDelimitedResponse>()
+            && Self::can_have_body(msg.req_method.as_ref(), msg.head.subject);
+        if close_delimited {
+            if [
+                header::CONTENT_LENGTH,
+                header::TRANSFER_ENCODING,
+                header::TRAILER,
+            ]
+            .iter()
+            .any(|name| msg.head.headers.contains_key(name))
+            {
+                return Err(crate::Error::new_user_header());
+            }
+            msg.head
+                .headers
+                .insert(header::CONNECTION, HeaderValue::from_static("close"));
+            msg.keep_alive = false;
+        }
+
         let mut wrote_len = false;
 
         // hyper currently doesn't support returning 1xx status codes as a Response
@@ -605,8 +629,6 @@ impl Server {
             }};
         }
 
-        let _ = ext;
-
         'headers: for (name, value) in msg.head.headers.into_ordered_iter() {
             handle_is_name_written!();
             is_name_written = false;
@@ -785,7 +807,12 @@ impl Server {
 
         handle_is_name_written!();
 
-        if !wrote_len {
+        if !wrote_len
+            && ext.self_contains::<CloseDelimitedResponse>()
+            && Self::can_have_body(msg.req_method.as_ref(), msg.head.subject)
+        {
+            encoder = Encoder::close_delimited();
+        } else if !wrote_len {
             encoder = match msg.body {
                 Some(BodyLength::Unknown) => {
                     if msg.head.version == Version::HTTP_10
@@ -1028,6 +1055,16 @@ impl Http1Transaction for Client {
                 extensions,
             };
             if let Some((decode, is_upgrade)) = Self::decoder(&head, ctx.req_method)? {
+                let framing = if !Server::can_have_body(ctx.req_method.as_ref(), status) {
+                    OriginalResponseBodyFraming::Empty
+                } else if head.headers.contains_key(header::TRANSFER_ENCODING) {
+                    OriginalResponseBodyFraming::TransferEncoded
+                } else if decode == DecodedLength::CLOSE_DELIMITED {
+                    OriginalResponseBodyFraming::CloseDelimited
+                } else {
+                    OriginalResponseBodyFraming::ContentLength
+                };
+                head.extensions.insert(framing);
                 return Ok(Some(ParsedMessage {
                     head,
                     decode,
@@ -2915,6 +2952,200 @@ mod tests {
                     assert_eq!(wire.contains("connection: close\r\n"), close);
                 }
             }
+        }
+    }
+
+    fn encode_close_delimited_test_response(
+        mut head: MessageHead<StatusCode>,
+        body: Option<BodyLength>,
+        method: Method,
+    ) -> crate::Result<(Encoder, Vec<u8>)> {
+        let mut wire = Vec::new();
+        let encoder = Server::encode(
+            Encode {
+                head: EncodeHead {
+                    version: head.version,
+                    subject: head.subject,
+                    headers: head.headers,
+                    extensions: &mut head.extensions,
+                },
+                body,
+                keep_alive: true,
+                req_method: &mut Some(method),
+                title_case_headers: false,
+                date_header: false,
+            },
+            &mut wire,
+        )?;
+        Ok((encoder, wire))
+    }
+
+    #[test]
+    fn explicit_close_delimited_response_overrides_size_hint_and_keep_alive() {
+        for version in [Version::HTTP_10, Version::HTTP_11] {
+            for body in [
+                None,
+                Some(BodyLength::Known(0)),
+                Some(BodyLength::Known(4)),
+                Some(BodyLength::Unknown),
+            ] {
+                let mut head = MessageHead {
+                    version,
+                    ..MessageHead::default()
+                };
+                head.extensions.insert(CloseDelimitedResponse);
+                head.headers
+                    .insert(header::CONNECTION, HeaderValue::from_static("keep-alive"));
+                let (encoder, wire) =
+                    encode_close_delimited_test_response(head, body, Method::GET).unwrap();
+                assert_eq!(encoder, Encoder::close_delimited().set_last(true));
+                assert_eq!(
+                    wire,
+                    format!("{version:?} 200 OK\r\nconnection: close\r\n\r\n").as_bytes()
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn explicit_close_delimited_response_rejects_conflicting_headers() {
+        for (name, value) in [
+            (header::CONTENT_LENGTH, "4"),
+            (header::TRANSFER_ENCODING, "chunked"),
+            (header::TRANSFER_ENCODING, "gzip"),
+            (header::TRAILER, "checksum"),
+        ] {
+            let mut head = MessageHead::default();
+            head.extensions.insert(CloseDelimitedResponse);
+            head.headers.insert(name, HeaderValue::from_static(value));
+            encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+                .unwrap_err();
+        }
+    }
+
+    #[test]
+    fn close_delimited_directive_does_not_change_bodyless_responses() {
+        for (method, status) in [
+            (Method::HEAD, StatusCode::OK),
+            (Method::GET, StatusCode::NO_CONTENT),
+            (Method::GET, StatusCode::NOT_MODIFIED),
+            (Method::CONNECT, StatusCode::OK),
+            (Method::GET, StatusCode::SWITCHING_PROTOCOLS),
+        ] {
+            let baseline = MessageHead {
+                subject: status,
+                ..MessageHead::default()
+            };
+            let marked = MessageHead {
+                subject: status,
+                ..MessageHead::default()
+            };
+            marked.extensions.insert(CloseDelimitedResponse);
+            assert_eq!(
+                encode_close_delimited_test_response(baseline, None, method.clone()).unwrap(),
+                encode_close_delimited_test_response(marked, None, method).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn close_delimited_directive_is_not_inherited_from_request() {
+        let request_extensions = Extensions::new();
+        request_extensions.insert(CloseDelimitedResponse);
+        let head = MessageHead {
+            extensions: request_extensions.fork(),
+            ..MessageHead::default()
+        };
+        let (encoder, _) =
+            encode_close_delimited_test_response(head, Some(BodyLength::Unknown), Method::GET)
+                .unwrap();
+        assert_eq!(encoder, Encoder::chunked());
+    }
+
+    #[test]
+    fn original_response_framing_is_recorded_and_overrides_inherited_metadata() {
+        use rama_http_types::proto::h1::ext::OriginalResponseBodyFraming as Framing;
+        for (version, method, status, headers, expected) in [
+            ("1.0", Method::GET, "200 OK", "", Framing::CloseDelimited),
+            ("1.1", Method::GET, "200 OK", "", Framing::CloseDelimited),
+            (
+                "1.1",
+                Method::GET,
+                "200 OK",
+                "Connection: close\r\n",
+                Framing::CloseDelimited,
+            ),
+            (
+                "1.1",
+                Method::GET,
+                "200 OK",
+                "Content-Length: 0\r\n",
+                Framing::ContentLength,
+            ),
+            (
+                "1.1",
+                Method::GET,
+                "200 OK",
+                "Content-Length: 4\r\n",
+                Framing::ContentLength,
+            ),
+            (
+                "1.1",
+                Method::GET,
+                "200 OK",
+                "Transfer-Encoding: chunked\r\n",
+                Framing::TransferEncoded,
+            ),
+            (
+                "1.1",
+                Method::GET,
+                "200 OK",
+                "Transfer-Encoding: gzip\r\n",
+                Framing::TransferEncoded,
+            ),
+            (
+                "1.1",
+                Method::HEAD,
+                "200 OK",
+                "Content-Length: 4\r\n",
+                Framing::Empty,
+            ),
+            ("1.1", Method::GET, "204 No Content", "", Framing::Empty),
+            ("1.1", Method::GET, "304 Not Modified", "", Framing::Empty),
+            ("1.1", Method::CONNECT, "200 OK", "", Framing::Empty),
+            (
+                "1.1",
+                Method::GET,
+                "101 Switching Protocols",
+                "",
+                Framing::Empty,
+            ),
+        ] {
+            let inherited = Extensions::new();
+            inherited.insert(if expected == Framing::CloseDelimited {
+                Framing::Empty
+            } else {
+                Framing::CloseDelimited
+            });
+            let mut raw =
+                BytesMut::from(format!("HTTP/{version} {status}\r\n{headers}\r\n").as_bytes());
+            let msg = Client::parse(
+                &mut raw,
+                ParseContext {
+                    req_method: &mut Some(method),
+                    h1_parser_config: Default::default(),
+                    h1_max_headers: None,
+                    h09_responses: false,
+                    on_informational: &mut None,
+                    prepared_extensions: &mut Some(inherited.fork()),
+                },
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(
+                msg.head.extensions.self_get_ref::<Framing>(),
+                Some(&expected)
+            );
         }
     }
 

--- a/rama-http-types/src/proto/h1/ext/mod.rs
+++ b/rama-http-types/src/proto/h1/ext/mod.rs
@@ -31,6 +31,9 @@
 mod reason_phrase;
 pub use reason_phrase::{InvalidReasonPhrase, ReasonPhrase};
 
+mod response_framing;
+pub use response_framing::{CloseDelimitedResponse, OriginalResponseBodyFraming};
+
 mod connection_close;
 pub use connection_close::ConnectionClose;
 

--- a/rama-http-types/src/proto/h1/ext/response_framing.rs
+++ b/rama-http-types/src/proto/h1/ext/response_framing.rs
@@ -1,0 +1,36 @@
+use rama_core::extensions::Extension;
+
+/// Request close-delimited framing when encoding an HTTP/1 response.
+///
+/// Insert this extension on the response itself. The encoder emits neither
+/// `Content-Length` nor `Transfer-Encoding`, adds `Connection: close`, streams
+/// the body unchanged, and closes the connection when the body ends. An exact
+/// body size hint does not override this choice. Request extensions inherited
+/// by a response do not enable it.
+///
+/// Conflicting `Content-Length`, `Transfer-Encoding`, or `Trailer` headers are
+/// rejected. The body must not produce trailers. This extension has no effect
+/// on responses that cannot carry a body (including HEAD and successful CONNECT)
+/// or on HTTP/2 connections.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Extension)]
+#[extension(tags(http))]
+pub struct CloseDelimitedResponse;
+
+/// Original HTTP/1 response framing, recorded by the client decoder before
+/// middleware can remove or change the framing headers.
+///
+/// Each parsed response receives its own value, overriding inherited metadata.
+/// This is informational; inserting it does not change outgoing framing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Extension)]
+#[extension(tags(http))]
+#[non_exhaustive]
+pub enum OriginalResponseBodyFraming {
+    /// No HTTP message body, for example a HEAD response or protocol upgrade.
+    Empty,
+    /// The response body has an explicit Content-Length.
+    ContentLength,
+    /// Transfer-Encoding was present, whether or not its final coding is chunked.
+    TransferEncoded,
+    /// A body delimited by EOF, with neither Content-Length nor Transfer-Encoding.
+    CloseDelimited,
+}

--- a/rama-http-types/src/proto/h1/ext/response_framing.rs
+++ b/rama-http-types/src/proto/h1/ext/response_framing.rs
@@ -1,15 +1,17 @@
 use rama_core::extensions::Extension;
 
-/// Request close-delimited framing when encoding an HTTP/1 response.
+/// Prefer close-delimited framing when encoding an HTTP/1 response.
 ///
-/// Insert this extension on the response itself. The encoder emits neither
+/// Insert this extension on the response or its inherited context.
+/// The encoder emits neither
 /// `Content-Length` nor `Transfer-Encoding`, adds `Connection: close`, streams
 /// the body unchanged, and closes the connection when the body ends. An exact
-/// body size hint does not override this choice. Request extensions inherited
-/// by a response do not enable it.
+/// body size hint does not override this choice. Like other context extensions,
+/// the preference remains effective when middleware derives a response from it.
 ///
-/// Conflicting `Content-Length`, `Transfer-Encoding`, or `Trailer` headers are
-/// rejected. The body must not produce trailers. This extension has no effect
+/// Explicit `Content-Length`, `Transfer-Encoding`, or `Trailer` headers take
+/// precedence, using the encoder's normal framing and validation rules. Without
+/// these headers, the body must not produce trailers. This extension has no effect
 /// on responses that cannot carry a body (including HEAD and successful CONNECT)
 /// or on HTTP/2 connections.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Extension)]

--- a/rama-icap/tests/http1_close_delimited.rs
+++ b/rama-icap/tests/http1_close_delimited.rs
@@ -1,0 +1,453 @@
+//! Raw HTTP -> MITM relay -> ICAP RESPMOD -> raw HTTP framing contracts.
+//! ICAP chunking and downstream HTTP framing are independent. Paused clocks
+//! prove incremental progress without waiting for real idle timeouts.
+#![cfg(feature = "http")]
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "bounded wire fixtures fail immediately on malformed data or stalled IO"
+)]
+
+use rama_core::{
+    Service, ServiceInput, error::BoxError, io::BridgeIo, layer::ArcLayer, rt::Executor,
+    service::service_fn,
+};
+use rama_http_backend::proxy::mitm::HttpMitmRelay;
+use rama_icap::{
+    client::Client,
+    http::layer::{AdaptationLayer, ServiceEndpoint},
+    proto::Preview,
+};
+use rama_net::{
+    client::{ConnectRequest, EstablishedClientConnection},
+    test_utils::client::MockSocket,
+};
+use std::{convert::Infallible, sync::Arc, time::Duration};
+use tokio::{
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, DuplexStream},
+    sync::Mutex,
+    task::JoinHandle,
+    time::{advance, timeout},
+};
+
+const WATCHDOG: Duration = Duration::from_secs(2);
+struct Relay {
+    client: BufReader<DuplexStream>,
+    origin: BufReader<DuplexStream>,
+    icap: BufReader<DuplexStream>,
+    done: JoinHandle<Result<(), BoxError>>,
+}
+impl Relay {
+    fn new(preview: bool) -> Self {
+        Self::with_local_response(preview, false)
+    }
+    fn with_local_response(preview: bool, local: bool) -> Self {
+        let (client, ingress) = tokio::io::duplex(4096);
+        let (egress, origin) = tokio::io::duplex(4096);
+        let (icap_client, icap) = tokio::io::duplex(4096);
+        let transport = Arc::new(Mutex::new(Some(icap_client)));
+        let connector = service_fn(move |input: ConnectRequest| {
+            let transport = Arc::clone(&transport);
+            async move {
+                Ok::<_, Infallible>(EstablishedClientConnection {
+                    input,
+                    conn: ServiceInput::new(
+                        transport
+                            .lock()
+                            .await
+                            .take()
+                            .expect("unexpected extra ICAP connection"),
+                    ),
+                })
+            }
+        });
+        let endpoint = ServiceEndpoint::new("icap://icap.test/respmod").unwrap();
+        let endpoint = if preview {
+            endpoint.with_preview(Preview::new(5))
+        } else {
+            endpoint
+        };
+        let layer = AdaptationLayer::new(Client::new(connector)).with_response_service(endpoint);
+        let done = tokio::spawn(async move {
+            if local {
+                use rama_core::{Layer as _, extensions::ExtensionsRef as _};
+                use rama_http_types::{
+                    Body, Request, Response, proto::h1::ext::CloseDelimitedResponse,
+                };
+                let adapted = layer.into_layer(service_fn(|_: Request| {
+                    let response = Response::new(Body::from("firstlast"));
+                    response.extensions().insert(CloseDelimitedResponse);
+                    std::future::ready(Ok::<_, Infallible>(response))
+                }));
+                let service = service_fn(move |request: Request| {
+                    let adapted = adapted.clone();
+                    async move {
+                        Ok::<_, Infallible>(
+                            adapted
+                                .serve(request)
+                                .await
+                                .expect("ICAP adaptation failed"),
+                        )
+                    }
+                });
+                rama_http_backend::server::HttpServer::auto(Executor::new())
+                    .serve(MockSocket::new(ingress), service)
+                    .await
+            } else {
+                HttpMitmRelay::new(Executor::new())
+                    .with_http_middleware((layer, ArcLayer::new()))
+                    .serve(BridgeIo(
+                        MockSocket::new(ingress),
+                        ServiceInput::new(egress),
+                    ))
+                    .await
+            }
+        });
+        Self {
+            client: BufReader::new(client),
+            origin: BufReader::new(origin),
+            icap: BufReader::new(icap),
+            done,
+        }
+    }
+    async fn begin(&mut self, version: &str, framing: Framing) {
+        write(
+            self.client.get_mut(),
+            b"GET / HTTP/1.1\r\nHost: origin.test\r\nTE: trailers\r\nConnection: TE\r\n\r\n",
+        )
+        .await;
+        assert!(
+            head(&mut self.origin)
+                .await
+                .starts_with("GET / HTTP/1.1\r\n")
+        );
+        write(
+            self.origin.get_mut(),
+            format!("HTTP/{version} 200 OK\r\n{}\r\n", framing.headers()).as_bytes(),
+        )
+        .await;
+        let outer = head(&mut self.icap).await;
+        assert!(
+            outer.starts_with("RESPMOD icap://icap.test/respmod ICAP/1.0\r\n"),
+            "{outer:?}"
+        );
+        assert!(outer.to_ascii_lowercase().contains("res-body="));
+        head(&mut self.icap).await; // Encapsulated request.
+        let response = head(&mut self.icap).await;
+        assert!(response.starts_with(&format!("HTTP/{version} 200 OK\r\n")));
+        if matches!(framing, Framing::Close) {
+            assert!(!response.to_ascii_lowercase().contains("content-length:"));
+            assert!(!response.to_ascii_lowercase().contains("transfer-encoding:"));
+        }
+    }
+    async fn adapted_head(&mut self, returned_headers: Option<&str>) -> String {
+        if let Some(headers) = returned_headers {
+            let response = format!("HTTP/1.1 200 OK\r\n{headers}\r\n");
+            write(self.icap.get_mut(), format!("ICAP/1.0 200 OK\r\nISTag: \"framing-test\"\r\nEncapsulated: res-hdr=0, res-body={}\r\n\r\n{response}", response.len()).as_bytes()).await;
+        } else {
+            write(
+                self.icap.get_mut(),
+                b"ICAP/1.0 200 OK\r\nISTag: \"framing-test\"\r\nEncapsulated: res-body=0\r\n\r\n",
+            )
+            .await;
+        }
+        head(&mut self.client).await
+    }
+    async fn finish(mut self, error: bool) {
+        if error {
+            timeout(WATCHDOG, &mut self.done)
+                .await
+                .unwrap()
+                .unwrap()
+                .expect_err("upstream fault was swallowed");
+        } else {
+            drop(self.client);
+            drop(self.origin);
+            drop(self.icap);
+            timeout(WATCHDOG, self.done)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Framing {
+    Close,
+    Length,
+    Chunked,
+}
+impl Framing {
+    fn headers(self) -> &'static str {
+        match self {
+            Self::Close => "",
+            Self::Length => "Content-Length: 9\r\nConnection: keep-alive\r\n",
+            Self::Chunked => "Transfer-Encoding: chunked\r\n",
+        }
+    }
+}
+async fn write(io: &mut DuplexStream, bytes: &[u8]) {
+    timeout(WATCHDOG, io.write_all(bytes))
+        .await
+        .unwrap()
+        .unwrap();
+}
+async fn bytes(io: &mut BufReader<DuplexStream>, len: usize) -> Vec<u8> {
+    let mut data = vec![0; len];
+    timeout(WATCHDOG, io.read_exact(&mut data))
+        .await
+        .unwrap()
+        .unwrap();
+    data
+}
+async fn head(io: &mut BufReader<DuplexStream>) -> String {
+    timeout(WATCHDOG, async {
+        let mut text = String::new();
+        while !text.ends_with("\r\n\r\n") {
+            assert_ne!(
+                io.read_line(&mut text).await.unwrap(),
+                0,
+                "incomplete head: {text:?}"
+            );
+            assert!(text.len() < 4096);
+        }
+        text
+    })
+    .await
+    .unwrap()
+}
+async fn pending(io: &mut BufReader<DuplexStream>) {
+    assert!(
+        timeout(Duration::from_millis(1), io.read_u8())
+            .await
+            .is_err(),
+        "unexpected bytes or EOF"
+    );
+}
+async fn eof(io: &mut BufReader<DuplexStream>) {
+    assert_eq!(
+        timeout(WATCHDOG, io.read(&mut [0])).await.unwrap().unwrap(),
+        0
+    );
+}
+async fn chunk(io: &mut DuplexStream, payload: &[u8]) {
+    write(io, format!("{:x}\r\n", payload.len()).as_bytes()).await;
+    write(io, payload).await;
+    write(io, b"\r\n").await;
+}
+async fn payload(io: &mut BufReader<DuplexStream>, expected: &[u8], chunked: bool) {
+    if !chunked {
+        assert_eq!(bytes(io, expected.len()).await, expected);
+        return;
+    }
+    let mut received = Vec::new();
+    while received.len() < expected.len() {
+        let mut line = String::new();
+        timeout(WATCHDOG, io.read_line(&mut line))
+            .await
+            .unwrap()
+            .unwrap();
+        let size = usize::from_str_radix(line.trim(), 16).unwrap();
+        assert!(size > 0 && size <= expected.len() - received.len());
+        received.extend(bytes(io, size).await);
+        assert_eq!(bytes(io, 2).await, b"\r\n");
+    }
+    assert_eq!(received, expected);
+}
+fn assert_framing(head: &str, version: &str, chunked: bool) {
+    assert!(
+        head.starts_with(&format!("HTTP/{version} 200 OK\r\n")),
+        "{head:?}"
+    );
+    let lower = head.to_ascii_lowercase();
+    assert_eq!(
+        lower.contains("transfer-encoding: chunked\r\n"),
+        chunked,
+        "{head:?}"
+    );
+    assert!(
+        !lower.contains("content-length:"),
+        "adaptation must not forward a stale length: {head:?}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn respmod_framing_matrix_streams_both_hops() {
+    for (version, framing) in [
+        ("1.0", Framing::Close),
+        ("1.1", Framing::Close),
+        ("1.0", Framing::Length),
+        ("1.1", Framing::Length),
+        ("1.1", Framing::Chunked),
+    ] {
+        for preview in [false, true] {
+            for returned_headers in [
+                None,
+                Some(""),
+                Some("Content-Length: 999\r\n"),
+                Some("Transfer-Encoding: chunked\r\n"),
+            ] {
+                let mut relay = Relay::new(preview);
+                relay.begin(version, framing).await;
+                if matches!(framing, Framing::Chunked) {
+                    chunk(relay.origin.get_mut(), b"first").await;
+                } else {
+                    write(relay.origin.get_mut(), b"first").await;
+                }
+                payload(&mut relay.icap, b"first", true).await;
+                if preview {
+                    assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+                    write(relay.icap.get_mut(), b"ICAP/1.0 100 Continue\r\n\r\n").await;
+                }
+                advance(Duration::from_secs(31)).await;
+                pending(&mut relay.icap).await;
+                pending(&mut relay.client).await; // No adaptation decision yet.
+                if matches!(framing, Framing::Chunked) {
+                    chunk(relay.origin.get_mut(), b"last").await;
+                    write(relay.origin.get_mut(), b"0\r\n\r\n").await;
+                } else {
+                    write(relay.origin.get_mut(), b"last").await;
+                }
+                payload(&mut relay.icap, b"last", true).await;
+                if matches!(framing, Framing::Close) {
+                    pending(&mut relay.icap).await;
+                    relay.origin.get_mut().shutdown().await.unwrap();
+                }
+                assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+                let head = relay.adapted_head(returned_headers).await;
+                let chunked = version == "1.1" && !matches!(framing, Framing::Close);
+                assert_framing(&head, version, chunked);
+                if matches!(framing, Framing::Close) {
+                    assert!(head.to_ascii_lowercase().contains("connection: close\r\n"));
+                }
+                for part in [b"adapted-first".as_slice(), b"adapted-last".as_slice()] {
+                    chunk(relay.icap.get_mut(), part).await;
+                    payload(&mut relay.client, part, chunked).await;
+                    advance(Duration::from_secs(31)).await;
+                    pending(&mut relay.client).await;
+                }
+                // ICAP's terminal chunk, not ICAP TCP EOF, completes this HTTP body.
+                write(relay.icap.get_mut(), b"0\r\n\r\n").await;
+                if chunked {
+                    assert_eq!(bytes(&mut relay.client, 5).await, b"0\r\n\r\n");
+                } else {
+                    eof(&mut relay.client).await;
+                }
+                relay.finish(false).await;
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn preview_204_replays_close_delimited_body_while_origin_remains_open() {
+    for version in ["1.0", "1.1"] {
+        let mut relay = Relay::new(true);
+        relay.begin(version, Framing::Close).await;
+        write(relay.origin.get_mut(), b"first").await;
+        payload(&mut relay.icap, b"first", true).await;
+        assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+        write(relay.icap.get_mut(), b"ICAP/1.0 204 No Content\r\nISTag: \"framing-test\"\r\nEncapsulated: null-body=0\r\n\r\n").await;
+        assert_framing(&head(&mut relay.client).await, version, false);
+        payload(&mut relay.client, b"first", false).await;
+        advance(Duration::from_secs(31)).await;
+        pending(&mut relay.client).await;
+        write(relay.origin.get_mut(), b"last").await;
+        payload(&mut relay.client, b"last", false).await;
+        pending(&mut relay.client).await;
+        relay.origin.get_mut().shutdown().await.unwrap();
+        eof(&mut relay.client).await;
+        relay.finish(false).await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn truncated_icap_response_does_not_wait_for_fixture_teardown() {
+    let mut relay = Relay::new(false);
+    relay.begin("1.1", Framing::Close).await;
+    relay.origin.get_mut().shutdown().await.unwrap();
+    assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+    assert_framing(&relay.adapted_head(Some("")).await, "1.1", false);
+    chunk(relay.icap.get_mut(), b"partial").await;
+    payload(&mut relay.client, b"partial", false).await;
+    relay.icap.get_mut().shutdown().await.unwrap(); // Missing ICAP terminal chunk.
+    eof(&mut relay.client).await;
+    relay.finish(true).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn empty_close_delimited_origin_preserves_framing_through_icap() {
+    for preview in [false, true] {
+        for unchanged in [false, true] {
+            if unchanged && !preview {
+                continue;
+            } // 204 is allowed within Preview.
+            let mut relay = Relay::new(preview);
+            relay.begin("1.1", Framing::Close).await;
+            relay.origin.get_mut().shutdown().await.unwrap();
+            let end = head(&mut relay.icap).await;
+            assert_eq!(
+                end,
+                if preview {
+                    "0; ieof\r\n\r\n"
+                } else {
+                    "0\r\n\r\n"
+                }
+            );
+            let response = if unchanged {
+                write(relay.icap.get_mut(), b"ICAP/1.0 204 No Content\r\nISTag: \"framing-test\"\r\nEncapsulated: null-body=0\r\n\r\n").await;
+                head(&mut relay.client).await
+            } else {
+                let response = relay.adapted_head(Some("")).await;
+                write(relay.icap.get_mut(), b"0\r\n\r\n").await;
+                response
+            };
+            assert_framing(&response, "1.1", false);
+            eof(&mut relay.client).await;
+            relay.finish(false).await;
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn icap_preserves_explicit_framing_without_mitm_metadata() {
+    let mut relay = Relay::with_local_response(false, true);
+    write(
+        relay.client.get_mut(),
+        b"GET / HTTP/1.1\r\nHost: origin.test\r\n\r\n",
+    )
+    .await;
+    head(&mut relay.icap).await;
+    head(&mut relay.icap).await;
+    head(&mut relay.icap).await;
+    payload(&mut relay.icap, b"firstlast", true).await;
+    assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+    assert_framing(&relay.adapted_head(Some("")).await, "1.1", false);
+    chunk(relay.icap.get_mut(), b"adapted").await;
+    payload(&mut relay.client, b"adapted", false).await;
+    pending(&mut relay.client).await;
+    write(relay.icap.get_mut(), b"0\r\n\r\n").await;
+    eof(&mut relay.client).await;
+    relay.finish(false).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn icap_added_trailers_override_close_delimited_framing() {
+    let mut relay = Relay::new(false);
+    relay.begin("1.1", Framing::Close).await;
+    relay.origin.get_mut().shutdown().await.unwrap();
+    assert_eq!(bytes(&mut relay.icap, 5).await, b"0\r\n\r\n");
+    let response = relay.adapted_head(Some("Trailer: x-checksum\r\n")).await;
+    assert_framing(&response, "1.1", true);
+    chunk(relay.icap.get_mut(), b"adapted").await;
+    payload(&mut relay.client, b"adapted", true).await;
+    pending(&mut relay.client).await;
+    write(relay.icap.get_mut(), b"0\r\nx-checksum: ok\r\n\r\n").await;
+    assert_eq!(
+        head(&mut relay.client).await.to_ascii_lowercase(),
+        "0\r\nx-checksum: ok\r\n\r\n"
+    );
+    relay.finish(false).await;
+}


### PR DESCRIPTION
Add more tests + support http/1.1 close-delimited responses in http relaying.